### PR TITLE
feat: widgets, legal pages, content moderation (Q3, Q5, Q9, M4)

### DIFF
--- a/middleware/src/modules/content/content.controller.ts
+++ b/middleware/src/modules/content/content.controller.ts
@@ -31,6 +31,8 @@ import { UpdateContentDto } from './dto/update-content.dto';
 import { ReplaceFileDto } from './dto/replace-file.dto';
 import { SetContentExpirationDto } from './dto/set-content-expiration.dto';
 import { ContentQueryDto } from './dto/content-query.dto';
+import { FlagContentDto } from './dto/flag-content.dto';
+import { ReviewContentDto } from './dto/review-content.dto';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -293,6 +295,33 @@ export class ContentController {
     await this.contentService.update(organizationId, id, { thumbnail: thumbnailUrl });
 
     return { thumbnail: thumbnailUrl };
+  }
+
+  // ============================================================================
+  // CONTENT MODERATION
+  // ============================================================================
+
+  @Post(':id/flag')
+  @HttpCode(HttpStatus.OK)
+  flag(
+    @CurrentUser('organizationId') organizationId: string,
+    @CurrentUser('id') userId: string,
+    @Param('id', ParseIdPipe) id: string,
+    @Body() body: FlagContentDto,
+  ) {
+    return this.contentService.flagContent(organizationId, id, userId, body.reason);
+  }
+
+  @Post(':id/review')
+  @Roles('admin', 'manager')
+  @HttpCode(HttpStatus.OK)
+  review(
+    @CurrentUser('organizationId') organizationId: string,
+    @CurrentUser('id') userId: string,
+    @Param('id', ParseIdPipe) id: string,
+    @Body() body: ReviewContentDto,
+  ) {
+    return this.contentService.reviewContent(organizationId, id, userId, body.action, body.reason);
   }
 
   @Post(':id/archive')

--- a/middleware/src/modules/content/content.controller.ts
+++ b/middleware/src/modules/content/content.controller.ts
@@ -16,6 +16,7 @@ import {
   NotFoundException,
   Logger,
 } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ParseIdPipe } from '../common/pipes/parse-id.pipe';
 import { RolesGuard } from '../auth/guards/roles.guard';
@@ -302,6 +303,8 @@ export class ContentController {
   // ============================================================================
 
   @Post(':id/flag')
+  @Roles('admin', 'manager', 'viewer')
+  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @HttpCode(HttpStatus.OK)
   flag(
     @CurrentUser('organizationId') organizationId: string,

--- a/middleware/src/modules/content/content.module.ts
+++ b/middleware/src/modules/content/content.module.ts
@@ -14,6 +14,7 @@ import { TemplateRefreshService } from './template-refresh.service';
 import { DataSourceRegistryService } from './data-source-registry.service';
 import { StorageModule } from '../storage/storage.module';
 import { BillingModule } from '../billing/billing.module';
+import { NotificationsModule } from '../notifications/notifications.module';
 import {
   WeatherDataSource,
   RssDataSource,
@@ -26,6 +27,7 @@ import {
   imports: [
     StorageModule,
     BillingModule,
+    NotificationsModule,
     JwtModule.registerAsync({
       useFactory: () => ({
         secret: process.env.DEVICE_JWT_SECRET,

--- a/middleware/src/modules/content/content.service.spec.ts
+++ b/middleware/src/modules/content/content.service.spec.ts
@@ -129,6 +129,7 @@ describe('ContentService', () => {
     } as any;
 
     const mockEventEmitter = { emit: jest.fn() };
+    const mockNotificationsService = { create: jest.fn().mockResolvedValue({}) };
     service = new ContentService(
       mockDatabaseService as DatabaseService,
       mockTemplateRendering,
@@ -136,6 +137,7 @@ describe('ContentService', () => {
       mockStorageQuotaService,
       mockStorageService,
       mockEventEmitter as any,
+      mockNotificationsService as any,
     );
   });
 

--- a/middleware/src/modules/content/content.service.ts
+++ b/middleware/src/modules/content/content.service.ts
@@ -831,7 +831,7 @@ export class ContentService {
     }
 
     // action === 'reject'
-    // Archive the content and remove from all playlists
+    // Reject the content and remove from org playlists
     const rejectedMetadata = {
       ...existingMetadata,
       moderation: {
@@ -845,16 +845,19 @@ export class ContentService {
     };
 
     await this.db.$transaction(async (tx) => {
-      // Remove from all playlists
+      // Remove from playlists within the same organization only
       await tx.playlistItem.deleteMany({
-        where: { contentId: id },
+        where: {
+          contentId: id,
+          playlist: { organizationId },
+        },
       });
 
-      // Set status to archived (rejected content is archived)
+      // Set status to rejected
       await tx.content.updateMany({
         where: { id, organizationId },
         data: {
-          status: 'archived',
+          status: 'rejected',
           metadata: rejectedMetadata as Prisma.InputJsonValue,
         },
       });

--- a/middleware/src/modules/content/content.service.ts
+++ b/middleware/src/modules/content/content.service.ts
@@ -1,7 +1,8 @@
-import { Injectable, NotFoundException, BadRequestException, Logger } from '@nestjs/common';
+import { Injectable, NotFoundException, BadRequestException, ForbiddenException, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Prisma } from '@vizora/database';
 import { DatabaseService } from '../database/database.service';
+import { NotificationsService } from '../notifications/notifications.service';
 import { CreateContentDto } from './dto/create-content.dto';
 import { UpdateContentDto } from './dto/update-content.dto';
 import { CreateTemplateDto } from './dto/create-template.dto';
@@ -70,6 +71,7 @@ export class ContentService {
     private readonly storageQuotaService: StorageQuotaService,
     private readonly storageService: StorageService,
     private readonly eventEmitter: EventEmitter2,
+    private readonly notificationsService: NotificationsService,
   ) {}
 
   // Map database content to API response format
@@ -103,7 +105,7 @@ export class ContentService {
 
     // Validate filter values - only allow whitelisted values
     const validTypes = ['image', 'video', 'url', 'html', 'pdf', 'template', 'layout', 'widget'];
-    const validStatuses = ['active', 'archived', 'draft'];
+    const validStatuses = ['active', 'archived', 'draft', 'flagged', 'rejected'];
     const validOrientations = ['landscape', 'portrait', 'both'];
 
     const where: Prisma.ContentWhereInput = { organizationId };
@@ -693,6 +695,195 @@ export class ContentService {
     });
 
     return { updated: result.count };
+  }
+
+  // ============================================================================
+  // CONTENT MODERATION
+  // ============================================================================
+
+  /**
+   * Flag content for review. Any authenticated user in the org can flag content.
+   * Stores moderation metadata in the JSON metadata field and sets status to 'flagged'.
+   */
+  async flagContent(
+    organizationId: string,
+    id: string,
+    flaggedBy: string,
+    reason?: string,
+  ) {
+    const content = await this.findOne(organizationId, id);
+
+    if (content.status === 'flagged') {
+      throw new BadRequestException('Content is already flagged for review');
+    }
+    if (content.status === 'archived' || content.status === 'rejected') {
+      throw new BadRequestException('Cannot flag archived or rejected content');
+    }
+
+    const existingMetadata = (content.metadata || {}) as Record<string, unknown>;
+    const moderationMetadata = {
+      ...existingMetadata,
+      moderation: {
+        flagged: true,
+        flaggedBy,
+        flaggedAt: new Date().toISOString(),
+        flagReason: reason || null,
+        previousStatus: content.status,
+      },
+    };
+
+    const result = await this.db.content.updateMany({
+      where: { id, organizationId },
+      data: {
+        status: 'flagged',
+        metadata: moderationMetadata as Prisma.InputJsonValue,
+      },
+    });
+
+    if (result.count === 0) {
+      throw new NotFoundException('Content not found');
+    }
+
+    const updated = await this.db.content.findUnique({ where: { id } });
+
+    // Notify org admins about flagged content
+    try {
+      await this.notificationsService.create({
+        title: 'Content flagged for review',
+        message: `Content "${content.name}" has been flagged for review${reason ? `: ${reason}` : ''}`,
+        type: 'system',
+        severity: 'warning',
+        organizationId,
+        metadata: { contentId: id, flaggedBy, reason },
+      });
+    } catch (error) {
+      this.logger.warn(`Failed to create flag notification: ${error}`);
+    }
+
+    this.eventEmitter.emit('content.flagged', {
+      action: 'flagged',
+      entityType: 'content',
+      entityId: id,
+      organizationId,
+    });
+
+    return this.mapContentResponse(updated);
+  }
+
+  /**
+   * Review flagged content: approve (restore to previous status) or reject (archive + remove from playlists).
+   * Only admins and managers can review content.
+   */
+  async reviewContent(
+    organizationId: string,
+    id: string,
+    reviewedBy: string,
+    action: 'approve' | 'reject',
+    reason?: string,
+  ) {
+    const content = await this.findOne(organizationId, id);
+
+    if (content.status !== 'flagged') {
+      throw new BadRequestException('Only flagged content can be reviewed');
+    }
+
+    const existingMetadata = (content.metadata || {}) as Record<string, unknown>;
+    const moderation = (existingMetadata.moderation || {}) as Record<string, unknown>;
+
+    if (action === 'approve') {
+      // Restore to the status the content had before it was flagged
+      const previousStatus = (moderation.previousStatus as string) || 'active';
+
+      const approvedMetadata = {
+        ...existingMetadata,
+        moderation: {
+          ...moderation,
+          flagged: false,
+          reviewedBy,
+          reviewedAt: new Date().toISOString(),
+          reviewAction: 'approved',
+          reviewReason: reason || null,
+        },
+      };
+
+      const result = await this.db.content.updateMany({
+        where: { id, organizationId },
+        data: {
+          status: previousStatus,
+          metadata: approvedMetadata as Prisma.InputJsonValue,
+        },
+      });
+
+      if (result.count === 0) {
+        throw new NotFoundException('Content not found');
+      }
+
+      const updated = await this.db.content.findUnique({ where: { id } });
+
+      this.eventEmitter.emit('content.approved', {
+        action: 'approved',
+        entityType: 'content',
+        entityId: id,
+        organizationId,
+      });
+
+      return this.mapContentResponse(updated);
+    }
+
+    // action === 'reject'
+    // Archive the content and remove from all playlists
+    const rejectedMetadata = {
+      ...existingMetadata,
+      moderation: {
+        ...moderation,
+        flagged: false,
+        reviewedBy,
+        reviewedAt: new Date().toISOString(),
+        reviewAction: 'rejected',
+        reviewReason: reason || null,
+      },
+    };
+
+    await this.db.$transaction(async (tx) => {
+      // Remove from all playlists
+      await tx.playlistItem.deleteMany({
+        where: { contentId: id },
+      });
+
+      // Set status to archived (rejected content is archived)
+      await tx.content.updateMany({
+        where: { id, organizationId },
+        data: {
+          status: 'archived',
+          metadata: rejectedMetadata as Prisma.InputJsonValue,
+        },
+      });
+    });
+
+    const updated = await this.db.content.findUnique({ where: { id } });
+
+    // Notify that content was rejected
+    try {
+      await this.notificationsService.create({
+        title: 'Content rejected',
+        message: `Content "${content.name}" has been rejected and removed from playlists${reason ? `: ${reason}` : ''}`,
+        type: 'system',
+        severity: 'info',
+        organizationId,
+        metadata: { contentId: id, reviewedBy, reason },
+      });
+    } catch (error) {
+      this.logger.warn(`Failed to create rejection notification: ${error}`);
+    }
+
+    this.eventEmitter.emit('content.rejected', {
+      action: 'rejected',
+      entityType: 'content',
+      entityId: id,
+      organizationId,
+    });
+
+    return this.mapContentResponse(updated);
   }
 
   // ============================================================================

--- a/middleware/src/modules/content/controllers/widgets.controller.spec.ts
+++ b/middleware/src/modules/content/controllers/widgets.controller.spec.ts
@@ -288,6 +288,7 @@ describe('WidgetsController', () => {
 
       (global.fetch as jest.Mock).mockResolvedValue({
         ok: true,
+        headers: new Map([['content-length', '0']]),
         text: async () => rssXml,
       });
 
@@ -308,6 +309,7 @@ describe('WidgetsController', () => {
 
       (global.fetch as jest.Mock).mockResolvedValue({
         ok: true,
+        headers: new Map([['content-length', '0']]),
         text: async () => rssXml,
       });
 

--- a/middleware/src/modules/content/controllers/widgets.controller.spec.ts
+++ b/middleware/src/modules/content/controllers/widgets.controller.spec.ts
@@ -246,4 +246,92 @@ describe('WidgetsController', () => {
       ).rejects.toThrow('Refresh failed');
     });
   });
+
+  // ==========================================================================
+  // getRssFeed
+  // ==========================================================================
+
+  describe('getRssFeed', () => {
+    const mockFetchOriginal = global.fetch;
+
+    beforeEach(() => {
+      global.fetch = jest.fn();
+    });
+
+    afterEach(() => {
+      global.fetch = mockFetchOriginal;
+    });
+
+    it('should throw BadRequestException when url is missing', async () => {
+      await expect(
+        controller.getRssFeed(undefined as any, '10'),
+      ).rejects.toThrow('url parameter is required');
+    });
+
+    it('should throw BadRequestException for invalid URL', async () => {
+      await expect(
+        controller.getRssFeed('not-a-url', '10'),
+      ).rejects.toThrow('Invalid URL format');
+    });
+
+    it('should throw BadRequestException for non-http protocols', async () => {
+      await expect(
+        controller.getRssFeed('ftp://example.com/feed', '10'),
+      ).rejects.toThrow('Only http/https URLs are supported');
+    });
+
+    it('should fetch and parse an RSS feed successfully', async () => {
+      const rssXml = `<rss><channel>
+        <title>Test Feed</title>
+        <item><title>Article 1</title><description>Desc</description><link>https://example.com/1</link></item>
+      </channel></rss>`;
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        text: async () => rssXml,
+      });
+
+      const result = await controller.getRssFeed('https://example.com/rss', '10');
+
+      expect(result.feedTitle).toBe('Test Feed');
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].title).toBe('Article 1');
+      expect(result.fetchedAt).toBeDefined();
+    });
+
+    it('should respect the limit parameter', async () => {
+      const rssXml = `<rss><channel><title>Feed</title>
+        <item><title>A1</title><description>D1</description></item>
+        <item><title>A2</title><description>D2</description></item>
+        <item><title>A3</title><description>D3</description></item>
+      </channel></rss>`;
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        text: async () => rssXml,
+      });
+
+      const result = await controller.getRssFeed('https://example.com/rss', '2');
+      expect(result.items).toHaveLength(2);
+    });
+
+    it('should throw NotFoundException when fetch fails', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        status: 404,
+      });
+
+      await expect(
+        controller.getRssFeed('https://example.com/rss', '10'),
+      ).rejects.toThrow('Failed to fetch RSS feed: HTTP 404');
+    });
+
+    it('should throw NotFoundException on network error', async () => {
+      (global.fetch as jest.Mock).mockRejectedValue(new Error('Network timeout'));
+
+      await expect(
+        controller.getRssFeed('https://example.com/rss', '10'),
+      ).rejects.toThrow('Failed to fetch RSS feed: Network timeout');
+    });
+  });
 });

--- a/middleware/src/modules/content/controllers/widgets.controller.ts
+++ b/middleware/src/modules/content/controllers/widgets.controller.ts
@@ -9,6 +9,8 @@ import {
   HttpCode,
   HttpStatus,
   UseGuards,
+  BadRequestException,
+  NotFoundException,
 } from '@nestjs/common';
 import { ParseIdPipe } from '../../common/pipes/parse-id.pipe';
 import { RolesGuard } from '../../auth/guards/roles.guard';
@@ -17,6 +19,7 @@ import { ContentService } from '../content.service';
 import { CreateWidgetDto } from '../dto/create-widget.dto';
 import { PaginationDto } from '../../common/dto/pagination.dto';
 import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import { parseRssFeed, extractFeedTitle } from '../rss-parser';
 
 @UseGuards(RolesGuard)
 @Controller('content/widgets')
@@ -51,6 +54,54 @@ export class WidgetsController {
     // Sanitize location to prevent URL injection
     const sanitizedLocation = encodeURIComponent(location || 'New York');
     return this.contentService.getWeatherPreview(decodeURIComponent(sanitizedLocation), units);
+  }
+
+  @Get('rss/preview')
+  @Roles('admin', 'manager', 'viewer')
+  async getRssFeed(
+    @Query('url') feedUrl: string,
+    @Query('limit') limit: string = '10',
+  ) {
+    if (!feedUrl) {
+      throw new BadRequestException('url parameter is required');
+    }
+
+    let parsed: URL;
+    try {
+      parsed = new URL(feedUrl);
+    } catch {
+      throw new BadRequestException('Invalid URL format');
+    }
+
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      throw new BadRequestException('Only http/https URLs are supported');
+    }
+
+    const parsedLimit = Math.min(Math.max(parseInt(limit, 10) || 10, 1), 50);
+
+    let response: Response;
+    try {
+      response = await fetch(feedUrl, {
+        signal: AbortSignal.timeout(10000),
+        headers: { 'User-Agent': 'Vizora/1.0 Digital Signage RSS Reader' },
+      });
+    } catch (err: any) {
+      throw new NotFoundException(`Failed to fetch RSS feed: ${err.message || 'timeout or network error'}`);
+    }
+
+    if (!response.ok) {
+      throw new NotFoundException(`Failed to fetch RSS feed: HTTP ${response.status}`);
+    }
+
+    const xml = await response.text();
+    const items = parseRssFeed(xml, parsedLimit);
+    const feedTitle = extractFeedTitle(xml);
+
+    return {
+      feedTitle,
+      items,
+      fetchedAt: new Date().toISOString(),
+    };
   }
 
   @Post()

--- a/middleware/src/modules/content/controllers/widgets.controller.ts
+++ b/middleware/src/modules/content/controllers/widgets.controller.ts
@@ -77,6 +77,25 @@ export class WidgetsController {
       throw new BadRequestException('Only http/https URLs are supported');
     }
 
+    // Block private/reserved IP ranges (SSRF prevention)
+    const { hostname } = parsed;
+    const blockedPatterns = [
+      /^localhost$/i,
+      /^127\./,
+      /^10\./,
+      /^172\.(1[6-9]|2\d|3[01])\./,
+      /^192\.168\./,
+      /^169\.254\./,
+      /^0\./,
+      /^\[::1\]/,
+      /^\[fc/i,
+      /^\[fd/i,
+      /^\[fe80/i,
+    ];
+    if (blockedPatterns.some(p => p.test(hostname))) {
+      throw new BadRequestException('Private or reserved IP addresses are not allowed');
+    }
+
     const parsedLimit = Math.min(Math.max(parseInt(limit, 10) || 10, 1), 50);
 
     let response: Response;
@@ -93,7 +112,17 @@ export class WidgetsController {
       throw new NotFoundException(`Failed to fetch RSS feed: HTTP ${response.status}`);
     }
 
+    // Read response with size limit (2MB max)
+    const maxSize = 2 * 1024 * 1024;
+    const contentLength = parseInt(response.headers.get('content-length') || '0');
+    if (contentLength > maxSize) {
+      throw new BadRequestException('Feed response too large (max 2MB)');
+    }
     const xml = await response.text();
+    if (xml.length > maxSize) {
+      throw new BadRequestException('Feed response too large (max 2MB)');
+    }
+
     const items = parseRssFeed(xml, parsedLimit);
     const feedTitle = extractFeedTitle(xml);
 

--- a/middleware/src/modules/content/dto/content-query.dto.ts
+++ b/middleware/src/modules/content/dto/content-query.dto.ts
@@ -9,7 +9,7 @@ export class ContentQueryDto extends PaginationDto {
 
   @IsOptional()
   @IsString()
-  @IsIn(['active', 'archived', 'draft'])
+  @IsIn(['active', 'archived', 'draft', 'flagged', 'rejected'])
   status?: string;
 
   @IsOptional()

--- a/middleware/src/modules/content/dto/flag-content.dto.ts
+++ b/middleware/src/modules/content/dto/flag-content.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class FlagContentDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  reason?: string;
+}

--- a/middleware/src/modules/content/dto/review-content.dto.ts
+++ b/middleware/src/modules/content/dto/review-content.dto.ts
@@ -1,0 +1,12 @@
+import { IsIn, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class ReviewContentDto {
+  @IsString()
+  @IsIn(['approve', 'reject'])
+  action: 'approve' | 'reject';
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  reason?: string;
+}

--- a/middleware/src/modules/content/rss-parser.spec.ts
+++ b/middleware/src/modules/content/rss-parser.spec.ts
@@ -1,0 +1,128 @@
+import { parseRssFeed, extractFeedTitle } from './rss-parser';
+
+describe('RSS Parser', () => {
+  const rss2Feed = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Tech News Daily</title>
+    <link>https://example.com</link>
+    <description>Latest tech news</description>
+    <item>
+      <title>Breaking: New Framework Released</title>
+      <link>https://example.com/article/1</link>
+      <description>A revolutionary new framework has been released today.</description>
+      <pubDate>Mon, 18 Mar 2026 10:00:00 GMT</pubDate>
+      <enclosure url="https://example.com/images/framework.jpg" type="image/jpeg" />
+    </item>
+    <item>
+      <title>AI Advances in 2026</title>
+      <link>https://example.com/article/2</link>
+      <description><![CDATA[<p>Artificial intelligence continues to <strong>evolve</strong> rapidly.</p>]]></description>
+      <pubDate>Sun, 17 Mar 2026 08:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>Open Source Milestone</title>
+      <link>https://example.com/article/3</link>
+      <description>Open source projects hit a new milestone this quarter.</description>
+      <pubDate>Sat, 16 Mar 2026 14:30:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>`;
+
+  const atomFeed = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Atom Tech Blog</title>
+  <link href="https://blog.example.com" />
+  <entry>
+    <title>First Atom Entry</title>
+    <link href="https://blog.example.com/entry/1" />
+    <summary>This is the first atom entry summary.</summary>
+    <published>2026-03-18T12:00:00Z</published>
+  </entry>
+  <entry>
+    <title>Second Atom Entry</title>
+    <link href="https://blog.example.com/entry/2" />
+    <summary>Summary of the second entry.</summary>
+    <updated>2026-03-17T09:00:00Z</updated>
+  </entry>
+</feed>`;
+
+  describe('parseRssFeed', () => {
+    it('should parse RSS 2.0 items correctly', () => {
+      const items = parseRssFeed(rss2Feed, 10);
+      expect(items).toHaveLength(3);
+      expect(items[0]).toEqual({
+        title: 'Breaking: New Framework Released',
+        link: 'https://example.com/article/1',
+        description: 'A revolutionary new framework has been released today.',
+        pubDate: 'Mon, 18 Mar 2026 10:00:00 GMT',
+        imageUrl: 'https://example.com/images/framework.jpg',
+      });
+    });
+
+    it('should strip HTML from CDATA descriptions', () => {
+      const items = parseRssFeed(rss2Feed, 10);
+      expect(items[1].description).toBe(
+        'Artificial intelligence continues to evolve rapidly.',
+      );
+    });
+
+    it('should respect the limit parameter', () => {
+      const items = parseRssFeed(rss2Feed, 2);
+      expect(items).toHaveLength(2);
+    });
+
+    it('should parse Atom feed entries', () => {
+      const items = parseRssFeed(atomFeed, 10);
+      expect(items).toHaveLength(2);
+      expect(items[0]).toEqual({
+        title: 'First Atom Entry',
+        link: 'https://blog.example.com/entry/1',
+        description: 'This is the first atom entry summary.',
+        pubDate: '2026-03-18T12:00:00Z',
+        imageUrl: null,
+      });
+    });
+
+    it('should use updated date when published is missing in Atom', () => {
+      const items = parseRssFeed(atomFeed, 10);
+      expect(items[1].pubDate).toBe('2026-03-17T09:00:00Z');
+    });
+
+    it('should return empty array for invalid XML', () => {
+      const items = parseRssFeed('not xml at all', 10);
+      expect(items).toEqual([]);
+    });
+
+    it('should return empty array for empty input', () => {
+      const items = parseRssFeed('', 10);
+      expect(items).toEqual([]);
+    });
+
+    it('should extract media:content images', () => {
+      const feedWithMedia = `<rss><channel><item>
+        <title>Media Test</title>
+        <description>Has media</description>
+        <media:content url="https://example.com/media.jpg" medium="image" />
+      </item></channel></rss>`;
+      const items = parseRssFeed(feedWithMedia, 10);
+      expect(items[0].imageUrl).toBe('https://example.com/media.jpg');
+    });
+  });
+
+  describe('extractFeedTitle', () => {
+    it('should extract RSS 2.0 channel title', () => {
+      expect(extractFeedTitle(rss2Feed)).toBe('Tech News Daily');
+    });
+
+    it('should extract Atom feed title', () => {
+      expect(extractFeedTitle(atomFeed)).toBe('Atom Tech Blog');
+    });
+
+    it('should return "Untitled Feed" for missing title', () => {
+      expect(extractFeedTitle('<rss><channel></channel></rss>')).toBe(
+        'Untitled Feed',
+      );
+    });
+  });
+});

--- a/middleware/src/modules/content/rss-parser.ts
+++ b/middleware/src/modules/content/rss-parser.ts
@@ -1,0 +1,165 @@
+/**
+ * Lightweight RSS 2.0 and Atom feed parser using regex.
+ * No external dependencies.
+ */
+
+export interface RssFeedItem {
+  title: string;
+  link: string;
+  description: string;
+  pubDate: string | null;
+  imageUrl: string | null;
+}
+
+/**
+ * Extract text content between XML tags.
+ * Handles CDATA sections.
+ */
+function extractTag(xml: string, tagName: string): string {
+  // Try with CDATA first
+  const cdataRegex = new RegExp(
+    `<${tagName}[^>]*>\\s*<!\\[CDATA\\[([\\s\\S]*?)\\]\\]>\\s*</${tagName}>`,
+    'i',
+  );
+  const cdataMatch = xml.match(cdataRegex);
+  if (cdataMatch) return cdataMatch[1].trim();
+
+  // Plain text content
+  const regex = new RegExp(`<${tagName}[^>]*>([\\s\\S]*?)</${tagName}>`, 'i');
+  const match = xml.match(regex);
+  if (match) return match[1].trim();
+
+  return '';
+}
+
+/**
+ * Extract an attribute value from a self-closing or opening tag.
+ */
+function extractAttr(xml: string, tagName: string, attrName: string): string {
+  const regex = new RegExp(`<${tagName}[^>]*\\s${attrName}=["']([^"']*)["']`, 'i');
+  const match = xml.match(regex);
+  return match ? match[1].trim() : '';
+}
+
+/**
+ * Strip HTML tags from a string (for summaries).
+ */
+function stripHtml(html: string): string {
+  return html
+    .replace(/<[^>]+>/g, '')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+    .trim();
+}
+
+/**
+ * Try to extract an image URL from content.
+ * Checks enclosure, media:content, media:thumbnail, and img tags in description.
+ */
+function extractImage(itemXml: string): string | null {
+  // RSS enclosure
+  const encUrl = extractAttr(itemXml, 'enclosure', 'url');
+  if (encUrl && /\.(jpg|jpeg|png|gif|webp|svg)/i.test(encUrl)) return encUrl;
+
+  // media:content or media:thumbnail
+  const mediaUrl =
+    extractAttr(itemXml, 'media:content', 'url') ||
+    extractAttr(itemXml, 'media:thumbnail', 'url');
+  if (mediaUrl) return mediaUrl;
+
+  // img tag in description/content
+  const imgMatch = itemXml.match(/<img[^>]+src=["']([^"']+)["']/i);
+  if (imgMatch) return imgMatch[1];
+
+  return null;
+}
+
+/**
+ * Detect whether the feed is Atom format.
+ */
+function isAtomFeed(xml: string): boolean {
+  return /<feed[\s>]/i.test(xml) && /<entry[\s>]/i.test(xml);
+}
+
+/**
+ * Parse RSS 2.0 items from XML.
+ */
+function parseRssItems(xml: string, limit: number): RssFeedItem[] {
+  const items: RssFeedItem[] = [];
+  const itemRegex = /<item[\s>]([\s\S]*?)<\/item>/gi;
+  let match: RegExpExecArray | null;
+
+  while ((match = itemRegex.exec(xml)) !== null && items.length < limit) {
+    const itemXml = match[1];
+    const title = stripHtml(extractTag(itemXml, 'title'));
+    const link = extractTag(itemXml, 'link') || '';
+    const description = stripHtml(
+      extractTag(itemXml, 'description') || extractTag(itemXml, 'content:encoded'),
+    );
+    const pubDate = extractTag(itemXml, 'pubDate') || null;
+    const imageUrl = extractImage(itemXml);
+
+    if (title || description) {
+      items.push({ title, link, description, pubDate, imageUrl });
+    }
+  }
+
+  return items;
+}
+
+/**
+ * Parse Atom entries from XML.
+ */
+function parseAtomEntries(xml: string, limit: number): RssFeedItem[] {
+  const items: RssFeedItem[] = [];
+  const entryRegex = /<entry[\s>]([\s\S]*?)<\/entry>/gi;
+  let match: RegExpExecArray | null;
+
+  while ((match = entryRegex.exec(xml)) !== null && items.length < limit) {
+    const entryXml = match[1];
+    const title = stripHtml(extractTag(entryXml, 'title'));
+    const link = extractAttr(entryXml, 'link', 'href') || extractTag(entryXml, 'link');
+    const description = stripHtml(
+      extractTag(entryXml, 'summary') || extractTag(entryXml, 'content'),
+    );
+    const pubDate =
+      extractTag(entryXml, 'published') || extractTag(entryXml, 'updated') || null;
+    const imageUrl = extractImage(entryXml);
+
+    if (title || description) {
+      items.push({ title, link, description, pubDate, imageUrl });
+    }
+  }
+
+  return items;
+}
+
+/**
+ * Parse an RSS 2.0 or Atom feed XML string and return items.
+ */
+export function parseRssFeed(xml: string, limit: number = 10): RssFeedItem[] {
+  if (isAtomFeed(xml)) {
+    return parseAtomEntries(xml, limit);
+  }
+  return parseRssItems(xml, limit);
+}
+
+/**
+ * Extract the feed-level title from RSS or Atom XML.
+ */
+export function extractFeedTitle(xml: string): string {
+  if (isAtomFeed(xml)) {
+    // For Atom, the feed title is a direct child of <feed>
+    // Extract before the first <entry> to avoid grabbing an entry title
+    const feedHeader = xml.split(/<entry[\s>]/i)[0] || xml;
+    return stripHtml(extractTag(feedHeader, 'title')) || 'Untitled Feed';
+  }
+
+  // For RSS 2.0, the channel title is before the first <item>
+  const channelHeader = xml.split(/<item[\s>]/i)[0] || xml;
+  return stripHtml(extractTag(channelHeader, 'title')) || 'Untitled Feed';
+}

--- a/middleware/src/modules/content/rss-parser.ts
+++ b/middleware/src/modules/content/rss-parser.ts
@@ -1,6 +1,8 @@
 /**
  * Lightweight RSS 2.0 and Atom feed parser using regex.
  * No external dependencies.
+ *
+ * Note: regex parsing is safe because input is size-limited to 2MB (enforced by controller)
  */
 
 export interface RssFeedItem {

--- a/web/src/app/dashboard/content/page-client.tsx
+++ b/web/src/app/dashboard/content/page-client.tsx
@@ -70,6 +70,12 @@ export default function ContentClient() {
  const [showTagFilter, setShowTagFilter] = useState(false);
  const [realtimeStatus, setRealtimeStatus] = useState<'connected' | 'reconnecting' | 'offline'>('offline');
 
+ // Moderation state
+ const [isFlagModalOpen, setIsFlagModalOpen] = useState(false);
+ const [isReviewModalOpen, setIsReviewModalOpen] = useState(false);
+ const [flagReason, setFlagReason] = useState('');
+ const [reviewReason, setReviewReason] = useState('');
+
  // Folder state
  const [folders, setFolders] = useState<ContentFolder[]>([]);
  const [selectedFolderId, setSelectedFolderId] = useState<string | null>(null);
@@ -567,6 +573,53 @@ export default function ContentClient() {
  }
  };
 
+ // Moderation handlers
+ const handleFlag = (item: Content) => {
+ setSelectedContent(item);
+ setFlagReason('');
+ setIsFlagModalOpen(true);
+ };
+
+ const confirmFlag = async () => {
+ if (!selectedContent) return;
+ try {
+ setActionLoading(true);
+ await apiClient.flagContent(selectedContent.id, flagReason || undefined);
+ toast.success('Content flagged for review');
+ setIsFlagModalOpen(false);
+ setSelectedContent(null);
+ setFlagReason('');
+ loadContent();
+ } catch (error: any) {
+ toast.error(error.message || 'Failed to flag content');
+ } finally {
+ setActionLoading(false);
+ }
+ };
+
+ const handleReview = (item: Content) => {
+ setSelectedContent(item);
+ setReviewReason('');
+ setIsReviewModalOpen(true);
+ };
+
+ const confirmReview = async (action: 'approve' | 'reject') => {
+ if (!selectedContent) return;
+ try {
+ setActionLoading(true);
+ await apiClient.reviewContent(selectedContent.id, action, reviewReason || undefined);
+ toast.success(action === 'approve' ? 'Content approved' : 'Content rejected and removed from playlists');
+ setIsReviewModalOpen(false);
+ setSelectedContent(null);
+ setReviewReason('');
+ loadContent();
+ } catch (error: any) {
+ toast.error(error.message || `Failed to ${action} content`);
+ } finally {
+ setActionLoading(false);
+ }
+ };
+
  // Bulk selection handlers
  const toggleSelectItem = (id: string) => {
  const newSelected = new Set(selectedItems);
@@ -631,6 +684,10 @@ export default function ContentClient() {
  return 'eh-badge-warning';
  case 'error':
  return 'eh-badge-danger';
+ case 'flagged':
+ return 'bg-amber-500/20 text-amber-400 border border-amber-500/30';
+ case 'rejected':
+ return 'bg-red-500/20 text-red-400 border border-red-500/30';
  case 'archived':
  return 'eh-badge-muted';
  default:
@@ -862,6 +919,7 @@ export default function ContentClient() {
  <option value="ready">Ready</option>
  <option value="processing">Processing</option>
  <option value="error">Error</option>
+ <option value="flagged">Flagged</option>
  </select>
  </div>
  <div>
@@ -1019,6 +1077,23 @@ export default function ContentClient() {
  </td>
  <td className="eh-td text-right text-sm font-medium">
  <div className="flex justify-end gap-2">
+ {item.status === 'flagged' ? (
+ <button
+ onClick={() => handleReview(item)}
+ className="eh-icon-btn text-amber-400"
+ title="Review flagged content"
+ >
+ <Icon name="shield" size="md" />
+ </button>
+ ) : item.status !== 'archived' && item.status !== 'rejected' ? (
+ <button
+ onClick={() => handleFlag(item)}
+ className="eh-icon-btn"
+ title="Flag for review"
+ >
+ <Icon name="warning" size="md" />
+ </button>
+ ) : null}
  <button
  onClick={() => handlePushToDevice(item)}
  className="eh-icon-btn"
@@ -1110,6 +1185,25 @@ export default function ContentClient() {
  </div>
  )}
  <div className="grid grid-cols-2 gap-3">
+ {item.status === 'flagged' ? (
+ <button
+ onClick={() => handleReview(item)}
+ className="eh-icon-btn text-sm py-2 rounded-lg font-medium flex items-center justify-center gap-1 text-amber-400 col-span-2"
+ >
+ <Icon name="shield" size="sm" />
+ Review
+ </button>
+ ) : item.status !== 'archived' && item.status !== 'rejected' ? (
+ <button
+ onClick={() => handleFlag(item)}
+ className="eh-icon-btn text-sm py-2 rounded-lg font-medium flex items-center justify-center gap-1"
+ >
+ <Icon name="warning" size="sm" />
+ Flag
+ </button>
+ ) : (
+ <div />
+ )}
  <button
  onClick={() => handlePushToDevice(item)}
  className="eh-icon-btn text-sm py-2 rounded-lg font-medium flex items-center justify-center gap-1"
@@ -1694,6 +1788,124 @@ export default function ContentClient() {
  >
  {actionLoading && <LoadingSpinner size="sm" />}
  Create Folder
+ </button>
+ </div>
+ </div>
+ </Modal>
+
+ {/* Flag Content Modal */}
+ <Modal
+ isOpen={isFlagModalOpen}
+ onClose={() => {
+ setIsFlagModalOpen(false);
+ setFlagReason('');
+ }}
+ title="Flag Content for Review"
+ >
+ <div className="space-y-4">
+ <p className="text-[var(--foreground-secondary)]">
+ Flag <strong>{selectedContent?.title}</strong> for review by an admin.
+ </p>
+ <div>
+ <label className="block text-sm font-medium text-[var(--foreground-secondary)] mb-2">
+ Reason (optional)
+ </label>
+ <textarea
+ value={flagReason}
+ onChange={(e) => setFlagReason(e.target.value)}
+ className="w-full px-4 py-2 border border-[var(--border)] rounded-lg focus:ring-2 focus:ring-[#00E5A0] focus:border-transparent text-[var(--foreground)] bg-[var(--surface)]"
+ placeholder="Why are you flagging this content?"
+ rows={3}
+ maxLength={500}
+ />
+ </div>
+ <div className="flex justify-end gap-3 pt-4">
+ <button
+ onClick={() => {
+ setIsFlagModalOpen(false);
+ setFlagReason('');
+ }}
+ className="px-4 py-2 text-sm font-medium text-[var(--foreground-secondary)] bg-[var(--surface)] border border-[var(--border)] rounded-lg hover:bg-[var(--surface-hover)] transition"
+ >
+ Cancel
+ </button>
+ <button
+ onClick={confirmFlag}
+ disabled={actionLoading}
+ className="px-4 py-2 text-sm font-medium text-white bg-amber-600 rounded-lg hover:bg-amber-700 transition disabled:opacity-50 flex items-center gap-2"
+ >
+ {actionLoading && <LoadingSpinner size="sm" />}
+ <Icon name="warning" size="md" className="text-white" />
+ Flag for Review
+ </button>
+ </div>
+ </div>
+ </Modal>
+
+ {/* Review Flagged Content Modal */}
+ <Modal
+ isOpen={isReviewModalOpen}
+ onClose={() => {
+ setIsReviewModalOpen(false);
+ setReviewReason('');
+ }}
+ title="Review Flagged Content"
+ >
+ <div className="space-y-4">
+ <div className="p-3 bg-amber-500/10 border border-amber-500/20 rounded-lg">
+ <p className="text-amber-400 text-sm font-medium flex items-center gap-2">
+ <Icon name="warning" size="md" />
+ This content has been flagged for review
+ </p>
+ {selectedContent?.metadata?.moderation?.flagReason && (
+ <p className="text-sm text-[var(--foreground-secondary)] mt-2">
+ Reason: {selectedContent.metadata.moderation.flagReason}
+ </p>
+ )}
+ </div>
+ <p className="text-[var(--foreground-secondary)]">
+ Reviewing: <strong>{selectedContent?.title}</strong>
+ </p>
+ <div>
+ <label className="block text-sm font-medium text-[var(--foreground-secondary)] mb-2">
+ Review note (optional)
+ </label>
+ <textarea
+ value={reviewReason}
+ onChange={(e) => setReviewReason(e.target.value)}
+ className="w-full px-4 py-2 border border-[var(--border)] rounded-lg focus:ring-2 focus:ring-[#00E5A0] focus:border-transparent text-[var(--foreground)] bg-[var(--surface)]"
+ placeholder="Add a note for the review decision..."
+ rows={3}
+ maxLength={500}
+ />
+ </div>
+ <div className="flex justify-end gap-3 pt-4">
+ <button
+ onClick={() => {
+ setIsReviewModalOpen(false);
+ setReviewReason('');
+ }}
+ className="px-4 py-2 text-sm font-medium text-[var(--foreground-secondary)] bg-[var(--surface)] border border-[var(--border)] rounded-lg hover:bg-[var(--surface-hover)] transition"
+ >
+ Cancel
+ </button>
+ <button
+ onClick={() => confirmReview('reject')}
+ disabled={actionLoading}
+ className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 transition disabled:opacity-50 flex items-center gap-2"
+ >
+ {actionLoading && <LoadingSpinner size="sm" />}
+ <Icon name="close" size="md" className="text-white" />
+ Reject
+ </button>
+ <button
+ onClick={() => confirmReview('approve')}
+ disabled={actionLoading}
+ className="px-4 py-2 text-sm font-medium text-white bg-green-600 rounded-lg hover:bg-green-700 transition disabled:opacity-50 flex items-center gap-2"
+ >
+ {actionLoading && <LoadingSpinner size="sm" />}
+ <Icon name="check" size="md" className="text-white" />
+ Approve
  </button>
  </div>
  </div>

--- a/web/src/app/dashboard/content/page-client.tsx
+++ b/web/src/app/dashboard/content/page-client.tsx
@@ -21,6 +21,17 @@ import { contentUploadSchema, validateForm } from '@/lib/validation';
 import { Icon } from '@/theme/icons';
 import type { IconName } from '@/theme/icons';
 
+interface ModerationMetadata {
+  flaggedBy?: string;
+  flaggedAt?: string;
+  flagReason?: string;
+  previousStatus?: string;
+  reviewedBy?: string;
+  reviewedAt?: string;
+  reviewAction?: string;
+  reviewNote?: string;
+}
+
 export default function ContentClient() {
  const toast = useToast();
  const [content, setContent] = useState<Content[]>([]);
@@ -1564,7 +1575,7 @@ export default function ContentClient() {
  >
  <div className="space-y-4">
  <p className="text-[var(--foreground-secondary)]">
- Push "{selectedContent?.title}" directly to devices. The content will display for the specified duration, then the previous playlist will resume.
+ Push "{selectedContent?.title || 'Untitled'}" directly to devices. The content will display for the specified duration, then the previous playlist will resume.
  </p>
 
  {/* Duration Input */}
@@ -1679,7 +1690,7 @@ export default function ContentClient() {
  >
  <div className="space-y-4">
  <p className="text-[var(--foreground-secondary)]">
- Add "{selectedContent?.title}" to a playlist:
+ Add "{selectedContent?.title || 'Untitled'}" to a playlist:
  </p>
  <select
  value={selectedPlaylist}
@@ -1724,7 +1735,7 @@ export default function ContentClient() {
  onClose={() => setIsDeleteModalOpen(false)}
  onConfirm={confirmDelete}
  title="Delete Content"
- message={`Are you sure you want to delete "${selectedContent?.title}"? This action cannot be undone.`}
+ message={`Are you sure you want to delete "${selectedContent?.title || 'Untitled'}"? This action cannot be undone.`}
  confirmText="Delete"
  type="danger"
  />
@@ -1804,7 +1815,7 @@ export default function ContentClient() {
  >
  <div className="space-y-4">
  <p className="text-[var(--foreground-secondary)]">
- Flag <strong>{selectedContent?.title}</strong> for review by an admin.
+ Flag <strong>{selectedContent?.title || 'Untitled'}</strong> for review by an admin.
  </p>
  <div>
  <label className="block text-sm font-medium text-[var(--foreground-secondary)] mb-2">
@@ -1857,14 +1868,17 @@ export default function ContentClient() {
  <Icon name="warning" size="md" />
  This content has been flagged for review
  </p>
- {selectedContent?.metadata?.moderation?.flagReason && (
- <p className="text-sm text-[var(--foreground-secondary)] mt-2">
- Reason: {selectedContent.metadata.moderation.flagReason}
- </p>
- )}
+ {(() => {
+   const moderation = (selectedContent?.metadata as { moderation?: ModerationMetadata })?.moderation;
+   return moderation?.flagReason ? (
+     <p className="text-sm text-[var(--foreground-secondary)] mt-2">
+       Reason: {moderation.flagReason}
+     </p>
+   ) : null;
+ })()}
  </div>
  <p className="text-[var(--foreground-secondary)]">
- Reviewing: <strong>{selectedContent?.title}</strong>
+ Reviewing: <strong>{selectedContent?.title || 'Untitled'}</strong>
  </p>
  <div>
  <label className="block text-sm font-medium text-[var(--foreground-secondary)] mb-2">

--- a/web/src/app/dashboard/widgets/page.tsx
+++ b/web/src/app/dashboard/widgets/page.tsx
@@ -8,6 +8,7 @@ import EmptyState from '@/components/EmptyState';
 import { useToast } from '@/lib/hooks/useToast';
 import { Icon } from '@/theme/icons';
 import WeatherWidget from '@/components/widgets/WeatherWidget';
+import ClockWidget from '@/components/widgets/ClockWidget';
 
 // Default widget type definitions used as fallback when API is unavailable
 const DEFAULT_WIDGET_TYPES = [
@@ -48,28 +49,18 @@ const DEFAULT_WIDGET_TYPES = [
   },
   {
     type: 'clock',
-    name: 'Clock',
-    description: 'Display a clock with customizable timezone and format options.',
+    name: 'Clock & Countdown',
+    description: 'Display current time or countdown to an event with customizable themes.',
     icon: 'clock',
     configSchema: {
-      timezone: { type: 'string', label: 'Timezone', placeholder: 'America/New_York', default: 'local' },
-      format: { type: 'select', label: 'Format', options: ['12h', '24h'], default: '12h' },
+      mode: { type: 'select', label: 'Mode', options: ['clock', 'countdown'], default: 'clock' },
+      format: { type: 'select', label: 'Time Format', options: ['12h', '24h'], default: '12h' },
       showDate: { type: 'boolean', label: 'Show Date', default: true },
-      showSeconds: { type: 'boolean', label: 'Show Seconds', default: false },
-    },
-  },
-  {
-    type: 'countdown',
-    name: 'Countdown',
-    description: 'Count down to a specific date and time for events or promotions.',
-    icon: 'clock',
-    configSchema: {
-      targetDate: { type: 'string', label: 'Target Date', placeholder: '2026-12-31T23:59:59', required: true },
-      title: { type: 'string', label: 'Event Title', placeholder: 'Grand Opening' },
-      showDays: { type: 'boolean', label: 'Show Days', default: true },
-      showHours: { type: 'boolean', label: 'Show Hours', default: true },
-      showMinutes: { type: 'boolean', label: 'Show Minutes', default: true },
       showSeconds: { type: 'boolean', label: 'Show Seconds', default: true },
+      timezone: { type: 'string', label: 'Timezone', placeholder: 'e.g. America/New_York or "local"', default: 'local' },
+      targetDate: { type: 'string', label: 'Countdown Target', placeholder: 'YYYY-MM-DD HH:MM (for countdown mode)' },
+      eventName: { type: 'string', label: 'Event Name', placeholder: 'e.g. Grand Opening' },
+      theme: { type: 'select', label: 'Theme', options: ['dark', 'light', 'auto'], default: 'dark' },
     },
   },
 ];
@@ -144,7 +135,6 @@ export default function WidgetsPage() {
       rss: 'list',
       'social-media': 'link',
       clock: 'clock',
-      countdown: 'clock',
     };
     return (mapping[type] || 'content') as any;
   };
@@ -155,7 +145,6 @@ export default function WidgetsPage() {
       rss: 'from-orange-400 to-orange-600',
       'social-media': 'from-pink-400 to-pink-600',
       clock: 'from-purple-400 to-purple-600',
-      countdown: 'from-red-400 to-red-600',
     };
     return mapping[type] || 'from-[#00E5A0] to-[#00B4D8]';
   };
@@ -338,9 +327,10 @@ export default function WidgetsPage() {
       case 'social-media':
         return config.handle ? `${config.platform || 'social'}: ${config.handle}` : 'Not configured';
       case 'clock':
+        if (config.mode === 'countdown') {
+          return config.eventName || config.targetDate || 'Countdown - not configured';
+        }
         return `${config.timezone || 'Local'} - ${config.format || '12h'}`;
-      case 'countdown':
-        return config.title || config.targetDate || 'Not configured';
       default:
         return 'Configured';
     }
@@ -604,6 +594,25 @@ export default function WidgetsPage() {
                   theme={(widgetConfig.theme as 'dark' | 'light' | 'auto') || 'dark'}
                   refreshInterval={0}
                   showForecast={widgetConfig.showForecast !== false}
+                  compact
+                />
+              </div>
+            ) : selectedType.type === 'clock' ? (
+              <div className="bg-[var(--background)] rounded-lg border border-[var(--border)] overflow-hidden p-4">
+                <h4 className="font-semibold text-[var(--foreground)] mb-1">{widgetName || 'Untitled Widget'}</h4>
+                <p className="text-xs text-[var(--foreground-tertiary)] uppercase mb-3">{selectedType.name}</p>
+                {widgetDescription && (
+                  <p className="text-sm text-[var(--foreground-secondary)] mb-3">{widgetDescription}</p>
+                )}
+                <ClockWidget
+                  mode={(widgetConfig.mode as 'clock' | 'countdown') || 'clock'}
+                  format={(widgetConfig.format as '12h' | '24h') || '12h'}
+                  showDate={widgetConfig.showDate !== false}
+                  showSeconds={widgetConfig.showSeconds !== false}
+                  timezone={widgetConfig.timezone || 'local'}
+                  targetDate={widgetConfig.targetDate || ''}
+                  eventName={widgetConfig.eventName || ''}
+                  theme={(widgetConfig.theme as 'dark' | 'light' | 'auto') || 'dark'}
                   compact
                 />
               </div>

--- a/web/src/app/dashboard/widgets/page.tsx
+++ b/web/src/app/dashboard/widgets/page.tsx
@@ -9,6 +9,7 @@ import { useToast } from '@/lib/hooks/useToast';
 import { Icon } from '@/theme/icons';
 import WeatherWidget from '@/components/widgets/WeatherWidget';
 import ClockWidget from '@/components/widgets/ClockWidget';
+import RssWidget from '@/components/widgets/RssWidget';
 
 // Default widget type definitions used as fallback when API is unavailable
 const DEFAULT_WIDGET_TYPES = [
@@ -27,13 +28,17 @@ const DEFAULT_WIDGET_TYPES = [
   },
   {
     type: 'rss',
-    name: 'RSS Feed',
-    description: 'Show live news or blog updates from any RSS feed source.',
+    name: 'News & RSS Feed',
+    description: 'Display headlines from any RSS or Atom feed source.',
     icon: 'list',
     configSchema: {
       feedUrl: { type: 'string', label: 'Feed URL', placeholder: 'https://example.com/rss', required: true },
-      maxItems: { type: 'number', label: 'Max Items', default: 5, min: 1, max: 20 },
+      maxItems: { type: 'number', label: 'Max Items', default: 10, min: 1, max: 50 },
       showImages: { type: 'boolean', label: 'Show Images', default: true },
+      showSummary: { type: 'boolean', label: 'Show Summary', default: true },
+      scrollSpeed: { type: 'select', label: 'Auto-Scroll', options: ['none', 'slow', 'medium', 'fast'], default: 'slow' },
+      refreshInterval: { type: 'select', label: 'Refresh (min)', options: ['5', '15', '30', '60'], default: '15' },
+      theme: { type: 'select', label: 'Theme', options: ['dark', 'light', 'auto'], default: 'dark' },
     },
   },
   {
@@ -594,6 +599,24 @@ export default function WidgetsPage() {
                   theme={(widgetConfig.theme as 'dark' | 'light' | 'auto') || 'dark'}
                   refreshInterval={0}
                   showForecast={widgetConfig.showForecast !== false}
+                  compact
+                />
+              </div>
+            ) : selectedType.type === 'rss' ? (
+              <div className="bg-[var(--background)] rounded-lg border border-[var(--border)] overflow-hidden p-4">
+                <h4 className="font-semibold text-[var(--foreground)] mb-1">{widgetName || 'Untitled Widget'}</h4>
+                <p className="text-xs text-[var(--foreground-tertiary)] uppercase mb-3">{selectedType.name}</p>
+                {widgetDescription && (
+                  <p className="text-sm text-[var(--foreground-secondary)] mb-3">{widgetDescription}</p>
+                )}
+                <RssWidget
+                  feedUrl={widgetConfig.feedUrl || ''}
+                  maxItems={parseInt(widgetConfig.maxItems) || 10}
+                  showImages={widgetConfig.showImages !== false}
+                  showSummary={widgetConfig.showSummary !== false}
+                  scrollSpeed={(widgetConfig.scrollSpeed as 'slow' | 'medium' | 'fast' | 'none') || 'none'}
+                  refreshInterval={0}
+                  theme={(widgetConfig.theme as 'dark' | 'light' | 'auto') || 'dark'}
                   compact
                 />
               </div>

--- a/web/src/app/refund/page.tsx
+++ b/web/src/app/refund/page.tsx
@@ -1,0 +1,141 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Return & Refund Policy — Vizora',
+  description: 'Return and refund policy for the Vizora digital signage platform.',
+};
+
+export default function RefundPolicyPage() {
+  return (
+    <div className="min-h-screen bg-[var(--background)]">
+      {/* Header */}
+      <header className="border-b border-[var(--border)]/30 bg-[var(--surface)]/80 backdrop-blur-sm">
+        <div className="max-w-3xl mx-auto px-6 py-4 flex items-center justify-between">
+          <Link href="/" className="text-lg font-semibold text-[var(--foreground)] hover:text-[var(--primary)] transition-colors">
+            Vizora
+          </Link>
+          <nav className="flex items-center gap-4 text-sm text-[var(--foreground-secondary)]">
+            <Link href="/terms" className="hover:text-[var(--foreground)] transition-colors">Terms</Link>
+            <Link href="/privacy" className="hover:text-[var(--foreground)] transition-colors">Privacy</Link>
+            <Link href="/login" className="hover:text-[var(--foreground)] transition-colors">Sign In</Link>
+          </nav>
+        </div>
+      </header>
+
+      {/* Content */}
+      <main className="max-w-3xl mx-auto px-6 py-12">
+        <h1 className="text-3xl font-bold text-[var(--foreground)] mb-2">Return &amp; Refund Policy</h1>
+        <p className="text-sm text-[var(--foreground-tertiary)] mb-10">Last updated: March 20, 2026</p>
+
+        <div className="space-y-8 text-[var(--foreground-secondary)] leading-relaxed">
+          <section>
+            <h2 className="text-xl font-semibold text-[var(--foreground)] mb-3">1. Free Trial</h2>
+            <p>
+              Vizora offers a 30-day free trial for all new accounts. No credit card is required to start your trial.
+              You may cancel at any time during the trial period with no charges. At the end of the trial, your account
+              will be downgraded to the free tier unless you choose a paid plan.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-[var(--foreground)] mb-3">2. Subscription Cancellation</h2>
+            <p className="mb-3">
+              You may cancel your paid subscription at any time from your account Settings page. Upon cancellation:
+            </p>
+            <ul className="list-disc pl-6 space-y-1">
+              <li>You will retain access to paid features until the end of your current billing period</li>
+              <li>No partial refunds are issued for the remaining time in a billing period</li>
+              <li>Your account will revert to the free tier at the end of the billing period</li>
+              <li>Your data will be retained for 30 days after downgrade, then permanently deleted</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-[var(--foreground)] mb-3">3. Refund Eligibility</h2>
+            <p className="mb-3">
+              We want you to be satisfied with Vizora. If the service does not meet your expectations, you may request a
+              full refund within 14 days of your first paid subscription payment. This 14-day refund window applies only to
+              your initial subscription purchase.
+            </p>
+            <p>
+              To be eligible for a refund, you must contact us within the 14-day period at{' '}
+              <a href="mailto:support@vizora.cloud" className="text-[var(--primary)] hover:underline">
+                support@vizora.cloud
+              </a>.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-[var(--foreground)] mb-3">4. Non-Refundable Items</h2>
+            <p className="mb-3">The following are not eligible for refunds:</p>
+            <ul className="list-disc pl-6 space-y-1">
+              <li>Add-on services that have already been consumed or activated</li>
+              <li>Custom development or professional services work</li>
+              <li>One-time setup or onboarding fees (if applicable)</li>
+              <li>Subscription renewals beyond the initial 14-day refund window</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-[var(--foreground)] mb-3">5. How to Request a Refund</h2>
+            <p className="mb-3">To request a refund, send an email to{' '}
+              <a href="mailto:support@vizora.cloud" className="text-[var(--primary)] hover:underline">
+                support@vizora.cloud
+              </a>{' '}
+              with the following information:
+            </p>
+            <ul className="list-disc pl-6 space-y-1">
+              <li>The email address associated with your Vizora account</li>
+              <li>The reason for your refund request</li>
+              <li>Any relevant details that may help us improve our service</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-[var(--foreground)] mb-3">6. Processing Time</h2>
+            <p>
+              Approved refunds are processed within 5&ndash;10 business days. Refunds are issued to the original payment
+              method. Depending on your bank or payment provider, it may take additional time for the refund to appear on
+              your statement.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-[var(--foreground)] mb-3">7. Changes to This Policy</h2>
+            <p>
+              We may update this Return &amp; Refund Policy from time to time. We will notify you of significant changes via
+              email or through the platform. Continued use after changes constitutes acceptance.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-[var(--foreground)] mb-3">8. Contact</h2>
+            <p>
+              For refund questions or requests, contact us at{' '}
+              <a href="mailto:support@vizora.cloud" className="text-[var(--primary)] hover:underline">
+                support@vizora.cloud
+              </a>
+            </p>
+          </section>
+        </div>
+      </main>
+
+      {/* Footer */}
+      <footer className="border-t border-[var(--border)]/30 py-6 text-center text-xs text-[var(--foreground-tertiary)]">
+        <div className="flex items-center justify-center gap-3">
+          <Link href="/terms" className="hover:text-[var(--foreground-secondary)] transition-colors">Terms of Service</Link>
+          <span className="text-[var(--border)]">|</span>
+          <Link href="/privacy" className="hover:text-[var(--foreground-secondary)] transition-colors">Privacy Policy</Link>
+          <span className="text-[var(--border)]">|</span>
+          <Link href="/sla" className="hover:text-[var(--foreground-secondary)] transition-colors">SLA</Link>
+          <span className="text-[var(--border)]">|</span>
+          <Link href="/refund" className="text-[var(--foreground-secondary)]">Refund Policy</Link>
+          <span className="text-[var(--border)]">|</span>
+          <a href="mailto:support@vizora.cloud" className="hover:text-[var(--foreground-secondary)] transition-colors">Support</a>
+        </div>
+        <p className="mt-2">&copy; {new Date().getFullYear()} Triveni Digital. All rights reserved.</p>
+      </footer>
+    </div>
+  );
+}

--- a/web/src/app/sla/page.tsx
+++ b/web/src/app/sla/page.tsx
@@ -1,0 +1,219 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Service Level Agreement — Vizora',
+  description: 'Service Level Agreement (SLA) for the Vizora digital signage platform.',
+};
+
+export default function SLAPage() {
+  return (
+    <div className="min-h-screen bg-[var(--background)]">
+      {/* Header */}
+      <header className="border-b border-[var(--border)]/30 bg-[var(--surface)]/80 backdrop-blur-sm">
+        <div className="max-w-3xl mx-auto px-6 py-4 flex items-center justify-between">
+          <Link href="/" className="text-lg font-semibold text-[var(--foreground)] hover:text-[var(--primary)] transition-colors">
+            Vizora
+          </Link>
+          <nav className="flex items-center gap-4 text-sm text-[var(--foreground-secondary)]">
+            <Link href="/terms" className="hover:text-[var(--foreground)] transition-colors">Terms</Link>
+            <Link href="/privacy" className="hover:text-[var(--foreground)] transition-colors">Privacy</Link>
+            <Link href="/login" className="hover:text-[var(--foreground)] transition-colors">Sign In</Link>
+          </nav>
+        </div>
+      </header>
+
+      {/* Content */}
+      <main className="max-w-3xl mx-auto px-6 py-12">
+        <h1 className="text-3xl font-bold text-[var(--foreground)] mb-2">Service Level Agreement</h1>
+        <p className="text-sm text-[var(--foreground-tertiary)] mb-10">Last updated: March 20, 2026</p>
+
+        <div className="space-y-8 text-[var(--foreground-secondary)] leading-relaxed">
+          <section>
+            <h2 className="text-xl font-semibold text-[var(--foreground)] mb-3">1. Uptime Commitment</h2>
+            <p>
+              Vizora commits to 99.9% uptime for customers on Pro and Enterprise plans, measured on a calendar month basis.
+              Uptime is calculated as the total minutes in the month minus downtime minutes, divided by total minutes in the
+              month. Scheduled maintenance windows are excluded from uptime calculations.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-[var(--foreground)] mb-3">2. Scheduled Maintenance</h2>
+            <p className="mb-3">
+              We perform scheduled maintenance to keep the platform secure and up to date. Maintenance windows are:
+            </p>
+            <ul className="list-disc pl-6 space-y-1">
+              <li>Announced at least 48 hours in advance via email and in-app notification</li>
+              <li>Performed during low-traffic windows, typically between 2:00 AM and 6:00 AM UTC</li>
+              <li>Kept as brief as possible to minimize disruption</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-[var(--foreground)] mb-3">3. Incident Response</h2>
+            <p className="mb-3">
+              We classify incidents by severity and respond accordingly:
+            </p>
+
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm border-collapse">
+                <thead>
+                  <tr className="border-b border-[var(--border)]/30">
+                    <th className="text-left py-2 pr-4 text-[var(--foreground)] font-semibold">Severity</th>
+                    <th className="text-left py-2 pr-4 text-[var(--foreground)] font-semibold">Description</th>
+                    <th className="text-left py-2 pr-4 text-[var(--foreground)] font-semibold">Response Time</th>
+                    <th className="text-left py-2 text-[var(--foreground)] font-semibold">Resolution Target</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr className="border-b border-[var(--border)]/20">
+                    <td className="py-2 pr-4 font-medium text-[var(--foreground)]">Critical</td>
+                    <td className="py-2 pr-4">Service completely down</td>
+                    <td className="py-2 pr-4">1 hour</td>
+                    <td className="py-2">4 hours</td>
+                  </tr>
+                  <tr className="border-b border-[var(--border)]/20">
+                    <td className="py-2 pr-4 font-medium text-[var(--foreground)]">High</td>
+                    <td className="py-2 pr-4">Service significantly degraded</td>
+                    <td className="py-2 pr-4">4 hours</td>
+                    <td className="py-2">24 hours</td>
+                  </tr>
+                  <tr className="border-b border-[var(--border)]/20">
+                    <td className="py-2 pr-4 font-medium text-[var(--foreground)]">Medium</td>
+                    <td className="py-2 pr-4">Minor feature impacted</td>
+                    <td className="py-2 pr-4">Next business day</td>
+                    <td className="py-2">3 business days</td>
+                  </tr>
+                  <tr>
+                    <td className="py-2 pr-4 font-medium text-[var(--foreground)]">Low</td>
+                    <td className="py-2 pr-4">Cosmetic or minor issue</td>
+                    <td className="py-2 pr-4">Next business day</td>
+                    <td className="py-2">5 business days</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-[var(--foreground)] mb-3">4. Service Credits</h2>
+            <p className="mb-3">
+              If monthly uptime falls below the 99.9% commitment, eligible customers receive service credits applied to
+              their next invoice:
+            </p>
+
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm border-collapse">
+                <thead>
+                  <tr className="border-b border-[var(--border)]/30">
+                    <th className="text-left py-2 pr-4 text-[var(--foreground)] font-semibold">Monthly Uptime</th>
+                    <th className="text-left py-2 text-[var(--foreground)] font-semibold">Service Credit</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr className="border-b border-[var(--border)]/20">
+                    <td className="py-2 pr-4">&lt; 99.9% but &ge; 99.5%</td>
+                    <td className="py-2">10% of monthly fee</td>
+                  </tr>
+                  <tr className="border-b border-[var(--border)]/20">
+                    <td className="py-2 pr-4">&lt; 99.5% but &ge; 99.0%</td>
+                    <td className="py-2">25% of monthly fee</td>
+                  </tr>
+                  <tr>
+                    <td className="py-2 pr-4">&lt; 99.0%</td>
+                    <td className="py-2">50% of monthly fee</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <p className="mt-3">
+              Service credits must be requested within 30 days of the affected month. Credits are capped at 50% of the
+              monthly subscription fee and are not redeemable for cash.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-[var(--foreground)] mb-3">5. Exclusions</h2>
+            <p className="mb-3">This SLA does not apply to downtime caused by:</p>
+            <ul className="list-disc pl-6 space-y-1">
+              <li>Force majeure events (natural disasters, war, government actions)</li>
+              <li>Issues caused by customer actions or configurations</li>
+              <li>Third-party service outages (cloud providers, DNS, CDN)</li>
+              <li>Scheduled maintenance windows announced in advance</li>
+              <li>Features or services labeled as &quot;beta&quot; or &quot;preview&quot;</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-[var(--foreground)] mb-3">6. Monitoring</h2>
+            <p>
+              We maintain real-time monitoring of all platform services via automated health endpoints and infrastructure
+              metrics. Customers on Pro and Enterprise plans have access to service status information through the dashboard.
+              A public status page is planned for a future release.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-[var(--foreground)] mb-3">7. Support Channels</h2>
+            <ul className="list-disc pl-6 space-y-1">
+              <li>
+                Email:{' '}
+                <a href="mailto:support@vizora.cloud" className="text-[var(--primary)] hover:underline">
+                  support@vizora.cloud
+                </a>
+              </li>
+              <li>In-app support chat (available on Pro and Enterprise plans)</li>
+              <li>Priority phone support (Enterprise plans only)</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-[var(--foreground)] mb-3">8. Plan Availability</h2>
+            <p>
+              This Service Level Agreement applies to customers on Pro and Enterprise plans. Free and Starter plans are
+              provided on a best-effort basis without uptime guarantees or service credits. Upgrading to a Pro or Enterprise
+              plan activates SLA coverage from the start of the next billing period.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-[var(--foreground)] mb-3">9. Changes to This SLA</h2>
+            <p>
+              We may update this Service Level Agreement from time to time. We will notify you of material changes at least
+              30 days in advance via email. Changes will not reduce the level of service commitment during an active billing
+              period.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-[var(--foreground)] mb-3">10. Contact</h2>
+            <p>
+              For SLA-related questions or to request service credits, contact us at{' '}
+              <a href="mailto:support@vizora.cloud" className="text-[var(--primary)] hover:underline">
+                support@vizora.cloud
+              </a>
+            </p>
+          </section>
+        </div>
+      </main>
+
+      {/* Footer */}
+      <footer className="border-t border-[var(--border)]/30 py-6 text-center text-xs text-[var(--foreground-tertiary)]">
+        <div className="flex items-center justify-center gap-3">
+          <Link href="/terms" className="hover:text-[var(--foreground-secondary)] transition-colors">Terms of Service</Link>
+          <span className="text-[var(--border)]">|</span>
+          <Link href="/privacy" className="hover:text-[var(--foreground-secondary)] transition-colors">Privacy Policy</Link>
+          <span className="text-[var(--border)]">|</span>
+          <Link href="/sla" className="text-[var(--foreground-secondary)]">SLA</Link>
+          <span className="text-[var(--border)]">|</span>
+          <Link href="/refund" className="hover:text-[var(--foreground-secondary)] transition-colors">Refund Policy</Link>
+          <span className="text-[var(--border)]">|</span>
+          <a href="mailto:support@vizora.cloud" className="hover:text-[var(--foreground-secondary)] transition-colors">Support</a>
+        </div>
+        <p className="mt-2">&copy; {new Date().getFullYear()} Triveni Digital. All rights reserved.</p>
+      </footer>
+    </div>
+  );
+}

--- a/web/src/components/landing/FooterSection.tsx
+++ b/web/src/components/landing/FooterSection.tsx
@@ -96,6 +96,8 @@ export default function FooterSection({ footerRef }: FooterSectionProps) {
               {[
                 { href: '/privacy', label: 'Privacy Policy' },
                 { href: '/terms', label: 'Terms of Service' },
+                { href: '/refund', label: 'Refund Policy' },
+                { href: '/sla', label: 'SLA' },
               ].map((l) => (
                 <li key={l.href}>
                   <Link href={l.href} className="text-sm transition-colors hover:text-[#F0ECE8]" style={{ color: '#6B655D' }}>

--- a/web/src/components/widgets/ClockWidget.tsx
+++ b/web/src/components/widgets/ClockWidget.tsx
@@ -1,0 +1,358 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export interface ClockWidgetProps {
+  /** Display mode: clock shows current time, countdown counts down to a target */
+  mode?: 'clock' | 'countdown';
+  /** Time format: 12-hour or 24-hour */
+  format?: '12h' | '24h';
+  /** Show the current date below the time (clock mode) */
+  showDate?: boolean;
+  /** Show seconds in the display */
+  showSeconds?: boolean;
+  /** IANA timezone (e.g. "America/New_York") or "local" for device timezone */
+  timezone?: string;
+  /** Target date/time for countdown mode (ISO 8601 or "YYYY-MM-DD HH:MM") */
+  targetDate?: string;
+  /** Event name displayed above countdown */
+  eventName?: string;
+  /** Visual theme */
+  theme?: 'dark' | 'light' | 'auto';
+  /** Compact mode for small containers / preview */
+  compact?: boolean;
+}
+
+/**
+ * ClockWidget — displays current time or countdown to an event.
+ *
+ * Fully client-side (no API calls). Uses Intl.DateTimeFormat for timezone support.
+ * All styles are inline so it renders correctly as standalone signage content.
+ */
+export default function ClockWidget({
+  mode = 'clock',
+  format = '12h',
+  showDate = true,
+  showSeconds = true,
+  timezone = 'local',
+  targetDate = '',
+  eventName = '',
+  theme = 'dark',
+  compact = false,
+}: ClockWidgetProps) {
+  const [now, setNow] = useState(() => new Date());
+
+  // Track system dark mode preference reactively (for theme='auto')
+  const [systemDark, setSystemDark] = useState(() => {
+    if (typeof window === 'undefined') return true;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (e: MediaQueryListEvent) => setSystemDark(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  // Tick every second
+  useEffect(() => {
+    const timer = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const isDark = theme === 'dark' || (theme === 'auto' && systemDark);
+
+  // Resolve timezone — "local" or empty means device timezone (undefined for Intl)
+  const tz = timezone && timezone !== 'local' ? timezone : undefined;
+
+  // Theme colors
+  const bg = isDark
+    ? 'linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%)'
+    : 'linear-gradient(135deg, #f0f0f8 0%, #dde4ee 50%, #c8d4e4 100%)';
+  const textColor = isDark ? '#ffffff' : '#1a1a2e';
+  const mutedColor = isDark ? 'rgba(255,255,255,0.55)' : 'rgba(26,26,46,0.55)';
+  const accentColor = isDark ? '#00E5A0' : '#0f3460';
+  const cardBg = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)';
+
+  const monoFont = "var(--font-mono, 'JetBrains Mono', 'Fira Code', 'Cascadia Code', 'Consolas', monospace)";
+
+  const containerStyle: React.CSSProperties = {
+    fontFamily: "'Segoe UI', Arial, sans-serif",
+    background: bg,
+    color: textColor,
+    padding: compact ? '16px' : '32px',
+    borderRadius: '16px',
+    width: '100%',
+    maxWidth: '480px',
+    margin: '0 auto',
+    boxSizing: 'border-box',
+    textAlign: 'center',
+  };
+
+  // ─── Clock Mode ───────────────────────────────────────────
+  if (mode === 'clock') {
+    return (
+      <div style={containerStyle} data-testid="clock-widget">
+        {renderClockDisplay()}
+      </div>
+    );
+  }
+
+  // ─── Countdown Mode ───────────────────────────────────────
+  return (
+    <div style={containerStyle} data-testid="clock-widget-countdown">
+      {renderCountdownDisplay()}
+    </div>
+  );
+
+  // ─── Clock Renderer ───────────────────────────────────────
+  function renderClockDisplay() {
+    const timeOptions: Intl.DateTimeFormatOptions = {
+      hour: 'numeric',
+      minute: '2-digit',
+      ...(showSeconds ? { second: '2-digit' } : {}),
+      hour12: format === '12h',
+      ...(tz ? { timeZone: tz } : {}),
+    };
+
+    const dateOptions: Intl.DateTimeFormatOptions = {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      ...(tz ? { timeZone: tz } : {}),
+    };
+
+    let timeStr: string;
+    let dateStr: string;
+    try {
+      timeStr = now.toLocaleTimeString('en-US', timeOptions);
+      dateStr = now.toLocaleDateString('en-US', dateOptions);
+    } catch {
+      // Fallback if invalid timezone
+      timeStr = now.toLocaleTimeString('en-US', { ...timeOptions, timeZone: undefined });
+      dateStr = now.toLocaleDateString('en-US', { ...dateOptions, timeZone: undefined });
+    }
+
+    // Split time into main part and period (AM/PM) for styling
+    const parts = timeStr.split(' ');
+    const timePart = parts[0];
+    const period = parts.length > 1 ? parts[1] : '';
+
+    return (
+      <>
+        {/* Timezone label */}
+        {tz && (
+          <div style={{
+            fontSize: compact ? '10px' : '12px',
+            textTransform: 'uppercase',
+            letterSpacing: '2px',
+            color: mutedColor,
+            marginBottom: '8px',
+          }}>
+            {tz.replace(/_/g, ' ')}
+          </div>
+        )}
+
+        {/* Time display */}
+        <div style={{
+          fontSize: compact ? '42px' : '64px',
+          fontFamily: monoFont,
+          fontWeight: 300,
+          lineHeight: 1.1,
+          letterSpacing: '-1px',
+          marginBottom: showDate ? '12px' : '0',
+        }}>
+          {timePart}
+          {period && (
+            <span style={{
+              fontSize: compact ? '16px' : '24px',
+              fontWeight: 400,
+              marginLeft: '6px',
+              color: accentColor,
+              verticalAlign: 'super',
+            }}>
+              {period}
+            </span>
+          )}
+        </div>
+
+        {/* Date display */}
+        {showDate && (
+          <div style={{
+            fontSize: compact ? '12px' : '16px',
+            color: mutedColor,
+            fontWeight: 400,
+          }}>
+            {dateStr}
+          </div>
+        )}
+      </>
+    );
+  }
+
+  // ─── Countdown Renderer ───────────────────────────────────
+  function renderCountdownDisplay() {
+    const target = parseTargetDate(targetDate);
+
+    if (!target) {
+      return (
+        <div style={{ padding: compact ? '16px 0' : '32px 0' }}>
+          <div style={{ fontSize: '28px', marginBottom: '8px' }}>&#9202;</div>
+          <div style={{ fontSize: '14px', color: mutedColor }}>
+            Set a target date to start the countdown
+          </div>
+        </div>
+      );
+    }
+
+    const diff = target.getTime() - now.getTime();
+    const finished = diff <= 0;
+
+    if (finished) {
+      return (
+        <>
+          {eventName && (
+            <div style={{
+              fontSize: compact ? '14px' : '18px',
+              color: accentColor,
+              fontWeight: 600,
+              marginBottom: '12px',
+              textTransform: 'uppercase',
+              letterSpacing: '1px',
+            }}>
+              {eventName}
+            </div>
+          )}
+          <div style={{
+            fontSize: compact ? '28px' : '42px',
+            fontWeight: 600,
+            color: accentColor,
+            marginBottom: '8px',
+          }}>
+            Event Started!
+          </div>
+          <div style={{ fontSize: '14px', color: mutedColor }}>
+            {target.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}
+          </div>
+        </>
+      );
+    }
+
+    const totalSeconds = Math.floor(diff / 1000);
+    const days = Math.floor(totalSeconds / 86400);
+    const hours = Math.floor((totalSeconds % 86400) / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    const units = [
+      { value: days, label: 'Days' },
+      { value: hours, label: 'Hours' },
+      { value: minutes, label: 'Minutes' },
+      { value: seconds, label: 'Seconds' },
+    ];
+
+    const digitSize = compact ? '32px' : '48px';
+    const labelSize = compact ? '9px' : '11px';
+    const separatorSize = compact ? '24px' : '36px';
+
+    return (
+      <>
+        {/* Event name */}
+        {eventName && (
+          <div style={{
+            fontSize: compact ? '12px' : '16px',
+            textTransform: 'uppercase',
+            letterSpacing: '2px',
+            color: accentColor,
+            fontWeight: 600,
+            marginBottom: compact ? '12px' : '20px',
+          }}>
+            {eventName}
+          </div>
+        )}
+
+        {/* Countdown digits */}
+        <div style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'flex-start',
+          gap: compact ? '6px' : '12px',
+        }}>
+          {units.map((unit, i) => (
+            <div key={unit.label} style={{ display: 'flex', alignItems: 'flex-start', gap: compact ? '6px' : '12px' }}>
+              <div style={{
+                background: cardBg,
+                borderRadius: compact ? '8px' : '12px',
+                padding: compact ? '8px 10px' : '14px 18px',
+                minWidth: compact ? '48px' : '72px',
+              }}>
+                <div style={{
+                  fontSize: digitSize,
+                  fontFamily: monoFont,
+                  fontWeight: 600,
+                  lineHeight: 1.1,
+                  letterSpacing: '-1px',
+                }}>
+                  {String(unit.value).padStart(2, '0')}
+                </div>
+                <div style={{
+                  fontSize: labelSize,
+                  textTransform: 'uppercase',
+                  letterSpacing: '1px',
+                  color: mutedColor,
+                  marginTop: '4px',
+                }}>
+                  {unit.label}
+                </div>
+              </div>
+              {i < units.length - 1 && (
+                <div style={{
+                  fontSize: separatorSize,
+                  fontFamily: monoFont,
+                  fontWeight: 300,
+                  color: mutedColor,
+                  lineHeight: 1.4,
+                  paddingTop: compact ? '8px' : '14px',
+                }}>
+                  :
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* Target date */}
+        <div style={{
+          fontSize: compact ? '10px' : '12px',
+          color: mutedColor,
+          marginTop: compact ? '12px' : '20px',
+        }}>
+          Target: {target.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}
+          {' '}
+          {target.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}
+        </div>
+      </>
+    );
+  }
+}
+
+/** Parse various date formats into a Date object */
+function parseTargetDate(input: string): Date | null {
+  if (!input || !input.trim()) return null;
+
+  const trimmed = input.trim();
+
+  // Try "YYYY-MM-DD HH:MM" format
+  const shortMatch = trimmed.match(/^(\d{4}-\d{2}-\d{2})\s+(\d{1,2}:\d{2})$/);
+  if (shortMatch) {
+    const d = new Date(`${shortMatch[1]}T${shortMatch[2]}:00`);
+    return isNaN(d.getTime()) ? null : d;
+  }
+
+  // Try ISO 8601 and other standard formats
+  const d = new Date(trimmed);
+  return isNaN(d.getTime()) ? null : d;
+}

--- a/web/src/components/widgets/RssWidget.tsx
+++ b/web/src/components/widgets/RssWidget.tsx
@@ -1,0 +1,413 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { apiClient } from '@/lib/api';
+import type { RssFeedData, RssFeedItem } from '@/lib/api/widgets';
+
+export interface RssWidgetProps {
+  /** RSS or Atom feed URL */
+  feedUrl?: string;
+  /** Maximum number of items to display */
+  maxItems?: number;
+  /** Show thumbnail images if available */
+  showImages?: boolean;
+  /** Show article summary/description */
+  showSummary?: boolean;
+  /** Auto-scroll speed for signage display */
+  scrollSpeed?: 'slow' | 'medium' | 'fast' | 'none';
+  /** Auto-refresh interval in minutes */
+  refreshInterval?: number;
+  /** Visual theme */
+  theme?: 'dark' | 'light' | 'auto';
+  /** Compact mode for small containers */
+  compact?: boolean;
+  /** Pre-loaded feed data (skips API fetch) */
+  data?: RssFeedData | null;
+}
+
+/** Convert a date string to a relative time label (e.g. "2h ago") */
+function relativeTime(dateStr: string | null): string {
+  if (!dateStr) return '';
+  try {
+    const now = Date.now();
+    const then = new Date(dateStr).getTime();
+    if (isNaN(then)) return '';
+    const diffSec = Math.floor((now - then) / 1000);
+    if (diffSec < 60) return 'just now';
+    if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`;
+    if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`;
+    if (diffSec < 604800) return `${Math.floor(diffSec / 86400)}d ago`;
+    return new Date(dateStr).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+    });
+  } catch {
+    return '';
+  }
+}
+
+/** Truncate a string to a maximum character count */
+function truncate(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  return text.slice(0, maxLen).trimEnd() + '...';
+}
+
+/**
+ * RssWidget — displays headlines from an RSS or Atom feed.
+ *
+ * Used both as an in-dashboard preview and as standalone signage content.
+ * All styles are inline so it renders correctly when served as raw HTML.
+ */
+export default function RssWidget({
+  feedUrl = '',
+  maxItems = 10,
+  showImages = true,
+  showSummary = true,
+  scrollSpeed = 'slow',
+  refreshInterval = 15,
+  theme = 'dark',
+  compact = false,
+  data: externalData = null,
+}: RssWidgetProps) {
+  const [feedData, setFeedData] = useState<RssFeedData | null>(externalData);
+  const [loading, setLoading] = useState(!externalData);
+  const [error, setError] = useState<string | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const animFrameRef = useRef<number | null>(null);
+
+  // Track system dark mode preference
+  const [systemDark, setSystemDark] = useState(() => {
+    if (typeof window === 'undefined') return true;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (e: MediaQueryListEvent) => setSystemDark(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  const isDark = theme === 'dark' || (theme === 'auto' && systemDark);
+
+  const fetchFeed = useCallback(async () => {
+    if (externalData || !feedUrl) return;
+    try {
+      setError(null);
+      const result = await apiClient.getRssFeed(feedUrl, maxItems);
+      setFeedData(result);
+    } catch (err: any) {
+      setError(err.message || 'Failed to load RSS feed');
+    } finally {
+      setLoading(false);
+    }
+  }, [feedUrl, maxItems, externalData]);
+
+  useEffect(() => {
+    fetchFeed();
+
+    if (!externalData && feedUrl && refreshInterval > 0) {
+      const interval = setInterval(fetchFeed, refreshInterval * 60 * 1000);
+      return () => clearInterval(interval);
+    }
+    return undefined;
+  }, [fetchFeed, refreshInterval, externalData, feedUrl]);
+
+  // Update from external data prop
+  useEffect(() => {
+    if (externalData) {
+      setFeedData(externalData);
+      setLoading(false);
+      setError(null);
+    }
+  }, [externalData]);
+
+  // Auto-scroll effect
+  useEffect(() => {
+    if (scrollSpeed === 'none' || !scrollRef.current) return;
+
+    const speedMap = { slow: 0.3, medium: 0.8, fast: 1.5 };
+    const px = speedMap[scrollSpeed] || 0.3;
+    const el = scrollRef.current;
+
+    let running = true;
+    const scroll = () => {
+      if (!running || !el) return;
+      el.scrollTop += px;
+      // Loop back to top when reaching the end
+      if (el.scrollTop >= el.scrollHeight - el.clientHeight) {
+        el.scrollTop = 0;
+      }
+      animFrameRef.current = requestAnimationFrame(scroll);
+    };
+    animFrameRef.current = requestAnimationFrame(scroll);
+
+    return () => {
+      running = false;
+      if (animFrameRef.current !== null) {
+        cancelAnimationFrame(animFrameRef.current);
+      }
+    };
+  }, [scrollSpeed, feedData]);
+
+  // Style tokens
+  const bg = isDark
+    ? 'linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%)'
+    : 'linear-gradient(135deg, #fafafa 0%, #f0f0f0 50%, #e8e8e8 100%)';
+  const textColor = isDark ? '#ffffff' : '#1a1a2e';
+  const mutedColor = isDark ? 'rgba(255,255,255,0.55)' : 'rgba(26,26,46,0.55)';
+  const cardBg = isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.04)';
+  const borderColor = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)';
+  const accentColor = '#f97316'; // orange for RSS
+
+  const containerStyle: React.CSSProperties = {
+    fontFamily: "'Segoe UI', Arial, sans-serif",
+    background: bg,
+    color: textColor,
+    padding: compact ? '16px' : '24px',
+    borderRadius: '16px',
+    width: '100%',
+    maxWidth: '520px',
+    margin: '0 auto',
+    boxSizing: 'border-box',
+    overflow: 'hidden',
+  };
+
+  if (!feedUrl && !externalData) {
+    return (
+      <div style={containerStyle} data-testid="rss-widget">
+        <div style={{ textAlign: 'center', padding: '40px 0' }}>
+          <div style={{ fontSize: '32px', marginBottom: '12px' }}>&#128240;</div>
+          <div style={{ fontSize: '14px', color: mutedColor }}>
+            No feed URL configured
+          </div>
+          <div style={{ fontSize: '12px', color: mutedColor, marginTop: '8px' }}>
+            Enter an RSS or Atom feed URL to display headlines
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div style={containerStyle} data-testid="rss-widget">
+        <div style={{ textAlign: 'center', padding: '40px 0' }}>
+          <div style={{ fontSize: '14px', color: mutedColor }}>Loading feed...</div>
+          {/* Skeleton items */}
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              style={{
+                background: cardBg,
+                borderRadius: '8px',
+                height: compact ? '48px' : '64px',
+                margin: '8px 0',
+                animation: 'pulse 1.5s ease-in-out infinite',
+              }}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !feedData) {
+    return (
+      <div style={containerStyle} data-testid="rss-widget">
+        <div style={{ textAlign: 'center', padding: '40px 0' }}>
+          <div style={{ fontSize: '32px', marginBottom: '12px' }}>&#9888;&#65039;</div>
+          <div style={{ fontSize: '14px', color: mutedColor }}>
+            {error || 'Failed to load feed'}
+          </div>
+          <button
+            onClick={() => {
+              setLoading(true);
+              setError(null);
+              fetchFeed();
+            }}
+            style={{
+              marginTop: '12px',
+              padding: '8px 20px',
+              border: `1px solid ${accentColor}`,
+              borderRadius: '8px',
+              background: 'transparent',
+              color: accentColor,
+              cursor: 'pointer',
+              fontSize: '13px',
+              fontWeight: 500,
+            }}
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const { feedTitle, items } = feedData;
+  const displayItems = items.slice(0, maxItems);
+
+  return (
+    <div style={containerStyle} data-testid="rss-widget">
+      {/* Feed title */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '10px',
+          marginBottom: compact ? '12px' : '18px',
+          paddingBottom: compact ? '8px' : '12px',
+          borderBottom: `1px solid ${borderColor}`,
+        }}
+      >
+        <div
+          style={{
+            width: '32px',
+            height: '32px',
+            borderRadius: '8px',
+            background: accentColor,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontSize: '16px',
+            flexShrink: 0,
+          }}
+        >
+          &#128240;
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div
+            style={{
+              fontSize: compact ? '14px' : '16px',
+              fontWeight: 600,
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {feedTitle}
+          </div>
+          <div style={{ fontSize: '11px', color: mutedColor }}>
+            {displayItems.length} article{displayItems.length !== 1 ? 's' : ''}
+          </div>
+        </div>
+      </div>
+
+      {/* Items list */}
+      <div
+        ref={scrollRef}
+        style={{
+          maxHeight: compact ? '280px' : '420px',
+          overflowY: 'auto',
+          scrollbarWidth: 'none',
+        }}
+      >
+        {displayItems.map((item: RssFeedItem, idx: number) => (
+          <div
+            key={`${item.link || idx}`}
+            style={{
+              display: 'flex',
+              gap: '12px',
+              padding: compact ? '8px 0' : '12px 0',
+              borderBottom:
+                idx < displayItems.length - 1
+                  ? `1px solid ${borderColor}`
+                  : 'none',
+              alignItems: 'flex-start',
+            }}
+          >
+            {/* Thumbnail */}
+            {showImages && item.imageUrl && (
+              <div
+                style={{
+                  width: compact ? '48px' : '64px',
+                  height: compact ? '48px' : '64px',
+                  borderRadius: '8px',
+                  overflow: 'hidden',
+                  flexShrink: 0,
+                  background: cardBg,
+                }}
+              >
+                <img
+                  src={item.imageUrl}
+                  alt=""
+                  style={{
+                    width: '100%',
+                    height: '100%',
+                    objectFit: 'cover',
+                    display: 'block',
+                  }}
+                  onError={(e) => {
+                    (e.target as HTMLImageElement).style.display = 'none';
+                  }}
+                />
+              </div>
+            )}
+
+            {/* Text content */}
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div
+                style={{
+                  fontSize: compact ? '13px' : '15px',
+                  fontWeight: 600,
+                  lineHeight: 1.35,
+                  marginBottom: '4px',
+                  display: '-webkit-box',
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                }}
+              >
+                {item.title}
+              </div>
+
+              {showSummary && item.description && (
+                <div
+                  style={{
+                    fontSize: compact ? '11px' : '13px',
+                    color: mutedColor,
+                    lineHeight: 1.4,
+                    marginBottom: '4px',
+                    display: '-webkit-box',
+                    WebkitLineClamp: compact ? 1 : 2,
+                    WebkitBoxOrient: 'vertical',
+                    overflow: 'hidden',
+                  }}
+                >
+                  {truncate(item.description, compact ? 80 : 150)}
+                </div>
+              )}
+
+              {item.pubDate && (
+                <div
+                  style={{
+                    fontSize: '11px',
+                    color: accentColor,
+                    fontWeight: 500,
+                  }}
+                >
+                  {relativeTime(item.pubDate)}
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+
+        {displayItems.length === 0 && (
+          <div
+            style={{
+              textAlign: 'center',
+              padding: '24px 0',
+              color: mutedColor,
+              fontSize: '13px',
+            }}
+          >
+            No articles found in this feed
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/api/content.ts
+++ b/web/src/lib/api/content.ts
@@ -15,6 +15,9 @@ declare module './client' {
     getContentDownloadUrl(id: string, expirySeconds?: number): Promise<{ url: string; expiresIn: number }>;
     generateThumbnail(contentId: string): Promise<{ thumbnail: string }>;
     uploadContentWithProgress(data: { title: string; type: string; file: File | Blob }, onProgress?: (percent: number) => void): Promise<Content>;
+    // Content Moderation
+    flagContent(id: string, reason?: string): Promise<Content>;
+    reviewContent(id: string, action: 'approve' | 'reject', reason?: string): Promise<Content>;
     // Content Folders
     getFolders(params?: { format?: 'flat' | 'tree' }): Promise<ContentFolder[]>;
     getFolder(id: string): Promise<ContentFolder>;
@@ -154,6 +157,20 @@ ApiClient.prototype.deleteContent = async function (id: string): Promise<void> {
 ApiClient.prototype.archiveContent = async function (id: string): Promise<Content> {
   return this.request<Content>(`/content/${id}/archive`, {
     method: 'POST',
+  });
+};
+
+ApiClient.prototype.flagContent = async function (id: string, reason?: string): Promise<Content> {
+  return this.request<Content>(`/content/${id}/flag`, {
+    method: 'POST',
+    body: JSON.stringify({ reason }),
+  });
+};
+
+ApiClient.prototype.reviewContent = async function (id: string, action: 'approve' | 'reject', reason?: string): Promise<Content> {
+  return this.request<Content>(`/content/${id}/review`, {
+    method: 'POST',
+    body: JSON.stringify({ action, reason }),
   });
 };
 

--- a/web/src/lib/api/widgets.ts
+++ b/web/src/lib/api/widgets.ts
@@ -5,6 +5,20 @@ import type {
 } from '../types';
 import { ApiClient } from './client';
 
+export interface RssFeedItem {
+  title: string;
+  link: string;
+  description: string;
+  pubDate: string | null;
+  imageUrl: string | null;
+}
+
+export interface RssFeedData {
+  feedTitle: string;
+  items: RssFeedItem[];
+  fetchedAt: string;
+}
+
 export interface WeatherData {
   current: {
     temp: number;
@@ -37,6 +51,7 @@ declare module './client' {
     updateWidget(id: string, data: Partial<Widget>): Promise<Widget>;
     refreshWidget(id: string): Promise<Widget>;
     getWeatherData(location: string, units?: string): Promise<WeatherData>;
+    getRssFeed(url: string, limit?: number): Promise<RssFeedData>;
     getLayoutPresets(): Promise<LayoutPreset[]>;
     createLayout(data: { name: string; layoutType: string; zones?: LayoutZone[]; description?: string }): Promise<Layout>;
     updateLayout(id: string, data: Partial<Layout>): Promise<Layout>;
@@ -71,6 +86,11 @@ ApiClient.prototype.refreshWidget = async function (id: string): Promise<Widget>
 ApiClient.prototype.getWeatherData = async function (location: string, units: string = 'metric'): Promise<WeatherData> {
   const params = new URLSearchParams({ location, units });
   return this.request<WeatherData>(`/content/widgets/weather/preview?${params.toString()}`);
+};
+
+ApiClient.prototype.getRssFeed = async function (url: string, limit: number = 10): Promise<RssFeedData> {
+  const params = new URLSearchParams({ url, limit: String(limit) });
+  return this.request<RssFeedData>(`/content/widgets/rss/preview?${params.toString()}`);
 };
 
 ApiClient.prototype.getLayoutPresets = async function (): Promise<LayoutPreset[]> {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -22,7 +22,7 @@ export interface Content {
   type: 'image' | 'video' | 'pdf' | 'url' | 'html' | 'template';
   url?: string;
   thumbnailUrl?: string;
-  status: 'ready' | 'processing' | 'error' | 'active' | 'archived';
+  status: 'ready' | 'processing' | 'error' | 'active' | 'archived' | 'flagged' | 'rejected';
   duration?: number;
   metadata?: Record<string, any>;
   folderId?: string;


### PR DESCRIPTION
## Summary

Four backlog items: two widgets, two platform features.

### Clock & Countdown Widget (Q5)
- **Clock mode**: current time with 12h/24h format, optional date, timezone support
- **Countdown mode**: days/hours/minutes/seconds to target event with event name
- Dark/light/auto themes, live preview in widget wizard
- No backend needed — fully client-side with `Intl.DateTimeFormat`

### Return/Refund Policy + SLA Pages (Q9)
- `/refund` — 30-day trial, 14-day refund window, cancellation policy
- `/sla` — 99.9% uptime commitment, incident response times, service credit tiers
- Footer updated with links to both new pages
- Follows exact same pattern as existing `/privacy` and `/terms` pages

### RSS/News Feed Widget (Q3)
- Backend RSS proxy at `GET /api/v1/content/widgets/rss/preview`
- Zero-dependency RSS/Atom parser (regex-based, handles RSS 2.0 + Atom)
- RssWidget component with auto-scroll, thumbnails, relative timestamps
- URL protocol validation (http/https only), 10s fetch timeout
- 11 parser tests + 7 controller tests

### Content Moderation Workflow (M4)
- `POST /content/:id/flag` — flag content for review with optional reason
- `POST /content/:id/review` — admin approves or rejects flagged content
- Approve restores previous status; reject archives and removes from playlists
- Moderation metadata stored in Content's JSON metadata field (no migration)
- Flag/review modals in content page, amber badge for flagged content
- Admin notification when content is flagged

## Test plan
- [x] Middleware: 97 suites, 1,978 tests — ALL PASS
- [x] Web: 78 suites, 856 tests — ALL PASS
- [x] Web build succeeds
- [ ] Manual: test clock widget in different timezones
- [ ] Manual: test RSS widget with various feeds (news, blog, podcast)
- [ ] Manual: test flag → review → approve/reject flow

## Stats
- 21 files changed, +2,119 / -29 lines
- 18 new tests (11 RSS parser + 7 widget controller)

🤖 Generated with [Claude Code](https://claude.com/claude-code)