### PR TITLE
fix: ParseIdPipe for CUID models + device detail page

### DIFF
--- a/middleware/src/modules/admin/admin.controller.ts
+++ b/middleware/src/modules/admin/admin.controller.ts
@@ -11,8 +11,8 @@ import {
   HttpCode,
   HttpStatus,
   UseGuards,
-  ParseUUIDPipe,
 } from '@nestjs/common';
+import { ParseIdPipe } from '../common/pipes/parse-id.pipe';
 import { Request } from 'express';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
@@ -82,7 +82,7 @@ export class AdminController {
   }
 
   @Get('plans/:id')
-  async getPlan(@Param('id', ParseUUIDPipe) id: string) {
+  async getPlan(@Param('id', ParseIdPipe) id: string) {
     return this.plansService.findOne(id);
   }
 
@@ -109,7 +109,7 @@ export class AdminController {
 
   @Put('plans/:id')
   async updatePlan(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Body() dto: UpdatePlanDto,
     @CurrentUser('userId') adminId: string,
     @Req() req: Request,
@@ -131,7 +131,7 @@ export class AdminController {
 
   @Delete('plans/:id')
   async deletePlan(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @CurrentUser('userId') adminId: string,
     @Req() req: Request,
   ) {
@@ -152,7 +152,7 @@ export class AdminController {
   @Post('plans/:id/duplicate')
   @HttpCode(HttpStatus.OK)
   async duplicatePlan(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @CurrentUser('userId') adminId: string,
     @Req() req: Request,
   ) {
@@ -201,7 +201,7 @@ export class AdminController {
   }
 
   @Get('promotions/:id')
-  async getPromotion(@Param('id', ParseUUIDPipe) id: string) {
+  async getPromotion(@Param('id', ParseIdPipe) id: string) {
     return this.promotionsService.findOne(id);
   }
 
@@ -232,7 +232,7 @@ export class AdminController {
 
   @Put('promotions/:id')
   async updatePromotion(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Body() dto: UpdatePromotionDto,
     @CurrentUser('userId') adminId: string,
     @Req() req: Request,
@@ -254,7 +254,7 @@ export class AdminController {
 
   @Delete('promotions/:id')
   async deletePromotion(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @CurrentUser('userId') adminId: string,
     @Req() req: Request,
   ) {
@@ -300,7 +300,7 @@ export class AdminController {
 
   @Get('promotions/:id/redemptions')
   async getPromotionRedemptions(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Query() pagination: PaginationDto,
   ) {
     return this.promotionsService.getRedemptions(id, pagination);
@@ -324,13 +324,13 @@ export class AdminController {
   }
 
   @Get('organizations/:id')
-  async getOrganization(@Param('id', ParseUUIDPipe) id: string) {
+  async getOrganization(@Param('id', ParseIdPipe) id: string) {
     return this.organizationsAdminService.findOne(id);
   }
 
   @Put('organizations/:id')
   async updateOrganization(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Body() dto: UpdateOrgAdminDto,
     @CurrentUser('userId') adminId: string,
     @Req() req: Request,
@@ -360,7 +360,7 @@ export class AdminController {
 
   @Delete('organizations/:id')
   async deleteOrganization(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @CurrentUser('userId') adminId: string,
     @Req() req: Request,
   ) {
@@ -382,7 +382,7 @@ export class AdminController {
   @Post('organizations/:id/extend-trial')
   @HttpCode(HttpStatus.OK)
   async extendTrial(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Body() dto: ExtendTrialDto,
     @CurrentUser('userId') adminId: string,
     @Req() req: Request,
@@ -405,7 +405,7 @@ export class AdminController {
   @Post('organizations/:id/suspend')
   @HttpCode(HttpStatus.OK)
   async suspendOrganization(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Body() body: SuspendOrgDto,
     @CurrentUser('userId') adminId: string,
     @Req() req: Request,
@@ -428,7 +428,7 @@ export class AdminController {
   @Post('organizations/:id/unsuspend')
   @HttpCode(HttpStatus.OK)
   async unsuspendOrganization(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @CurrentUser('userId') adminId: string,
     @Req() req: Request,
   ) {
@@ -447,14 +447,14 @@ export class AdminController {
   }
 
   @Get('organizations/:id/stats')
-  async getOrganizationStats(@Param('id', ParseUUIDPipe) id: string) {
+  async getOrganizationStats(@Param('id', ParseIdPipe) id: string) {
     return this.organizationsAdminService.getStats(id);
   }
 
   @Post('organizations/:id/notes')
   @HttpCode(HttpStatus.OK)
   async addOrganizationNote(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Body() dto: OrgNotesDto,
     @CurrentUser('userId') adminId: string,
   ) {
@@ -481,13 +481,13 @@ export class AdminController {
   }
 
   @Get('users/:id')
-  async getUser(@Param('id', ParseUUIDPipe) id: string) {
+  async getUser(@Param('id', ParseIdPipe) id: string) {
     return this.usersAdminService.findOne(id);
   }
 
   @Put('users/:id')
   async updateUser(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Body() dto: UpdateUserAdminDto,
     @CurrentUser('userId') adminId: string,
     @Req() req: Request,
@@ -510,7 +510,7 @@ export class AdminController {
   @Post('users/:id/disable')
   @HttpCode(HttpStatus.OK)
   async disableUser(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @CurrentUser('userId') adminId: string,
     @Req() req: Request,
   ) {
@@ -532,7 +532,7 @@ export class AdminController {
   @Post('users/:id/enable')
   @HttpCode(HttpStatus.OK)
   async enableUser(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @CurrentUser('userId') adminId: string,
     @Req() req: Request,
   ) {
@@ -554,7 +554,7 @@ export class AdminController {
   @Post('users/:id/reset-password')
   @HttpCode(HttpStatus.OK)
   async resetUserPassword(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @CurrentUser('userId') adminId: string,
     @Req() req: Request,
   ) {
@@ -575,7 +575,7 @@ export class AdminController {
   @Post('users/:id/grant-super-admin')
   @HttpCode(HttpStatus.OK)
   async grantSuperAdmin(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @CurrentUser('userId') adminId: string,
     @Req() req: Request,
   ) {
@@ -597,7 +597,7 @@ export class AdminController {
   @Post('users/:id/revoke-super-admin')
   @HttpCode(HttpStatus.OK)
   async revokeSuperAdmin(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @CurrentUser('userId') adminId: string,
     @Req() req: Request,
   ) {
@@ -839,7 +839,7 @@ export class AdminController {
 
   @Delete('security/ip-blocklist/:id')
   async unblockIp(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @CurrentUser('userId') adminId: string,
     @Req() req: Request,
   ) {
@@ -866,7 +866,7 @@ export class AdminController {
   @Post('security/api-keys/:id/revoke')
   @HttpCode(HttpStatus.OK)
   async revokeApiKey(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @CurrentUser('userId') adminId: string,
     @Req() req: Request,
   ) {
@@ -894,7 +894,7 @@ export class AdminController {
   }
 
   @Get('announcements/:id')
-  async getAnnouncement(@Param('id', ParseUUIDPipe) id: string) {
+  async getAnnouncement(@Param('id', ParseIdPipe) id: string) {
     return this.announcementsService.findOne(id);
   }
 
@@ -935,7 +935,7 @@ export class AdminController {
 
   @Put('announcements/:id')
   async updateAnnouncement(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Body() dto: UpdateAnnouncementDto,
     @CurrentUser('userId') adminId: string,
     @Req() req: Request,
@@ -957,7 +957,7 @@ export class AdminController {
 
   @Delete('announcements/:id')
   async deleteAnnouncement(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @CurrentUser('userId') adminId: string,
     @Req() req: Request,
   ) {
@@ -978,7 +978,7 @@ export class AdminController {
   @Post('announcements/:id/publish')
   @HttpCode(HttpStatus.OK)
   async publishAnnouncement(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @CurrentUser('userId') adminId: string,
     @Req() req: Request,
   ) {

--- a/middleware/src/modules/analytics/analytics.controller.ts
+++ b/middleware/src/modules/analytics/analytics.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Get, Query, Param, UseGuards, ParseUUIDPipe } from '@nestjs/common';
+import { Controller, Get, Query, Param, UseGuards } from '@nestjs/common';
+import { ParseIdPipe } from '../common/pipes/parse-id.pipe';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { AnalyticsService } from './analytics.service';
@@ -83,7 +84,7 @@ export class AnalyticsController {
   @Roles('admin', 'manager')
   getContentMetrics(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('contentId', ParseUUIDPipe) contentId: string,
+    @Param('contentId', ParseIdPipe) contentId: string,
     @Query('range') range: string = 'month',
   ) {
     return this.analyticsService.getContentMetrics(organizationId, contentId, range);
@@ -92,7 +93,7 @@ export class AnalyticsController {
   @Get('device-uptime/:deviceId')
   @Roles('admin', 'manager', 'viewer')
   getDeviceUptime(
-    @Param('deviceId', ParseUUIDPipe) deviceId: string,
+    @Param('deviceId', ParseIdPipe) deviceId: string,
     @Query('days') days?: string,
     @CurrentUser('organizationId') organizationId: string,
   ) {

--- a/middleware/src/modules/api-keys/api-keys.controller.ts
+++ b/middleware/src/modules/api-keys/api-keys.controller.ts
@@ -6,8 +6,8 @@ import {
   Body,
   Param,
   UseGuards,
-  ParseUUIDPipe,
 } from '@nestjs/common';
+import { ParseIdPipe } from '../common/pipes/parse-id.pipe';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
@@ -38,7 +38,7 @@ export class ApiKeysController {
   @Delete(':id')
   @Roles('admin')
   async revoke(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @CurrentUser('organizationId') organizationId: string,
   ) {
     await this.apiKeysService.revoke(organizationId, id);

--- a/middleware/src/modules/common/pipes/parse-id.pipe.spec.ts
+++ b/middleware/src/modules/common/pipes/parse-id.pipe.spec.ts
@@ -1,0 +1,94 @@
+import { BadRequestException } from '@nestjs/common';
+import { ParseIdPipe } from './parse-id.pipe';
+
+describe('ParseIdPipe', () => {
+  let pipe: ParseIdPipe;
+
+  beforeEach(() => {
+    pipe = new ParseIdPipe();
+  });
+
+  describe('UUID format', () => {
+    it('should accept valid UUID v4', () => {
+      expect(pipe.transform('550e8400-e29b-41d4-a716-446655440000')).toBe(
+        '550e8400-e29b-41d4-a716-446655440000',
+      );
+    });
+
+    it('should accept uppercase UUID', () => {
+      expect(pipe.transform('550E8400-E29B-41D4-A716-446655440000')).toBe(
+        '550E8400-E29B-41D4-A716-446655440000',
+      );
+    });
+
+    it('should accept UUID from production Display model', () => {
+      expect(pipe.transform('40f404bc-cac1-41d0-9845-f08da16a4f8b')).toBe(
+        '40f404bc-cac1-41d0-9845-f08da16a4f8b',
+      );
+    });
+  });
+
+  describe('CUID format', () => {
+    it('should accept valid CUID', () => {
+      expect(pipe.transform('cmm51bbdw000h12315wr7in5n')).toBe(
+        'cmm51bbdw000h12315wr7in5n',
+      );
+    });
+
+    it('should accept longer CUIDs', () => {
+      expect(pipe.transform('clh2k3j4g0000qw08a1b2c3d4e5')).toBe(
+        'clh2k3j4g0000qw08a1b2c3d4e5',
+      );
+    });
+
+    it('should accept CUID from production Content model', () => {
+      expect(pipe.transform('cmm51bbdw000h12315wr7in5n')).toBe(
+        'cmm51bbdw000h12315wr7in5n',
+      );
+    });
+  });
+
+  describe('invalid values', () => {
+    it('should reject empty string', () => {
+      expect(() => pipe.transform('')).toThrow(BadRequestException);
+    });
+
+    it('should reject random string', () => {
+      expect(() => pipe.transform('not-an-id')).toThrow(BadRequestException);
+    });
+
+    it('should reject SQL injection attempt', () => {
+      expect(() => pipe.transform("'; DROP TABLE users; --")).toThrow(BadRequestException);
+    });
+
+    it('should reject path traversal', () => {
+      expect(() => pipe.transform('../../../etc/passwd')).toThrow(BadRequestException);
+    });
+
+    it('should reject incomplete UUID', () => {
+      expect(() => pipe.transform('550e8400-e29b-41d4')).toThrow(BadRequestException);
+    });
+
+    it('should reject CUID that does not start with c', () => {
+      expect(() => pipe.transform('xmm51bbdw000h12315wr7in5n')).toThrow(BadRequestException);
+    });
+
+    it('should reject too-short CUID', () => {
+      expect(() => pipe.transform('cabcdef123')).toThrow(BadRequestException);
+    });
+  });
+
+  describe('whitespace handling', () => {
+    it('should trim whitespace from valid UUID', () => {
+      expect(pipe.transform('  550e8400-e29b-41d4-a716-446655440000  ')).toBe(
+        '550e8400-e29b-41d4-a716-446655440000',
+      );
+    });
+
+    it('should trim whitespace from valid CUID', () => {
+      expect(pipe.transform('  cmm51bbdw000h12315wr7in5n  ')).toBe(
+        'cmm51bbdw000h12315wr7in5n',
+      );
+    });
+  });
+});

--- a/middleware/src/modules/common/pipes/parse-id.pipe.ts
+++ b/middleware/src/modules/common/pipes/parse-id.pipe.ts
@@ -1,0 +1,38 @@
+import { PipeTransform, Injectable, BadRequestException } from '@nestjs/common';
+
+/**
+ * Validates that a route parameter is a valid Prisma ID (UUID or CUID).
+ *
+ * Prisma uses cuid() by default for most models (Content, Playlist, Schedule,
+ * DisplayGroup, etc.) and uuid() for a few (Organization, User, Display).
+ * This pipe accepts both formats so controllers don't need to know which
+ * ID strategy a model uses.
+ *
+ * UUID v4:  e.g. "550e8400-e29b-41d4-a716-446655440000"
+ * CUID:     e.g. "clh2k3j4g0000qw08a1b2c3d4" (starts with 'c', 25+ chars)
+ */
+@Injectable()
+export class ParseIdPipe implements PipeTransform<string, string> {
+  // UUID v1–v5 pattern (8-4-4-4-12 hex)
+  private static readonly UUID_RE =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+  // CUID pattern: starts with 'c', followed by lowercase alphanumeric, 20-30 chars total
+  private static readonly CUID_RE = /^c[a-z0-9]{19,29}$/;
+
+  transform(value: string): string {
+    if (!value || typeof value !== 'string') {
+      throw new BadRequestException('ID parameter is required');
+    }
+
+    const trimmed = value.trim();
+
+    if (ParseIdPipe.UUID_RE.test(trimmed) || ParseIdPipe.CUID_RE.test(trimmed)) {
+      return trimmed;
+    }
+
+    throw new BadRequestException(
+      'Validation failed (valid ID expected — UUID or CUID format)',
+    );
+  }
+}

--- a/middleware/src/modules/common/pipes/parse-id.pipe.ts
+++ b/middleware/src/modules/common/pipes/parse-id.pipe.ts
@@ -17,7 +17,8 @@ export class ParseIdPipe implements PipeTransform<string, string> {
   private static readonly UUID_RE =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-  // CUID pattern: starts with 'c', followed by lowercase alphanumeric, 20-30 chars total
+  // CUID pattern: starts with 'c', followed by lowercase alphanumeric, 20-30 chars total.
+  // Prisma's cuid() always generates lowercase, so no case-insensitive flag needed.
   private static readonly CUID_RE = /^c[a-z0-9]{19,29}$/;
 
   transform(value: string): string {

--- a/middleware/src/modules/content/content.controller.ts
+++ b/middleware/src/modules/content/content.controller.ts
@@ -15,9 +15,9 @@ import {
   BadRequestException,
   NotFoundException,
   Logger,
-  ParseUUIDPipe,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { ParseIdPipe } from '../common/pipes/parse-id.pipe';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { RequiresSubscription } from '../billing/decorators/requires-subscription.decorator';
@@ -187,7 +187,7 @@ export class ContentController {
   @Get(':id')
   findOne(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
   ) {
     return this.contentService.findOne(organizationId, id);
   }
@@ -200,7 +200,7 @@ export class ContentController {
   @Get(':id/download')
   async getDownloadUrl(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Query('expirySeconds') expirySeconds?: string,
   ): Promise<{ url: string; expiresIn: number }> {
     const content = await this.contentService.findOne(organizationId, id);
@@ -241,7 +241,7 @@ export class ContentController {
   @Roles('admin', 'manager')
   update(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Body() updateContentDto: UpdateContentDto,
   ) {
     return this.contentService.update(organizationId, id, updateContentDto);
@@ -252,7 +252,7 @@ export class ContentController {
   @HttpCode(HttpStatus.OK)
   async generateThumbnail(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
   ) {
     // Get content
     const content = await this.contentService.findOne(organizationId, id);
@@ -299,7 +299,7 @@ export class ContentController {
   @Roles('admin', 'manager')
   archive(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
   ) {
     return this.contentService.archive(organizationId, id);
   }
@@ -308,7 +308,7 @@ export class ContentController {
   @Roles('admin')
   remove(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
   ) {
     return this.contentService.remove(organizationId, id);
   }
@@ -323,7 +323,7 @@ export class ContentController {
   @UseInterceptors(FileInterceptor('file', { limits: { fileSize: 100 * 1024 * 1024 } }))
   async replaceFile(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @UploadedFile() file: Express.Multer.File,
     @Body() replaceFileDto: ReplaceFileDto,
   ) {
@@ -422,7 +422,7 @@ export class ContentController {
   @Get(':id/versions')
   getVersionHistory(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
   ) {
     return this.contentService.getVersionHistory(organizationId, id);
   }
@@ -432,7 +432,7 @@ export class ContentController {
   @HttpCode(HttpStatus.OK)
   restore(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
   ) {
     return this.contentService.restore(organizationId, id);
   }
@@ -445,7 +445,7 @@ export class ContentController {
   @Roles('admin', 'manager')
   async setExpiration(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Body() body: SetContentExpirationDto,
   ) {
     const expiresAtDate = new Date(body.expiresAt);
@@ -468,7 +468,7 @@ export class ContentController {
   @HttpCode(HttpStatus.OK)
   clearExpiration(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
   ) {
     return this.contentService.clearExpiration(organizationId, id);
   }

--- a/middleware/src/modules/content/content.module.ts
+++ b/middleware/src/modules/content/content.module.ts
@@ -34,7 +34,7 @@ import {
   ],
   controllers: [
     // Sub-path controllers MUST be listed before ContentController to prevent
-    // ContentController's @Get(':id') (with ParseUUIDPipe) from matching
+    // ContentController's @Get(':id') (with ParseIdPipe) from matching
     // /content/widgets, /content/layouts, /content/templates, /content/bulk as :id params → 400
     WidgetsController,
     LayoutsController,

--- a/middleware/src/modules/content/controllers/layouts.controller.ts
+++ b/middleware/src/modules/content/controllers/layouts.controller.ts
@@ -8,8 +8,8 @@ import {
   Param,
   Query,
   UseGuards,
-  ParseUUIDPipe,
 } from '@nestjs/common';
+import { ParseIdPipe } from '../../common/pipes/parse-id.pipe';
 import { RolesGuard } from '../../auth/guards/roles.guard';
 import { Roles } from '../../auth/decorators/roles.decorator';
 import { ContentService } from '../content.service';
@@ -51,7 +51,7 @@ export class LayoutsController {
   @Roles('admin', 'manager')
   updateLayout(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Body() dto: UpdateLayoutDto,
   ) {
     return this.contentService.updateLayout(organizationId, id, dto);
@@ -61,7 +61,7 @@ export class LayoutsController {
   @Roles('admin', 'manager', 'viewer')
   getResolvedLayout(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
   ) {
     return this.contentService.getResolvedLayout(organizationId, id);
   }
@@ -70,7 +70,7 @@ export class LayoutsController {
   @Roles('admin', 'manager')
   deleteLayout(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
   ) {
     return this.contentService.remove(organizationId, id);
   }

--- a/middleware/src/modules/content/controllers/templates.controller.ts
+++ b/middleware/src/modules/content/controllers/templates.controller.ts
@@ -8,8 +8,8 @@ import {
   HttpCode,
   HttpStatus,
   UseGuards,
-  ParseUUIDPipe,
 } from '@nestjs/common';
+import { ParseIdPipe } from '../../common/pipes/parse-id.pipe';
 import { RolesGuard } from '../../auth/guards/roles.guard';
 import { Roles } from '../../auth/decorators/roles.decorator';
 import { ContentService } from '../content.service';
@@ -37,7 +37,7 @@ export class TemplatesController {
   @Roles('admin', 'manager')
   updateTemplate(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Body() dto: UpdateTemplateDto,
   ) {
     return this.contentService.updateTemplate(organizationId, id, dto);
@@ -63,7 +63,7 @@ export class TemplatesController {
   @SkipOutputSanitize()
   getRenderedTemplate(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
   ) {
     return this.contentService.getRenderedTemplate(organizationId, id);
   }
@@ -73,7 +73,7 @@ export class TemplatesController {
   @HttpCode(HttpStatus.OK)
   refreshTemplate(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
   ) {
     return this.contentService.triggerTemplateRefresh(organizationId, id);
   }

--- a/middleware/src/modules/content/controllers/widgets.controller.ts
+++ b/middleware/src/modules/content/controllers/widgets.controller.ts
@@ -9,8 +9,8 @@ import {
   HttpCode,
   HttpStatus,
   UseGuards,
-  ParseUUIDPipe,
 } from '@nestjs/common';
+import { ParseIdPipe } from '../../common/pipes/parse-id.pipe';
 import { RolesGuard } from '../../auth/guards/roles.guard';
 import { Roles } from '../../auth/decorators/roles.decorator';
 import { ContentService } from '../content.service';
@@ -51,7 +51,7 @@ export class WidgetsController {
   @Roles('admin', 'manager')
   updateWidget(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Body() dto: Partial<CreateWidgetDto>,
   ) {
     return this.contentService.updateWidget(organizationId, id, dto);
@@ -62,7 +62,7 @@ export class WidgetsController {
   @HttpCode(HttpStatus.OK)
   refreshWidget(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
   ) {
     return this.contentService.refreshWidget(organizationId, id);
   }

--- a/middleware/src/modules/content/device-content.controller.ts
+++ b/middleware/src/modules/content/device-content.controller.ts
@@ -9,8 +9,8 @@ import {
   ForbiddenException,
   UnauthorizedException,
   Logger,
-  ParseUUIDPipe,
 } from '@nestjs/common';
+import { ParseIdPipe } from '../common/pipes/parse-id.pipe';
 import type { Request, Response } from 'express';
 import { JwtService } from '@nestjs/jwt';
 import { Public } from '../auth/decorators/public.decorator';
@@ -83,7 +83,7 @@ export class DeviceContentController {
   @SkipEnvelope()
   @SkipOutputSanitize()
   async serveFile(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Req() req: Request,
     @Res() res: Response,
   ): Promise<void> {

--- a/middleware/src/modules/display-groups/display-groups.controller.ts
+++ b/middleware/src/modules/display-groups/display-groups.controller.ts
@@ -8,8 +8,8 @@ import {
   Delete,
   Query,
   UseGuards,
-  ParseUUIDPipe,
 } from '@nestjs/common';
+import { ParseIdPipe } from '../common/pipes/parse-id.pipe';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { DisplayGroupsService } from './display-groups.service';
@@ -44,7 +44,7 @@ export class DisplayGroupsController {
   @Get(':id')
   findOne(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
   ) {
     return this.displayGroupsService.findOne(organizationId, id);
   }
@@ -53,7 +53,7 @@ export class DisplayGroupsController {
   @Roles('admin', 'manager')
   update(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Body() updateDisplayGroupDto: UpdateDisplayGroupDto,
   ) {
     return this.displayGroupsService.update(organizationId, id, updateDisplayGroupDto);
@@ -63,7 +63,7 @@ export class DisplayGroupsController {
   @Roles('admin')
   remove(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
   ) {
     return this.displayGroupsService.remove(organizationId, id);
   }
@@ -72,7 +72,7 @@ export class DisplayGroupsController {
   @Roles('admin', 'manager')
   addDisplays(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Body() manageDisplaysDto: ManageDisplaysDto,
   ) {
     return this.displayGroupsService.addDisplays(organizationId, id, manageDisplaysDto);
@@ -82,7 +82,7 @@ export class DisplayGroupsController {
   @Roles('admin', 'manager')
   removeDisplays(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Body() manageDisplaysDto: ManageDisplaysDto,
   ) {
     return this.displayGroupsService.removeDisplays(organizationId, id, manageDisplaysDto);

--- a/middleware/src/modules/folders/folders.controller.ts
+++ b/middleware/src/modules/folders/folders.controller.ts
@@ -10,8 +10,8 @@ import {
   UseGuards,
   HttpCode,
   HttpStatus,
-  ParseUUIDPipe,
 } from '@nestjs/common';
+import { ParseIdPipe } from '../common/pipes/parse-id.pipe';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { FoldersService } from './folders.service';
@@ -49,7 +49,7 @@ export class FoldersController {
   @Get(':id')
   findOne(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
   ) {
     return this.foldersService.findOne(organizationId, id);
   }
@@ -58,7 +58,7 @@ export class FoldersController {
   @Roles('admin', 'manager')
   update(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Body() updateFolderDto: UpdateFolderDto,
   ) {
     return this.foldersService.update(organizationId, id, updateFolderDto);
@@ -68,7 +68,7 @@ export class FoldersController {
   @Roles('admin', 'manager')
   remove(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
   ) {
     return this.foldersService.remove(organizationId, id);
   }
@@ -78,7 +78,7 @@ export class FoldersController {
   @HttpCode(HttpStatus.OK)
   moveContent(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Body() moveContentDto: MoveContentDto,
   ) {
     return this.foldersService.moveContent(organizationId, id, moveContentDto);
@@ -87,7 +87,7 @@ export class FoldersController {
   @Get(':id/content')
   getContents(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Query() pagination: PaginationDto,
   ) {
     return this.foldersService.getContents(organizationId, id, pagination);

--- a/middleware/src/modules/notifications/notifications.controller.ts
+++ b/middleware/src/modules/notifications/notifications.controller.ts
@@ -9,8 +9,8 @@ import {
   HttpCode,
   HttpStatus,
   UseGuards,
-  ParseUUIDPipe,
 } from '@nestjs/common';
+import { ParseIdPipe } from '../common/pipes/parse-id.pipe';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
@@ -87,7 +87,7 @@ export class NotificationsController {
   @Patch(':id/read')
   markAsRead(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
   ) {
     return this.notificationsService.markAsRead(organizationId, id);
   }
@@ -98,7 +98,7 @@ export class NotificationsController {
   @Patch(':id/dismiss')
   dismiss(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
   ) {
     return this.notificationsService.dismiss(organizationId, id);
   }

--- a/middleware/src/modules/playlists/playlists.controller.ts
+++ b/middleware/src/modules/playlists/playlists.controller.ts
@@ -8,8 +8,8 @@ import {
   Delete,
   Query,
   UseGuards,
-  ParseUUIDPipe,
 } from '@nestjs/common';
+import { ParseIdPipe } from '../common/pipes/parse-id.pipe';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { RequiresSubscription } from '../billing/decorators/requires-subscription.decorator';
@@ -48,7 +48,7 @@ export class PlaylistsController {
   @Get(':id')
   findOne(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
   ) {
     return this.playlistsService.findOne(organizationId, id);
   }
@@ -57,7 +57,7 @@ export class PlaylistsController {
   @Roles('admin', 'manager')
   update(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Body() updatePlaylistDto: UpdatePlaylistDto,
   ) {
     return this.playlistsService.update(organizationId, id, updatePlaylistDto);
@@ -67,7 +67,7 @@ export class PlaylistsController {
   @Roles('admin', 'manager')
   duplicate(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
   ) {
     return this.playlistsService.duplicate(organizationId, id);
   }
@@ -76,7 +76,7 @@ export class PlaylistsController {
   @Roles('admin', 'manager')
   reorder(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Body() reorderDto: ReorderPlaylistDto,
   ) {
     return this.playlistsService.reorder(organizationId, id, reorderDto.itemIds);
@@ -86,7 +86,7 @@ export class PlaylistsController {
   @Roles('admin', 'manager')
   addItem(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) playlistId: string,
+    @Param('id', ParseIdPipe) playlistId: string,
     @Body() dto: AddPlaylistItemDto,
   ) {
     return this.playlistsService.addItem(organizationId, playlistId, dto.contentId, dto.duration);
@@ -96,8 +96,8 @@ export class PlaylistsController {
   @Roles('admin', 'manager')
   updateItem(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) playlistId: string,
-    @Param('itemId', ParseUUIDPipe) itemId: string,
+    @Param('id', ParseIdPipe) playlistId: string,
+    @Param('itemId', ParseIdPipe) itemId: string,
     @Body() updateDto: UpdatePlaylistItemDto,
   ) {
     return this.playlistsService.updateItem(organizationId, playlistId, itemId, updateDto);
@@ -107,8 +107,8 @@ export class PlaylistsController {
   @Roles('admin')
   removeItem(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) playlistId: string,
-    @Param('itemId', ParseUUIDPipe) itemId: string,
+    @Param('id', ParseIdPipe) playlistId: string,
+    @Param('itemId', ParseIdPipe) itemId: string,
   ) {
     return this.playlistsService.removeItem(organizationId, playlistId, itemId);
   }
@@ -117,7 +117,7 @@ export class PlaylistsController {
   @Roles('admin')
   remove(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
   ) {
     return this.playlistsService.remove(organizationId, id);
   }

--- a/middleware/src/modules/schedules/schedules.controller.ts
+++ b/middleware/src/modules/schedules/schedules.controller.ts
@@ -10,8 +10,8 @@ import {
   Req,
   UseGuards,
   UnauthorizedException,
-  ParseUUIDPipe,
 } from '@nestjs/common';
+import { ParseIdPipe } from '../common/pipes/parse-id.pipe';
 import type { Request } from 'express';
 import { JwtService } from '@nestjs/jwt';
 import { RolesGuard } from '../auth/guards/roles.guard';
@@ -69,7 +69,7 @@ export class SchedulesController {
 
   @Get('active/:displayId')
   @Public() // Bypass user JWT guard -- device JWT verified manually below
-  findActiveSchedules(@Param('displayId', ParseUUIDPipe) displayId: string, @Req() req: Request) {
+  findActiveSchedules(@Param('displayId', ParseIdPipe) displayId: string, @Req() req: Request) {
     // Verify device JWT to prevent unauthenticated schedule access
     const token = (req.headers.authorization as string)?.replace('Bearer ', '');
     if (!token) {
@@ -94,7 +94,7 @@ export class SchedulesController {
   @Get(':id')
   findOne(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
   ) {
     return this.schedulesService.findOne(organizationId, id);
   }
@@ -103,7 +103,7 @@ export class SchedulesController {
   @Roles('admin', 'manager')
   update(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Body() updateScheduleDto: UpdateScheduleDto,
   ) {
     return this.schedulesService.update(organizationId, id, updateScheduleDto);
@@ -113,7 +113,7 @@ export class SchedulesController {
   @Roles('admin', 'manager')
   duplicate(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
   ) {
     return this.schedulesService.duplicate(organizationId, id);
   }
@@ -122,7 +122,7 @@ export class SchedulesController {
   @Roles('admin')
   remove(
     @CurrentUser('organizationId') organizationId: string,
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
   ) {
     return this.schedulesService.remove(organizationId, id);
   }

--- a/middleware/src/modules/template-library/template-library.controller.ts
+++ b/middleware/src/modules/template-library/template-library.controller.ts
@@ -10,8 +10,8 @@ import {
   UseGuards,
   HttpCode,
   HttpStatus,
-  ParseUUIDPipe,
 } from '@nestjs/common';
+import { ParseIdPipe } from '../common/pipes/parse-id.pipe';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
@@ -91,14 +91,14 @@ export class TemplateLibraryController {
 
   @Get(':id')
   @Roles('admin', 'manager', 'viewer')
-  findOne(@Param('id', ParseUUIDPipe) id: string) {
+  findOne(@Param('id', ParseIdPipe) id: string) {
     return this.templateLibraryService.findOne(id);
   }
 
   @Get(':id/preview')
   @Roles('admin', 'manager', 'viewer')
   @SkipOutputSanitize()
-  getPreview(@Param('id', ParseUUIDPipe) id: string) {
+  getPreview(@Param('id', ParseIdPipe) id: string) {
     return this.templateLibraryService.getPreview(id);
   }
 
@@ -106,7 +106,7 @@ export class TemplateLibraryController {
   @Roles('admin', 'manager')
   @HttpCode(HttpStatus.CREATED)
   clone(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @CurrentUser('organizationId') organizationId: string,
     @Body() dto: CloneTemplateDto,
   ) {
@@ -117,7 +117,7 @@ export class TemplateLibraryController {
   @Roles('admin', 'manager')
   @HttpCode(HttpStatus.CREATED)
   publish(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @CurrentUser('organizationId') organizationId: string,
     @CurrentUser('id') userId: string,
     @Body() dto: PublishTemplateDto,
@@ -129,7 +129,7 @@ export class TemplateLibraryController {
   @Roles('admin', 'manager')
   @SkipOutputSanitize()
   saveUserTemplate(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @CurrentUser('organizationId') organizationId: string,
     @Body() dto: UpdateTemplateDto,
   ) {
@@ -140,7 +140,7 @@ export class TemplateLibraryController {
   @Roles('admin')
   @UseGuards(SuperAdminGuard)
   setFeatured(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Body('isFeatured') isFeatured: boolean,
   ) {
     return this.templateLibraryService.setFeatured(id, isFeatured);
@@ -150,7 +150,7 @@ export class TemplateLibraryController {
   @Roles('admin')
   @UseGuards(SuperAdminGuard)
   update(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param('id', ParseIdPipe) id: string,
     @Body() dto: UpdateTemplateDto,
   ) {
     return this.templateLibraryService.updateTemplate(id, dto);
@@ -160,7 +160,7 @@ export class TemplateLibraryController {
   @Roles('admin')
   @UseGuards(SuperAdminGuard)
   @HttpCode(HttpStatus.NO_CONTENT)
-  remove(@Param('id', ParseUUIDPipe) id: string) {
+  remove(@Param('id', ParseIdPipe) id: string) {
     return this.templateLibraryService.deleteTemplate(id);
   }
 }

--- a/web/src/app/dashboard/devices/[id]/page.tsx
+++ b/web/src/app/dashboard/devices/[id]/page.tsx
@@ -1,0 +1,241 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { apiClient } from '@/lib/api';
+import { Display } from '@/lib/types';
+import LoadingSpinner from '@/components/LoadingSpinner';
+import DeviceStatusIndicator from '@/components/DeviceStatusIndicator';
+import { Icon } from '@/theme/icons';
+
+// Extended display type for fields the backend returns but the base type doesn't include
+interface DisplayDetail extends Display {
+  resolution?: string;
+  description?: string;
+  timezone?: string;
+  metadata?: Record<string, any>;
+  pairedAt?: string;
+  deviceIdentifier?: string;
+}
+
+export default function DeviceDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const deviceId = params.id as string;
+
+  const [device, setDevice] = useState<DisplayDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!deviceId) return;
+
+    const loadDevice = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const data = await apiClient.getDisplay(deviceId);
+        setDevice(data as DisplayDetail);
+      } catch (err: any) {
+        setError(err.message || 'Failed to load device');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadDevice();
+  }, [deviceId]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <LoadingSpinner size="lg" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-6">
+        <Link
+          href="/dashboard/devices"
+          className="inline-flex items-center gap-2 text-sm text-[var(--foreground-secondary)] hover:text-[var(--foreground)] transition"
+        >
+          <Icon name="chevronLeft" size="sm" />
+          Back to Devices
+        </Link>
+        <div className="bg-[var(--surface)] rounded-lg shadow p-12 text-center">
+          <Icon name="error" size="2xl" className="text-red-500 mx-auto mb-4" />
+          <h2 className="text-xl font-semibold text-[var(--foreground)] mb-2">Device Not Found</h2>
+          <p className="text-[var(--foreground-secondary)] mb-6">{error}</p>
+          <button
+            onClick={() => router.push('/dashboard/devices')}
+            className="px-6 py-2 bg-[#00E5A0] text-[#061A21] rounded-lg hover:bg-[#00CC8E] transition font-medium"
+          >
+            Return to Devices
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!device) return null;
+
+  const formatDate = (date: Date | string | undefined) => {
+    if (!date) return 'N/A';
+    return new Date(String(date)).toLocaleString();
+  };
+
+  const infoRows: { label: string; value: React.ReactNode }[] = [
+    {
+      label: 'Status',
+      value: <DeviceStatusIndicator deviceId={device.id} showLabel showTime />,
+    },
+    {
+      label: 'Location',
+      value: device.location || '\u2014',
+    },
+    {
+      label: 'Device ID',
+      value: (
+        <span className="font-mono text-xs bg-[var(--background-secondary)] px-2 py-1 rounded">
+          {device.deviceIdentifier || device.deviceId || device.id}
+        </span>
+      ),
+    },
+    {
+      label: 'Resolution',
+      value: device.resolution || '\u2014',
+    },
+    {
+      label: 'Orientation',
+      value: device.orientation
+        ? device.orientation.charAt(0).toUpperCase() + device.orientation.slice(1)
+        : '\u2014',
+    },
+    {
+      label: 'Timezone',
+      value: device.timezone || '\u2014',
+    },
+    {
+      label: 'Last Seen',
+      value: formatDate(device.lastSeen || device.lastHeartbeat),
+    },
+    {
+      label: 'Paired At',
+      value: formatDate(device.pairedAt),
+    },
+    {
+      label: 'Created',
+      value: formatDate(device.createdAt),
+    },
+    {
+      label: 'Updated',
+      value: formatDate(device.updatedAt),
+    },
+  ];
+
+  // Extract metadata fields if present (firmware, IP, OS, model, etc.)
+  const metadata = device.metadata || {};
+  const metadataRows: { label: string; value: string }[] = [];
+  if (metadata.ipAddress) metadataRows.push({ label: 'IP Address', value: metadata.ipAddress });
+  if (metadata.firmwareVersion) metadataRows.push({ label: 'Firmware Version', value: metadata.firmwareVersion });
+  if (metadata.os) metadataRows.push({ label: 'Operating System', value: metadata.os });
+  if (metadata.model) metadataRows.push({ label: 'Model', value: metadata.model });
+  if (metadata.appVersion) metadataRows.push({ label: 'App Version', value: metadata.appVersion });
+  if (metadata.userAgent) metadataRows.push({ label: 'User Agent', value: metadata.userAgent });
+
+  return (
+    <div className="space-y-6">
+      {/* Back link */}
+      <Link
+        href="/dashboard/devices"
+        className="inline-flex items-center gap-2 text-sm text-[var(--foreground-secondary)] hover:text-[var(--foreground)] transition"
+      >
+        <Icon name="chevronLeft" size="sm" />
+        Back to Devices
+      </Link>
+
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <div className="p-3 bg-[var(--background-secondary)] rounded-lg">
+            <Icon name="devices" size="2xl" className="text-[#00E5A0]" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-[var(--foreground)]">{device.nickname || 'Unnamed Device'}</h1>
+            {device.description && (
+              <p className="text-sm text-[var(--foreground-secondary)] mt-1">{device.description}</p>
+            )}
+          </div>
+        </div>
+        <span
+          className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium ${
+            device.status === 'online'
+              ? 'bg-success-100 text-success-800 dark:bg-success-900 dark:text-success-200'
+              : 'bg-[var(--background-secondary)] text-[var(--foreground-secondary)]'
+          }`}
+        >
+          <span
+            className={`h-2 w-2 rounded-full ${
+              device.status === 'online' ? 'bg-success-500' : 'bg-[var(--foreground-tertiary)]'
+            }`}
+          />
+          {device.status === 'online' ? 'Online' : 'Offline'}
+        </span>
+      </div>
+
+      {/* Device Information */}
+      <div className="bg-[var(--surface)] rounded-lg shadow overflow-hidden">
+        <div className="px-6 py-4 border-b border-[var(--border)]">
+          <h2 className="text-lg font-semibold text-[var(--foreground)]">Device Information</h2>
+        </div>
+        <div className="divide-y divide-[var(--border)]">
+          {infoRows.map((row) => (
+            <div key={row.label} className="px-6 py-4 flex items-center justify-between">
+              <span className="text-sm font-medium text-[var(--foreground-secondary)]">{row.label}</span>
+              <span className="text-sm text-[var(--foreground)]">{row.value}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Metadata / Hardware Info */}
+      {metadataRows.length > 0 && (
+        <div className="bg-[var(--surface)] rounded-lg shadow overflow-hidden">
+          <div className="px-6 py-4 border-b border-[var(--border)]">
+            <h2 className="text-lg font-semibold text-[var(--foreground)]">Hardware Details</h2>
+          </div>
+          <div className="divide-y divide-[var(--border)]">
+            {metadataRows.map((row) => (
+              <div key={row.label} className="px-6 py-4 flex items-center justify-between">
+                <span className="text-sm font-medium text-[var(--foreground-secondary)]">{row.label}</span>
+                <span className="text-sm text-[var(--foreground)] font-mono">{row.value}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Current Playlist */}
+      {device.currentPlaylistId && (
+        <div className="bg-[var(--surface)] rounded-lg shadow overflow-hidden">
+          <div className="px-6 py-4 border-b border-[var(--border)]">
+            <h2 className="text-lg font-semibold text-[var(--foreground)]">Current Content</h2>
+          </div>
+          <div className="px-6 py-4">
+            <Link
+              href={`/dashboard/playlists/${device.currentPlaylistId}`}
+              className="inline-flex items-center gap-2 text-[#00E5A0] hover:text-[#00CC8E] transition font-medium"
+            >
+              <Icon name="playlists" size="md" />
+              View Assigned Playlist
+              <Icon name="chevronRight" size="sm" />
+            </Link>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/dashboard/devices/[id]/page.tsx
+++ b/web/src/app/dashboard/devices/[id]/page.tsx
@@ -37,8 +37,8 @@ export default function DeviceDetailPage() {
         setError(null);
         const data = await apiClient.getDisplay(deviceId);
         setDevice(data as DisplayDetail);
-      } catch (err: any) {
-        setError(err.message || 'Failed to load device');
+      } catch (err: unknown) {
+        setError(err instanceof Error ? err.message : 'Failed to load device');
       } finally {
         setLoading(false);
       }


### PR DESCRIPTION
## Summary
- **BUG 1**: Template detail modal showed "Template not found" because `ParseUUIDPipe` rejected Prisma CUID IDs with `400 Validation failed (uuid is expected)`. Created `ParseIdPipe` accepting both UUID and CUID formats, applied to 14 controllers operating on CUID models.
- **BUG 2**: `/dashboard/devices/{id}` returned 404 — no dynamic route existed. Added device detail page with info, hardware details, and content assignment.
- **BUG 3**: Trial expiration banner — working as designed, no fix needed.

## Test plan
- [x] 1847 middleware unit tests pass (including 15 new ParseIdPipe tests)
- [x] Middleware build passes
- [x] Web build passes (new `/dashboard/devices/[id]` route confirmed in output)
- [x] Code review completed — all findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)