### PR TITLE
Fix content upload failure and missing thumbnails

### DIFF
--- a/middleware/src/modules/content/file-validation.service.ts
+++ b/middleware/src/modules/content/file-validation.service.ts
@@ -160,7 +160,7 @@ export class FileValidationService {
       /onerror=/i,
       /onload=/i,
       /eval\(/i,
-      /base64,/i, // Base64-encoded executables
+      /data:\s*[^;]{1,50};\s*base64,/i, // data: URI with Base64-encoded payload
       /%PDF.*\/JS/i, // PDF with JavaScript
       /\/EmbeddedFile/i, // PDF with embedded files
     ];

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -499,7 +499,9 @@ class ApiClient {
         if (process.env.NODE_ENV === 'development') {
           console.log('[API] File upload successful');
         }
-        return result.content || result;
+        // Unwrap response envelope { success, data: { content, fileHash } }
+        const unwrapped = (result && typeof result === 'object' && 'success' in result && 'data' in result) ? result.data : result;
+        return unwrapped.content || unwrapped;
       } catch (error) {
         clearTimeout(timeoutId);
         if (error instanceof Error && error.name === 'AbortError') {
@@ -1430,6 +1432,15 @@ class ApiClient {
   async removeQrOverlay(displayId: string): Promise<void> {
     return this.request<void>(`/displays/${displayId}/qr-overlay`, {
       method: 'DELETE',
+    });
+  }
+
+  /**
+   * Trigger thumbnail generation for a content item.
+   */
+  async generateThumbnail(contentId: string): Promise<{ thumbnail: string }> {
+    return this.request<{ thumbnail: string }>(`/content/${contentId}/thumbnail`, {
+      method: 'POST',
     });
   }
 


### PR DESCRIPTION
## Summary

- **Fix upload failure**: The `/base64,/i` regex in `FileValidationService.detectSuspiciousContent` was false-positiving on legitimate JPEG files whose EXIF/XMP metadata contained `base64,` strings. Narrowed the pattern to only match actual `data:` URI attacks (`/data:\s*[^;]{1,50};\s*base64,/i`).
- **Fix response envelope unwrapping**: The `createContent` multipart upload path bypassed `request()` and used raw `fetch`, but didn't unwrap the `{ success, data }` response envelope. This caused `newContent.id` to always be `undefined`, silently skipping thumbnail generation after upload.
- **Fix broken thumbnail trigger**: Replaced non-existent `apiClient.post()` calls with a new `generateThumbnail()` API method that properly uses `this.request()`.
- **Auto-generate missing thumbnails**: On content page load, detects image items without thumbnails and triggers background generation via `POST /content/:id/thumbnail`, then refreshes the list.

## Test plan

- [x] All 1731 middleware tests pass (84 suites), including 2 new tests
- [x] New test: JPEG with XMP base64 metadata passes validation
- [x] New test: Malicious `data:text/html;base64,...` payload is still rejected
- [ ] Manual: Upload a JPG image via the Upload Content dialog — should succeed
- [ ] Manual: Verify thumbnail appears for newly uploaded image content
- [ ] Manual: Verify existing image content without thumbnails gets thumbnails after page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)