### PR TITLE
feat(mobile): production readiness — auth fixes, tests, build config

### DIFF
--- a/mobile/.maestro/01-login.yaml
+++ b/mobile/.maestro/01-login.yaml
@@ -1,0 +1,25 @@
+appId: com.vizora.companion
+name: Login Flow
+---
+# Launch app — should show login screen
+- launchApp
+
+# Verify login screen elements
+- assertVisible: "VIZORA"
+- assertVisible: "Sign In"
+
+# Enter credentials
+- tapOn:
+    id: "email-input"
+- inputText: "test@vizora.cloud"
+- tapOn:
+    id: "password-input"
+- inputText: "TestPass123!"
+
+# Submit login
+- tapOn: "Sign In"
+
+# Verify navigation to Displays screen
+- assertVisible:
+    text: "Displays"
+    timeout: 10000

--- a/mobile/.maestro/02-devices.yaml
+++ b/mobile/.maestro/02-devices.yaml
@@ -1,0 +1,25 @@
+appId: com.vizora.companion
+name: Devices List
+---
+# Prerequisite: user must be logged in
+- launchApp
+
+# Wait for Displays screen
+- assertVisible:
+    text: "Displays"
+    timeout: 10000
+
+# Verify header elements
+- assertVisible: "Sign Out"
+
+# If devices exist, tap the first one
+- tapOn:
+    index: 0
+    optional: true
+    id: "device-card"
+
+# Verify device detail screen loads (if a device was tapped)
+- assertVisible:
+    text: "Device Info"
+    timeout: 5000
+    optional: true

--- a/mobile/.maestro/03-content.yaml
+++ b/mobile/.maestro/03-content.yaml
@@ -1,0 +1,31 @@
+appId: com.vizora.companion
+name: Content Tab
+---
+# Prerequisite: user must be logged in
+- launchApp
+
+# Wait for main screen
+- assertVisible:
+    text: "Displays"
+    timeout: 10000
+
+# Navigate to Content tab
+- tapOn: "Content"
+
+# Verify content screen loads
+- assertVisible:
+    text: "Content"
+    timeout: 5000
+
+# Test type filter if visible
+- tapOn:
+    text: "Images"
+    optional: true
+
+- tapOn:
+    text: "Videos"
+    optional: true
+
+- tapOn:
+    text: "All"
+    optional: true

--- a/mobile/.maestro/04-logout.yaml
+++ b/mobile/.maestro/04-logout.yaml
@@ -1,0 +1,19 @@
+appId: com.vizora.companion
+name: Logout Flow
+---
+# Prerequisite: user must be logged in
+- launchApp
+
+# Wait for main screen
+- assertVisible:
+    text: "Displays"
+    timeout: 10000
+
+# Tap Sign Out
+- tapOn: "Sign Out"
+
+# Verify return to login screen
+- assertVisible:
+    text: "Sign In"
+    timeout: 5000
+- assertVisible: "VIZORA"

--- a/mobile/app/__tests__/login.test.tsx
+++ b/mobile/app/__tests__/login.test.tsx
@@ -1,0 +1,176 @@
+import React from 'react';
+import { Alert } from 'react-native';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { useRouter } from 'expo-router';
+import LoginScreen from '../(auth)/login';
+import { api, ApiError } from '../../src/api/client';
+import { useAuthStore } from '../../src/stores/auth';
+
+// Mock the API client
+jest.mock('../../src/api/client', () => {
+  const actual = jest.requireActual('../../src/api/client');
+  return {
+    ...actual,
+    api: {
+      login: jest.fn(),
+    },
+  };
+});
+
+// Mock the auth store
+const mockSetAuth = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../src/stores/auth', () => ({
+  useAuthStore: jest.fn((selector: (s: unknown) => unknown) =>
+    selector({ setAuth: mockSetAuth }),
+  ),
+}));
+
+// Let validation use real implementation (no mock)
+
+const mockRouter = { push: jest.fn(), replace: jest.fn(), back: jest.fn() };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useRouter as jest.Mock).mockReturnValue(mockRouter);
+});
+
+describe('LoginScreen', () => {
+  it('renders email input, password input, and Sign In button', () => {
+    const { getByPlaceholderText, getByText } = render(<LoginScreen />);
+
+    expect(getByPlaceholderText('you@company.com')).toBeTruthy();
+    expect(getByPlaceholderText('Enter your password')).toBeTruthy();
+    expect(getByText('Sign In')).toBeTruthy();
+  });
+
+  it('shows alert when email is empty', () => {
+    const alertSpy = jest.spyOn(Alert, 'alert');
+    const { getByText } = render(<LoginScreen />);
+
+    fireEvent.press(getByText('Sign In'));
+
+    expect(alertSpy).toHaveBeenCalledWith('Error', 'Email is required.');
+    expect((api.login as jest.Mock)).not.toHaveBeenCalled();
+  });
+
+  it('shows alert when email format is invalid', () => {
+    const alertSpy = jest.spyOn(Alert, 'alert');
+    const { getByPlaceholderText, getByText } = render(<LoginScreen />);
+
+    fireEvent.changeText(getByPlaceholderText('you@company.com'), 'not-an-email');
+    fireEvent.press(getByText('Sign In'));
+
+    expect(alertSpy).toHaveBeenCalledWith('Error', 'Please enter a valid email address.');
+    expect((api.login as jest.Mock)).not.toHaveBeenCalled();
+  });
+
+  it('shows alert when password is empty', () => {
+    const alertSpy = jest.spyOn(Alert, 'alert');
+    const { getByPlaceholderText, getByText } = render(<LoginScreen />);
+
+    fireEvent.changeText(getByPlaceholderText('you@company.com'), 'user@test.com');
+    fireEvent.press(getByText('Sign In'));
+
+    expect(alertSpy).toHaveBeenCalledWith('Error', 'Please enter your password.');
+    expect((api.login as jest.Mock)).not.toHaveBeenCalled();
+  });
+
+  it('calls api.login and navigates on success', async () => {
+    const mockUser = {
+      id: '1',
+      email: 'user@test.com',
+      firstName: 'John',
+      lastName: 'Doe',
+      role: 'admin',
+      organizationId: 'org-1',
+    };
+    (api.login as jest.Mock).mockResolvedValue({
+      access_token: 'jwt-token-123',
+      user: mockUser,
+    });
+
+    const { getByPlaceholderText, getByText } = render(<LoginScreen />);
+
+    fireEvent.changeText(getByPlaceholderText('you@company.com'), 'user@test.com');
+    fireEvent.changeText(getByPlaceholderText('Enter your password'), 'Password1!');
+    fireEvent.press(getByText('Sign In'));
+
+    await waitFor(() => {
+      expect(api.login).toHaveBeenCalledWith('user@test.com', 'Password1!');
+    });
+
+    await waitFor(() => {
+      expect(mockSetAuth).toHaveBeenCalledWith('jwt-token-123', mockUser);
+    });
+
+    await waitFor(() => {
+      expect(mockRouter.replace).toHaveBeenCalledWith('/(main)/devices');
+    });
+  });
+
+  it('reads res.token when access_token is absent', async () => {
+    const mockUser = {
+      id: '2',
+      email: 'user2@test.com',
+      firstName: 'Jane',
+      lastName: 'Doe',
+      role: 'user',
+      organizationId: 'org-2',
+    };
+    (api.login as jest.Mock).mockResolvedValue({
+      token: 'fallback-token',
+      user: mockUser,
+    });
+
+    const { getByPlaceholderText, getByText } = render(<LoginScreen />);
+
+    fireEvent.changeText(getByPlaceholderText('you@company.com'), 'user2@test.com');
+    fireEvent.changeText(getByPlaceholderText('Enter your password'), 'Password1!');
+    fireEvent.press(getByText('Sign In'));
+
+    await waitFor(() => {
+      expect(mockSetAuth).toHaveBeenCalledWith('fallback-token', mockUser);
+    });
+  });
+
+  it('shows alert with ApiError message on API failure', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert');
+    (api.login as jest.Mock).mockRejectedValue(new ApiError(401, 'Invalid credentials'));
+
+    const { getByPlaceholderText, getByText } = render(<LoginScreen />);
+
+    fireEvent.changeText(getByPlaceholderText('you@company.com'), 'user@test.com');
+    fireEvent.changeText(getByPlaceholderText('Enter your password'), 'Password1!');
+    fireEvent.press(getByText('Sign In'));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith('Login Failed', 'Invalid credentials');
+    });
+  });
+
+  it('shows generic network error message for non-ApiError failures', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert');
+    (api.login as jest.Mock).mockRejectedValue(new TypeError('Network request failed'));
+
+    const { getByPlaceholderText, getByText } = render(<LoginScreen />);
+
+    fireEvent.changeText(getByPlaceholderText('you@company.com'), 'user@test.com');
+    fireEvent.changeText(getByPlaceholderText('Enter your password'), 'Password1!');
+    fireEvent.press(getByText('Sign In'));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Login Failed',
+        'Could not connect to server. Check your network.',
+      );
+    });
+  });
+
+  it('sign up link navigates to register screen', () => {
+    const { getByText } = render(<LoginScreen />);
+
+    fireEvent.press(getByText(/Don't have an account/));
+
+    expect(mockRouter.push).toHaveBeenCalledWith('/(auth)/register');
+  });
+});

--- a/mobile/app/__tests__/register.test.tsx
+++ b/mobile/app/__tests__/register.test.tsx
@@ -1,0 +1,211 @@
+import React from 'react';
+import { Alert } from 'react-native';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { useRouter } from 'expo-router';
+import RegisterScreen from '../(auth)/register';
+import { api, ApiError } from '../../src/api/client';
+import { useAuthStore } from '../../src/stores/auth';
+
+// Mock the API client
+jest.mock('../../src/api/client', () => {
+  const actual = jest.requireActual('../../src/api/client');
+  return {
+    ...actual,
+    api: {
+      register: jest.fn(),
+    },
+  };
+});
+
+// Mock the auth store
+const mockSetAuth = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../src/stores/auth', () => ({
+  useAuthStore: jest.fn((selector: (s: unknown) => unknown) =>
+    selector({ setAuth: mockSetAuth }),
+  ),
+}));
+
+// Let validation use real implementation (no mock)
+
+const mockRouter = { push: jest.fn(), replace: jest.fn(), back: jest.fn() };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useRouter as jest.Mock).mockReturnValue(mockRouter);
+});
+
+/**
+ * Helper: get the "Create Account" button element (not the title).
+ * The screen has both a title and a button with the same text.
+ * The button text is the last element returned by getAllByText.
+ */
+function getSubmitButton(helpers: ReturnType<typeof render>) {
+  const elements = helpers.getAllByText('Create Account');
+  // The button text is the second occurrence (index 1)
+  return elements[elements.length - 1];
+}
+
+/** Fill all form fields with valid data */
+function fillValidForm(helpers: ReturnType<typeof render>) {
+  const { getByPlaceholderText } = helpers;
+  fireEvent.changeText(getByPlaceholderText('John'), 'Alice');
+  fireEvent.changeText(getByPlaceholderText('Doe'), 'Smith');
+  fireEvent.changeText(getByPlaceholderText('you@company.com'), 'alice@corp.com');
+  fireEvent.changeText(getByPlaceholderText('Min. 8 characters'), 'StrongPass1!');
+  fireEvent.changeText(getByPlaceholderText('Acme Corp'), 'Test Org');
+}
+
+describe('RegisterScreen', () => {
+  it('renders all input fields and Create Account button', () => {
+    const helpers = render(<RegisterScreen />);
+    const { getByPlaceholderText, getAllByText } = helpers;
+
+    expect(getByPlaceholderText('John')).toBeTruthy();
+    expect(getByPlaceholderText('Doe')).toBeTruthy();
+    expect(getByPlaceholderText('you@company.com')).toBeTruthy();
+    expect(getByPlaceholderText('Min. 8 characters')).toBeTruthy();
+    expect(getByPlaceholderText('Acme Corp')).toBeTruthy();
+    // Title and button both say "Create Account"
+    expect(getAllByText('Create Account').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows alert for empty first name', () => {
+    const alertSpy = jest.spyOn(Alert, 'alert');
+    const helpers = render(<RegisterScreen />);
+
+    fireEvent.press(getSubmitButton(helpers));
+
+    expect(alertSpy).toHaveBeenCalledWith('Error', 'First name is required.');
+    expect((api.register as jest.Mock)).not.toHaveBeenCalled();
+  });
+
+  it('shows alert for empty last name', () => {
+    const alertSpy = jest.spyOn(Alert, 'alert');
+    const helpers = render(<RegisterScreen />);
+    const { getByPlaceholderText } = helpers;
+
+    fireEvent.changeText(getByPlaceholderText('John'), 'Alice');
+    fireEvent.press(getSubmitButton(helpers));
+
+    expect(alertSpy).toHaveBeenCalledWith('Error', 'Last name is required.');
+  });
+
+  it('shows alert for invalid email', () => {
+    const alertSpy = jest.spyOn(Alert, 'alert');
+    const helpers = render(<RegisterScreen />);
+    const { getByPlaceholderText } = helpers;
+
+    fireEvent.changeText(getByPlaceholderText('John'), 'Alice');
+    fireEvent.changeText(getByPlaceholderText('Doe'), 'Smith');
+    fireEvent.changeText(getByPlaceholderText('you@company.com'), 'bad-email');
+    fireEvent.press(getSubmitButton(helpers));
+
+    expect(alertSpy).toHaveBeenCalledWith('Error', 'Please enter a valid email address.');
+  });
+
+  it('shows alert for weak password (missing uppercase)', () => {
+    const alertSpy = jest.spyOn(Alert, 'alert');
+    const helpers = render(<RegisterScreen />);
+    const { getByPlaceholderText } = helpers;
+
+    fireEvent.changeText(getByPlaceholderText('John'), 'Alice');
+    fireEvent.changeText(getByPlaceholderText('Doe'), 'Smith');
+    fireEvent.changeText(getByPlaceholderText('you@company.com'), 'alice@corp.com');
+    fireEvent.changeText(getByPlaceholderText('Min. 8 characters'), 'alllower1');
+    fireEvent.press(getSubmitButton(helpers));
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Error',
+      'Password must include uppercase, lowercase, and a number or special character.',
+    );
+  });
+
+  it('shows alert for short org name (< 2 chars)', () => {
+    const alertSpy = jest.spyOn(Alert, 'alert');
+    const helpers = render(<RegisterScreen />);
+    const { getByPlaceholderText } = helpers;
+
+    fireEvent.changeText(getByPlaceholderText('John'), 'Alice');
+    fireEvent.changeText(getByPlaceholderText('Doe'), 'Smith');
+    fireEvent.changeText(getByPlaceholderText('you@company.com'), 'alice@corp.com');
+    fireEvent.changeText(getByPlaceholderText('Min. 8 characters'), 'StrongPass1!');
+    fireEvent.changeText(getByPlaceholderText('Acme Corp'), 'A');
+    fireEvent.press(getSubmitButton(helpers));
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Error',
+      'Organization name must be at least 2 characters.',
+    );
+  });
+
+  it('calls api.register and navigates on success', async () => {
+    const mockUser = {
+      id: '1',
+      email: 'alice@corp.com',
+      firstName: 'Alice',
+      lastName: 'Smith',
+      role: 'admin',
+      organizationId: 'org-1',
+    };
+    (api.register as jest.Mock).mockResolvedValue({
+      access_token: 'jwt-token-456',
+      user: mockUser,
+    });
+
+    const helpers = render(<RegisterScreen />);
+    fillValidForm(helpers);
+
+    fireEvent.press(getSubmitButton(helpers));
+
+    await waitFor(() => {
+      expect(api.register).toHaveBeenCalledWith({
+        firstName: 'Alice',
+        lastName: 'Smith',
+        email: 'alice@corp.com',
+        password: 'StrongPass1!',
+        organizationName: 'Test Org',
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockSetAuth).toHaveBeenCalledWith('jwt-token-456', mockUser);
+    });
+
+    await waitFor(() => {
+      expect(mockRouter.replace).toHaveBeenCalledWith('/(main)/devices');
+    });
+  });
+
+  it('shows alert on API failure with ApiError', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert');
+    (api.register as jest.Mock).mockRejectedValue(
+      new ApiError(409, 'Email already registered'),
+    );
+
+    const helpers = render(<RegisterScreen />);
+    fillValidForm(helpers);
+
+    fireEvent.press(getSubmitButton(helpers));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith('Registration Failed', 'Email already registered');
+    });
+  });
+
+  it('shows generic network error for non-ApiError failures', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert');
+    (api.register as jest.Mock).mockRejectedValue(new TypeError('Network request failed'));
+
+    const helpers = render(<RegisterScreen />);
+    fillValidForm(helpers);
+
+    fireEvent.press(getSubmitButton(helpers));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Registration Failed',
+        'Could not connect to server.',
+      );
+    });
+  });
+});

--- a/mobile/jest.config.ts
+++ b/mobile/jest.config.ts
@@ -3,7 +3,7 @@ import type { Config } from 'jest';
 const config: Config = {
   preset: 'jest-expo',
   transformIgnorePatterns: [
-    'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg|zustand)',
+    'node_modules/(?!\\.pnpm|((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg|zustand)',
   ],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',

--- a/mobile/jest.setup.ts
+++ b/mobile/jest.setup.ts
@@ -1,4 +1,23 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
+// Eagerly resolve all lazy globals installed by expo/src/winter/runtime.native.ts
+// to prevent Jest 30's "import outside test scope" error when lazily triggered.
+const _g = globalThis as Record<string, unknown>;
+for (const key of [
+  'TextDecoder',
+  'TextDecoderStream',
+  'TextEncoderStream',
+  'URL',
+  'URLSearchParams',
+  '__ExpoImportMetaRegistry',
+  'structuredClone',
+]) {
+  try {
+    void _g[key];
+  } catch {
+    // ignore — some may not be defined
+  }
+}
+
 // Mock expo-secure-store
 jest.mock('expo-secure-store', () => {
   const store: Record<string, string> = {};

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -35,6 +35,7 @@
     "@types/react": "~19.1.0",
     "jest": "^30.2.0",
     "jest-expo": "^55.0.9",
+    "react-test-renderer": "19.1.0",
     "ts-node": "^10.9.2",
     "typescript": "~5.9.2"
   },

--- a/mobile/src/api/__tests__/client.test.ts
+++ b/mobile/src/api/__tests__/client.test.ts
@@ -1,0 +1,502 @@
+import { api, ApiError } from '../client';
+import { useAuthStore } from '../../stores/auth';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock the auth store so we can control the token returned by getState()
+jest.mock('../../stores/auth', () => ({
+  useAuthStore: {
+    getState: jest.fn(() => ({ token: null })),
+  },
+}));
+
+// We need access to the mock for type-safe usage
+const mockGetState = useAuthStore.getState as jest.Mock;
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// ---------------------------------------------------------------------------
+// XHR mock helpers
+// ---------------------------------------------------------------------------
+type XHRInstance = {
+  open: jest.Mock;
+  send: jest.Mock;
+  setRequestHeader: jest.Mock;
+  upload: { onprogress: ((event: Partial<ProgressEvent>) => void) | null };
+  onload: (() => void) | null;
+  onerror: (() => void) | null;
+  status: number;
+  responseText: string;
+};
+
+let lastXhr: XHRInstance;
+
+function createMockXHR(): XHRInstance {
+  const xhr: XHRInstance = {
+    open: jest.fn(),
+    send: jest.fn(),
+    setRequestHeader: jest.fn(),
+    upload: { onprogress: null },
+    onload: null,
+    onerror: null,
+    status: 0,
+    responseText: '',
+  };
+  lastXhr = xhr;
+  return xhr;
+}
+
+// Replace global XMLHttpRequest with our mock
+(global as unknown as Record<string, unknown>).XMLHttpRequest = jest.fn(
+  () => createMockXHR(),
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    json: jest.fn().mockResolvedValue(data),
+  } as unknown as Response;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ApiClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetState.mockReturnValue({ token: null });
+  });
+
+  // -----------------------------------------------------------------------
+  // request() — envelope unwrapping
+  // -----------------------------------------------------------------------
+  describe('request — envelope unwrapping', () => {
+    it('unwraps { success, data } envelope and returns data', async () => {
+      const payload = { id: '1', name: 'Display A' };
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ success: true, data: payload }),
+      );
+
+      const result = await api.getDisplays();
+
+      expect(result).toEqual(payload);
+    });
+
+    it('passes through non-envelope JSON as-is', async () => {
+      const payload = { custom: 'value', other: 42 };
+      mockFetch.mockResolvedValueOnce(jsonResponse(payload));
+
+      const result = await api.getDisplays();
+
+      expect(result).toEqual(payload);
+    });
+
+    it('passes through envelope with success but missing data as-is', async () => {
+      const payload = { success: true, message: 'ok' };
+      mockFetch.mockResolvedValueOnce(jsonResponse(payload));
+
+      const result = await api.getDisplays();
+
+      // No 'data' key, so it should not unwrap
+      expect(result).toEqual(payload);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // request() — Bearer token injection
+  // -----------------------------------------------------------------------
+  describe('request — Bearer token', () => {
+    it('includes Authorization header when token is present', async () => {
+      mockGetState.mockReturnValue({ token: 'my-jwt-token' });
+      mockFetch.mockResolvedValueOnce(jsonResponse([]));
+
+      await api.getDisplays();
+
+      const [, fetchOptions] = mockFetch.mock.calls[0];
+      expect(fetchOptions.headers).toMatchObject({
+        Authorization: 'Bearer my-jwt-token',
+      });
+    });
+
+    it('omits Authorization header when token is null', async () => {
+      mockGetState.mockReturnValue({ token: null });
+      mockFetch.mockResolvedValueOnce(jsonResponse([]));
+
+      await api.getDisplays();
+
+      const [, fetchOptions] = mockFetch.mock.calls[0];
+      expect(fetchOptions.headers).not.toHaveProperty('Authorization');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // request() — ApiError on non-OK response
+  // -----------------------------------------------------------------------
+  describe('request — error handling', () => {
+    it('throws ApiError with status and message from error body', async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ message: 'Unauthorized' }, 401),
+      );
+
+      await expect(api.getDisplays()).rejects.toThrow(ApiError);
+      await expect(
+        api.getDisplays().catch((e: ApiError) => {
+          expect(e.status).toBe(401);
+          expect(e.message).toBe('Unauthorized');
+          throw e;
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('falls back to "Request failed" when error body has no message', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({}, 500));
+
+      try {
+        await api.getDisplays();
+        // Should not reach here
+        expect(true).toBe(false);
+      } catch (err) {
+        expect(err).toBeInstanceOf(ApiError);
+        expect((err as ApiError).status).toBe(500);
+        expect((err as ApiError).message).toBe('Request failed');
+      }
+    });
+
+    it('falls back to statusText when error body JSON parsing fails', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        statusText: 'Bad Gateway',
+        json: jest.fn().mockRejectedValue(new Error('invalid json')),
+      } as unknown as Response);
+
+      try {
+        await api.getDisplays();
+      } catch (err) {
+        expect(err).toBeInstanceOf(ApiError);
+        expect((err as ApiError).status).toBe(502);
+        expect((err as ApiError).message).toBe('Bad Gateway');
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // login
+  // -----------------------------------------------------------------------
+  describe('login', () => {
+    it('calls POST /api/v1/auth/login with email and password', async () => {
+      const loginResponse = {
+        access_token: 'tok-123',
+        user: {
+          id: 'u1',
+          email: 'a@b.com',
+          firstName: 'A',
+          lastName: 'B',
+          role: 'admin',
+          organizationId: 'org-1',
+        },
+      };
+      mockFetch.mockResolvedValueOnce(jsonResponse(loginResponse));
+
+      const result = await api.login('a@b.com', 'secret');
+
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toBe('http://localhost:3000/api/v1/auth/login');
+      expect(options.method).toBe('POST');
+      expect(JSON.parse(options.body)).toEqual({
+        email: 'a@b.com',
+        password: 'secret',
+      });
+      expect(result).toEqual(loginResponse);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // register
+  // -----------------------------------------------------------------------
+  describe('register', () => {
+    it('calls POST /api/v1/auth/register with RegisterData body', async () => {
+      const registerData = {
+        email: 'new@user.com',
+        password: 'pass123',
+        firstName: 'New',
+        lastName: 'User',
+        organizationName: 'TestOrg',
+      };
+      const registerResponse = {
+        token: 'new-token',
+        user: {
+          id: 'u2',
+          email: 'new@user.com',
+          firstName: 'New',
+          lastName: 'User',
+          role: 'admin',
+          organizationId: 'org-2',
+        },
+      };
+      mockFetch.mockResolvedValueOnce(jsonResponse(registerResponse));
+
+      const result = await api.register(registerData);
+
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toBe('http://localhost:3000/api/v1/auth/register');
+      expect(options.method).toBe('POST');
+      expect(JSON.parse(options.body)).toEqual(registerData);
+      expect(result).toEqual(registerResponse);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // uploadFile
+  // -----------------------------------------------------------------------
+  describe('uploadFile', () => {
+    it('uses XMLHttpRequest to POST to /api/v1/content/upload', async () => {
+      mockGetState.mockReturnValue({ token: 'upload-token' });
+      const onProgress = jest.fn();
+
+      const uploadPromise = api.uploadFile(
+        'file:///photo.jpg',
+        'photo.jpg',
+        'image/jpeg',
+        onProgress,
+      );
+
+      // Verify XHR was configured correctly
+      expect(lastXhr.open).toHaveBeenCalledWith(
+        'POST',
+        'http://localhost:3000/api/v1/content/upload',
+      );
+      expect(lastXhr.setRequestHeader).toHaveBeenCalledWith(
+        'Authorization',
+        'Bearer upload-token',
+      );
+
+      // Simulate progress
+      lastXhr.upload.onprogress!({ lengthComputable: true, loaded: 50, total: 100 });
+      expect(onProgress).toHaveBeenCalledWith(50);
+
+      lastXhr.upload.onprogress!({ lengthComputable: true, loaded: 100, total: 100 });
+      expect(onProgress).toHaveBeenCalledWith(100);
+
+      // Simulate successful response
+      lastXhr.status = 200;
+      lastXhr.responseText = JSON.stringify({
+        success: true,
+        data: { id: 'c1', name: 'photo.jpg', type: 'image' },
+      });
+      lastXhr.onload!();
+
+      const result = await uploadPromise;
+      expect(result).toEqual({ id: 'c1', name: 'photo.jpg', type: 'image' });
+    });
+
+    it('does not set Authorization header when no token', async () => {
+      mockGetState.mockReturnValue({ token: null });
+
+      const uploadPromise = api.uploadFile(
+        'file:///photo.jpg',
+        'photo.jpg',
+        'image/jpeg',
+      );
+
+      expect(lastXhr.setRequestHeader).not.toHaveBeenCalled();
+
+      // Complete the upload to avoid hanging promise
+      lastXhr.status = 200;
+      lastXhr.responseText = JSON.stringify({ id: 'c1', name: 'photo.jpg' });
+      lastXhr.onload!();
+
+      await uploadPromise;
+    });
+
+    it('calls onProgress with percentage on upload progress', async () => {
+      mockGetState.mockReturnValue({ token: null });
+      const onProgress = jest.fn();
+
+      const uploadPromise = api.uploadFile(
+        'file:///video.mp4',
+        'video.mp4',
+        'video/mp4',
+        onProgress,
+      );
+
+      // Simulate progress events
+      lastXhr.upload.onprogress!({ lengthComputable: true, loaded: 25, total: 100 });
+      expect(onProgress).toHaveBeenCalledWith(25);
+
+      lastXhr.upload.onprogress!({ lengthComputable: true, loaded: 75, total: 100 });
+      expect(onProgress).toHaveBeenCalledWith(75);
+
+      // Non-computable progress should be ignored
+      lastXhr.upload.onprogress!({ lengthComputable: false, loaded: 0, total: 0 });
+      expect(onProgress).toHaveBeenCalledTimes(2);
+
+      // Complete
+      lastXhr.status = 200;
+      lastXhr.responseText = JSON.stringify({ id: 'c2' });
+      lastXhr.onload!();
+      await uploadPromise;
+    });
+
+    it('unwraps envelope from upload response', async () => {
+      mockGetState.mockReturnValue({ token: null });
+
+      const uploadPromise = api.uploadFile(
+        'file:///img.png',
+        'img.png',
+        'image/png',
+      );
+
+      lastXhr.status = 201;
+      lastXhr.responseText = JSON.stringify({
+        success: true,
+        data: { id: 'c3', name: 'img.png', type: 'image' },
+      });
+      lastXhr.onload!();
+
+      const result = await uploadPromise;
+      expect(result).toEqual({ id: 'c3', name: 'img.png', type: 'image' });
+    });
+
+    it('passes through non-envelope upload response', async () => {
+      mockGetState.mockReturnValue({ token: null });
+
+      const uploadPromise = api.uploadFile(
+        'file:///img.png',
+        'img.png',
+        'image/png',
+      );
+
+      lastXhr.status = 200;
+      lastXhr.responseText = JSON.stringify({ id: 'c4', name: 'img.png' });
+      lastXhr.onload!();
+
+      const result = await uploadPromise;
+      expect(result).toEqual({ id: 'c4', name: 'img.png' });
+    });
+
+    it('rejects with ApiError on non-2xx response', async () => {
+      mockGetState.mockReturnValue({ token: null });
+
+      const uploadPromise = api.uploadFile(
+        'file:///bad.jpg',
+        'bad.jpg',
+        'image/jpeg',
+      );
+
+      lastXhr.status = 413;
+      lastXhr.responseText = JSON.stringify({ message: 'File too large' });
+      lastXhr.onload!();
+
+      await expect(uploadPromise).rejects.toThrow(ApiError);
+      await expect(uploadPromise).rejects.toMatchObject({
+        status: 413,
+        message: 'File too large',
+      });
+    });
+
+    it('rejects with ApiError on invalid server response', async () => {
+      mockGetState.mockReturnValue({ token: null });
+
+      const uploadPromise = api.uploadFile(
+        'file:///bad.jpg',
+        'bad.jpg',
+        'image/jpeg',
+      );
+
+      lastXhr.status = 200;
+      lastXhr.responseText = 'not json';
+      lastXhr.onload!();
+
+      await expect(uploadPromise).rejects.toThrow(ApiError);
+      await expect(uploadPromise).rejects.toMatchObject({
+        status: 200,
+        message: 'Invalid server response',
+      });
+    });
+
+    it('rejects with ApiError on network error', async () => {
+      mockGetState.mockReturnValue({ token: null });
+
+      const uploadPromise = api.uploadFile(
+        'file:///fail.jpg',
+        'fail.jpg',
+        'image/jpeg',
+      );
+
+      lastXhr.onerror!();
+
+      await expect(uploadPromise).rejects.toThrow(ApiError);
+      await expect(uploadPromise).rejects.toMatchObject({
+        status: 0,
+        message: 'Network error during upload',
+      });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildQuery (exported indirectly via getContent)
+// ---------------------------------------------------------------------------
+describe('buildQuery (via api.getContent)', () => {
+  const mockGetState2 = useAuthStore.getState as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetState2.mockReturnValue({ token: null });
+  });
+
+  it('filters out null and undefined values from params', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse([]));
+
+    await api.getContent({ type: 'image', page: undefined, limit: null as unknown as undefined });
+
+    const url: string = mockFetch.mock.calls[0][0];
+    expect(url).toContain('type=image');
+    expect(url).not.toContain('page');
+    expect(url).not.toContain('limit');
+  });
+
+  it('converts values to strings in query params', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse([]));
+
+    await api.getContent({ page: 2, limit: 10 });
+
+    const url: string = mockFetch.mock.calls[0][0];
+    expect(url).toContain('page=2');
+    expect(url).toContain('limit=10');
+  });
+
+  it('sends no query string when params are omitted', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse([]));
+
+    await api.getContent();
+
+    const url: string = mockFetch.mock.calls[0][0];
+    expect(url).toBe('http://localhost:3000/api/v1/content');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ApiError
+// ---------------------------------------------------------------------------
+describe('ApiError', () => {
+  it('has correct name, status, and message', () => {
+    const err = new ApiError(404, 'Not Found');
+    expect(err.name).toBe('ApiError');
+    expect(err.status).toBe(404);
+    expect(err.message).toBe('Not Found');
+    expect(err).toBeInstanceOf(Error);
+  });
+});

--- a/mobile/src/components/__tests__/ConnectionStatus.test.tsx
+++ b/mobile/src/components/__tests__/ConnectionStatus.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { ConnectionStatus } from '../ConnectionStatus';
+
+describe('ConnectionStatus', () => {
+  it('renders with teal color when isConnected=true', () => {
+    const { toJSON } = render(<ConnectionStatus isConnected={true} />);
+    const tree = toJSON();
+    // The root View should have backgroundColor set to colors.teal (#00E5A0)
+    expect(tree).not.toBeNull();
+    const style = (tree as { props: { style: Record<string, unknown> } }).props
+      .style;
+    const flatStyle = Object.assign(
+      {},
+      ...(Array.isArray(style) ? style : [style]),
+    );
+    expect(flatStyle.backgroundColor).toBe('#00E5A0');
+  });
+
+  it('renders with offline color when isConnected=false', () => {
+    const { toJSON } = render(<ConnectionStatus isConnected={false} />);
+    const tree = toJSON();
+    expect(tree).not.toBeNull();
+    const style = (tree as { props: { style: Record<string, unknown> } }).props
+      .style;
+    const flatStyle = Object.assign(
+      {},
+      ...(Array.isArray(style) ? style : [style]),
+    );
+    expect(flatStyle.backgroundColor).toBe('#EF4444');
+  });
+});

--- a/mobile/src/components/__tests__/StatusBadge.test.tsx
+++ b/mobile/src/components/__tests__/StatusBadge.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { StatusBadge } from '../StatusBadge';
+
+describe('StatusBadge', () => {
+  it('renders "Online" label for status="online"', () => {
+    const { getByText } = render(<StatusBadge status="online" />);
+    const label = getByText('Online');
+    expect(label).toBeTruthy();
+    // The color style should use colors.online (#22C55E)
+    expect(label.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ color: '#22C55E' })]),
+    );
+  });
+
+  it('renders "Offline" label for status="offline"', () => {
+    const { getByText } = render(<StatusBadge status="offline" />);
+    const label = getByText('Offline');
+    expect(label).toBeTruthy();
+    // The color style should use colors.offline (#EF4444)
+    expect(label.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ color: '#EF4444' })]),
+    );
+  });
+
+  it('renders "Pairing" label for status="pairing"', () => {
+    const { getByText } = render(<StatusBadge status="pairing" />);
+    const label = getByText('Pairing');
+    expect(label).toBeTruthy();
+    // The color style should use colors.pairing (#F59E0B)
+    expect(label.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ color: '#F59E0B' })]),
+    );
+  });
+});

--- a/mobile/src/hooks/__tests__/useSocket.test.ts
+++ b/mobile/src/hooks/__tests__/useSocket.test.ts
@@ -1,0 +1,291 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { io } from 'socket.io-client';
+import { useSocket } from '../useSocket';
+import { useAuthStore } from '../../stores/auth';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Override the jest.setup.ts mock of socket.io-client with a richer version
+// that captures event handlers so we can simulate socket events in tests.
+jest.mock('socket.io-client');
+
+// Override the jest.setup.ts mock of stores/auth so we control it per-test
+jest.mock('../../stores/auth');
+
+const mockIo = io as jest.Mock;
+const mockUseAuthStore = useAuthStore as unknown as jest.Mock;
+
+// Creates a mock socket that tracks event listeners
+function createMockSocket() {
+  const listeners: Record<string, Array<(...args: unknown[]) => void>> = {};
+
+  const socket = {
+    on: jest.fn((event: string, cb: (...args: unknown[]) => void) => {
+      if (!listeners[event]) listeners[event] = [];
+      listeners[event].push(cb);
+      return socket;
+    }),
+    off: jest.fn((event: string, cb: (...args: unknown[]) => void) => {
+      if (listeners[event]) {
+        listeners[event] = listeners[event].filter((fn) => fn !== cb);
+      }
+      return socket;
+    }),
+    emit: jest.fn(),
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    connected: false,
+    removeAllListeners: jest.fn(() => {
+      Object.keys(listeners).forEach((k) => delete listeners[k]);
+    }),
+    // Test helper: simulate a socket event
+    __emit(event: string, ...args: unknown[]) {
+      (listeners[event] ?? []).forEach((cb) => cb(...args));
+    },
+    __listeners: listeners,
+  };
+
+  return socket;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Set what useAuthStore returns when called as a selector hook.
+ * useAuthStore is called with selector functions: useAuthStore((s) => s.token)
+ * We mock it so that each call invokes the selector against our fake state.
+ */
+function setAuthState(state: { token: string | null; user: { organizationId: string } | null }) {
+  mockUseAuthStore.mockImplementation((selector: (s: typeof state) => unknown) => {
+    return selector(state);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useSocket', () => {
+  let mockSocket: ReturnType<typeof createMockSocket>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSocket = createMockSocket();
+    mockIo.mockReturnValue(mockSocket);
+    // Default: no auth
+    setAuthState({ token: null, user: null });
+  });
+
+  describe('when no token is available', () => {
+    it('does not create a socket connection', () => {
+      setAuthState({ token: null, user: null });
+
+      renderHook(() => useSocket());
+
+      expect(mockIo).not.toHaveBeenCalled();
+    });
+
+    it('returns isConnected=false and null socket', () => {
+      setAuthState({ token: null, user: null });
+
+      const { result } = renderHook(() => useSocket());
+
+      expect(result.current.isConnected).toBe(false);
+      expect(result.current.socket).toBeNull();
+      expect(result.current.connectionError).toBeNull();
+    });
+  });
+
+  describe('when no organizationId is available', () => {
+    it('does not create a socket connection', () => {
+      setAuthState({ token: 'some-token', user: null });
+
+      renderHook(() => useSocket());
+
+      expect(mockIo).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when token and organizationId are available', () => {
+    beforeEach(() => {
+      setAuthState({
+        token: 'test-token',
+        user: { organizationId: 'org-1' },
+      });
+    });
+
+    it('creates a socket connection with correct config', () => {
+      renderHook(() => useSocket());
+
+      expect(mockIo).toHaveBeenCalledWith('http://localhost:3002', {
+        auth: { token: 'test-token' },
+        transports: ['websocket'],
+        reconnection: true,
+        reconnectionDelay: 1000,
+        reconnectionDelayMax: 5000,
+        reconnectionAttempts: 5,
+        autoConnect: true,
+      });
+    });
+
+    it('sets isConnected=true on connect event', () => {
+      const { result } = renderHook(() => useSocket());
+
+      act(() => {
+        mockSocket.__emit('connect');
+      });
+
+      expect(result.current.isConnected).toBe(true);
+    });
+
+    it('emits join:organization on connect', () => {
+      renderHook(() => useSocket());
+
+      act(() => {
+        mockSocket.__emit('connect');
+      });
+
+      expect(mockSocket.emit).toHaveBeenCalledWith('join:organization', {
+        organizationId: 'org-1',
+      });
+    });
+
+    it('clears connectionError on connect', () => {
+      const { result } = renderHook(() => useSocket());
+
+      // First trigger an error
+      act(() => {
+        mockSocket.__emit('connect_error', new Error('Connection refused'));
+      });
+      expect(result.current.connectionError).toBe('Connection refused');
+
+      // Then connect
+      act(() => {
+        mockSocket.__emit('connect');
+      });
+      expect(result.current.connectionError).toBeNull();
+    });
+
+    it('sets isConnected=false on disconnect event', () => {
+      const { result } = renderHook(() => useSocket());
+
+      // Connect first
+      act(() => {
+        mockSocket.__emit('connect');
+      });
+      expect(result.current.isConnected).toBe(true);
+
+      // Then disconnect
+      act(() => {
+        mockSocket.__emit('disconnect');
+      });
+      expect(result.current.isConnected).toBe(false);
+    });
+
+    it('sets connectionError on connect_error event', () => {
+      const { result } = renderHook(() => useSocket());
+
+      act(() => {
+        mockSocket.__emit('connect_error', new Error('Auth failed'));
+      });
+
+      expect(result.current.connectionError).toBe('Auth failed');
+      expect(result.current.isConnected).toBe(false);
+    });
+  });
+
+  describe('on() method — event subscription', () => {
+    beforeEach(() => {
+      setAuthState({
+        token: 'test-token',
+        user: { organizationId: 'org-1' },
+      });
+    });
+
+    it('subscribes to events and returns unsubscribe function', () => {
+      const { result } = renderHook(() => useSocket());
+      const callback = jest.fn();
+
+      let unsub: () => void;
+      act(() => {
+        unsub = result.current.on('device:status', callback);
+      });
+
+      expect(mockSocket.on).toHaveBeenCalledWith('device:status', callback);
+
+      // Unsubscribe
+      act(() => {
+        unsub();
+      });
+
+      expect(mockSocket.off).toHaveBeenCalledWith('device:status', callback);
+    });
+
+    it('returns a no-op unsubscribe when socket is null', () => {
+      // No auth → no socket
+      setAuthState({ token: null, user: null });
+
+      const { result } = renderHook(() => useSocket());
+      const callback = jest.fn();
+
+      let unsub: () => void;
+      act(() => {
+        unsub = result.current.on('some:event', callback);
+      });
+
+      // Should not throw
+      act(() => {
+        unsub();
+      });
+
+      expect(mockSocket.on).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cleanup on unmount', () => {
+    it('disconnects socket and removes listeners on unmount', () => {
+      setAuthState({
+        token: 'test-token',
+        user: { organizationId: 'org-1' },
+      });
+
+      const { unmount } = renderHook(() => useSocket());
+
+      unmount();
+
+      expect(mockSocket.removeAllListeners).toHaveBeenCalled();
+      expect(mockSocket.disconnect).toHaveBeenCalled();
+    });
+  });
+
+  describe('cleanup on auth change', () => {
+    it('disconnects old socket when token changes', () => {
+      setAuthState({
+        token: 'token-1',
+        user: { organizationId: 'org-1' },
+      });
+
+      const { rerender } = renderHook(() => useSocket());
+
+      // Change auth state
+      const oldSocket = mockSocket;
+      mockSocket = createMockSocket();
+      mockIo.mockReturnValue(mockSocket);
+
+      setAuthState({
+        token: 'token-2',
+        user: { organizationId: 'org-1' },
+      });
+
+      rerender({});
+
+      // Old socket should have been cleaned up
+      expect(oldSocket.removeAllListeners).toHaveBeenCalled();
+      expect(oldSocket.disconnect).toHaveBeenCalled();
+    });
+  });
+});

--- a/mobile/src/hooks/__tests__/useUpload.test.ts
+++ b/mobile/src/hooks/__tests__/useUpload.test.ts
@@ -1,0 +1,270 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useUpload } from '../useUpload';
+import { api } from '../../api/client';
+import { useContentStore } from '../../stores/content';
+import type { Content } from '../../types';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('../../api/client', () => ({
+  api: {
+    uploadFile: jest.fn(),
+  },
+}));
+
+jest.mock('../../stores/content', () => ({
+  useContentStore: {
+    getState: jest.fn(() => ({
+      addItem: jest.fn(),
+    })),
+  },
+}));
+
+const mockUploadFile = api.uploadFile as jest.Mock;
+const mockGetState = useContentStore.getState as jest.Mock;
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const mockContent: Content = {
+  id: 'content-1',
+  name: 'photo.jpg',
+  type: 'image',
+  url: 'https://cdn.example.com/photo.jpg',
+  thumbnailUrl: null,
+  mimeType: 'image/jpeg',
+  fileSize: 12345,
+  duration: null,
+  status: 'ready',
+  organizationId: 'org-1',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useUpload', () => {
+  let mockAddItem: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAddItem = jest.fn();
+    mockGetState.mockReturnValue({ addItem: mockAddItem });
+  });
+
+  describe('initial state', () => {
+    it('should start with status idle', () => {
+      const { result } = renderHook(() => useUpload());
+
+      expect(result.current.state).toEqual({ status: 'idle' });
+    });
+  });
+
+  describe('upload — success flow', () => {
+    it('transitions to uploading, then success', async () => {
+      mockUploadFile.mockResolvedValueOnce(mockContent);
+
+      const { result } = renderHook(() => useUpload());
+
+      let uploadResult: Content | undefined;
+
+      await act(async () => {
+        uploadResult = await result.current.upload(
+          'file:///photo.jpg',
+          'photo.jpg',
+          'image/jpeg',
+        );
+      });
+
+      // Final state should be success with the content
+      expect(result.current.state).toEqual({
+        status: 'success',
+        content: mockContent,
+      });
+
+      // Should return the content
+      expect(uploadResult).toEqual(mockContent);
+    });
+
+    it('passes onProgress callback to api.uploadFile', async () => {
+      mockUploadFile.mockResolvedValueOnce(mockContent);
+
+      const { result } = renderHook(() => useUpload());
+
+      await act(async () => {
+        await result.current.upload('file:///photo.jpg', 'photo.jpg', 'image/jpeg');
+      });
+
+      // Verify uploadFile was called with correct args
+      expect(mockUploadFile).toHaveBeenCalledWith(
+        'file:///photo.jpg',
+        'photo.jpg',
+        'image/jpeg',
+        expect.any(Function),
+      );
+    });
+
+    it('adds uploaded content to the content store', async () => {
+      mockUploadFile.mockResolvedValueOnce(mockContent);
+
+      const { result } = renderHook(() => useUpload());
+
+      await act(async () => {
+        await result.current.upload('file:///photo.jpg', 'photo.jpg', 'image/jpeg');
+      });
+
+      expect(mockAddItem).toHaveBeenCalledWith(mockContent);
+    });
+
+    it('transitions through uploading with progress 0 initially', async () => {
+      // Use a deferred promise so we can observe intermediate state
+      let resolveUpload!: (value: Content) => void;
+      mockUploadFile.mockReturnValueOnce(
+        new Promise<Content>((resolve) => {
+          resolveUpload = resolve;
+        }),
+      );
+
+      const { result } = renderHook(() => useUpload());
+
+      // Start upload (don't await yet)
+      let uploadPromise: Promise<Content | undefined>;
+      act(() => {
+        uploadPromise = result.current.upload(
+          'file:///photo.jpg',
+          'photo.jpg',
+          'image/jpeg',
+        );
+      });
+
+      // The state should be 'uploading' with progress 0
+      expect(result.current.state).toEqual({
+        status: 'uploading',
+        progress: 0,
+      });
+
+      // Now resolve
+      await act(async () => {
+        resolveUpload(mockContent);
+        await uploadPromise!;
+      });
+
+      expect(result.current.state).toEqual({
+        status: 'success',
+        content: mockContent,
+      });
+    });
+  });
+
+  describe('upload — error flow', () => {
+    it('transitions to error state on failure', async () => {
+      mockUploadFile.mockRejectedValueOnce(new Error('Network error'));
+
+      const { result } = renderHook(() => useUpload());
+
+      await act(async () => {
+        await result.current
+          .upload('file:///bad.jpg', 'bad.jpg', 'image/jpeg')
+          .catch(() => {
+            // Expected — the hook re-throws
+          });
+      });
+
+      expect(result.current.state).toEqual({
+        status: 'error',
+        message: 'Network error',
+      });
+    });
+
+    it('uses "Upload failed" message for non-Error exceptions', async () => {
+      mockUploadFile.mockRejectedValueOnce('string error');
+
+      const { result } = renderHook(() => useUpload());
+
+      await act(async () => {
+        await result.current
+          .upload('file:///bad.jpg', 'bad.jpg', 'image/jpeg')
+          .catch(() => {
+            // Expected
+          });
+      });
+
+      expect(result.current.state).toEqual({
+        status: 'error',
+        message: 'Upload failed',
+      });
+    });
+
+    it('re-throws the error to the caller', async () => {
+      const uploadError = new Error('Upload rejected');
+      mockUploadFile.mockRejectedValueOnce(uploadError);
+
+      const { result } = renderHook(() => useUpload());
+
+      await expect(
+        act(async () => {
+          await result.current.upload('file:///bad.jpg', 'bad.jpg', 'image/jpeg');
+        }),
+      ).rejects.toThrow('Upload rejected');
+    });
+
+    it('does not add to content store on failure', async () => {
+      mockUploadFile.mockRejectedValueOnce(new Error('fail'));
+
+      const { result } = renderHook(() => useUpload());
+
+      await act(async () => {
+        await result.current
+          .upload('file:///bad.jpg', 'bad.jpg', 'image/jpeg')
+          .catch(() => {});
+      });
+
+      expect(mockAddItem).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reset', () => {
+    it('returns to idle state after success', async () => {
+      mockUploadFile.mockResolvedValueOnce(mockContent);
+
+      const { result } = renderHook(() => useUpload());
+
+      await act(async () => {
+        await result.current.upload('file:///photo.jpg', 'photo.jpg', 'image/jpeg');
+      });
+
+      expect(result.current.state.status).toBe('success');
+
+      act(() => {
+        result.current.reset();
+      });
+
+      expect(result.current.state).toEqual({ status: 'idle' });
+    });
+
+    it('returns to idle state after error', async () => {
+      mockUploadFile.mockRejectedValueOnce(new Error('fail'));
+
+      const { result } = renderHook(() => useUpload());
+
+      await act(async () => {
+        await result.current
+          .upload('file:///bad.jpg', 'bad.jpg', 'image/jpeg')
+          .catch(() => {});
+      });
+
+      expect(result.current.state.status).toBe('error');
+
+      act(() => {
+        result.current.reset();
+      });
+
+      expect(result.current.state).toEqual({ status: 'idle' });
+    });
+  });
+});

--- a/mobile/src/stores/__tests__/auth.test.ts
+++ b/mobile/src/stores/__tests__/auth.test.ts
@@ -1,0 +1,119 @@
+import { useAuthStore } from '../auth';
+
+// The jest.setup.ts already mocks expo-secure-store with an in-memory store
+const SecureStore = require('expo-secure-store');
+
+const mockUser = {
+  id: 'user-1',
+  email: 'test@example.com',
+  firstName: 'Test',
+  lastName: 'User',
+  role: 'admin',
+  organizationId: 'org-1',
+};
+
+const initialState = {
+  token: null,
+  user: null,
+  isLoading: true,
+  isAuthenticated: false,
+};
+
+describe('useAuthStore', () => {
+  beforeEach(() => {
+    SecureStore.__reset();
+    jest.clearAllMocks();
+    useAuthStore.setState(initialState);
+  });
+
+  describe('initial state', () => {
+    it('should have isLoading=true, isAuthenticated=false, token=null, user=null', () => {
+      const state = useAuthStore.getState();
+      expect(state.isLoading).toBe(true);
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.token).toBeNull();
+      expect(state.user).toBeNull();
+    });
+  });
+
+  describe('setAuth', () => {
+    it('should store token and user in SecureStore and update state', async () => {
+      await useAuthStore.getState().setAuth('my-token', mockUser);
+
+      // Verify SecureStore was called
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith('vizora_auth_token', 'my-token');
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+        'vizora_user',
+        JSON.stringify(mockUser),
+      );
+
+      // Verify zustand state updated
+      const state = useAuthStore.getState();
+      expect(state.token).toBe('my-token');
+      expect(state.user).toEqual(mockUser);
+      expect(state.isAuthenticated).toBe(true);
+      expect(state.isLoading).toBe(false);
+    });
+  });
+
+  describe('logout', () => {
+    it('should clear SecureStore and reset state', async () => {
+      // First set auth so there is something to clear
+      await useAuthStore.getState().setAuth('my-token', mockUser);
+      expect(useAuthStore.getState().isAuthenticated).toBe(true);
+
+      await useAuthStore.getState().logout();
+
+      // Verify SecureStore deletions
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('vizora_auth_token');
+      expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('vizora_user');
+
+      // Verify state is cleared
+      const state = useAuthStore.getState();
+      expect(state.token).toBeNull();
+      expect(state.user).toBeNull();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.isLoading).toBe(false);
+    });
+  });
+
+  describe('loadStoredAuth', () => {
+    it('should restore auth from SecureStore', async () => {
+      // Pre-populate SecureStore
+      await SecureStore.setItemAsync('vizora_auth_token', 'stored-token');
+      await SecureStore.setItemAsync('vizora_user', JSON.stringify(mockUser));
+
+      await useAuthStore.getState().loadStoredAuth();
+
+      const state = useAuthStore.getState();
+      expect(state.token).toBe('stored-token');
+      expect(state.user).toEqual(mockUser);
+      expect(state.isAuthenticated).toBe(true);
+      expect(state.isLoading).toBe(false);
+    });
+
+    it('should set isLoading=false when no stored auth exists', async () => {
+      await useAuthStore.getState().loadStoredAuth();
+
+      const state = useAuthStore.getState();
+      expect(state.token).toBeNull();
+      expect(state.user).toBeNull();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.isLoading).toBe(false);
+    });
+
+    it('should handle corrupt JSON gracefully', async () => {
+      // Store a valid token but invalid JSON for user
+      await SecureStore.setItemAsync('vizora_auth_token', 'some-token');
+      await SecureStore.setItemAsync('vizora_user', '{not valid json!!!');
+
+      await useAuthStore.getState().loadStoredAuth();
+
+      // Should catch the parse error and just set isLoading false
+      const state = useAuthStore.getState();
+      expect(state.isLoading).toBe(false);
+      // Token and user should remain null since the catch block fires
+      expect(state.isAuthenticated).toBe(false);
+    });
+  });
+});

--- a/mobile/src/stores/__tests__/content.test.ts
+++ b/mobile/src/stores/__tests__/content.test.ts
@@ -1,0 +1,162 @@
+import { useContentStore } from '../content';
+import { api } from '../../api/client';
+import type { Content } from '../../types';
+
+jest.mock('../../api/client', () => ({
+  api: {
+    getContent: jest.fn(),
+    deleteContent: jest.fn(),
+  },
+}));
+
+const mockedApi = api as jest.Mocked<typeof api>;
+
+const makeContent = (overrides: Partial<Content> = {}): Content => ({
+  id: 'content-1',
+  name: 'Welcome Banner',
+  type: 'image',
+  url: 'https://cdn.example.com/banner.png',
+  thumbnailUrl: 'https://cdn.example.com/banner-thumb.png',
+  mimeType: 'image/png',
+  fileSize: 204800,
+  duration: null,
+  status: 'active',
+  organizationId: 'org-1',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  ...overrides,
+});
+
+const initialState = {
+  items: [],
+  isLoading: false,
+  error: null,
+};
+
+describe('useContentStore', () => {
+  beforeEach(() => {
+    useContentStore.setState(initialState);
+    jest.clearAllMocks();
+  });
+
+  describe('fetchContent', () => {
+    it('should fetch content without params and set items', async () => {
+      const items = [makeContent(), makeContent({ id: 'content-2', name: 'Promo Video' })];
+      mockedApi.getContent.mockResolvedValue(items);
+
+      await useContentStore.getState().fetchContent();
+
+      expect(mockedApi.getContent).toHaveBeenCalledWith(undefined);
+      const state = useContentStore.getState();
+      expect(state.items).toEqual(items);
+      expect(state.isLoading).toBe(false);
+      expect(state.error).toBeNull();
+    });
+
+    it('should pass filter params to API', async () => {
+      mockedApi.getContent.mockResolvedValue([]);
+
+      await useContentStore.getState().fetchContent({ type: 'video', page: 1, limit: 10 });
+
+      expect(mockedApi.getContent).toHaveBeenCalledWith({ type: 'video', page: 1, limit: 10 });
+    });
+
+    it('should set error on failure', async () => {
+      mockedApi.getContent.mockRejectedValue(new Error('Server down'));
+
+      await useContentStore.getState().fetchContent();
+
+      const state = useContentStore.getState();
+      expect(state.error).toBe('Server down');
+      expect(state.isLoading).toBe(false);
+      expect(state.items).toEqual([]);
+    });
+
+    it('should use fallback error message for non-Error throws', async () => {
+      mockedApi.getContent.mockRejectedValue(42);
+
+      await useContentStore.getState().fetchContent();
+
+      expect(useContentStore.getState().error).toBe('Failed to load content');
+    });
+
+    it('should default to empty array if response is not an array', async () => {
+      mockedApi.getContent.mockResolvedValue({ data: [] } as unknown as Content[]);
+
+      await useContentStore.getState().fetchContent();
+
+      expect(useContentStore.getState().items).toEqual([]);
+    });
+
+    it('should set isLoading=true while fetching', async () => {
+      let capturedLoading = false;
+      mockedApi.getContent.mockImplementation(async () => {
+        capturedLoading = useContentStore.getState().isLoading;
+        return [];
+      });
+
+      await useContentStore.getState().fetchContent();
+
+      expect(capturedLoading).toBe(true);
+      expect(useContentStore.getState().isLoading).toBe(false);
+    });
+
+    it('should clear previous error when starting a new fetch', async () => {
+      useContentStore.setState({ error: 'old error' });
+      mockedApi.getContent.mockResolvedValue([]);
+
+      await useContentStore.getState().fetchContent();
+
+      expect(useContentStore.getState().error).toBeNull();
+    });
+  });
+
+  describe('deleteContent', () => {
+    it('should call API and remove item from state', async () => {
+      const item1 = makeContent({ id: 'content-1' });
+      const item2 = makeContent({ id: 'content-2' });
+      useContentStore.setState({ items: [item1, item2] });
+
+      mockedApi.deleteContent.mockResolvedValue(undefined);
+
+      await useContentStore.getState().deleteContent('content-1');
+
+      expect(mockedApi.deleteContent).toHaveBeenCalledWith('content-1');
+      const state = useContentStore.getState();
+      expect(state.items).toHaveLength(1);
+      expect(state.items[0].id).toBe('content-2');
+    });
+
+    it('should propagate API errors', async () => {
+      useContentStore.setState({ items: [makeContent()] });
+      mockedApi.deleteContent.mockRejectedValue(new Error('Forbidden'));
+
+      await expect(useContentStore.getState().deleteContent('content-1')).rejects.toThrow('Forbidden');
+
+      // State should not change on error since the throw happens before set()
+      expect(useContentStore.getState().items).toHaveLength(1);
+    });
+  });
+
+  describe('addItem', () => {
+    it('should prepend item to items array', () => {
+      const existing = makeContent({ id: 'content-1' });
+      useContentStore.setState({ items: [existing] });
+
+      const newItem = makeContent({ id: 'content-new', name: 'New Upload' });
+      useContentStore.getState().addItem(newItem);
+
+      const state = useContentStore.getState();
+      expect(state.items).toHaveLength(2);
+      expect(state.items[0].id).toBe('content-new');
+      expect(state.items[1].id).toBe('content-1');
+    });
+
+    it('should work on empty items array', () => {
+      const newItem = makeContent({ id: 'content-new' });
+      useContentStore.getState().addItem(newItem);
+
+      expect(useContentStore.getState().items).toEqual([newItem]);
+    });
+  });
+});

--- a/mobile/src/stores/__tests__/devices.test.ts
+++ b/mobile/src/stores/__tests__/devices.test.ts
@@ -1,0 +1,204 @@
+import { useDevicesStore } from '../devices';
+import { api } from '../../api/client';
+import type { Display, DeviceStatusEvent } from '../../types';
+
+jest.mock('../../api/client', () => ({
+  api: {
+    getDisplays: jest.fn(),
+    updateDisplay: jest.fn(),
+    deleteDisplay: jest.fn(),
+  },
+}));
+
+const mockedApi = api as jest.Mocked<typeof api>;
+
+const makeDisplay = (overrides: Partial<Display> = {}): Display => ({
+  id: 'disp-1',
+  nickname: 'Lobby Screen',
+  deviceIdentifier: 'device-abc',
+  status: 'online',
+  location: 'Lobby',
+  orientation: 'landscape',
+  resolution: '1920x1080',
+  lastSeen: '2026-01-01T00:00:00Z',
+  lastHeartbeat: '2026-01-01T00:00:00Z',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  organizationId: 'org-1',
+  currentPlaylistId: null,
+  ...overrides,
+});
+
+const initialState = {
+  displays: [],
+  isLoading: false,
+  error: null,
+};
+
+describe('useDevicesStore', () => {
+  beforeEach(() => {
+    useDevicesStore.setState(initialState);
+    jest.clearAllMocks();
+  });
+
+  describe('fetchDisplays', () => {
+    it('should set displays on success (array response)', async () => {
+      const displays = [makeDisplay(), makeDisplay({ id: 'disp-2', nickname: 'Break Room' })];
+      mockedApi.getDisplays.mockResolvedValue(displays);
+
+      await useDevicesStore.getState().fetchDisplays();
+
+      const state = useDevicesStore.getState();
+      expect(state.displays).toEqual(displays);
+      expect(state.isLoading).toBe(false);
+      expect(state.error).toBeNull();
+    });
+
+    it('should handle envelope-wrapped response with data field', async () => {
+      const displays = [makeDisplay()];
+      mockedApi.getDisplays.mockResolvedValue({ data: displays } as unknown as Display[]);
+
+      await useDevicesStore.getState().fetchDisplays();
+
+      expect(useDevicesStore.getState().displays).toEqual(displays);
+    });
+
+    it('should handle envelope-wrapped response with displays field', async () => {
+      const displays = [makeDisplay()];
+      mockedApi.getDisplays.mockResolvedValue({ displays } as unknown as Display[]);
+
+      await useDevicesStore.getState().fetchDisplays();
+
+      expect(useDevicesStore.getState().displays).toEqual(displays);
+    });
+
+    it('should handle envelope-wrapped response with items field', async () => {
+      const displays = [makeDisplay()];
+      mockedApi.getDisplays.mockResolvedValue({ items: displays } as unknown as Display[]);
+
+      await useDevicesStore.getState().fetchDisplays();
+
+      expect(useDevicesStore.getState().displays).toEqual(displays);
+    });
+
+    it('should fall back to empty array for unknown shape', async () => {
+      mockedApi.getDisplays.mockResolvedValue({ something: 'else' } as unknown as Display[]);
+
+      await useDevicesStore.getState().fetchDisplays();
+
+      expect(useDevicesStore.getState().displays).toEqual([]);
+    });
+
+    it('should set error message on failure', async () => {
+      mockedApi.getDisplays.mockRejectedValue(new Error('Network error'));
+
+      await useDevicesStore.getState().fetchDisplays();
+
+      const state = useDevicesStore.getState();
+      expect(state.error).toBe('Network error');
+      expect(state.isLoading).toBe(false);
+      expect(state.displays).toEqual([]);
+    });
+
+    it('should use fallback error message for non-Error throws', async () => {
+      mockedApi.getDisplays.mockRejectedValue('something went wrong');
+
+      await useDevicesStore.getState().fetchDisplays();
+
+      expect(useDevicesStore.getState().error).toBe('Failed to load displays');
+    });
+
+    it('should set isLoading=true while fetching', async () => {
+      let capturedLoading = false;
+      mockedApi.getDisplays.mockImplementation(async () => {
+        capturedLoading = useDevicesStore.getState().isLoading;
+        return [];
+      });
+
+      await useDevicesStore.getState().fetchDisplays();
+
+      expect(capturedLoading).toBe(true);
+      expect(useDevicesStore.getState().isLoading).toBe(false);
+    });
+  });
+
+  describe('updateDisplayStatus', () => {
+    it('should update matching display status and lastSeen', () => {
+      const display1 = makeDisplay({ id: 'disp-1', status: 'online' });
+      const display2 = makeDisplay({ id: 'disp-2', status: 'online' });
+      useDevicesStore.setState({ displays: [display1, display2] });
+
+      const event: DeviceStatusEvent = {
+        deviceId: 'disp-1',
+        status: 'offline',
+        timestamp: '2026-02-26T12:00:00Z',
+      };
+
+      useDevicesStore.getState().updateDisplayStatus(event);
+
+      const state = useDevicesStore.getState();
+      expect(state.displays[0].status).toBe('offline');
+      expect(state.displays[0].lastSeen).toBe('2026-02-26T12:00:00Z');
+      // Second display should be unchanged
+      expect(state.displays[1].status).toBe('online');
+    });
+
+    it('should not modify displays when deviceId does not match', () => {
+      const display = makeDisplay({ id: 'disp-1', status: 'online' });
+      useDevicesStore.setState({ displays: [display] });
+
+      const event: DeviceStatusEvent = {
+        deviceId: 'nonexistent',
+        status: 'offline',
+        timestamp: '2026-02-26T12:00:00Z',
+      };
+
+      useDevicesStore.getState().updateDisplayStatus(event);
+
+      expect(useDevicesStore.getState().displays[0].status).toBe('online');
+    });
+  });
+
+  describe('updateDisplay', () => {
+    it('should call API and update the matching display in state', async () => {
+      const original = makeDisplay({ id: 'disp-1', nickname: 'Old Name' });
+      useDevicesStore.setState({ displays: [original] });
+
+      const updatedDisplay = { ...original, nickname: 'New Name' };
+      mockedApi.updateDisplay.mockResolvedValue(updatedDisplay);
+
+      const result = await useDevicesStore.getState().updateDisplay('disp-1', { nickname: 'New Name' });
+
+      expect(mockedApi.updateDisplay).toHaveBeenCalledWith('disp-1', { nickname: 'New Name' });
+      expect(result).toEqual(updatedDisplay);
+      expect(useDevicesStore.getState().displays[0].nickname).toBe('New Name');
+    });
+  });
+
+  describe('removeDisplay', () => {
+    it('should call API and remove display from state', async () => {
+      const display1 = makeDisplay({ id: 'disp-1' });
+      const display2 = makeDisplay({ id: 'disp-2' });
+      useDevicesStore.setState({ displays: [display1, display2] });
+
+      mockedApi.deleteDisplay.mockResolvedValue(undefined);
+
+      await useDevicesStore.getState().removeDisplay('disp-1');
+
+      expect(mockedApi.deleteDisplay).toHaveBeenCalledWith('disp-1');
+      const state = useDevicesStore.getState();
+      expect(state.displays).toHaveLength(1);
+      expect(state.displays[0].id).toBe('disp-2');
+    });
+  });
+
+  describe('setDisplays', () => {
+    it('should directly set the displays array', () => {
+      const displays = [makeDisplay(), makeDisplay({ id: 'disp-2' })];
+
+      useDevicesStore.getState().setDisplays(displays);
+
+      expect(useDevicesStore.getState().displays).toEqual(displays);
+    });
+  });
+});

--- a/mobile/src/stores/__tests__/playlists.test.ts
+++ b/mobile/src/stores/__tests__/playlists.test.ts
@@ -1,0 +1,208 @@
+import { usePlaylistsStore } from '../playlists';
+import { api } from '../../api/client';
+import type { Playlist, PlaylistItem } from '../../types';
+
+jest.mock('../../api/client', () => ({
+  api: {
+    getPlaylists: jest.fn(),
+    getPlaylist: jest.fn(),
+    addPlaylistItem: jest.fn(),
+    removePlaylistItem: jest.fn(),
+    reorderPlaylist: jest.fn(),
+  },
+}));
+
+const mockedApi = api as jest.Mocked<typeof api>;
+
+const makePlaylist = (overrides: Partial<Playlist> = {}): Playlist => ({
+  id: 'pl-1',
+  name: 'Default Playlist',
+  description: 'Main lobby playlist',
+  isDefault: true,
+  organizationId: 'org-1',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  ...overrides,
+});
+
+const makePlaylistItem = (overrides: Partial<PlaylistItem> = {}): PlaylistItem => ({
+  id: 'item-1',
+  playlistId: 'pl-1',
+  contentId: 'content-1',
+  duration: 10,
+  order: 0,
+  createdAt: '2026-01-01T00:00:00Z',
+  ...overrides,
+});
+
+const initialState = {
+  items: [],
+  isLoading: false,
+  error: null,
+};
+
+describe('usePlaylistsStore', () => {
+  beforeEach(() => {
+    usePlaylistsStore.setState(initialState);
+    jest.clearAllMocks();
+  });
+
+  describe('fetchPlaylists', () => {
+    it('should fetch playlists and set items on success', async () => {
+      const playlists = [makePlaylist(), makePlaylist({ id: 'pl-2', name: 'Second Playlist' })];
+      mockedApi.getPlaylists.mockResolvedValue(playlists);
+
+      await usePlaylistsStore.getState().fetchPlaylists();
+
+      expect(mockedApi.getPlaylists).toHaveBeenCalledWith(undefined);
+      const state = usePlaylistsStore.getState();
+      expect(state.items).toEqual(playlists);
+      expect(state.isLoading).toBe(false);
+      expect(state.error).toBeNull();
+    });
+
+    it('should pass pagination params to API', async () => {
+      mockedApi.getPlaylists.mockResolvedValue([]);
+
+      await usePlaylistsStore.getState().fetchPlaylists({ page: 2, limit: 5, search: 'lobby' });
+
+      expect(mockedApi.getPlaylists).toHaveBeenCalledWith({ page: 2, limit: 5, search: 'lobby' });
+    });
+
+    it('should set error on failure', async () => {
+      mockedApi.getPlaylists.mockRejectedValue(new Error('Unauthorized'));
+
+      await usePlaylistsStore.getState().fetchPlaylists();
+
+      const state = usePlaylistsStore.getState();
+      expect(state.error).toBe('Unauthorized');
+      expect(state.isLoading).toBe(false);
+      expect(state.items).toEqual([]);
+    });
+
+    it('should use fallback error message for non-Error throws', async () => {
+      mockedApi.getPlaylists.mockRejectedValue(null);
+
+      await usePlaylistsStore.getState().fetchPlaylists();
+
+      expect(usePlaylistsStore.getState().error).toBe('Failed to load playlists');
+    });
+
+    it('should default to empty array if response is not an array', async () => {
+      mockedApi.getPlaylists.mockResolvedValue({ data: [] } as unknown as Playlist[]);
+
+      await usePlaylistsStore.getState().fetchPlaylists();
+
+      expect(usePlaylistsStore.getState().items).toEqual([]);
+    });
+
+    it('should set isLoading=true while fetching', async () => {
+      let capturedLoading = false;
+      mockedApi.getPlaylists.mockImplementation(async () => {
+        capturedLoading = usePlaylistsStore.getState().isLoading;
+        return [];
+      });
+
+      await usePlaylistsStore.getState().fetchPlaylists();
+
+      expect(capturedLoading).toBe(true);
+      expect(usePlaylistsStore.getState().isLoading).toBe(false);
+    });
+
+    it('should clear previous error when starting a new fetch', async () => {
+      usePlaylistsStore.setState({ error: 'stale error' });
+      mockedApi.getPlaylists.mockResolvedValue([]);
+
+      await usePlaylistsStore.getState().fetchPlaylists();
+
+      expect(usePlaylistsStore.getState().error).toBeNull();
+    });
+  });
+
+  describe('getPlaylist', () => {
+    it('should call api.getPlaylist and return the result', async () => {
+      const playlist = makePlaylist({
+        id: 'pl-1',
+        items: [makePlaylistItem()],
+      });
+      mockedApi.getPlaylist.mockResolvedValue(playlist);
+
+      const result = await usePlaylistsStore.getState().getPlaylist('pl-1');
+
+      expect(mockedApi.getPlaylist).toHaveBeenCalledWith('pl-1');
+      expect(result).toEqual(playlist);
+    });
+
+    it('should propagate errors', async () => {
+      mockedApi.getPlaylist.mockRejectedValue(new Error('Not found'));
+
+      await expect(usePlaylistsStore.getState().getPlaylist('nonexistent')).rejects.toThrow('Not found');
+    });
+  });
+
+  describe('addPlaylistItem', () => {
+    it('should call api.addPlaylistItem and return the new item', async () => {
+      const newItem = makePlaylistItem({ id: 'item-new', contentId: 'content-5' });
+      mockedApi.addPlaylistItem.mockResolvedValue(newItem);
+
+      const result = await usePlaylistsStore.getState().addPlaylistItem('pl-1', 'content-5');
+
+      expect(mockedApi.addPlaylistItem).toHaveBeenCalledWith('pl-1', 'content-5', undefined);
+      expect(result).toEqual(newItem);
+    });
+
+    it('should pass duration when provided', async () => {
+      const newItem = makePlaylistItem({ duration: 30 });
+      mockedApi.addPlaylistItem.mockResolvedValue(newItem);
+
+      await usePlaylistsStore.getState().addPlaylistItem('pl-1', 'content-5', 30);
+
+      expect(mockedApi.addPlaylistItem).toHaveBeenCalledWith('pl-1', 'content-5', 30);
+    });
+
+    it('should propagate errors', async () => {
+      mockedApi.addPlaylistItem.mockRejectedValue(new Error('Conflict'));
+
+      await expect(
+        usePlaylistsStore.getState().addPlaylistItem('pl-1', 'content-5'),
+      ).rejects.toThrow('Conflict');
+    });
+  });
+
+  describe('removePlaylistItem', () => {
+    it('should call api.removePlaylistItem with correct args', async () => {
+      mockedApi.removePlaylistItem.mockResolvedValue(undefined);
+
+      await usePlaylistsStore.getState().removePlaylistItem('pl-1', 'item-1');
+
+      expect(mockedApi.removePlaylistItem).toHaveBeenCalledWith('pl-1', 'item-1');
+    });
+
+    it('should propagate errors', async () => {
+      mockedApi.removePlaylistItem.mockRejectedValue(new Error('Forbidden'));
+
+      await expect(
+        usePlaylistsStore.getState().removePlaylistItem('pl-1', 'item-1'),
+      ).rejects.toThrow('Forbidden');
+    });
+  });
+
+  describe('reorderPlaylist', () => {
+    it('should call api.reorderPlaylist with correct args', async () => {
+      mockedApi.reorderPlaylist.mockResolvedValue(undefined);
+      const newOrder = ['item-3', 'item-1', 'item-2'];
+
+      await usePlaylistsStore.getState().reorderPlaylist('pl-1', newOrder);
+
+      expect(mockedApi.reorderPlaylist).toHaveBeenCalledWith('pl-1', newOrder);
+    });
+
+    it('should propagate errors', async () => {
+      mockedApi.reorderPlaylist.mockRejectedValue(new Error('Bad request'));
+
+      await expect(
+        usePlaylistsStore.getState().reorderPlaylist('pl-1', ['item-1']),
+      ).rejects.toThrow('Bad request');
+    });
+  });
+});

--- a/mobile/src/utils/__tests__/formatters.test.ts
+++ b/mobile/src/utils/__tests__/formatters.test.ts
@@ -1,0 +1,108 @@
+import { timeAgo, formatDate, formatBytes } from '../formatters';
+
+describe('timeAgo', () => {
+  it('returns "Never" for null', () => {
+    expect(timeAgo(null)).toBe('Never');
+  });
+
+  it('returns "Never" for undefined', () => {
+    expect(timeAgo(undefined)).toBe('Never');
+  });
+
+  it('returns "Just now" for dates less than 60 seconds ago', () => {
+    const now = new Date();
+    expect(timeAgo(now.toISOString())).toBe('Just now');
+
+    const thirtySecsAgo = new Date(now.getTime() - 30 * 1000);
+    expect(timeAgo(thirtySecsAgo.toISOString())).toBe('Just now');
+  });
+
+  it('returns "Xm ago" for dates less than 1 hour ago', () => {
+    const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000);
+    expect(timeAgo(fiveMinAgo.toISOString())).toBe('5m ago');
+
+    const thirtyMinAgo = new Date(Date.now() - 30 * 60 * 1000);
+    expect(timeAgo(thirtyMinAgo.toISOString())).toBe('30m ago');
+  });
+
+  it('returns "Xh ago" for dates less than 1 day ago', () => {
+    const twoHoursAgo = new Date(Date.now() - 2 * 3600 * 1000);
+    expect(timeAgo(twoHoursAgo.toISOString())).toBe('2h ago');
+
+    const twelveHoursAgo = new Date(Date.now() - 12 * 3600 * 1000);
+    expect(timeAgo(twelveHoursAgo.toISOString())).toBe('12h ago');
+  });
+
+  it('returns "Xd ago" for dates less than 1 week ago', () => {
+    const threeDaysAgo = new Date(Date.now() - 3 * 86400 * 1000);
+    expect(timeAgo(threeDaysAgo.toISOString())).toBe('3d ago');
+
+    const sixDaysAgo = new Date(Date.now() - 6 * 86400 * 1000);
+    expect(timeAgo(sixDaysAgo.toISOString())).toBe('6d ago');
+  });
+
+  it('returns a formatted date for dates older than 1 week', () => {
+    const twoWeeksAgo = new Date(Date.now() - 14 * 86400 * 1000);
+    const result = timeAgo(twoWeeksAgo.toISOString());
+    // Should fall through to formatDate, which returns a locale-formatted string
+    expect(result).not.toBe('Never');
+    expect(result).not.toMatch(/ago$/);
+    expect(result).not.toBe('Just now');
+    // Should contain a year number
+    expect(result).toMatch(/\d{4}/);
+  });
+});
+
+describe('formatDate', () => {
+  it('returns "N/A" for null', () => {
+    expect(formatDate(null)).toBe('N/A');
+  });
+
+  it('returns "N/A" for undefined', () => {
+    expect(formatDate(undefined)).toBe('N/A');
+  });
+
+  it('returns a short formatted date string', () => {
+    // Use a fixed date to avoid locale-dependent month names
+    const result = formatDate('2024-01-15T12:00:00Z');
+    // Should contain day, year, and a month abbreviation
+    expect(result).toMatch(/15/);
+    expect(result).toMatch(/2024/);
+    // Month should be "Jan" in English locales (test env default)
+    expect(result).toMatch(/Jan/);
+  });
+});
+
+describe('formatBytes', () => {
+  it('returns "0 B" for null', () => {
+    expect(formatBytes(null)).toBe('0 B');
+  });
+
+  it('returns "0 B" for undefined', () => {
+    expect(formatBytes(undefined)).toBe('0 B');
+  });
+
+  it('returns "0 B" for 0', () => {
+    expect(formatBytes(0)).toBe('0 B');
+  });
+
+  it('formats bytes correctly', () => {
+    expect(formatBytes(500)).toBe('500 B');
+    expect(formatBytes(1)).toBe('1 B');
+  });
+
+  it('formats kilobytes correctly', () => {
+    expect(formatBytes(1024)).toBe('1.0 KB');
+    expect(formatBytes(1536)).toBe('1.5 KB');
+  });
+
+  it('formats megabytes correctly', () => {
+    expect(formatBytes(1048576)).toBe('1.0 MB');
+    expect(formatBytes(5 * 1024 * 1024)).toBe('5.0 MB');
+  });
+
+  it('formats gigabytes correctly', () => {
+    expect(formatBytes(1073741824)).toBe('1.0 GB');
+    expect(formatBytes(2.5 * 1024 * 1024 * 1024)).toBe('2.5 GB');
+  });
+});

--- a/mobile/src/utils/__tests__/validation.test.ts
+++ b/mobile/src/utils/__tests__/validation.test.ts
@@ -1,0 +1,144 @@
+import {
+  validateEmail,
+  validatePassword,
+  validateName,
+  validateOrgName,
+} from '../validation';
+
+describe('validateEmail', () => {
+  it('returns null for valid emails', () => {
+    expect(validateEmail('user@example.com')).toBeNull();
+    expect(validateEmail('test.user@domain.org')).toBeNull();
+    expect(validateEmail('name+tag@company.co')).toBeNull();
+  });
+
+  it('returns error for empty string', () => {
+    expect(validateEmail('')).toBe('Email is required.');
+    expect(validateEmail('   ')).toBe('Email is required.');
+  });
+
+  it('returns error for invalid format - no @', () => {
+    expect(validateEmail('userexample.com')).toBe(
+      'Please enter a valid email address.',
+    );
+  });
+
+  it('returns error for invalid format - no domain', () => {
+    expect(validateEmail('user@')).toBe(
+      'Please enter a valid email address.',
+    );
+  });
+
+  it('returns error for invalid format - no TLD', () => {
+    expect(validateEmail('user@domain')).toBe(
+      'Please enter a valid email address.',
+    );
+  });
+});
+
+describe('validatePassword', () => {
+  it('returns null for valid passwords', () => {
+    expect(validatePassword('SecurePass1!')).toBeNull();
+    expect(validatePassword('MyP@ssw0rd')).toBeNull();
+    expect(validatePassword('Abcdefg1')).toBeNull();
+  });
+
+  it('returns error for empty password', () => {
+    expect(validatePassword('')).toBe('Password is required.');
+  });
+
+  it('returns error for password shorter than 8 characters', () => {
+    expect(validatePassword('Ab1!')).toBe(
+      'Password must be at least 8 characters.',
+    );
+    expect(validatePassword('Short1!')).toBe(
+      'Password must be at least 8 characters.',
+    );
+  });
+
+  it('returns error for password longer than 100 characters', () => {
+    const longPassword = 'A1!' + 'a'.repeat(98);
+    expect(validatePassword(longPassword)).toBe(
+      'Password must be 100 characters or fewer.',
+    );
+  });
+
+  it('returns error for password missing uppercase', () => {
+    expect(validatePassword('lowercase1!')).toBe(
+      'Password must include uppercase, lowercase, and a number or special character.',
+    );
+  });
+
+  it('returns error for password missing lowercase', () => {
+    expect(validatePassword('UPPERCASE1!')).toBe(
+      'Password must include uppercase, lowercase, and a number or special character.',
+    );
+  });
+
+  it('returns error for password missing number or special character', () => {
+    expect(validatePassword('NoNumbersHere')).toBe(
+      'Password must include uppercase, lowercase, and a number or special character.',
+    );
+  });
+});
+
+describe('validateName', () => {
+  it('returns null for valid names', () => {
+    expect(validateName('John', 'First name')).toBeNull();
+    expect(validateName('AB', 'Last name')).toBeNull();
+    expect(validateName('A longer name value', 'Name')).toBeNull();
+  });
+
+  it('returns error for empty name', () => {
+    expect(validateName('', 'First name')).toBe('First name is required.');
+    expect(validateName('   ', 'Last name')).toBe('Last name is required.');
+  });
+
+  it('returns error for name shorter than 2 characters', () => {
+    expect(validateName('A', 'First name')).toBe(
+      'First name must be at least 2 characters.',
+    );
+  });
+
+  it('returns error for name longer than 100 characters', () => {
+    const longName = 'A'.repeat(101);
+    expect(validateName(longName, 'First name')).toBe(
+      'First name must be 100 characters or fewer.',
+    );
+  });
+
+  it('uses the field parameter in error messages', () => {
+    expect(validateName('', 'Display name')).toBe(
+      'Display name is required.',
+    );
+    expect(validateName('X', 'Username')).toBe(
+      'Username must be at least 2 characters.',
+    );
+  });
+});
+
+describe('validateOrgName', () => {
+  it('returns null for valid org names', () => {
+    expect(validateOrgName('Acme Inc.')).toBeNull();
+    expect(validateOrgName('AB')).toBeNull();
+    expect(validateOrgName('My Organization')).toBeNull();
+  });
+
+  it('returns error for empty org name', () => {
+    expect(validateOrgName('')).toBe('Organization name is required.');
+    expect(validateOrgName('   ')).toBe('Organization name is required.');
+  });
+
+  it('returns error for org name shorter than 2 characters', () => {
+    expect(validateOrgName('A')).toBe(
+      'Organization name must be at least 2 characters.',
+    );
+  });
+
+  it('returns error for org name longer than 255 characters', () => {
+    const longName = 'A'.repeat(256);
+    expect(validateOrgName(longName)).toBe(
+      'Organization name must be 255 characters or fewer.',
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,13 +177,13 @@ importers:
         version: 5.6.6(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.104.1)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))
+        version: 29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
       swc-loader:
         specifier: ^0.2.6
         version: 0.2.7(@swc/core@1.5.29(@swc/helpers@0.5.18))(webpack@5.104.1)
       ts-jest:
         specifier: ^29.1.2
-        version: 29.4.6(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(jest-util@30.2.0)(jest@29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(jest-util@30.2.0)(jest@29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -461,7 +461,7 @@ importers:
         version: 8.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-router:
         specifier: ~6.0.23
-        version: 6.0.23(@expo/metro-runtime@6.1.2)(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.2.4(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        version: 6.0.23(@expo/metro-runtime@6.1.2)(@testing-library/react-native@13.3.3(jest@30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)))(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0))(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.2.4(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-secure-store:
         specifier: ~15.0.8
         version: 15.0.8(expo@54.0.33)
@@ -490,9 +490,27 @@ importers:
         specifier: ^5.0.0
         version: 5.0.11(@types/react@19.1.17)(react@19.1.0)(use-sync-external-store@1.6.0(react@19.1.0))
     devDependencies:
+      '@testing-library/react-native':
+        specifier: ^13.3.3
+        version: 13.3.3(jest@30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)))(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
       '@types/react':
         specifier: ~19.1.0
         version: 19.1.17
+      jest:
+        specifier: ^30.2.0
+        version: 30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))
+      jest-expo:
+        specifier: ^55.0.9
+        version: 55.0.9(@babel/core@7.28.6)(expo@54.0.33)(jest@30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)))(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react-test-renderer:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)
       typescript:
         specifier: ~5.9.2
         version: 5.9.3
@@ -511,13 +529,13 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.2.0
-        version: 30.2.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
+        version: 30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
       prisma:
         specifier: 5.22.0
         version: 5.22.0
       ts-jest:
         specifier: ^29.4.6
-        version: 29.4.6(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(jest-util@30.2.0)(jest@30.2.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(jest-util@30.2.0)(jest@30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)))(typescript@5.9.3)
 
   packages/shared:
     dependencies:
@@ -2050,11 +2068,20 @@ packages:
   '@expo/config-plugins@54.0.4':
     resolution: {integrity: sha512-g2yXGICdoOw5i3LkQSDxl2Q5AlQCrG7oniu0pCPPO+UxGb7He4AFqSvPSy8HpRUj55io17hT62FTjYRD+d6j3Q==}
 
+  '@expo/config-plugins@55.0.6':
+    resolution: {integrity: sha512-cIox6FjZlFaaX40rbQ3DvP9e87S5X85H9uw+BAxJE5timkMhuByy3GAlOsj1h96EyzSiol7Q6YIGgY1Jiz4M+A==}
+
   '@expo/config-types@54.0.10':
     resolution: {integrity: sha512-/J16SC2an1LdtCZ67xhSkGXpALYUVUNyZws7v+PVsFZxClYehDSoKLqyRaGkpHlYrCc08bS0RF5E0JV6g50psA==}
 
+  '@expo/config-types@55.0.5':
+    resolution: {integrity: sha512-sCmSUZG4mZ/ySXvfyyBdhjivz8Q539X1NondwDdYG7s3SBsk+wsgPJzYsqgAG/P9+l0xWjUD2F+kQ1cAJ6NNLg==}
+
   '@expo/config@12.0.13':
     resolution: {integrity: sha512-Cu52arBa4vSaupIWsF0h7F/Cg//N374nYb7HAxV0I4KceKA7x2UXpYaHOL7EEYYvp7tZdThBjvGpVmr8ScIvaQ==}
+
+  '@expo/config@55.0.8':
+    resolution: {integrity: sha512-D7RYYHfErCgEllGxNwdYdkgzLna7zkzUECBV3snbUpf7RvIpB5l1LpCgzuVoc5KVew5h7N1Tn4LnT/tBSUZsQg==}
 
   '@expo/devcert@1.2.1':
     resolution: {integrity: sha512-qC4eaxmKMTmJC2ahwyui6ud8f3W60Ss7pMkpBq40Hu3zyiAaugPXnZ24145U7K36qO9UHdZUVxsCvIpz2RYYCA==}
@@ -2079,6 +2106,9 @@ packages:
 
   '@expo/image-utils@0.8.8':
     resolution: {integrity: sha512-HHHaG4J4nKjTtVa1GG9PCh763xlETScfEyNxxOvfTRr8IKPJckjTyqSLEtdJoFNJ1vqiABEjW7tqGhqGibZLeA==}
+
+  '@expo/json-file@10.0.12':
+    resolution: {integrity: sha512-inbDycp1rMAelAofg7h/mMzIe+Owx6F7pur3XdQ3EPTy00tme+4P6FWgHKUcjN8dBSrnbRNpSyh5/shzHyVCyQ==}
 
   '@expo/json-file@10.0.8':
     resolution: {integrity: sha512-9LOTh1PgKizD1VXfGQ88LtDH0lRwq9lsTb4aichWTWSWqy3Ugfkhfm3BhzBIkJJfQQ5iJu3m/BoRlEIjoCGcnQ==}
@@ -2115,10 +2145,21 @@ packages:
   '@expo/plist@0.4.8':
     resolution: {integrity: sha512-pfNtErGGzzRwHP+5+RqswzPDKkZrx+Cli0mzjQaus1ZWFsog5ibL+nVT3NcporW51o8ggnt7x813vtRbPiyOrQ==}
 
+  '@expo/plist@0.5.2':
+    resolution: {integrity: sha512-o4xdVdBpe4aTl3sPMZ2u3fJH4iG1I768EIRk1xRZP+GaFI93MaR3JvoFibYqxeTmLQ1p1kNEVqylfUjezxx45g==}
+
   '@expo/prebuild-config@54.0.8':
     resolution: {integrity: sha512-EA7N4dloty2t5Rde+HP0IEE+nkAQiu4A/+QGZGT9mFnZ5KKjPPkqSyYcRvP5bhQE10D+tvz6X0ngZpulbMdbsg==}
     peerDependencies:
       expo: '*'
+
+  '@expo/require-utils@55.0.2':
+    resolution: {integrity: sha512-dV5oCShQ1umKBKagMMT4B/N+SREsQe3lU4Zgmko5AO0rxKV0tynZT6xXs+e2JxuqT4Rz997atg7pki0BnZb4uw==}
+    peerDependencies:
+      typescript: ^5.0.0 || ^5.0.0-0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@expo/schema-utils@0.1.8':
     resolution: {integrity: sha512-9I6ZqvnAvKKDiO+ZF8BpQQFYWXOJvTAL5L/227RUbWG1OVZDInFifzCBiqAZ3b67NRfeAgpgvbA7rejsqhY62A==}
@@ -4805,6 +4846,18 @@ packages:
     resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
 
+  '@testing-library/react-native@13.3.3':
+    resolution: {integrity: sha512-k6Mjsd9dbZgvY4Bl7P1NIpePQNi+dfYtlJ5voi9KQlynxSyQkfOgJmYGCYmw/aSgH/rUcFvG8u5gd4npzgRDyg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      jest: '>=29.0.0'
+      react: '>=18.2.0'
+      react-native: '>=0.71'
+      react-test-renderer: '>=18.2.0'
+    peerDependenciesMeta:
+      jest:
+        optional: true
+
   '@testing-library/react@16.3.2':
     resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
     engines: {node: '>=18'}
@@ -5630,6 +5683,10 @@ packages:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
 
+  ansi-escapes@6.2.1:
+    resolution: {integrity: sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==}
+    engines: {node: '>=14.16'}
+
   ansi-html-community@0.0.8:
     resolution: {integrity: sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==}
     engines: {'0': node >= 0.8.0}
@@ -6164,6 +6221,10 @@ packages:
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
+
+  char-regex@2.0.2:
+    resolution: {integrity: sha512-cbGOjAptfM2LVmWhwRFHEKTPkLwNddVmuqYZQt895yXwAsWsXObCG+YN4DGQ/JBtT4GP1a1lPPdio2z413LmTg==}
+    engines: {node: '>=12.20'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -8501,6 +8562,17 @@ packages:
     resolution: {integrity: sha512-ElU8v92QJ9UrYsKrxDIKCxu6PfNj4Hdcktcn0JX12zqNdqWHB0N+hwOnnBBXvjLd2vApZtuLUGs1QSY+MsXoNA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  jest-expo@55.0.9:
+    resolution: {integrity: sha512-6wz7JJUeW2e0+APRQP7eOcXKPdI7bdmAIoBiPJbtzSBRlghho8LzPcv4jkoVFoYi8SKb9k3BTKx4GcUlyVMedw==}
+    hasBin: true
+    peerDependencies:
+      expo: '*'
+      react-native: '*'
+      react-server-dom-webpack: ~19.0.4 || ~19.1.5 || ~19.2.4
+    peerDependenciesMeta:
+      react-server-dom-webpack:
+        optional: true
+
   jest-get-type@29.6.3:
     resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -8617,6 +8689,15 @@ packages:
   jest-validate@30.2.0:
     resolution: {integrity: sha512-FBGWi7dP2hpdi8nBoWxSsLvBFewKAg0+uSQwBaof4Y4DPgBabXgpSYC5/lR7VmnIlSpASmCi/ntRWPbv7089Pw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-watch-select-projects@2.0.0:
+    resolution: {integrity: sha512-j00nW4dXc2NiCW6znXgFLF9g8PJ0zP25cpQ1xRro/HU2GBfZQFZD0SoXnAlaoKkIY4MlfTMkKGbNXFpvCdjl1w==}
+
+  jest-watch-typeahead@2.2.1:
+    resolution: {integrity: sha512-jYpYmUnTzysmVnwq49TAxlmtOAwp8QIqvZyoofQFn8fiWhEDZj33ZXzg3JA4nGnzWFm1hbWf3ADpteUokvXgFA==}
+    engines: {node: ^14.17.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      jest: ^27.0.0 || ^28.0.0 || ^29.0.0
 
   jest-watcher@29.7.0:
     resolution: {integrity: sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==}
@@ -10509,6 +10590,16 @@ packages:
       '@types/react':
         optional: true
 
+  react-test-renderer@19.1.0:
+    resolution: {integrity: sha512-jXkSl3CpvPYEF+p/eGDLB4sPoDX8pKkYvRl9+rR8HxLY0X04vW7hCm1/0zHoUSjPZ3bDa+wXWNTDVIw/R8aDVw==}
+    peerDependencies:
+      react: ^19.1.0
+
+  react-test-renderer@19.2.0:
+    resolution: {integrity: sha512-zLCFMHFE9vy/w3AxO0zNxy6aAupnCuLSVOJYDe/Tp+ayGI1f2PLQsFVPANSD42gdSbmYx5oN+1VWDhcXtq7hAQ==}
+    peerDependencies:
+      react: ^19.2.0
+
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
@@ -11107,6 +11198,10 @@ packages:
     resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
     engines: {node: '>=12'}
 
+  slash@5.1.0:
+    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
+    engines: {node: '>=14.16'}
+
   slice-ansi@3.0.0:
     resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
     engines: {node: '>=8'}
@@ -11174,6 +11269,10 @@ packages:
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
 
+  source-map@0.5.6:
+    resolution: {integrity: sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==}
+    engines: {node: '>=0.10.0'}
+
   source-map@0.5.7:
     resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
     engines: {node: '>=0.10.0'}
@@ -11217,6 +11316,9 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
+  stack-generator@2.0.10:
+    resolution: {integrity: sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==}
+
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
@@ -11226,6 +11328,12 @@ packages:
 
   stackframe@1.3.4:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
+
+  stacktrace-gps@3.1.2:
+    resolution: {integrity: sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==}
+
+  stacktrace-js@2.0.2:
+    resolution: {integrity: sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==}
 
   stacktrace-parser@0.1.11:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
@@ -11280,6 +11388,10 @@ packages:
   string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
     engines: {node: '>=10'}
+
+  string-length@5.0.1:
+    resolution: {integrity: sha512-9Ep08KAMUn0OadnVaBuRdE2l615CQ508kr0XMadjClfYpdCyvrbFp6Taebo8yyxokQ4viUd/xPPUA4FGgUa0ow==}
+    engines: {node: '>=12.20'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -13973,7 +14085,7 @@ snapshots:
       wrap-ansi: 7.0.0
       ws: 8.19.0
     optionalDependencies:
-      expo-router: 6.0.23(@expo/metro-runtime@6.1.2)(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.2.4(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-router: 6.0.23(@expo/metro-runtime@6.1.2)(@testing-library/react-native@13.3.3(jest@30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)))(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0))(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.2.4(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native: 0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - bufferutil
@@ -14004,7 +14116,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@expo/config-plugins@55.0.6':
+    dependencies:
+      '@expo/config-types': 55.0.5
+      '@expo/json-file': 10.0.12
+      '@expo/plist': 0.5.2
+      '@expo/sdk-runtime-versions': 1.0.0
+      chalk: 4.1.2
+      debug: 4.4.3
+      getenv: 2.0.0
+      glob: 13.0.1
+      resolve-from: 5.0.0
+      semver: 7.7.3
+      slugify: 1.6.6
+      xcode: 3.0.1
+      xml2js: 0.6.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@expo/config-types@54.0.10': {}
+
+  '@expo/config-types@55.0.5': {}
 
   '@expo/config@12.0.13':
     dependencies:
@@ -14023,6 +14155,23 @@ snapshots:
       sucrase: 3.35.1
     transitivePeerDependencies:
       - supports-color
+
+  '@expo/config@55.0.8(typescript@5.9.3)':
+    dependencies:
+      '@expo/config-plugins': 55.0.6
+      '@expo/config-types': 55.0.5
+      '@expo/json-file': 10.0.12
+      '@expo/require-utils': 55.0.2(typescript@5.9.3)
+      deepmerge: 4.3.1
+      getenv: 2.0.0
+      glob: 13.0.1
+      resolve-from: 5.0.0
+      resolve-workspace-root: 2.0.1
+      semver: 7.7.3
+      slugify: 1.6.6
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   '@expo/devcert@1.2.1':
     dependencies:
@@ -14076,6 +14225,11 @@ snapshots:
       semver: 7.7.3
       temp-dir: 2.0.0
       unique-string: 2.0.0
+
+  '@expo/json-file@10.0.12':
+    dependencies:
+      '@babel/code-frame': 7.28.6
+      json5: 2.2.3
 
   '@expo/json-file@10.0.8':
     dependencies:
@@ -14165,6 +14319,12 @@ snapshots:
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
+  '@expo/plist@0.5.2':
+    dependencies:
+      '@xmldom/xmldom': 0.8.11
+      base64-js: 1.5.1
+      xmlbuilder: 15.1.1
+
   '@expo/prebuild-config@54.0.8(expo@54.0.33)':
     dependencies:
       '@expo/config': 12.0.13
@@ -14178,6 +14338,16 @@ snapshots:
       resolve-from: 5.0.0
       semver: 7.7.3
       xml2js: 0.6.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@expo/require-utils@55.0.2(typescript@5.9.3)':
+    dependencies:
+      '@babel/code-frame': 7.28.6
+      '@babel/core': 7.28.6
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.28.6)
+    optionalDependencies:
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -14536,7 +14706,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))':
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -14550,7 +14720,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -14571,7 +14741,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@30.2.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))':
+  '@jest/core@30.2.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 30.2.0
       '@jest/pattern': 30.0.1
@@ -14586,7 +14756,43 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.2.0
-      jest-config: 30.2.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
+      jest-config: 30.2.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))
+      jest-haste-map: 30.2.0
+      jest-message-util: 30.2.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.2.0
+      jest-resolve-dependencies: 30.2.0
+      jest-runner: 30.2.0
+      jest-runtime: 30.2.0
+      jest-snapshot: 30.2.0
+      jest-util: 30.2.0
+      jest-validate: 30.2.0
+      jest-watcher: 30.2.0
+      micromatch: 4.0.8
+      pretty-format: 30.2.0
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  '@jest/core@30.2.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))':
+    dependencies:
+      '@jest/console': 30.2.0
+      '@jest/pattern': 30.0.1
+      '@jest/reporters': 30.2.0
+      '@jest/test-result': 30.2.0
+      '@jest/transform': 30.2.0
+      '@jest/types': 30.2.0
+      '@types/node': 20.19.9
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 4.3.1
+      exit-x: 0.2.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 30.2.0
+      jest-config: 30.2.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
       jest-haste-map: 30.2.0
       jest-message-util: 30.2.0
       jest-regex-util: 30.0.1
@@ -17690,6 +17896,18 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
+  '@testing-library/react-native@13.3.3(jest@30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)))(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      jest-matcher-utils: 30.2.0
+      picocolors: 1.1.1
+      pretty-format: 30.2.0
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0)
+      react-test-renderer: 19.1.0(react@19.1.0)
+      redent: 3.0.0
+    optionalDependencies:
+      jest: 30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))
+
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.28.6
@@ -18656,6 +18874,8 @@ snapshots:
     dependencies:
       type-fest: 0.21.3
 
+  ansi-escapes@6.2.1: {}
+
   ansi-html-community@0.0.8: {}
 
   ansi-regex@4.1.1: {}
@@ -19331,6 +19551,8 @@ snapshots:
 
   char-regex@1.0.2: {}
 
+  char-regex@2.0.2: {}
+
   chokidar@3.6.0:
     dependencies:
       anymatch: 3.1.3
@@ -19701,13 +19923,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)):
+  create-jest@29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -19716,13 +19938,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)):
+  create-jest@29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -20672,7 +20894,7 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0)
 
-  expo-router@6.0.23(@expo/metro-runtime@6.1.2)(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.2.4(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+  expo-router@6.0.23(@expo/metro-runtime@6.1.2)(@testing-library/react-native@13.3.3(jest@30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)))(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0))(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.2.4(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       '@expo/metro-runtime': 6.1.2(expo@54.0.33)(react-dom@19.2.4(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@expo/schema-utils': 0.1.8
@@ -20705,6 +20927,7 @@ snapshots:
       use-latest-callback: 0.2.6(react@19.1.0)
       vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.2.4(react@19.1.0))(react@19.1.0)
     optionalDependencies:
+      '@testing-library/react-native': 13.3.3(jest@30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)))(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)
       react-dom: 19.2.4(react@19.1.0)
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
@@ -21968,6 +22191,25 @@ snapshots:
       - supports-color
       - ts-node
 
+  jest-cli@29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   jest-cli@29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))
@@ -21987,34 +22229,34 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)):
+  jest-cli@30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest-cli@30.2.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)):
-    dependencies:
-      '@jest/core': 30.2.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
+      '@jest/core': 30.2.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.2.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
+      jest-config: 30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))
+      jest-util: 30.2.0
+      jest-validate: 30.2.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest-cli@30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 30.2.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
+      '@jest/test-result': 30.2.0
+      '@jest/types': 30.2.0
+      chalk: 4.1.2
+      exit-x: 0.2.2
+      import-local: 3.2.0
+      jest-config: 30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
       jest-util: 30.2.0
       jest-validate: 30.2.0
       yargs: 17.7.2
@@ -22087,7 +22329,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)):
+  jest-config@29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.28.6
       '@jest/test-sequencer': 29.7.0
@@ -22113,7 +22355,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.19.9
-      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)
+      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -22149,38 +22391,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.28.6
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.6)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.1.0
-      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@30.2.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)):
+  jest-config@30.2.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.28.6
       '@jest/get-type': 30.1.0
@@ -22208,7 +22419,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.19.9
-      ts-node: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)
+      ts-node: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -22241,6 +22452,72 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.19.9
+      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.28.6
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.2.0
+      '@jest/types': 30.2.0
+      babel-jest: 30.2.0(@babel/core@7.28.6)
+      chalk: 4.1.2
+      ci-info: 4.3.1
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.2.0(babel-plugin-macros@3.1.0)
+      jest-docblock: 30.2.0
+      jest-environment-node: 30.2.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.2.0
+      jest-runner: 30.2.0
+      jest-util: 30.2.0
+      jest-validate: 30.2.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 30.2.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.1.0
+      ts-node: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.28.6
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.2.0
+      '@jest/types': 30.2.0
+      babel-jest: 30.2.0(@babel/core@7.28.6)
+      chalk: 4.1.2
+      ci-info: 4.3.1
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.2.0(babel-plugin-macros@3.1.0)
+      jest-docblock: 30.2.0
+      jest-environment-node: 30.2.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.2.0
+      jest-runner: 30.2.0
+      jest-util: 30.2.0
+      jest-validate: 30.2.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 30.2.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.1.0
       ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -22317,6 +22594,34 @@ snapshots:
       jest-mock: 30.2.0
       jest-util: 30.2.0
       jest-validate: 30.2.0
+
+  jest-expo@55.0.9(@babel/core@7.28.6)(expo@54.0.33)(jest@30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)))(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
+    dependencies:
+      '@expo/config': 55.0.8(typescript@5.9.3)
+      '@expo/json-file': 10.0.12
+      '@jest/create-cache-key-function': 29.7.0
+      '@jest/globals': 29.7.0
+      babel-jest: 29.7.0(@babel/core@7.28.6)
+      expo: 54.0.33(@babel/core@7.28.6)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      jest-environment-jsdom: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-watch-select-projects: 2.0.0
+      jest-watch-typeahead: 2.2.1(jest@30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)))
+      json5: 2.2.3
+      lodash: 4.17.21
+      react-native: 0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0)
+      react-test-renderer: 19.2.0(react@19.1.0)
+      server-only: 0.0.1
+      stacktrace-js: 2.0.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - canvas
+      - jest
+      - react
+      - supports-color
+      - typescript
+      - utf-8-validate
 
   jest-get-type@29.6.3: {}
 
@@ -22654,6 +22959,23 @@ snapshots:
       leven: 3.1.0
       pretty-format: 30.2.0
 
+  jest-watch-select-projects@2.0.0:
+    dependencies:
+      ansi-escapes: 4.3.2
+      chalk: 3.0.0
+      prompts: 2.4.2
+
+  jest-watch-typeahead@2.2.1(jest@30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))):
+    dependencies:
+      ansi-escapes: 6.2.1
+      chalk: 4.1.2
+      jest: 30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))
+      jest-regex-util: 29.6.3
+      jest-watcher: 29.7.0
+      slash: 5.1.0
+      string-length: 5.0.1
+      strip-ansi: 7.1.2
+
   jest-watcher@29.7.0:
     dependencies:
       '@jest/test-result': 29.7.0
@@ -22709,6 +23031,18 @@ snapshots:
       - supports-color
       - ts-node
 
+  jest@29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   jest@29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))
@@ -22721,24 +23055,25 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)):
+  jest@30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))
-      '@jest/types': 29.6.3
+      '@jest/core': 30.2.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))
+      '@jest/types': 30.2.0
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))
+      jest-cli: 30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
+      - esbuild-register
       - supports-color
       - ts-node
 
-  jest@30.2.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)):
+  jest@30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 30.2.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
+      '@jest/core': 30.2.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
       '@jest/types': 30.2.0
       import-local: 3.2.0
-      jest-cli: 30.2.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
+      jest-cli: 30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -24768,6 +25103,18 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.17
 
+  react-test-renderer@19.1.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-is: 19.2.4
+      scheduler: 0.26.0
+
+  react-test-renderer@19.2.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-is: 19.2.4
+      scheduler: 0.27.0
+
   react-transition-group@4.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@babel/runtime': 7.28.6
@@ -25449,6 +25796,8 @@ snapshots:
 
   slash@4.0.0: {}
 
+  slash@5.1.0: {}
+
   slice-ansi@3.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -25552,6 +25901,8 @@ snapshots:
       buffer-from: 1.1.2
       source-map: 0.6.1
 
+  source-map@0.5.6: {}
+
   source-map@0.5.7: {}
 
   source-map@0.6.1: {}
@@ -25596,6 +25947,10 @@ snapshots:
   sprintf-js@1.1.3:
     optional: true
 
+  stack-generator@2.0.10:
+    dependencies:
+      stackframe: 1.3.4
+
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
@@ -25604,6 +25959,17 @@ snapshots:
     optional: true
 
   stackframe@1.3.4: {}
+
+  stacktrace-gps@3.1.2:
+    dependencies:
+      source-map: 0.5.6
+      stackframe: 1.3.4
+
+  stacktrace-js@2.0.2:
+    dependencies:
+      error-stack-parser: 2.1.4
+      stack-generator: 2.0.10
+      stacktrace-gps: 3.1.2
 
   stacktrace-parser@0.1.11:
     dependencies:
@@ -25655,6 +26021,11 @@ snapshots:
     dependencies:
       char-regex: 1.0.2
       strip-ansi: 6.0.1
+
+  string-length@5.0.1:
+    dependencies:
+      char-regex: 2.0.2
+      strip-ansi: 7.1.2
 
   string-width@4.2.3:
     dependencies:
@@ -26080,6 +26451,26 @@ snapshots:
       babel-jest: 30.2.0(@babel/core@7.28.6)
       jest-util: 30.2.0
 
+  ts-jest@29.4.6(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(jest-util@30.2.0)(jest@29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)))(typescript@5.9.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.8
+      jest: 29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.3
+      type-fest: 4.41.0
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.28.6
+      '@jest/transform': 30.2.0
+      '@jest/types': 30.2.0
+      babel-jest: 30.2.0(@babel/core@7.28.6)
+      jest-util: 30.2.0
+
   ts-jest@29.4.6(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(jest-util@30.2.0)(jest@29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
@@ -26100,32 +26491,12 @@ snapshots:
       babel-jest: 30.2.0(@babel/core@7.28.6)
       jest-util: 30.2.0
 
-  ts-jest@29.4.6(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(jest-util@30.2.0)(jest@29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(jest-util@30.2.0)(jest@30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
-      jest: 29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.7.3
-      type-fest: 4.41.0
-      typescript: 5.9.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.28.6
-      '@jest/transform': 30.2.0
-      '@jest/types': 30.2.0
-      babel-jest: 30.2.0(@babel/core@7.28.6)
-      jest-util: 30.2.0
-
-  ts-jest@29.4.6(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(jest-util@30.2.0)(jest@30.2.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)))(typescript@5.9.3):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.8
-      jest: 30.2.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
+      jest: 30.2.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -26198,27 +26569,6 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 20.19.9
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.5.29(@swc/helpers@0.5.18)
-    optional: true
-
-  ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 25.1.0
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3


### PR DESCRIPTION
## Summary

- **Fix critical auth blocker**: Add `access_token` to login/register response body so mobile app can authenticate (was cookie-only, mobile got `undefined`)
- **Fix register DTO mismatch**: Split `name` into `firstName`/`lastName` to match backend `RegisterDto`; update `User` type across stores/API client/screens
- **Add production config**: `EXPO_PUBLIC_*` env vars, `eas.json` with dev/preview/production profiles, dynamic `app.config.ts` with OTA updates and version codes
- **Replace silent error swallowing**: Logger util replaces `.catch(() => {})` in 3 components
- **Add input validation**: Client-side validation matching backend constraints (email, password strength, name length)
- **Add comprehensive test suite**: 153 tests across 13 suites — stores, API client, hooks, utils, components, screen integration tests, and Maestro E2E flows
- **Fix Android display content rendering**: Resolve critical bug in display-android content cache and rendering

## Test plan

- [x] Mobile: 13 suites, 153 tests all pass (`cd mobile && npm test`)
- [x] Middleware: 84 suites, 1734 tests all pass (no regressions from auth controller change)
- [x] Realtime: 9 suites, 205 tests all pass
- [x] Web: 70/73 suites pass (3 pre-existing RSC admin failures, documented in CLAUDE.md)
- [ ] Maestro E2E: Run `maestro test mobile/.maestro/` on Android emulator with backend running

🤖 Generated with [Claude Code](https://claude.com/claude-code)