### PR TITLE
fix(web): address E2E test findings across dashboard

### DIFF
--- a/web/src/app/dashboard/analytics/page-client.tsx
+++ b/web/src/app/dashboard/analytics/page-client.tsx
@@ -99,6 +99,10 @@ export default function AnalyticsClient() {
  const bandwidthUsage = useBandwidthUsage(dateRange);
  const playlistPerformance = usePlaylistPerformance(dateRange);
 
+ const allMockData = deviceMetrics.isMockData && contentPerformance.isMockData &&
+   usageTrends.isMockData && deviceDistribution.isMockData &&
+   bandwidthUsage.isMockData && playlistPerformance.isMockData;
+
  // Real-time analytics updates
  useRealtimeEvents({
  enabled: true,
@@ -260,6 +264,16 @@ export default function AnalyticsClient() {
  icon="overview"
  />
  </div>
+
+ {/* Mock data notice */}
+ {allMockData && (
+   <div className="bg-amber-500/10 border border-amber-500/20 rounded-lg px-4 py-3 flex items-center gap-3">
+     <span className="text-amber-400 text-sm font-medium">Demo Data</span>
+     <span className="text-sm text-[var(--foreground-secondary)]">
+       Connect devices and generate content to see real analytics.
+     </span>
+   </div>
+ )}
 
  {/* Charts Grid */}
  <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/web/src/app/dashboard/content/page-client.tsx
+++ b/web/src/app/dashboard/content/page-client.tsx
@@ -81,6 +81,11 @@ export default function ContentClient() {
 
  // Real-time event handling
  const reconnectTimerRef = useRef<NodeJS.Timeout | null>(null);
+ useEffect(() => {
+   return () => {
+     if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
+   };
+ }, []);
  const handleConnectionChange = useCallback((connected: boolean | null) => {
  if (reconnectTimerRef.current) {
  clearTimeout(reconnectTimerRef.current);

--- a/web/src/app/dashboard/content/page-client.tsx
+++ b/web/src/app/dashboard/content/page-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { apiClient } from '@/lib/api';
 import { Content, Display, Playlist, ContentFolder } from '@/lib/types';
@@ -80,7 +80,12 @@ export default function ContentClient() {
  const [targetFolderId, setTargetFolderId] = useState<string | null>(null);
 
  // Real-time event handling
+ const reconnectTimerRef = useRef<NodeJS.Timeout | null>(null);
  const handleConnectionChange = useCallback((connected: boolean | null) => {
+ if (reconnectTimerRef.current) {
+ clearTimeout(reconnectTimerRef.current);
+ reconnectTimerRef.current = null;
+ }
  if (connected === true) {
  setRealtimeStatus('connected');
  toast.info('Real-time sync enabled');
@@ -89,6 +94,8 @@ export default function ContentClient() {
  } else {
  // null = reconnecting (WebSocket dropped but browser is online)
  setRealtimeStatus('reconnecting');
+ // After 15s of reconnecting, show offline to set proper expectations
+ reconnectTimerRef.current = setTimeout(() => setRealtimeStatus('offline'), 15000);
  }
  }, [toast]);
 

--- a/web/src/app/dashboard/layout.tsx
+++ b/web/src/app/dashboard/layout.tsx
@@ -43,13 +43,20 @@ export default function DashboardLayout({
   });
   const [userMenuOpen, setUserMenuOpen] = useState(false);
 
-  // Auto-close sidebar when resizing below lg breakpoint
+  // Sync sidebar with viewport — close below lg, open above lg (debounced)
   useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
     const handleResize = () => {
-      if (window.innerWidth < 1024) setSidebarOpen(false);
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        setSidebarOpen(window.innerWidth >= 1024);
+      }, 150);
     };
     window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
+    return () => {
+      clearTimeout(timer);
+      window.removeEventListener('resize', handleResize);
+    };
   }, []);
 
   const isActive = (item: typeof navigation[0]) => {

--- a/web/src/app/dashboard/layout.tsx
+++ b/web/src/app/dashboard/layout.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useAuth } from '@/lib/hooks/useAuth';
 import Breadcrumbs from '@/components/Breadcrumbs';
 import ThemeToggle from '@/components/ThemeToggle';
@@ -37,8 +37,20 @@ export default function DashboardLayout({
   const pathname = usePathname();
   const router = useRouter();
   const { user, loading: authLoading, logout: handleLogoutAuth } = useAuth();
-  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [sidebarOpen, setSidebarOpen] = useState(() => {
+    if (typeof window !== 'undefined') return window.innerWidth >= 1024;
+    return true;
+  });
   const [userMenuOpen, setUserMenuOpen] = useState(false);
+
+  // Auto-close sidebar when resizing below lg breakpoint
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth < 1024) setSidebarOpen(false);
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
 
   const isActive = (item: typeof navigation[0]) => {
     if (item.exactMatch) {

--- a/web/src/app/dashboard/templates/page.tsx
+++ b/web/src/app/dashboard/templates/page.tsx
@@ -292,7 +292,7 @@ export default function TemplateLibraryPage() {
         <TemplateSidebar
           categories={categories}
           selectedCategory={selectedCategory}
-          onCategoryChange={(cat) => { setSelectedCategory(cat); setPage(1); }}
+          onCategoryChange={(cat) => { setSelectedCategory(cat); setSearchQuery(''); setPage(1); }}
           selectedOrientation={selectedOrientation}
           onOrientationChange={(o) => { setSelectedOrientation(o); setPage(1); }}
           selectedDifficulty={selectedDifficulty}
@@ -336,7 +336,7 @@ export default function TemplateLibraryPage() {
                 <>
                   <select
                     value={selectedCategory}
-                    onChange={(e) => { setSelectedCategory(e.target.value); setPage(1); }}
+                    onChange={(e) => { setSelectedCategory(e.target.value); setSearchQuery(''); setPage(1); }}
                     className="flex-shrink-0 px-3 py-1.5 rounded-lg text-xs bg-[var(--surface)] border border-[var(--border)] text-[var(--foreground-secondary)]"
                   >
                     <option value="">All Categories</option>

--- a/web/src/components/TrialBanner.tsx
+++ b/web/src/components/TrialBanner.tsx
@@ -41,7 +41,7 @@ export default function TrialBanner() {
         <div className="px-4 sm:px-6 lg:px-8 py-2.5 flex items-center justify-between gap-4">
           <div className="flex items-center gap-3 min-w-0">
             <div className="w-2 h-2 bg-red-400 rounded-full animate-pulse shrink-0" />
-            <p className="text-sm text-red-100 truncate sm:whitespace-normal">
+            <p className="text-sm text-red-100 truncate sm:whitespace-normal sm:overflow-visible">
               <span className="font-semibold">Your free trial has ended.</span>
               <span className="hidden sm:inline">{' '}Your data is safe. Upgrade to pick up where you left off.</span>
             </p>
@@ -63,7 +63,7 @@ export default function TrialBanner() {
         <div className="px-4 sm:px-6 lg:px-8 py-2.5 flex items-center justify-between gap-4">
           <div className="flex items-center gap-3 min-w-0">
             <div className="w-2 h-2 bg-amber-400 rounded-full animate-pulse shrink-0" />
-            <p className="text-sm text-amber-100 truncate sm:whitespace-normal">
+            <p className="text-sm text-amber-100 truncate sm:whitespace-normal sm:overflow-visible">
               <span className="font-semibold">Free Trial</span>
               {' '}&mdash; {daysRemaining} {daysRemaining === 1 ? 'day' : 'days'} remaining.<span className="hidden sm:inline"> Upgrade to keep your screens running.</span>
             </p>
@@ -96,7 +96,7 @@ export default function TrialBanner() {
       <div className="px-4 sm:px-6 lg:px-8 py-2 flex items-center justify-between gap-4">
         <div className="flex items-center gap-3 min-w-0">
           <div className="w-2 h-2 bg-[#00E5A0] rounded-full shrink-0" />
-          <p className="text-sm text-[#00E5A0]/90 truncate sm:whitespace-normal">
+          <p className="text-sm text-[#00E5A0]/90 truncate sm:whitespace-normal sm:overflow-visible">
             <span className="font-semibold">Free Trial</span>
             {' '}&mdash; {daysRemaining} days remaining
           </p>

--- a/web/src/components/TrialBanner.tsx
+++ b/web/src/components/TrialBanner.tsx
@@ -41,9 +41,9 @@ export default function TrialBanner() {
         <div className="px-4 sm:px-6 lg:px-8 py-2.5 flex items-center justify-between gap-4">
           <div className="flex items-center gap-3 min-w-0">
             <div className="w-2 h-2 bg-red-400 rounded-full animate-pulse shrink-0" />
-            <p className="text-sm text-red-100 truncate">
+            <p className="text-sm text-red-100 truncate sm:whitespace-normal">
               <span className="font-semibold">Your free trial has ended.</span>
-              {' '}Your data is safe. Upgrade to pick up where you left off.
+              <span className="hidden sm:inline">{' '}Your data is safe. Upgrade to pick up where you left off.</span>
             </p>
           </div>
           <Link
@@ -63,9 +63,9 @@ export default function TrialBanner() {
         <div className="px-4 sm:px-6 lg:px-8 py-2.5 flex items-center justify-between gap-4">
           <div className="flex items-center gap-3 min-w-0">
             <div className="w-2 h-2 bg-amber-400 rounded-full animate-pulse shrink-0" />
-            <p className="text-sm text-amber-100 truncate">
+            <p className="text-sm text-amber-100 truncate sm:whitespace-normal">
               <span className="font-semibold">Free Trial</span>
-              {' '}&mdash; {daysRemaining} {daysRemaining === 1 ? 'day' : 'days'} remaining. Upgrade to keep your screens running.
+              {' '}&mdash; {daysRemaining} {daysRemaining === 1 ? 'day' : 'days'} remaining.<span className="hidden sm:inline"> Upgrade to keep your screens running.</span>
             </p>
           </div>
           <div className="flex items-center gap-2 shrink-0">
@@ -96,7 +96,7 @@ export default function TrialBanner() {
       <div className="px-4 sm:px-6 lg:px-8 py-2 flex items-center justify-between gap-4">
         <div className="flex items-center gap-3 min-w-0">
           <div className="w-2 h-2 bg-[#00E5A0] rounded-full shrink-0" />
-          <p className="text-sm text-[#00E5A0]/90 truncate">
+          <p className="text-sm text-[#00E5A0]/90 truncate sm:whitespace-normal">
             <span className="font-semibold">Free Trial</span>
             {' '}&mdash; {daysRemaining} days remaining
           </p>

--- a/web/src/components/providers/CustomizationProvider.tsx
+++ b/web/src/components/providers/CustomizationProvider.tsx
@@ -42,14 +42,14 @@ export function CustomizationProvider({ children }: { children: React.ReactNode 
     // Fetch branding from API
     const fetchBranding = async () => {
       try {
-        const orgRes = await fetch('/api/organizations/current', { credentials: 'include' });
+        const orgRes = await fetch('/api/v1/organizations/current', { credentials: 'include' });
         if (!orgRes.ok) return;
         const orgJson = await orgRes.json();
         const org = orgJson?.data ?? orgJson;
         if (!org?.id) return;
         setOrganizationId(org.id);
 
-        const brandingRes = await fetch(`/api/organizations/${org.id}/branding`, { credentials: 'include' });
+        const brandingRes = await fetch(`/api/v1/organizations/${org.id}/branding`, { credentials: 'include' });
         if (!brandingRes.ok) return;
         const brandingJson = await brandingRes.json();
         const branding = brandingJson?.data ?? brandingJson;
@@ -109,7 +109,7 @@ export function CustomizationProvider({ children }: { children: React.ReactNode 
     // Persist to API if we have an org ID
     if (organizationId) {
       try {
-        await fetch(`/api/organizations/${organizationId}/branding`, {
+        await fetch(`/api/v1/organizations/${organizationId}/branding`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',

--- a/web/src/components/templates/AIDesignerModal.tsx
+++ b/web/src/components/templates/AIDesignerModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { apiClient } from '@/lib/api';
 
 interface AIDesignerModalProps {
@@ -37,6 +37,15 @@ export default function AIDesignerModal({ onClose, onTemplateGenerated }: AIDesi
   const [selectedStyle, setSelectedStyle] = useState('');
   const [generationStep, setGenerationStep] = useState(0);
   const [error, setError] = useState<string | null>(null);
+
+  // Close on Escape key
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
 
   const handleGenerate = async () => {
     if (!prompt.trim()) return;

--- a/web/src/components/templates/AIDesignerModal.tsx
+++ b/web/src/components/templates/AIDesignerModal.tsx
@@ -41,11 +41,11 @@ export default function AIDesignerModal({ onClose, onTemplateGenerated }: AIDesi
   // Close on Escape key
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key === 'Escape' && step !== 'generating') onClose();
     };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [onClose]);
+  }, [onClose, step]);
 
   const handleGenerate = async () => {
     if (!prompt.trim()) return;

--- a/web/src/components/templates/TemplateCard.tsx
+++ b/web/src/components/templates/TemplateCard.tsx
@@ -62,7 +62,9 @@ export default function TemplateCard({
   variant = 'grid',
 }: TemplateCardProps) {
   const [imgError, setImgError] = useState(false);
-  const thumb = thumbnailUrl || previewImageUrl;
+  const rawThumb = thumbnailUrl || previewImageUrl;
+  // Skip img for relative seed thumbnail paths — those files aren't deployed
+  const thumb = rawThumb && /^\/templates\/seed\//.test(rawThumb) ? null : rawThumb;
   const catColor = CATEGORY_COLORS[category || 'general'] || CATEGORY_COLORS.general;
   const diffConfig = DIFFICULTY_CONFIG[difficulty || ''];
 

--- a/web/src/lib/hooks/useNotifications.ts
+++ b/web/src/lib/hooks/useNotifications.ts
@@ -12,7 +12,7 @@ interface UseNotificationsOptions {
 }
 
 export function useNotifications(options: UseNotificationsOptions = {}) {
-  const { pollInterval = 30000, autoFetch = true } = options;
+  const { pollInterval = 120000, autoFetch = true } = options;
   const { user } = useAuth();
   const [notifications, setNotifications] = useState<AppNotification[]>([]);
   const [unreadCount, setUnreadCount] = useState(0);


### PR DESCRIPTION
## Summary
- Fix 10 issues found during E2E testing of vizora.cloud (3 critical, 3 high, 4 medium)
- Mobile sidebar defaults closed on small viewports, auto-syncs with resize (debounced)
- Template seed thumbnail 404s eliminated by skipping `<img>` for undeployed paths
- Category/search conflict resolved, AI Designer gets Escape key, notification polling reduced
- Org branding API URLs fixed (`/api/` → `/api/v1/`), analytics shows "Demo Data" banner
- WebSocket status transitions to "Offline" after 15s of reconnecting, trial banner responsive

## Files changed (9)
- `web/src/app/dashboard/layout.tsx` — mobile sidebar + debounced resize
- `web/src/components/templates/TemplateCard.tsx` — seed thumbnail filter
- `web/src/app/dashboard/templates/page.tsx` — clear search on category select
- `web/src/components/templates/AIDesignerModal.tsx` — Escape key (guarded during generation)
- `web/src/lib/hooks/useNotifications.ts` — poll interval 30s → 120s
- `web/src/components/providers/CustomizationProvider.tsx` — API prefix fix
- `web/src/app/dashboard/analytics/page-client.tsx` — mock data banner
- `web/src/app/dashboard/content/page-client.tsx` — reconnect timeout + cleanup
- `web/src/components/TrialBanner.tsx` — mobile truncation fix

## Test plan
- [x] 18/18 related unit tests pass
- [x] No new TypeScript errors in modified files
- [ ] Manual: resize browser to 375x812 — sidebar should be collapsed
- [ ] Manual: templates page — no console 404 errors for thumbnails
- [ ] Manual: AI Designer modal — Escape key closes it (not during generation)
- [ ] Manual: click template category — search bar clears
- [ ] Manual: check console — no support/requests 500 or branding 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)