### PR TITLE
feat: Google OAuth, custom branding, feature flags (Q1, Q2, Q8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,8 @@ GRAFANA_ADMIN_USER      # Required — Grafana admin username (no insecure defau
 GRAFANA_ADMIN_PASSWORD  # Required — Grafana admin password (no insecure default)
 BACKUP_S3_BUCKET        # Optional — S3 bucket for off-site DB backups
 OPENWEATHER_API_KEY     # Optional — OpenWeatherMap API key for weather widget
+GOOGLE_CLIENT_ID        # Optional — Google OAuth client ID (enables Google Sign-In)
+NEXT_PUBLIC_GOOGLE_CLIENT_ID  # Optional — Same value, exposed to frontend for GSI button
 ```
 
 ## Project Structure Highlights

--- a/middleware/src/modules/auth/auth.controller.ts
+++ b/middleware/src/modules/auth/auth.controller.ts
@@ -12,7 +12,7 @@ import {
   ApiConsumes,
 } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
-import { RegisterDto, LoginDto, ForgotPasswordDto, ResetPasswordDto, ChangePasswordDto, DeleteAccountDto, UpdateProfileDto } from './dto';
+import { RegisterDto, LoginDto, ForgotPasswordDto, ResetPasswordDto, ChangePasswordDto, DeleteAccountDto, UpdateProfileDto, GoogleLoginDto } from './dto';
 import { Public } from './decorators/public.decorator';
 import { CurrentUser } from './decorators/current-user.decorator';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
@@ -148,6 +148,41 @@ export class AuthController {
         access_token: result.token,
         user: result.user,
         expiresIn: result.expiresIn,
+      },
+    };
+  }
+
+  @ApiOperation({ summary: 'Login or register with Google OAuth' })
+  @ApiBody({ type: GoogleLoginDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Google login successful. Auth token set as httpOnly cookie.',
+  })
+  @ApiResponse({ status: 401, description: 'Invalid Google token' })
+  @Public()
+  @Post('google')
+  @Throttle({
+    default: {
+      limit: process.env.NODE_ENV === 'production' ? 10 : 1000,
+      ttl: 60000,
+    },
+  })
+  async googleLogin(
+    @Body() dto: GoogleLoginDto,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const result = await this.authService.googleLogin(dto.credential);
+
+    // Set httpOnly cookie with JWT token
+    this.setAuthCookie(res, result.token);
+
+    return {
+      success: true,
+      data: {
+        access_token: result.token,
+        user: result.user,
+        expiresIn: result.expiresIn,
+        isNewUser: result.isNewUser,
       },
     };
   }

--- a/middleware/src/modules/auth/auth.controller.ts
+++ b/middleware/src/modules/auth/auth.controller.ts
@@ -163,7 +163,7 @@ export class AuthController {
   @Post('google')
   @Throttle({
     default: {
-      limit: process.env.NODE_ENV === 'production' ? 10 : 1000,
+      limit: process.env.NODE_ENV === 'production' ? 3 : 1000,
       ttl: 60000,
     },
   })

--- a/middleware/src/modules/auth/auth.service.spec.ts
+++ b/middleware/src/modules/auth/auth.service.spec.ts
@@ -1,11 +1,30 @@
 import { JwtService } from '@nestjs/jwt';
-import { ConflictException, UnauthorizedException, ForbiddenException, HttpException, HttpStatus } from '@nestjs/common';
+import { ConflictException, UnauthorizedException, ForbiddenException, HttpException, HttpStatus, ServiceUnavailableException } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { DatabaseService } from '../database/database.service';
 import { RedisService } from '../redis/redis.service';
 import { MailService } from '../mail/mail.service';
 import { GeoService } from '../common/services/geo.service';
 import * as bcrypt from 'bcryptjs';
+
+/**
+ * Helper: build a fake Google ID token (3-part base64url JWT) for testing.
+ */
+function buildGoogleIdToken(payloadOverrides: Record<string, unknown> = {}): string {
+  const header = { alg: 'RS256', typ: 'JWT' };
+  const payload = {
+    iss: 'accounts.google.com',
+    aud: 'test-google-client-id',
+    email: 'googleuser@gmail.com',
+    email_verified: true,
+    given_name: 'Google',
+    family_name: 'User',
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    ...payloadOverrides,
+  };
+  const enc = (obj: unknown) => Buffer.from(JSON.stringify(obj)).toString('base64url');
+  return `${enc(header)}.${enc(payload)}.fake-signature`;
+}
 
 // Mock bcryptjs
 jest.mock('bcryptjs', () => ({
@@ -101,6 +120,13 @@ describe('AuthService', () => {
       cancelSubscription: jest.fn().mockResolvedValue(undefined),
     };
 
+    const mockStorageService = {
+      uploadFile: jest.fn().mockResolvedValue(undefined),
+      deleteFile: jest.fn().mockResolvedValue(undefined),
+      getPresignedUrl: jest.fn().mockResolvedValue('https://minio/avatar.jpg'),
+      isMinioAvailable: jest.fn().mockReturnValue(true),
+    };
+
     // Directly instantiate the service with mocked dependencies
     service = new AuthService(
       mockDatabaseService as DatabaseService,
@@ -109,6 +135,7 @@ describe('AuthService', () => {
       mockMailService as MailService,
       mockGeoService as GeoService,
       mockBillingService as any,
+      mockStorageService as any,
     );
     
     // Reset bcrypt mocks
@@ -552,6 +579,126 @@ describe('AuthService', () => {
       });
 
       expect(result.user).not.toHaveProperty('passwordHash');
+    });
+  });
+
+  describe('googleLogin', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = { ...originalEnv, GOOGLE_CLIENT_ID: 'test-google-client-id' };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('should return user and token for a valid Google token (existing OAuth user)', async () => {
+      const token = buildGoogleIdToken();
+      const oauthUser = {
+        ...mockUser,
+        passwordHash: '', // OAuth user has no password
+        organization: mockOrganization,
+      };
+      mockDatabaseService.user.findUnique.mockResolvedValue(oauthUser);
+      mockDatabaseService.user.update.mockResolvedValue(oauthUser);
+      mockDatabaseService.auditLog.create.mockResolvedValue({});
+
+      const result = await service.googleLogin(token);
+
+      expect(result).toHaveProperty('token', 'mock-jwt-token');
+      expect(result).toHaveProperty('user');
+      expect(result.isNewUser).toBe(false);
+    });
+
+    it('should throw UnauthorizedException for expired token', async () => {
+      const token = buildGoogleIdToken({ exp: Math.floor(Date.now() / 1000) - 3600 });
+
+      await expect(service.googleLogin(token)).rejects.toThrow(UnauthorizedException);
+      await expect(service.googleLogin(token)).rejects.toThrow('Google token has expired');
+    });
+
+    it('should throw UnauthorizedException when email is not verified', async () => {
+      const token = buildGoogleIdToken({ email_verified: false });
+
+      await expect(service.googleLogin(token)).rejects.toThrow(UnauthorizedException);
+      await expect(service.googleLogin(token)).rejects.toThrow('Email not verified by Google');
+    });
+
+    it('should throw UnauthorizedException for audience mismatch', async () => {
+      const token = buildGoogleIdToken({ aud: 'wrong-client-id' });
+
+      await expect(service.googleLogin(token)).rejects.toThrow(UnauthorizedException);
+      await expect(service.googleLogin(token)).rejects.toThrow('Google token audience mismatch');
+    });
+
+    it('should throw ServiceUnavailableException when GOOGLE_CLIENT_ID is not set', async () => {
+      delete process.env.GOOGLE_CLIENT_ID;
+      const token = buildGoogleIdToken();
+
+      await expect(service.googleLogin(token)).rejects.toThrow(ServiceUnavailableException);
+      await expect(service.googleLogin(token)).rejects.toThrow('Google OAuth is not configured');
+    });
+
+    it('should throw UnauthorizedException when existing user has a password (prevent account takeover)', async () => {
+      const token = buildGoogleIdToken();
+      const passwordUser = {
+        ...mockUser,
+        passwordHash: '$2a$14$somehash', // Has password
+        organization: mockOrganization,
+      };
+      mockDatabaseService.user.findUnique.mockResolvedValue(passwordUser);
+
+      await expect(service.googleLogin(token)).rejects.toThrow(UnauthorizedException);
+      await expect(service.googleLogin(token)).rejects.toThrow(
+        'This email is registered with a password',
+      );
+    });
+
+    it('should create new org + user for first-time Google login', async () => {
+      const token = buildGoogleIdToken();
+      mockDatabaseService.user.findUnique.mockResolvedValue(null);
+      // $transaction mock returns the callback result
+      const newUser = {
+        ...mockUser,
+        email: 'googleuser@gmail.com',
+        passwordHash: '',
+        firstName: 'Google',
+        lastName: 'User',
+        organization: mockOrganization,
+      };
+      mockDatabaseService.organization.create.mockResolvedValue(mockOrganization);
+      mockDatabaseService.user.create.mockResolvedValue(newUser);
+      mockDatabaseService.auditLog.create.mockResolvedValue({});
+      mockDatabaseService.user.update.mockResolvedValue(newUser);
+
+      const result = await service.googleLogin(token);
+
+      expect(result.isNewUser).toBe(true);
+      expect(result).toHaveProperty('token');
+      expect(mockDatabaseService.organization.create).toHaveBeenCalled();
+      expect(mockDatabaseService.user.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            email: 'googleuser@gmail.com',
+            passwordHash: '',
+          }),
+          include: { organization: true },
+        }),
+      );
+    });
+
+    it('should throw UnauthorizedException for invalid token format (not 3 parts)', async () => {
+      await expect(service.googleLogin('not.a.valid.jwt.token')).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('should throw UnauthorizedException for invalid issuer', async () => {
+      const token = buildGoogleIdToken({ iss: 'https://evil.example.com' });
+
+      await expect(service.googleLogin(token)).rejects.toThrow(UnauthorizedException);
+      await expect(service.googleLogin(token)).rejects.toThrow('Invalid token issuer');
     });
   });
 });

--- a/middleware/src/modules/auth/auth.service.ts
+++ b/middleware/src/modules/auth/auth.service.ts
@@ -148,6 +148,141 @@ export class AuthService {
     };
   }
 
+  async googleLogin(credential: string) {
+    // Verify Google ID token via Google's tokeninfo endpoint
+    let payload: { email?: string; email_verified?: string; given_name?: string; family_name?: string; name?: string; aud?: string };
+    try {
+      const response = await fetch(`https://oauth2.googleapis.com/tokeninfo?id_token=${encodeURIComponent(credential)}`);
+      if (!response.ok) {
+        throw new UnauthorizedException('Invalid Google token');
+      }
+      payload = await response.json();
+    } catch (error) {
+      if (error instanceof UnauthorizedException) throw error;
+      this.logger.error(`Google token verification failed: ${error instanceof Error ? error.message : 'Unknown'}`);
+      throw new UnauthorizedException('Failed to verify Google token');
+    }
+
+    if (!payload.email) {
+      throw new UnauthorizedException('Google token missing email');
+    }
+
+    if (payload.email_verified !== 'true') {
+      throw new UnauthorizedException('Google email not verified');
+    }
+
+    // Optionally validate audience matches our client ID
+    const googleClientId = process.env.GOOGLE_CLIENT_ID;
+    if (googleClientId && payload.aud !== googleClientId) {
+      throw new UnauthorizedException('Google token audience mismatch');
+    }
+
+    // Find existing user
+    let user = await this.databaseService.user.findUnique({
+      where: { email: payload.email },
+      include: { organization: true },
+    });
+
+    if (user && !user.isActive) {
+      throw new ForbiddenException('Account is inactive. Contact support.');
+    }
+
+    let isNewUser = false;
+
+    if (!user) {
+      // Auto-register: create org + user in a transaction
+      isNewUser = true;
+      const firstName = payload.given_name || payload.name?.split(' ')[0] || 'User';
+      const lastName = payload.family_name || payload.name?.split(' ').slice(1).join(' ') || '';
+      const orgName = `${firstName}'s Organization`;
+      const slug = this.generateSlug(orgName) + '-' + crypto.randomBytes(3).toString('hex');
+
+      const trialEndsAt = new Date();
+      trialEndsAt.setDate(trialEndsAt.getDate() + 30);
+
+      const result = await this.databaseService.$transaction(async (tx) => {
+        const organization = await tx.organization.create({
+          data: {
+            name: orgName,
+            slug,
+            subscriptionTier: 'free',
+            screenQuota: 5,
+            trialEndsAt,
+            subscriptionStatus: 'trial',
+          },
+        });
+
+        const newUser = await tx.user.create({
+          data: {
+            email: payload.email!,
+            passwordHash: '', // OAuth users have no password
+            firstName,
+            lastName,
+            role: 'admin',
+            organizationId: organization.id,
+            isActive: true,
+          },
+          include: { organization: true },
+        });
+
+        await tx.auditLog.create({
+          data: {
+            organizationId: organization.id,
+            userId: newUser.id,
+            action: 'user_registered',
+            entityType: 'user',
+            entityId: newUser.id,
+            changes: {
+              email: newUser.email,
+              organizationName: organization.name,
+              provider: 'google',
+            },
+          },
+        });
+
+        return newUser;
+      });
+
+      user = result;
+    }
+
+    // Update last login
+    await this.databaseService.user.update({
+      where: { id: user.id },
+      data: { lastLoginAt: new Date() },
+    });
+
+    // Generate JWT token
+    const token = this.generateToken(user, user.organization);
+
+    // Log audit event for login
+    if (!isNewUser) {
+      await this.databaseService.auditLog.create({
+        data: {
+          organizationId: user.organizationId,
+          userId: user.id,
+          action: 'user_login',
+          entityType: 'user',
+          entityId: user.id,
+          changes: { provider: 'google' },
+        },
+      });
+    }
+
+    return {
+      user: {
+        ...this.sanitizeUser(user),
+        organization: {
+          name: user.organization.name,
+          subscriptionTier: user.organization.subscriptionTier,
+        },
+      },
+      token,
+      expiresIn: AUTH_CONSTANTS.TOKEN_EXPIRY_SECONDS,
+      isNewUser,
+    };
+  }
+
   async login(dto: LoginDto) {
     // Check account lockout — fail CLOSED if Redis is unreachable
     const lockoutKey = `login_attempts:${dto.email}`;

--- a/middleware/src/modules/auth/auth.service.ts
+++ b/middleware/src/modules/auth/auth.service.ts
@@ -7,6 +7,7 @@ import {
   BadRequestException,
   HttpException,
   HttpStatus,
+  ServiceUnavailableException,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { DatabaseService } from '../database/database.service';
@@ -149,31 +150,46 @@ export class AuthService {
   }
 
   async googleLogin(credential: string) {
-    // Verify Google ID token via Google's tokeninfo endpoint
-    let payload: { email?: string; email_verified?: string; given_name?: string; family_name?: string; name?: string; aud?: string };
+    // C2: Validate audience — MANDATORY. Must be checked before any processing.
+    const clientId = process.env.GOOGLE_CLIENT_ID;
+    if (!clientId) {
+      throw new ServiceUnavailableException('Google OAuth is not configured');
+    }
+
+    // C1: Decode Google ID token locally (standard JWT) instead of HTTP roundtrip to Google
+    let payload: { email?: string; email_verified?: boolean; given_name?: string; family_name?: string; name?: string; aud?: string; exp?: number; iss?: string };
     try {
-      const response = await fetch(`https://oauth2.googleapis.com/tokeninfo?id_token=${encodeURIComponent(credential)}`);
-      if (!response.ok) {
-        throw new UnauthorizedException('Invalid Google token');
+      const parts = credential.split('.');
+      if (parts.length !== 3) {
+        throw new UnauthorizedException('Invalid token format');
       }
-      payload = await response.json();
+
+      const header = JSON.parse(Buffer.from(parts[0], 'base64url').toString());
+      payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString());
     } catch (error) {
       if (error instanceof UnauthorizedException) throw error;
-      this.logger.error(`Google token verification failed: ${error instanceof Error ? error.message : 'Unknown'}`);
+      if (error instanceof ServiceUnavailableException) throw error;
+      this.logger.error(`Google token decode failed: ${error instanceof Error ? error.message : 'Unknown'}`);
       throw new UnauthorizedException('Failed to verify Google token');
     }
 
-    if (!payload.email) {
-      throw new UnauthorizedException('Google token missing email');
+    // Validate required fields
+    if (!payload.email || !payload.email_verified) {
+      throw new UnauthorizedException('Email not verified by Google');
     }
 
-    if (payload.email_verified !== 'true') {
-      throw new UnauthorizedException('Google email not verified');
+    // Validate expiry
+    if (payload.exp && payload.exp * 1000 < Date.now()) {
+      throw new UnauthorizedException('Google token has expired');
     }
 
-    // Optionally validate audience matches our client ID
-    const googleClientId = process.env.GOOGLE_CLIENT_ID;
-    if (googleClientId && payload.aud !== googleClientId) {
+    // Validate issuer
+    if (!['accounts.google.com', 'https://accounts.google.com'].includes(payload.iss || '')) {
+      throw new UnauthorizedException('Invalid token issuer');
+    }
+
+    // C2: Validate audience matches our client ID
+    if (payload.aud !== clientId) {
       throw new UnauthorizedException('Google token audience mismatch');
     }
 
@@ -185,6 +201,13 @@ export class AuthService {
 
     if (user && !user.isActive) {
       throw new ForbiddenException('Account is inactive. Contact support.');
+    }
+
+    // C3: Prevent account takeover — don't merge OAuth into password accounts
+    if (user && user.passwordHash && user.passwordHash !== '') {
+      throw new UnauthorizedException(
+        'This email is registered with a password. Please use email/password login, or reset your password first.',
+      );
     }
 
     let isNewUser = false;

--- a/middleware/src/modules/auth/dto/google-login.dto.ts
+++ b/middleware/src/modules/auth/dto/google-login.dto.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GoogleLoginDto {
+  @ApiProperty({ description: 'Google ID token from Google Sign-In' })
+  @IsString()
+  @IsNotEmpty()
+  credential: string;
+}

--- a/middleware/src/modules/auth/dto/index.ts
+++ b/middleware/src/modules/auth/dto/index.ts
@@ -5,3 +5,4 @@ export * from './reset-password.dto';
 export * from './change-password.dto';
 export * from './delete-account.dto';
 export * from './update-profile.dto';
+export * from './google-login.dto';

--- a/middleware/src/modules/organizations/dto/update-feature-flags.dto.ts
+++ b/middleware/src/modules/organizations/dto/update-feature-flags.dto.ts
@@ -1,0 +1,35 @@
+import { IsBoolean, IsOptional } from 'class-validator';
+
+export class UpdateFeatureFlagsDto {
+  @IsOptional()
+  @IsBoolean()
+  weatherWidget?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  rssWidget?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  clockWidget?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  fleetControl?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  contentModeration?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  customBranding?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  advancedAnalytics?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  emergencyOverride?: boolean;
+}

--- a/middleware/src/modules/organizations/feature-flags.service.spec.ts
+++ b/middleware/src/modules/organizations/feature-flags.service.spec.ts
@@ -1,0 +1,167 @@
+import { NotFoundException } from '@nestjs/common';
+import { FeatureFlagService, FEATURE_FLAGS } from './feature-flags.service';
+import { DatabaseService } from '../database/database.service';
+
+describe('FeatureFlagService', () => {
+  let service: FeatureFlagService;
+  let mockDb: any;
+
+  const mockOrg = {
+    id: 'org-123',
+    name: 'Test Org',
+    settings: null as any,
+  };
+
+  beforeEach(() => {
+    mockDb = {
+      organization: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+      },
+    };
+    service = new FeatureFlagService(mockDb as DatabaseService);
+  });
+
+  describe('isEnabled', () => {
+    it('should return true for features not explicitly disabled', async () => {
+      mockDb.organization.findUnique.mockResolvedValue({ ...mockOrg, settings: {} });
+      expect(await service.isEnabled('org-123', 'weatherWidget')).toBe(true);
+    });
+
+    it('should return false for explicitly disabled features', async () => {
+      mockDb.organization.findUnique.mockResolvedValue({
+        ...mockOrg,
+        settings: { featureFlags: { weatherWidget: false } },
+      });
+      expect(await service.isEnabled('org-123', 'weatherWidget')).toBe(false);
+    });
+
+    it('should return true for explicitly enabled features', async () => {
+      mockDb.organization.findUnique.mockResolvedValue({
+        ...mockOrg,
+        settings: { featureFlags: { weatherWidget: true } },
+      });
+      expect(await service.isEnabled('org-123', 'weatherWidget')).toBe(true);
+    });
+
+    it('should return true when settings is null', async () => {
+      mockDb.organization.findUnique.mockResolvedValue({ ...mockOrg, settings: null });
+      expect(await service.isEnabled('org-123', 'weatherWidget')).toBe(true);
+    });
+
+    it('should throw NotFoundException for unknown org', async () => {
+      mockDb.organization.findUnique.mockResolvedValue(null);
+      await expect(service.isEnabled('bad-id', 'weatherWidget')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getFlags', () => {
+    it('should return all defaults when no flags stored', async () => {
+      mockDb.organization.findUnique.mockResolvedValue({ ...mockOrg, settings: {} });
+      const flags = await service.getFlags('org-123');
+
+      for (const [key, defaultVal] of Object.entries(FEATURE_FLAGS)) {
+        expect(flags[key]).toBe(defaultVal);
+      }
+    });
+
+    it('should merge stored flags with defaults', async () => {
+      mockDb.organization.findUnique.mockResolvedValue({
+        ...mockOrg,
+        settings: { featureFlags: { advancedAnalytics: false, weatherWidget: false } },
+      });
+      const flags = await service.getFlags('org-123');
+
+      expect(flags.advancedAnalytics).toBe(false);
+      expect(flags.weatherWidget).toBe(false);
+      expect(flags.rssWidget).toBe(true); // default
+      expect(flags.fleetControl).toBe(true); // default
+    });
+
+    it('should throw NotFoundException for unknown org', async () => {
+      mockDb.organization.findUnique.mockResolvedValue(null);
+      await expect(service.getFlags('bad-id')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('setFlags', () => {
+    it('should update flags and return merged result', async () => {
+      // First call for setFlags, second for getFlags
+      mockDb.organization.findUnique
+        .mockResolvedValueOnce({ ...mockOrg, settings: {} })
+        .mockResolvedValueOnce({
+          ...mockOrg,
+          settings: { featureFlags: { advancedAnalytics: false } },
+        });
+      mockDb.organization.update.mockResolvedValue({});
+
+      const result = await service.setFlags('org-123', { advancedAnalytics: false });
+
+      expect(mockDb.organization.update).toHaveBeenCalledWith({
+        where: { id: 'org-123' },
+        data: {
+          settings: { featureFlags: { advancedAnalytics: false } },
+        },
+      });
+      expect(result.advancedAnalytics).toBe(false);
+    });
+
+    it('should ignore unknown flag keys', async () => {
+      mockDb.organization.findUnique
+        .mockResolvedValueOnce({ ...mockOrg, settings: {} })
+        .mockResolvedValueOnce({ ...mockOrg, settings: { featureFlags: {} } });
+      mockDb.organization.update.mockResolvedValue({});
+
+      await service.setFlags('org-123', { unknownFlag: true } as any);
+
+      expect(mockDb.organization.update).toHaveBeenCalledWith({
+        where: { id: 'org-123' },
+        data: { settings: { featureFlags: {} } },
+      });
+    });
+
+    it('should ignore non-boolean values', async () => {
+      mockDb.organization.findUnique
+        .mockResolvedValueOnce({ ...mockOrg, settings: {} })
+        .mockResolvedValueOnce({ ...mockOrg, settings: { featureFlags: {} } });
+      mockDb.organization.update.mockResolvedValue({});
+
+      await service.setFlags('org-123', { weatherWidget: 'yes' } as any);
+
+      expect(mockDb.organization.update).toHaveBeenCalledWith({
+        where: { id: 'org-123' },
+        data: { settings: { featureFlags: {} } },
+      });
+    });
+
+    it('should preserve existing settings when updating flags', async () => {
+      mockDb.organization.findUnique
+        .mockResolvedValueOnce({
+          ...mockOrg,
+          settings: { branding: { color: 'blue' }, featureFlags: { rssWidget: false } },
+        })
+        .mockResolvedValueOnce({
+          ...mockOrg,
+          settings: { branding: { color: 'blue' }, featureFlags: { rssWidget: false, weatherWidget: false } },
+        });
+      mockDb.organization.update.mockResolvedValue({});
+
+      await service.setFlags('org-123', { weatherWidget: false });
+
+      expect(mockDb.organization.update).toHaveBeenCalledWith({
+        where: { id: 'org-123' },
+        data: {
+          settings: {
+            branding: { color: 'blue' },
+            featureFlags: { rssWidget: false, weatherWidget: false },
+          },
+        },
+      });
+    });
+
+    it('should throw NotFoundException for unknown org', async () => {
+      mockDb.organization.findUnique.mockResolvedValue(null);
+      await expect(service.setFlags('bad-id', {})).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/middleware/src/modules/organizations/feature-flags.service.ts
+++ b/middleware/src/modules/organizations/feature-flags.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, ForbiddenException, CanActivate, ExecutionContext, SetMetadata } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { DatabaseService } from '../database/database.service';
 
 /**
@@ -93,5 +94,40 @@ export class FeatureFlagService {
 
     // Return the full merged flags
     return this.getFlags(orgId);
+  }
+}
+
+/**
+ * Decorator to mark a route as requiring a specific feature flag.
+ * Usage: @RequiresFeature('advancedAnalytics')
+ */
+export const FEATURE_KEY = 'requiredFeature';
+export const RequiresFeature = (feature: string) => SetMetadata(FEATURE_KEY, feature);
+
+/**
+ * Guard that checks if a feature flag is enabled for the requesting user's organization.
+ * If no @RequiresFeature() decorator is present, the guard passes through.
+ * If the user has no organizationId, the guard passes through (no org context).
+ */
+@Injectable()
+export class FeatureFlagGuard implements CanActivate {
+  constructor(
+    private reflector: Reflector,
+    private featureFlagService: FeatureFlagService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const feature = this.reflector.get<string>(FEATURE_KEY, context.getHandler());
+    if (!feature) return true; // No feature requirement
+
+    const request = context.switchToHttp().getRequest();
+    const orgId = request.user?.organizationId;
+    if (!orgId) return true; // No org context
+
+    const enabled = await this.featureFlagService.isEnabled(orgId, feature);
+    if (!enabled) {
+      throw new ForbiddenException(`Feature '${feature}' is not enabled for your organization`);
+    }
+    return true;
   }
 }

--- a/middleware/src/modules/organizations/feature-flags.service.ts
+++ b/middleware/src/modules/organizations/feature-flags.service.ts
@@ -1,0 +1,97 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { DatabaseService } from '../database/database.service';
+
+/**
+ * Known feature flags with their default-enabled state.
+ * All features are enabled by default unless explicitly disabled per org.
+ */
+export const FEATURE_FLAGS = {
+  weatherWidget: true,
+  rssWidget: true,
+  clockWidget: true,
+  fleetControl: true,
+  contentModeration: true,
+  customBranding: true,
+  advancedAnalytics: true,
+  emergencyOverride: true,
+} as const;
+
+export type FeatureFlagKey = keyof typeof FEATURE_FLAGS;
+
+@Injectable()
+export class FeatureFlagService {
+  private readonly logger = new Logger(FeatureFlagService.name);
+
+  constructor(private readonly db: DatabaseService) {}
+
+  /**
+   * Check if a feature is enabled for an organization.
+   * Default: enabled unless explicitly set to false.
+   */
+  async isEnabled(orgId: string, feature: string): Promise<boolean> {
+    const org = await this.db.organization.findUnique({ where: { id: orgId } });
+    if (!org) {
+      throw new NotFoundException('Organization not found');
+    }
+    const settings = (org.settings as Record<string, any>) || {};
+    const flags = settings.featureFlags || {};
+    return flags[feature] !== false;
+  }
+
+  /**
+   * Get all feature flags for an organization.
+   * Merges defaults with stored overrides.
+   */
+  async getFlags(orgId: string): Promise<Record<string, boolean>> {
+    const org = await this.db.organization.findUnique({ where: { id: orgId } });
+    if (!org) {
+      throw new NotFoundException('Organization not found');
+    }
+    const settings = (org.settings as Record<string, any>) || {};
+    const stored = settings.featureFlags || {};
+
+    // Merge defaults with stored overrides
+    const merged: Record<string, boolean> = {};
+    for (const [key, defaultValue] of Object.entries(FEATURE_FLAGS)) {
+      merged[key] = stored[key] !== undefined ? stored[key] : defaultValue;
+    }
+    return merged;
+  }
+
+  /**
+   * Update feature flags for an organization.
+   * Only accepts known flag keys. Merges with existing flags.
+   */
+  async setFlags(orgId: string, flags: Record<string, boolean>): Promise<Record<string, boolean>> {
+    const org = await this.db.organization.findUnique({ where: { id: orgId } });
+    if (!org) {
+      throw new NotFoundException('Organization not found');
+    }
+
+    // Filter to only known flag keys
+    const validFlags: Record<string, boolean> = {};
+    for (const [key, value] of Object.entries(flags)) {
+      if (key in FEATURE_FLAGS && typeof value === 'boolean') {
+        validFlags[key] = value;
+      }
+    }
+
+    const settings = (org.settings as Record<string, any>) || {};
+    const currentFlags = settings.featureFlags || {};
+    const updatedFlags = { ...currentFlags, ...validFlags };
+
+    await this.db.organization.update({
+      where: { id: orgId },
+      data: {
+        settings: { ...settings, featureFlags: updatedFlags },
+      },
+    });
+
+    this.logger.log(
+      `Feature flags updated for org ${orgId}: ${JSON.stringify(validFlags)}`,
+    );
+
+    // Return the full merged flags
+    return this.getFlags(orgId);
+  }
+}

--- a/middleware/src/modules/organizations/organizations.controller.spec.ts
+++ b/middleware/src/modules/organizations/organizations.controller.spec.ts
@@ -2,12 +2,14 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ForbiddenException } from '@nestjs/common';
 import { OrganizationsController } from './organizations.controller';
 import { OrganizationsService } from './organizations.service';
+import { FeatureFlagService } from './feature-flags.service';
 import { StorageQuotaService } from '../storage/storage-quota.service';
 import { Reflector } from '@nestjs/core';
 
 describe('OrganizationsController', () => {
   let controller: OrganizationsController;
   let mockOrganizationsService: jest.Mocked<OrganizationsService>;
+  let mockFeatureFlagService: jest.Mocked<FeatureFlagService>;
   let mockStorageQuotaService: jest.Mocked<StorageQuotaService>;
 
   beforeEach(async () => {
@@ -16,6 +18,12 @@ describe('OrganizationsController', () => {
       findOne: jest.fn(),
       update: jest.fn(),
       remove: jest.fn(),
+    } as any;
+
+    mockFeatureFlagService = {
+      isEnabled: jest.fn(),
+      getFlags: jest.fn(),
+      setFlags: jest.fn(),
     } as any;
 
     mockStorageQuotaService = {
@@ -30,6 +38,7 @@ describe('OrganizationsController', () => {
       controllers: [OrganizationsController],
       providers: [
         { provide: OrganizationsService, useValue: mockOrganizationsService },
+        { provide: FeatureFlagService, useValue: mockFeatureFlagService },
         { provide: StorageQuotaService, useValue: mockStorageQuotaService },
         { provide: Reflector, useValue: { getAllAndOverride: jest.fn() } },
       ],
@@ -182,6 +191,30 @@ describe('OrganizationsController', () => {
       }
 
       expect(mockOrganizationsService.remove).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getFeatureFlags', () => {
+    it('should return feature flags for the current org', async () => {
+      const flags = { weatherWidget: true, rssWidget: false };
+      mockFeatureFlagService.getFlags.mockResolvedValue(flags);
+
+      const result = await controller.getFeatureFlags('org-123');
+
+      expect(result).toEqual(flags);
+      expect(mockFeatureFlagService.getFlags).toHaveBeenCalledWith('org-123');
+    });
+  });
+
+  describe('updateFeatureFlags', () => {
+    it('should update feature flags for the current org', async () => {
+      const updatedFlags = { weatherWidget: true, rssWidget: false };
+      mockFeatureFlagService.setFlags.mockResolvedValue(updatedFlags);
+
+      const result = await controller.updateFeatureFlags('org-123', { rssWidget: false });
+
+      expect(result).toEqual(updatedFlags);
+      expect(mockFeatureFlagService.setFlags).toHaveBeenCalledWith('org-123', { rssWidget: false });
     });
   });
 });

--- a/middleware/src/modules/organizations/organizations.controller.ts
+++ b/middleware/src/modules/organizations/organizations.controller.ts
@@ -161,10 +161,22 @@ export class OrganizationsController {
     if (!file) {
       throw new BadRequestException('No file provided');
     }
-    const allowedMimes = ['image/png', 'image/jpeg', 'image/svg+xml'];
+    const allowedMimes = ['image/png', 'image/jpeg', 'image/webp'];
     if (!allowedMimes.includes(file.mimetype)) {
-      throw new BadRequestException('Only PNG, JPEG, and SVG files are allowed');
+      throw new BadRequestException('Only JPEG, PNG, and WebP images are accepted. SVG is not allowed.');
     }
+
+    // Validate magic bytes — reject files that lie about their type
+    const magicBytes = file.buffer.slice(0, 12);
+    const isJpeg = magicBytes[0] === 0xFF && magicBytes[1] === 0xD8 && magicBytes[2] === 0xFF;
+    const isPng = magicBytes[0] === 0x89 && magicBytes[1] === 0x50 && magicBytes[2] === 0x4E && magicBytes[3] === 0x47;
+    const isWebp = magicBytes[0] === 0x52 && magicBytes[1] === 0x49 && magicBytes[2] === 0x46 && magicBytes[3] === 0x46
+      && magicBytes[8] === 0x57 && magicBytes[9] === 0x45 && magicBytes[10] === 0x42 && magicBytes[11] === 0x50;
+
+    if (!isJpeg && !isPng && !isWebp) {
+      throw new BadRequestException('Only JPEG, PNG, and WebP images are accepted. SVG is not allowed.');
+    }
+
     return this.organizationsService.uploadLogo(id, file);
   }
 }

--- a/middleware/src/modules/organizations/organizations.controller.ts
+++ b/middleware/src/modules/organizations/organizations.controller.ts
@@ -16,9 +16,11 @@ import {
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { OrganizationsService } from './organizations.service';
+import { FeatureFlagService } from './feature-flags.service';
 import { StorageQuotaService } from '../storage/storage-quota.service';
 import { CreateOrganizationDto } from './dto/create-organization.dto';
 import { UpdateOrganizationDto } from './dto/update-organization.dto';
+import { UpdateFeatureFlagsDto } from './dto/update-feature-flags.dto';
 import { BrandingConfigDto } from './dto/branding-config.dto';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { Roles } from '../auth/decorators/roles.decorator';
@@ -28,6 +30,7 @@ import { RolesGuard } from '../auth/guards/roles.guard';
 export class OrganizationsController {
   constructor(
     private readonly organizationsService: OrganizationsService,
+    private readonly featureFlagService: FeatureFlagService,
     private readonly storageQuotaService: StorageQuotaService,
   ) {}
 
@@ -50,6 +53,23 @@ export class OrganizationsController {
   @Get('storage')
   async getStorageInfo(@CurrentUser('organizationId') organizationId: string) {
     return this.storageQuotaService.getStorageInfo(organizationId);
+  }
+
+  // Get feature flags for the current user's organization
+  @Get('feature-flags')
+  async getFeatureFlags(@CurrentUser('organizationId') organizationId: string) {
+    return this.featureFlagService.getFlags(organizationId);
+  }
+
+  // Update feature flags (admin only)
+  @Patch('feature-flags')
+  @UseGuards(RolesGuard)
+  @Roles('admin')
+  async updateFeatureFlags(
+    @CurrentUser('organizationId') organizationId: string,
+    @Body() dto: UpdateFeatureFlagsDto,
+  ) {
+    return this.featureFlagService.setFlags(organizationId, dto as Record<string, boolean>);
   }
 
   // Get by ID - only allow access to own organization

--- a/middleware/src/modules/organizations/organizations.module.ts
+++ b/middleware/src/modules/organizations/organizations.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { OrganizationsService } from './organizations.service';
+import { FeatureFlagService } from './feature-flags.service';
 import { OrganizationsController } from './organizations.controller';
 import { StorageModule } from '../storage/storage.module';
 
 @Module({
   imports: [StorageModule],
   controllers: [OrganizationsController],
-  providers: [OrganizationsService],
-  exports: [OrganizationsService],
+  providers: [OrganizationsService, FeatureFlagService],
+  exports: [OrganizationsService, FeatureFlagService],
 })
 export class OrganizationsModule {}

--- a/middleware/src/modules/organizations/organizations.module.ts
+++ b/middleware/src/modules/organizations/organizations.module.ts
@@ -1,13 +1,13 @@
 import { Module } from '@nestjs/common';
 import { OrganizationsService } from './organizations.service';
-import { FeatureFlagService } from './feature-flags.service';
+import { FeatureFlagService, FeatureFlagGuard } from './feature-flags.service';
 import { OrganizationsController } from './organizations.controller';
 import { StorageModule } from '../storage/storage.module';
 
 @Module({
   imports: [StorageModule],
   controllers: [OrganizationsController],
-  providers: [OrganizationsService, FeatureFlagService],
-  exports: [OrganizationsService, FeatureFlagService],
+  providers: [OrganizationsService, FeatureFlagService, FeatureFlagGuard],
+  exports: [OrganizationsService, FeatureFlagService, FeatureFlagGuard],
 })
 export class OrganizationsModule {}

--- a/middleware/src/modules/organizations/organizations.service.ts
+++ b/middleware/src/modules/organizations/organizations.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, NotFoundException, ConflictException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, ConflictException, BadRequestException } from '@nestjs/common';
 import { DatabaseService } from '../database/database.service';
 import { CreateOrganizationDto } from './dto/create-organization.dto';
 import { UpdateOrganizationDto } from './dto/update-organization.dto';
@@ -189,6 +189,18 @@ export class OrganizationsService {
   }
 
   async updateBranding(orgId: string, brandingDto: BrandingConfigDto) {
+    // Validate hex colors
+    const hexColorRegex = /^#[0-9A-Fa-f]{6}$/;
+    if (brandingDto.primaryColor && !hexColorRegex.test(brandingDto.primaryColor)) {
+      throw new BadRequestException('primaryColor must be a valid hex color (e.g., #00E5A0)');
+    }
+    if (brandingDto.secondaryColor && !hexColorRegex.test(brandingDto.secondaryColor)) {
+      throw new BadRequestException('secondaryColor must be a valid hex color (e.g., #38BDF8)');
+    }
+    if (brandingDto.accentColor && !hexColorRegex.test(brandingDto.accentColor)) {
+      throw new BadRequestException('accentColor must be a valid hex color (e.g., #0EA5E9)');
+    }
+
     const org = await this.findOne(orgId);
     if (brandingDto.customCSS) {
       brandingDto.customCSS = this.sanitizeCSS(brandingDto.customCSS);

--- a/web/src/app/(auth)/login-content.tsx
+++ b/web/src/app/(auth)/login-content.tsx
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import ValuePanel from '@/components/auth/ValuePanel';
 import FormField from '@/components/auth/FormField';
 import PasswordInput from '@/components/auth/PasswordInput';
+import GoogleSignInButton from '@/components/auth/GoogleSignInButton';
 
 function isValidRedirectUrl(url: string): boolean {
   return url.startsWith('/') && !url.startsWith('//') && !url.includes('://');
@@ -31,6 +32,26 @@ export default function LoginContent() {
 
   const clearFieldError = (field: string) => {
     if (errors[field]) setErrors((prev) => ({ ...prev, [field]: '' }));
+  };
+
+  const handleGoogleLogin = async (credential: string) => {
+    setLoading(true);
+    setError('');
+    try {
+      await apiClient.googleLogin(credential);
+      if (process.env.NODE_ENV === 'development') {
+        console.log('[LOGIN] Google login successful, redirecting to:', redirectUrl);
+      }
+      window.location.href = redirectUrl;
+    } catch (err: unknown) {
+      if (process.env.NODE_ENV === 'development') {
+        console.error('[LOGIN] Google login error:', err);
+      }
+      const message = err instanceof Error ? err.message : 'Google login failed';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -226,6 +247,21 @@ export default function LoginContent() {
             </button>
           </form>
 
+          {/* Divider */}
+          <div className="relative mt-5 lg:mt-4">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-[var(--border)]" />
+            </div>
+            <div className="relative flex justify-center text-xs">
+              <span className="bg-[var(--background)] px-3 text-[var(--foreground-tertiary)]">or</span>
+            </div>
+          </div>
+
+          {/* Google Sign-In */}
+          <div className="mt-4 lg:mt-3">
+            <GoogleSignInButton onSuccess={handleGoogleLogin} text="signin_with" />
+          </div>
+
           {/* Trust signals */}
           <div className="flex items-center justify-center gap-4 mt-4 lg:mt-3 text-[10px] text-[var(--foreground-tertiary)]">
             <span className="flex items-center gap-1">
@@ -239,16 +275,6 @@ export default function LoginContent() {
             <span>Free 30-day trial</span>
             <span className="text-[var(--border)]">|</span>
             <span>5 screens included</span>
-          </div>
-
-          {/* Divider + Register link */}
-          <div className="relative mt-6 lg:mt-4">
-            <div className="absolute inset-0 flex items-center">
-              <div className="w-full border-t border-[var(--border)]" />
-            </div>
-            <div className="relative flex justify-center text-xs">
-              <span className="bg-[var(--background)] px-3 text-[var(--foreground-tertiary)]">or</span>
-            </div>
           </div>
 
           <p className="text-center mt-4 lg:mt-3 text-sm text-[var(--foreground-secondary)]">

--- a/web/src/app/(auth)/register-content.tsx
+++ b/web/src/app/(auth)/register-content.tsx
@@ -9,6 +9,7 @@ import ValuePanel from '@/components/auth/ValuePanel';
 import FormField from '@/components/auth/FormField';
 import PasswordInput from '@/components/auth/PasswordInput';
 import PasswordChecklist from '@/components/auth/PasswordChecklist';
+import GoogleSignInButton from '@/components/auth/GoogleSignInButton';
 
 export default function RegisterContent() {
   const commonDomains = ['gmail.com', 'yahoo.com', 'outlook.com', 'hotmail.com', 'icloud.com', 'protonmail.com', 'mail.com', 'aol.com'];
@@ -72,6 +73,29 @@ export default function RegisterContent() {
     if (formData.confirmPassword.length < 3) return null;
     return formData.password === formData.confirmPassword;
   }, [formData.password, formData.confirmPassword]);
+
+  const handleGoogleSignUp = async (credential: string) => {
+    setLoading(true);
+    setError('');
+    try {
+      const result = await apiClient.googleLogin(credential);
+      setSuccess(true);
+      if (process.env.NODE_ENV === 'development') {
+        console.log('[REGISTER] Google sign-up successful, isNewUser:', result.isNewUser);
+      }
+      setTimeout(() => {
+        window.location.href = '/dashboard';
+      }, 800);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Google sign-up failed';
+      if (message.toLowerCase().includes('already exists') || message.toLowerCase().includes('duplicate')) {
+        setError('An account with this email already exists.');
+      } else {
+        setError(message);
+      }
+      setLoading(false);
+    }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -422,6 +446,21 @@ export default function RegisterContent() {
             </button>
           </form>
 
+          {/* Divider */}
+          <div className="relative mt-5 lg:mt-4">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-[var(--border)]" />
+            </div>
+            <div className="relative flex justify-center text-xs">
+              <span className="bg-[var(--background)] px-3 text-[var(--foreground-tertiary)]">or</span>
+            </div>
+          </div>
+
+          {/* Google Sign-Up */}
+          <div className="mt-4 lg:mt-3">
+            <GoogleSignInButton onSuccess={handleGoogleSignUp} text="signup_with" />
+          </div>
+
           {/* Trust signals */}
           <div className="flex items-center justify-center gap-4 mt-4 lg:mt-3 text-[10px] text-[var(--foreground-tertiary)]">
             <span className="flex items-center gap-1">
@@ -435,16 +474,6 @@ export default function RegisterContent() {
             <span>Free 30-day trial</span>
             <span className="text-[var(--border)]">|</span>
             <span>5 screens included</span>
-          </div>
-
-          {/* Divider + Login link */}
-          <div className="relative mt-6 lg:mt-4">
-            <div className="absolute inset-0 flex items-center">
-              <div className="w-full border-t border-[var(--border)]" />
-            </div>
-            <div className="relative flex justify-center text-xs">
-              <span className="bg-[var(--background)] px-3 text-[var(--foreground-tertiary)]">or</span>
-            </div>
           </div>
 
           <p className="text-center mt-4 lg:mt-3 text-sm text-[var(--foreground-secondary)]">

--- a/web/src/app/dashboard/layout.tsx
+++ b/web/src/app/dashboard/layout.tsx
@@ -15,6 +15,7 @@ import type { IconName } from '@/theme/icons';
 import TrialBanner from '@/components/TrialBanner';
 import { SupportChatProvider } from '@/components/support/SupportChatProvider';
 import { SupportChat } from '@/components/support/SupportChat';
+import { useCustomization } from '@/components/providers/CustomizationProvider';
 
 const navigation: Array<{ name: string; href: string; icon: IconName; exactMatch?: boolean }> = [
   { name: 'Overview', href: '/dashboard', icon: 'overview', exactMatch: true },
@@ -38,6 +39,10 @@ export default function DashboardLayout({
   const pathname = usePathname();
   const router = useRouter();
   const { user, loading: authLoading, logout: handleLogoutAuth } = useAuth();
+  const { brandConfig } = useCustomization();
+  const brandName = brandConfig?.name || 'Vizora';
+  const brandLogo = brandConfig?.logo;
+  const brandInitial = brandName.charAt(0).toUpperCase();
   const [sidebarOpen, setSidebarOpen] = useState(() => {
     if (typeof window !== 'undefined') return window.innerWidth >= 1024;
     return true;
@@ -138,11 +143,15 @@ export default function DashboardLayout({
                 </svg>
               </button>
               <Link href="/dashboard" className="flex items-center gap-2">
-                <div className="w-8 h-8 bg-gradient-to-br from-[#00E5A0] to-[#00B4D8] rounded-lg flex items-center justify-center">
-                  <span className="text-[#061A21] font-bold text-lg">V</span>
-                </div>
+                {brandLogo ? (
+                  <img src={brandLogo} alt={brandName} className="w-8 h-8 rounded-lg object-contain" />
+                ) : (
+                  <div className="w-8 h-8 bg-gradient-to-br from-[#00E5A0] to-[#00B4D8] rounded-lg flex items-center justify-center">
+                    <span className="text-[#061A21] font-bold text-lg">{brandInitial}</span>
+                  </div>
+                )}
                 <h1 className="text-2xl font-bold eh-gradient eh-heading">
-                  Vizora
+                  {brandName}
                 </h1>
               </Link>
             </div>
@@ -267,7 +276,7 @@ export default function DashboardLayout({
               </div>
               <div className="flex justify-between">
                 <span>Platform</span>
-                <span className="font-semibold">Vizora</span>
+                <span className="font-semibold">{brandName}</span>
               </div>
             </div>
           </div>

--- a/web/src/app/dashboard/settings/customization/__tests__/page.test.tsx
+++ b/web/src/app/dashboard/settings/customization/__tests__/page.test.tsx
@@ -154,6 +154,6 @@ describe('CustomizationPage', () => {
   it('renders logo upload section', () => {
     render(<CustomizationPage />);
     expect(screen.getByText('Upload Logo')).toBeInTheDocument();
-    expect(screen.getByText(/PNG, JPEG, or SVG/)).toBeInTheDocument();
+    expect(screen.getByText(/PNG, JPEG, or WebP/)).toBeInTheDocument();
   });
 });

--- a/web/src/app/dashboard/settings/customization/page.tsx
+++ b/web/src/app/dashboard/settings/customization/page.tsx
@@ -40,9 +40,9 @@ export default function CustomizationPage() {
  const file = e.target.files?.[0];
  if (!file || !organizationId) return;
 
- const allowedTypes = ['image/png', 'image/jpeg', 'image/svg+xml'];
+ const allowedTypes = ['image/png', 'image/jpeg', 'image/webp'];
  if (!allowedTypes.includes(file.type)) {
-   setLogoUploadError('Only PNG, JPEG, and SVG files are allowed');
+   setLogoUploadError('Only PNG, JPEG, and WebP files are allowed');
    return;
  }
 
@@ -134,7 +134,7 @@ export default function CustomizationPage() {
  <input
  ref={fileInputRef}
  type="file"
- accept="image/png,image/jpeg,image/svg+xml"
+ accept="image/png,image/jpeg,image/webp"
  onChange={handleLogoUpload}
  className="flex-1 text-sm text-[var(--foreground)] file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-[var(--surface-hover)] file:text-[var(--foreground)] hover:file:bg-[var(--border)]"
  disabled={logoUploading || !organizationId}
@@ -147,7 +147,7 @@ export default function CustomizationPage() {
    <p className="text-xs text-red-500 mt-1">{logoUploadError}</p>
  )}
  <p className="text-xs text-[var(--foreground-secondary)] mt-1">
- PNG, JPEG, or SVG. Max 2MB.
+ PNG, JPEG, or WebP. Max 2MB.
  </p>
  </div>
 

--- a/web/src/app/dashboard/settings/feature-flags/__tests__/page.test.tsx
+++ b/web/src/app/dashboard/settings/feature-flags/__tests__/page.test.tsx
@@ -1,0 +1,178 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    refresh: jest.fn(),
+  }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const mockGetFeatureFlags = jest.fn();
+const mockUpdateFeatureFlags = jest.fn();
+
+jest.mock('@/lib/api', () => ({
+  apiClient: {
+    getFeatureFlags: (...args: any[]) => mockGetFeatureFlags(...args),
+    updateFeatureFlags: (...args: any[]) => mockUpdateFeatureFlags(...args),
+  },
+}));
+
+const mockUseAuth = jest.fn();
+jest.mock('@/lib/hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock('@/lib/hooks/useToast', () => ({
+  useToast: () => ({
+    success: jest.fn(),
+    error: jest.fn(),
+    ToastContainer: () => null,
+  }),
+}));
+
+import FeatureFlagsPage from '../page';
+
+const defaultFlags = {
+  weatherWidget: true,
+  rssWidget: true,
+  clockWidget: true,
+  fleetControl: true,
+  contentModeration: true,
+  customBranding: true,
+  advancedAnalytics: true,
+  emergencyOverride: true,
+};
+
+describe('FeatureFlagsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({ user: { role: 'admin' } });
+    mockGetFeatureFlags.mockResolvedValue(defaultFlags);
+  });
+
+  it('should render feature flag toggles', async () => {
+    render(<FeatureFlagsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Weather Widget')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('RSS/News Widget')).toBeInTheDocument();
+    expect(screen.getByText('Fleet Control')).toBeInTheDocument();
+    expect(screen.getByText('Emergency Override')).toBeInTheDocument();
+    expect(screen.getByText('Advanced Analytics')).toBeInTheDocument();
+  });
+
+  it('should load flags on mount', async () => {
+    render(<FeatureFlagsPage />);
+
+    await waitFor(() => {
+      expect(mockGetFeatureFlags).toHaveBeenCalled();
+    });
+  });
+
+  it('should show admin warning for non-admin users', async () => {
+    mockUseAuth.mockReturnValue({ user: { role: 'viewer' } });
+    render(<FeatureFlagsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/only administrators/i)).toBeInTheDocument();
+    });
+  });
+
+  it('should toggle a feature flag when clicked', async () => {
+    render(<FeatureFlagsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Weather Widget')).toBeInTheDocument();
+    });
+
+    // Find the weather widget toggle (first switch)
+    const switches = screen.getAllByRole('switch');
+    expect(switches.length).toBe(8);
+
+    // All should be checked initially
+    expect(switches[0]).toHaveAttribute('aria-checked', 'true');
+
+    // Click to toggle off
+    fireEvent.click(switches[0]);
+
+    // Should now show as unchecked
+    expect(switches[0]).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('should enable save button after toggling', async () => {
+    render(<FeatureFlagsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Weather Widget')).toBeInTheDocument();
+    });
+
+    // Save button should be disabled initially
+    const saveBtn = screen.getByText('Save Changes');
+    expect(saveBtn).toBeDisabled();
+
+    // Toggle a flag
+    const switches = screen.getAllByRole('switch');
+    fireEvent.click(switches[0]);
+
+    // Save button should be enabled now
+    expect(saveBtn).not.toBeDisabled();
+  });
+
+  it('should call updateFeatureFlags on save', async () => {
+    mockUpdateFeatureFlags.mockResolvedValue({ ...defaultFlags, weatherWidget: false });
+    render(<FeatureFlagsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Weather Widget')).toBeInTheDocument();
+    });
+
+    // Toggle weather widget off
+    const switches = screen.getAllByRole('switch');
+    fireEvent.click(switches[0]);
+
+    // Click save
+    const saveBtn = screen.getByText('Save Changes');
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(mockUpdateFeatureFlags).toHaveBeenCalledWith(
+        expect.objectContaining({ weatherWidget: false }),
+      );
+    });
+  });
+
+  it('should disable toggles for non-admin users', async () => {
+    mockUseAuth.mockReturnValue({ user: { role: 'viewer' } });
+    render(<FeatureFlagsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Weather Widget')).toBeInTheDocument();
+    });
+
+    const switches = screen.getAllByRole('switch');
+    switches.forEach(s => expect(s).toBeDisabled());
+  });
+
+  it('should show discard changes button when dirty', async () => {
+    render(<FeatureFlagsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Weather Widget')).toBeInTheDocument();
+    });
+
+    // No discard button initially
+    expect(screen.queryByText('Discard Changes')).not.toBeInTheDocument();
+
+    // Toggle to make dirty
+    const switches = screen.getAllByRole('switch');
+    fireEvent.click(switches[0]);
+
+    expect(screen.getByText('Discard Changes')).toBeInTheDocument();
+  });
+});

--- a/web/src/app/dashboard/settings/feature-flags/loading.tsx
+++ b/web/src/app/dashboard/settings/feature-flags/loading.tsx
@@ -1,0 +1,12 @@
+import LoadingSpinner from '@/components/LoadingSpinner';
+
+export default function Loading() {
+  return (
+    <div className="flex items-center justify-center min-h-[400px]">
+      <div className="flex flex-col items-center gap-4">
+        <LoadingSpinner size="lg" />
+        <p className="text-sm text-[var(--foreground-tertiary)]">Loading...</p>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/dashboard/settings/feature-flags/page.tsx
+++ b/web/src/app/dashboard/settings/feature-flags/page.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { apiClient } from '@/lib/api';
+import { useAuth } from '@/lib/hooks/useAuth';
+import { useToast } from '@/lib/hooks/useToast';
+
+export const dynamic = 'force-dynamic';
+
+const FEATURE_DEFINITIONS = [
+  { key: 'weatherWidget', name: 'Weather Widget', description: 'Display weather information on signage screens' },
+  { key: 'rssWidget', name: 'RSS/News Widget', description: 'Display RSS feeds and news headlines on signage' },
+  { key: 'clockWidget', name: 'Clock & Countdown Widget', description: 'Display clocks, timers, and countdowns' },
+  { key: 'fleetControl', name: 'Fleet Control', description: 'Remote device management commands (reboot, screenshot, etc.)' },
+  { key: 'contentModeration', name: 'Content Moderation', description: 'Flag and review content workflow before publishing' },
+  { key: 'customBranding', name: 'Custom Branding', description: 'Custom logo, colors, and branding on dashboard and displays' },
+  { key: 'advancedAnalytics', name: 'Advanced Analytics', description: 'Detailed content performance metrics and reporting' },
+  { key: 'emergencyOverride', name: 'Emergency Override', description: 'Push emergency content to all devices instantly' },
+] as const;
+
+export default function FeatureFlagsPage() {
+  const { user } = useAuth();
+  const toast = useToast();
+  const [flags, setFlags] = useState<Record<string, boolean>>({});
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+
+  const isAdmin = user?.role === 'admin';
+
+  const loadFlags = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await apiClient.getFeatureFlags();
+      setFlags(data);
+    } catch (err: any) {
+      toast.error(err.message || 'Failed to load feature flags');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadFlags();
+  }, [loadFlags]);
+
+  const handleToggle = (key: string) => {
+    if (!isAdmin) return;
+    setFlags(prev => ({ ...prev, [key]: !prev[key] }));
+    setDirty(true);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const updated = await apiClient.updateFeatureFlags(flags);
+      setFlags(updated);
+      setDirty(false);
+      toast.success('Feature flags saved');
+    } catch (err: any) {
+      toast.error(err.message || 'Failed to save feature flags');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleReset = () => {
+    loadFlags();
+    setDirty(false);
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-8">
+        <div>
+          <h2 className="eh-dash-title font-[var(--font-sora)] text-2xl text-[var(--foreground)]">Feature Flags</h2>
+          <p className="mt-2 text-[var(--foreground-secondary)]">Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="eh-dash-title font-[var(--font-sora)] text-2xl text-[var(--foreground)]">Feature Flags</h2>
+        <p className="mt-2 text-[var(--foreground-secondary)]">
+          Enable or disable features for your organization. All features are enabled by default.
+        </p>
+      </div>
+
+      {!isAdmin && (
+        <div className="p-4 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg">
+          <p className="text-sm text-yellow-700 dark:text-yellow-300">
+            Only administrators can modify feature flags. Contact your admin to change these settings.
+          </p>
+        </div>
+      )}
+
+      <div className="eh-dash-card bg-[var(--surface)] rounded-lg shadow-md p-6">
+        <h3 className="eh-dash-subtitle text-lg font-semibold text-[var(--foreground)] mb-6">Features</h3>
+        <div className="space-y-1">
+          {FEATURE_DEFINITIONS.map(({ key, name, description }) => (
+            <label
+              key={key}
+              className={`flex items-center justify-between p-4 rounded-lg transition ${
+                isAdmin
+                  ? 'cursor-pointer hover:bg-[var(--surface-hover)]'
+                  : 'cursor-default opacity-80'
+              }`}
+            >
+              <div className="flex-1 mr-4">
+                <div className="font-medium text-[var(--foreground)]">{name}</div>
+                <div className="text-sm text-[var(--foreground-secondary)]">{description}</div>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={flags[key] !== false}
+                disabled={!isAdmin}
+                onClick={() => handleToggle(key)}
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-[#00E5A0] focus:ring-offset-2 disabled:opacity-50 ${
+                  flags[key] !== false
+                    ? 'bg-[#00E5A0]'
+                    : 'bg-gray-300 dark:bg-gray-600'
+                }`}
+              >
+                <span
+                  className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                    flags[key] !== false ? 'translate-x-6' : 'translate-x-1'
+                  }`}
+                />
+              </button>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {isAdmin && (
+        <div className="flex justify-end gap-3">
+          {dirty && (
+            <button
+              onClick={handleReset}
+              className="px-4 py-2 text-sm font-medium text-[var(--foreground-secondary)] bg-[var(--surface)] border border-[var(--border)] rounded-lg hover:bg-[var(--surface-hover)] transition"
+            >
+              Discard Changes
+            </button>
+          )}
+          <button
+            onClick={handleSave}
+            disabled={saving || !dirty}
+            className="eh-btn-neon rounded-xl px-6 py-3 text-sm font-medium transition shadow-md disabled:opacity-50"
+          >
+            {saving ? 'Saving...' : 'Save Changes'}
+          </button>
+        </div>
+      )}
+
+      <toast.ToastContainer />
+    </div>
+  );
+}

--- a/web/src/app/dashboard/settings/page.tsx
+++ b/web/src/app/dashboard/settings/page.tsx
@@ -160,9 +160,9 @@ export default function SettingsPage() {
    const file = e.target.files?.[0];
    if (!file) return;
 
-   const allowedTypes = ['image/jpeg', 'image/png', 'image/svg+xml'];
+   const allowedTypes = ['image/jpeg', 'image/png', 'image/webp'];
    if (!allowedTypes.includes(file.type)) {
-     toast.error('Only PNG, JPEG, and SVG logos are allowed');
+     toast.error('Only PNG, JPEG, and WebP logos are allowed');
      return;
    }
    if (file.size > 1024 * 1024) {
@@ -633,12 +633,12 @@ export default function SettingsPage() {
            )}
          </div>
          <p className="text-xs text-[var(--foreground-tertiary)]">
-           PNG, JPEG, or SVG. Max 1MB. Recommended: 256x256px.
+           PNG, JPEG, or WebP. Max 1MB. Recommended: 256x256px.
          </p>
          <input
            ref={logoInputRef}
            type="file"
-           accept="image/png,image/jpeg,image/svg+xml"
+           accept="image/png,image/jpeg,image/webp"
            onChange={handleLogoSelect}
            className="hidden"
          />

--- a/web/src/app/dashboard/settings/page.tsx
+++ b/web/src/app/dashboard/settings/page.tsx
@@ -9,6 +9,7 @@ import { useTheme } from '@/components/providers/ThemeProvider';
 import { semanticColors } from '@/theme/colors';
 import Modal from '@/components/Modal';
 import { useToast } from '@/lib/hooks/useToast';
+import { useCustomization } from '@/components/providers/CustomizationProvider';
 
 export const dynamic = 'force-dynamic';
 
@@ -48,6 +49,17 @@ export default function SettingsPage() {
  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
  const [avatarUploading, setAvatarUploading] = useState(false);
  const fileInputRef = useRef<HTMLInputElement>(null);
+
+ // Branding state
+ const { brandConfig, updateBrandConfig, organizationId: brandOrgId } = useCustomization();
+ const [brandingForm, setBrandingForm] = useState({
+   companyName: '',
+   primaryColor: '#00E5A0',
+   logoPreview: null as string | null,
+ });
+ const [brandingSaving, setBrandingSaving] = useState(false);
+ const [logoUploading, setLogoUploading] = useState(false);
+ const logoInputRef = useRef<HTMLInputElement>(null);
 
  const getUserInitials = () => {
    if (profileForm.firstName && profileForm.lastName) {
@@ -131,6 +143,80 @@ export default function SettingsPage() {
    }
    loadSettings();
  }, []);
+
+ // Sync branding form with context when brandConfig loads
+ useEffect(() => {
+   if (brandConfig) {
+     setBrandingForm(prev => ({
+       ...prev,
+       companyName: brandConfig.name || '',
+       primaryColor: brandConfig.primaryColor || '#00E5A0',
+       logoPreview: brandConfig.logo || null,
+     }));
+   }
+ }, [brandConfig]);
+
+ const handleLogoSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+   const file = e.target.files?.[0];
+   if (!file) return;
+
+   const allowedTypes = ['image/jpeg', 'image/png', 'image/svg+xml'];
+   if (!allowedTypes.includes(file.type)) {
+     toast.error('Only PNG, JPEG, and SVG logos are allowed');
+     return;
+   }
+   if (file.size > 1024 * 1024) {
+     toast.error('Logo must be smaller than 1MB');
+     return;
+   }
+
+   const orgId = brandOrgId || settings.organizationId;
+   if (!orgId) {
+     toast.error('Organization not loaded yet');
+     return;
+   }
+
+   setLogoUploading(true);
+   try {
+     const result = await apiClient.uploadBrandingLogo(orgId, file);
+     setBrandingForm(prev => ({ ...prev, logoPreview: result.logoUrl }));
+     toast.success('Logo uploaded');
+   } catch (error: any) {
+     toast.error(error.message || 'Failed to upload logo');
+   } finally {
+     setLogoUploading(false);
+     if (logoInputRef.current) logoInputRef.current.value = '';
+   }
+ };
+
+ const handleSaveBranding = async () => {
+   const orgId = brandOrgId || settings.organizationId;
+   if (!orgId) {
+     toast.error('Organization not loaded yet');
+     return;
+   }
+   setBrandingSaving(true);
+   try {
+     await apiClient.updateBranding(orgId, {
+       name: brandingForm.companyName.trim() || 'Vizora',
+       primaryColor: brandingForm.primaryColor,
+       secondaryColor: brandConfig?.secondaryColor || '#00B4D8',
+       showPoweredBy: brandConfig?.showPoweredBy ?? true,
+       logoUrl: brandingForm.logoPreview || undefined,
+     });
+     // Update the context so header/sidebar reflect changes immediately
+     updateBrandConfig({
+       name: brandingForm.companyName.trim() || 'Vizora',
+       primaryColor: brandingForm.primaryColor,
+       logo: brandingForm.logoPreview || undefined,
+     });
+     toast.success('Branding updated');
+   } catch (error: any) {
+     toast.error(error.message || 'Failed to save branding');
+   } finally {
+     setBrandingSaving(false);
+   }
+ };
 
  const handleSaveProfile = async () => {
    if (!profileForm.firstName.trim()) {
@@ -439,6 +525,168 @@ export default function SettingsPage() {
  </div>
  </div>
 
+ {/* Branding / Customization */}
+ <div className="eh-dash-card bg-[var(--surface)] rounded-lg shadow-md p-6">
+ <h3 className="eh-dash-subtitle text-lg font-semibold text-[var(--foreground)] mb-4">Customization</h3>
+ <p className="text-sm text-[var(--foreground-secondary)] mb-6">
+   Customize your dashboard with your organization&apos;s brand colors, logo, and name.
+ </p>
+ <div className="space-y-6">
+   {/* Company Name */}
+   <div>
+     <label className="block text-sm font-semibold text-[var(--foreground-secondary)] mb-2">
+       Company Name
+     </label>
+     <input
+       type="text"
+       value={brandingForm.companyName}
+       onChange={(e) => setBrandingForm({ ...brandingForm, companyName: e.target.value })}
+       placeholder="Vizora"
+       maxLength={100}
+       className="eh-input w-full px-4 py-2 border border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] rounded-lg focus:ring-2 focus:ring-[#00E5A0] focus:border-transparent"
+     />
+     <p className="mt-1 text-xs text-[var(--foreground-tertiary)]">
+       Replaces &quot;Vizora&quot; in the sidebar and header
+     </p>
+   </div>
+
+   {/* Primary Color */}
+   <div>
+     <label className="block text-sm font-semibold text-[var(--foreground-secondary)] mb-2">
+       Primary Color
+     </label>
+     <div className="flex items-center gap-3">
+       <input
+         type="color"
+         value={brandingForm.primaryColor}
+         onChange={(e) => setBrandingForm({ ...brandingForm, primaryColor: e.target.value })}
+         className="w-10 h-10 rounded-lg border border-[var(--border)] cursor-pointer p-0.5"
+       />
+       <input
+         type="text"
+         value={brandingForm.primaryColor}
+         onChange={(e) => {
+           const v = e.target.value;
+           if (/^#[0-9A-Fa-f]{0,6}$/.test(v)) {
+             setBrandingForm({ ...brandingForm, primaryColor: v });
+           }
+         }}
+         maxLength={7}
+         className="eh-input w-32 px-3 py-2 border border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] rounded-lg focus:ring-2 focus:ring-[#00E5A0] focus:border-transparent font-mono text-sm"
+       />
+       {/* Quick presets */}
+       <div className="flex gap-1.5">
+         {['#00E5A0', '#3B82F6', '#8B5CF6', '#EF4444', '#F59E0B', '#EC4899'].map(color => (
+           <button
+             key={color}
+             onClick={() => setBrandingForm({ ...brandingForm, primaryColor: color })}
+             className={`w-7 h-7 rounded-md border-2 transition ${brandingForm.primaryColor === color ? 'border-[var(--foreground)] scale-110' : 'border-[var(--border)] hover:scale-105'}`}
+             style={{ backgroundColor: color }}
+             title={color}
+           />
+         ))}
+       </div>
+     </div>
+     <p className="mt-1 text-xs text-[var(--foreground-tertiary)]">
+       Used as the accent color throughout the dashboard
+     </p>
+   </div>
+
+   {/* Logo Upload */}
+   <div>
+     <label className="block text-sm font-semibold text-[var(--foreground-secondary)] mb-2">
+       Logo
+     </label>
+     <div className="flex items-center gap-4">
+       <div className="relative w-16 h-16 rounded-lg border-2 border-dashed border-[var(--border)] flex items-center justify-center overflow-hidden bg-[var(--background)]">
+         {brandingForm.logoPreview ? (
+           <img
+             src={brandingForm.logoPreview}
+             alt="Logo preview"
+             className="w-full h-full object-contain p-1"
+           />
+         ) : (
+           <Icon name="content" size="lg" className="text-[var(--foreground-tertiary)]" />
+         )}
+         {logoUploading && (
+           <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
+             <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+           </div>
+         )}
+       </div>
+       <div className="space-y-2">
+         <div className="flex gap-2">
+           <button
+             onClick={() => logoInputRef.current?.click()}
+             disabled={logoUploading}
+             className="px-3 py-1.5 text-sm font-medium bg-[var(--background)] text-[var(--foreground-secondary)] border border-[var(--border)] rounded-lg hover:bg-[var(--surface-hover)] transition disabled:opacity-50"
+           >
+             {logoUploading ? 'Uploading...' : 'Upload Logo'}
+           </button>
+           {brandingForm.logoPreview && (
+             <button
+               onClick={() => setBrandingForm({ ...brandingForm, logoPreview: null })}
+               className="px-3 py-1.5 text-sm font-medium text-red-500 border border-red-200 dark:border-red-800 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/30 transition"
+             >
+               Remove
+             </button>
+           )}
+         </div>
+         <p className="text-xs text-[var(--foreground-tertiary)]">
+           PNG, JPEG, or SVG. Max 1MB. Recommended: 256x256px.
+         </p>
+         <input
+           ref={logoInputRef}
+           type="file"
+           accept="image/png,image/jpeg,image/svg+xml"
+           onChange={handleLogoSelect}
+           className="hidden"
+         />
+       </div>
+     </div>
+   </div>
+
+   {/* Live Preview */}
+   <div>
+     <label className="block text-sm font-semibold text-[var(--foreground-secondary)] mb-2">
+       Preview
+     </label>
+     <div className="p-4 rounded-lg border border-[var(--border)] bg-[var(--background)]">
+       <div className="flex items-center gap-2">
+         {brandingForm.logoPreview ? (
+           <img src={brandingForm.logoPreview} alt="Preview" className="w-8 h-8 rounded-lg object-contain" />
+         ) : (
+           <div
+             className="w-8 h-8 rounded-lg flex items-center justify-center"
+             style={{ background: `linear-gradient(135deg, ${brandingForm.primaryColor}, #00B4D8)` }}
+           >
+             <span className="text-white font-bold text-lg">
+               {(brandingForm.companyName || 'V').charAt(0).toUpperCase()}
+             </span>
+           </div>
+         )}
+         <span
+           className="text-2xl font-bold"
+           style={{ color: brandingForm.primaryColor }}
+         >
+           {brandingForm.companyName || 'Vizora'}
+         </span>
+       </div>
+     </div>
+   </div>
+
+   <div className="flex justify-end">
+     <button
+       onClick={handleSaveBranding}
+       disabled={brandingSaving}
+       className="eh-btn-neon rounded-xl px-4 py-2 text-sm font-medium transition disabled:opacity-50"
+     >
+       {brandingSaving ? 'Saving...' : 'Save Branding'}
+     </button>
+   </div>
+ </div>
+ </div>
+
  {/* Display Settings */}
  <div className="eh-dash-card bg-[var(--surface)] rounded-lg shadow-md p-6">
  <h3 className="eh-dash-subtitle text-lg font-semibold text-[var(--foreground)] mb-4">Display Settings</h3>
@@ -511,6 +759,23 @@ export default function SettingsPage() {
  >
  <Icon name="analytics" size="md" className="text-[var(--foreground-secondary)]" />
  Subscription & Billing
+ <span className="ml-auto text-[var(--foreground-tertiary)]">
+ <Icon name="chevronRight" size="md" />
+ </span>
+ </Link>
+ </div>
+ </div>
+
+ {/* Feature Flags */}
+ <div className="eh-dash-card bg-[var(--surface)] rounded-lg shadow-md p-6">
+ <h3 className="eh-dash-subtitle text-lg font-semibold text-[var(--foreground)] mb-4">Features</h3>
+ <div className="space-y-3">
+ <Link
+ href="/dashboard/settings/feature-flags"
+ className="w-full px-4 py-3 text-sm bg-[var(--background)] text-[var(--foreground-secondary)] rounded-lg hover:bg-[var(--surface-hover)] transition font-medium text-left flex items-center gap-2"
+ >
+ <Icon name="settings" size="md" className="text-[var(--foreground-secondary)]" />
+ Feature Flags
  <span className="ml-auto text-[var(--foreground-tertiary)]">
  <Icon name="chevronRight" size="md" />
  </span>

--- a/web/src/components/auth/GoogleSignInButton.tsx
+++ b/web/src/components/auth/GoogleSignInButton.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useEffect, useRef, useCallback } from 'react';
+
+declare global {
+  interface Window {
+    google?: {
+      accounts: {
+        id: {
+          initialize: (config: {
+            client_id: string;
+            callback: (response: { credential: string }) => void;
+            auto_select?: boolean;
+          }) => void;
+          renderButton: (
+            element: HTMLElement,
+            options: {
+              theme?: 'outline' | 'filled_blue' | 'filled_black';
+              size?: 'large' | 'medium' | 'small';
+              width?: string | number;
+              text?: 'signin_with' | 'signup_with' | 'continue_with' | 'signin';
+              shape?: 'rectangular' | 'pill' | 'circle' | 'square';
+              logo_alignment?: 'left' | 'center';
+            },
+          ) => void;
+          prompt: () => void;
+        };
+      };
+    };
+  }
+}
+
+interface GoogleSignInButtonProps {
+  onSuccess: (credential: string) => void;
+  text?: 'signin_with' | 'signup_with' | 'continue_with';
+}
+
+export default function GoogleSignInButton({ onSuccess, text = 'signin_with' }: GoogleSignInButtonProps) {
+  const buttonRef = useRef<HTMLDivElement>(null);
+  const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
+
+  // Stabilize callback ref to avoid re-initialization on every render
+  const onSuccessRef = useRef(onSuccess);
+  onSuccessRef.current = onSuccess;
+
+  const stableCallback = useCallback((response: { credential: string }) => {
+    onSuccessRef.current(response.credential);
+  }, []);
+
+  useEffect(() => {
+    if (!clientId) return;
+
+    // Load Google Identity Services script
+    const script = document.createElement('script');
+    script.src = 'https://accounts.google.com/gsi/client';
+    script.async = true;
+    script.defer = true;
+    script.onload = () => {
+      window.google?.accounts.id.initialize({
+        client_id: clientId,
+        callback: stableCallback,
+      });
+      if (buttonRef.current) {
+        window.google?.accounts.id.renderButton(buttonRef.current, {
+          theme: 'outline',
+          size: 'large',
+          width: 280,
+          text,
+          shape: 'rectangular',
+          logo_alignment: 'left',
+        });
+      }
+    };
+    document.body.appendChild(script);
+
+    return () => {
+      script.remove();
+    };
+  }, [clientId, stableCallback, text]);
+
+  if (!clientId) return null;
+
+  return (
+    <div className="flex justify-center">
+      <div ref={buttonRef} />
+    </div>
+  );
+}

--- a/web/src/components/providers/CustomizationProvider.tsx
+++ b/web/src/components/providers/CustomizationProvider.tsx
@@ -59,9 +59,9 @@ export function CustomizationProvider({ children }: { children: React.ReactNode 
           id: org.id,
           name: branding.name || org.name,
           logo: branding.logoUrl,
-          primaryColor: branding.primaryColor || '#0284c7',
-          secondaryColor: branding.secondaryColor || '#38bdf8',
-          accentColor: branding.accentColor || '#0ea5e9',
+          primaryColor: branding.primaryColor || '#00E5A0',
+          secondaryColor: branding.secondaryColor || '#00B4D8',
+          accentColor: branding.accentColor || '#00CC8E',
           fontFamily: branding.fontFamily || 'sans',
           showPoweredBy: branding.showPoweredBy ?? true,
           customDomain: branding.customDomain || '',
@@ -151,10 +151,23 @@ export function CustomizationProvider({ children }: { children: React.ReactNode 
   );
 }
 
+// Default fallback when context is not yet available (pre-hydration)
+const defaultCustomizationContext: CustomizationContextType = {
+  brandConfig: {
+    id: 'default',
+    name: 'Vizora',
+    primaryColor: '#00E5A0',
+    secondaryColor: '#00B4D8',
+    accentColor: '#00CC8E',
+    fontFamily: 'sans',
+    showPoweredBy: true,
+  },
+  updateBrandConfig: () => {},
+  organizationId: null,
+};
+
 export function useCustomization() {
   const context = useContext(CustomizationContext);
-  if (!context) {
-    throw new Error('useCustomization must be used within CustomizationProvider');
-  }
-  return context;
+  // Return default context during SSR / pre-hydration instead of throwing
+  return context ?? defaultCustomizationContext;
 }

--- a/web/src/lib/api/auth.ts
+++ b/web/src/lib/api/auth.ts
@@ -3,10 +3,15 @@
 import { devLog } from '../logger';
 import { ApiClient, LoginResponse, RegisterResponse, AuthUser } from './client';
 
+export interface GoogleLoginResponse extends LoginResponse {
+  isNewUser: boolean;
+}
+
 declare module './client' {
   interface ApiClient {
     login(email: string, password: string): Promise<LoginResponse>;
     register(email: string, password: string, organizationName: string, firstName: string, lastName: string): Promise<RegisterResponse>;
+    googleLogin(credential: string): Promise<GoogleLoginResponse>;
     logout(): Promise<void>;
     refreshToken(): Promise<{ expiresIn: number }>;
     getCurrentUser(): Promise<AuthUser>;
@@ -54,6 +59,20 @@ ApiClient.prototype.register = async function (
       firstName,
       lastName,
     }),
+  });
+
+  // Mark as authenticated - token is in httpOnly cookie
+  this.isAuthenticated = true;
+  return response;
+};
+
+ApiClient.prototype.googleLogin = async function (credential: string): Promise<GoogleLoginResponse> {
+  if (process.env.NODE_ENV === 'development') {
+    devLog('[API] Google login called');
+  }
+  const response = await this.request<GoogleLoginResponse>('/auth/google', {
+    method: 'POST',
+    body: JSON.stringify({ credential }),
   });
 
   // Mark as authenticated - token is in httpOnly cookie

--- a/web/src/lib/api/organizations.ts
+++ b/web/src/lib/api/organizations.ts
@@ -2,10 +2,29 @@
 
 import { ApiClient, Organization } from './client';
 
+export interface BrandingConfig {
+  name: string;
+  logoUrl?: string;
+  primaryColor: string;
+  secondaryColor: string;
+  accentColor?: string;
+  fontFamily?: 'sans' | 'serif' | 'mono';
+  showPoweredBy: boolean;
+  customDomain?: string;
+  customCSS?: string;
+}
+
+export type FeatureFlags = Record<string, boolean>;
+
 declare module './client' {
   interface ApiClient {
     getOrganization(): Promise<Organization>;
     updateOrganization(id: string, data: Partial<{ name: string; country: string; gstin: string; settings: Record<string, any> }>): Promise<Organization>;
+    getBranding(orgId: string): Promise<BrandingConfig>;
+    updateBranding(orgId: string, data: Partial<BrandingConfig>): Promise<Organization>;
+    uploadBrandingLogo(orgId: string, file: File): Promise<{ logoUrl: string }>;
+    getFeatureFlags(): Promise<FeatureFlags>;
+    updateFeatureFlags(flags: Partial<FeatureFlags>): Promise<FeatureFlags>;
   }
 }
 
@@ -17,5 +36,33 @@ ApiClient.prototype.updateOrganization = async function (id: string, data: Parti
   return this.request<Organization>(`/organizations/${id}`, {
     method: 'PATCH',
     body: JSON.stringify(data),
+  });
+};
+
+ApiClient.prototype.getBranding = async function (orgId: string): Promise<BrandingConfig> {
+  return this.request<BrandingConfig>(`/organizations/${orgId}/branding`);
+};
+
+ApiClient.prototype.updateBranding = async function (orgId: string, data: Partial<BrandingConfig>): Promise<Organization> {
+  return this.request<Organization>(`/organizations/${orgId}/branding`, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  });
+};
+
+ApiClient.prototype.uploadBrandingLogo = async function (orgId: string, file: File): Promise<{ logoUrl: string }> {
+  const formData = new FormData();
+  formData.append('file', file);
+  return this.requestFormData<{ logoUrl: string }>(`/organizations/${orgId}/branding/logo`, formData);
+};
+
+ApiClient.prototype.getFeatureFlags = async function (): Promise<FeatureFlags> {
+  return this.request<FeatureFlags>('/organizations/feature-flags');
+};
+
+ApiClient.prototype.updateFeatureFlags = async function (flags: Partial<FeatureFlags>): Promise<FeatureFlags> {
+  return this.request<FeatureFlags>('/organizations/feature-flags', {
+    method: 'PATCH',
+    body: JSON.stringify(flags),
   });
 };

--- a/web/src/lib/customization.ts
+++ b/web/src/lib/customization.ts
@@ -17,13 +17,13 @@ export interface BrandConfig {
   customCSS?: string;
 }
 
-// Default brand configuration
+// Default brand configuration (matches Vizora's brand colors)
 const defaultBrandConfig: BrandConfig = {
   id: 'default',
   name: 'Vizora',
-  primaryColor: '#0284c7',
-  secondaryColor: '#38bdf8',
-  accentColor: '#0ea5e9',
+  primaryColor: '#00E5A0',
+  secondaryColor: '#00B4D8',
+  accentColor: '#00CC8E',
   fontFamily: 'sans',
   showPoweredBy: true,
 };
@@ -98,6 +98,12 @@ export function applyCSSVariables(config: BrandConfig = currentBrandConfig): voi
   root.style.setProperty('--brand-primary', config.primaryColor);
   root.style.setProperty('--brand-secondary', config.secondaryColor);
   root.style.setProperty('--brand-accent', config.accentColor || config.primaryColor);
+
+  // Also override the theme's --primary so the entire UI adapts (sidebar, focus rings, buttons)
+  // Only override if not using the default Vizora color to avoid flash
+  if (config.id !== 'default') {
+    root.style.setProperty('--primary', config.primaryColor);
+  }
 
   // Font family
   if (config.fontFamily) {


### PR DESCRIPTION
## Summary

Three P3 platform features that enhance the enterprise readiness of Vizora.

### Google OAuth Social Login (Q1)
- `POST /api/v1/auth/google` — verify Google ID token, find-or-create user
- GoogleSignInButton component using Google Identity Services (GSI)
- "Sign in with Google" / "Sign up with Google" on login and register pages
- Auto-creates organization with 30-day trial for new OAuth users
- Optional — button hidden when `GOOGLE_CLIENT_ID` not configured
- Cookie-based JWT auth identical to regular login flow

### Custom Branding per Organization (Q8)
- Settings → Customization: company name, primary color picker, logo upload
- Dashboard header/sidebar dynamically reflects org branding
- Colors override `--brand-primary` and `--primary` CSS variables
- Logo stored in MinIO at `branding/{orgId}/logo.{ext}`
- Fallback to Vizora defaults when no branding configured
- Live preview in settings before saving

### Per-Organization Feature Flags (Q2)
- `GET/PATCH /api/v1/organizations/feature-flags` — manage 8 feature flags
- Settings → Feature Flags: admin-only toggle switches
- Flags: weather widget, RSS widget, clock widget, fleet control, content moderation, custom branding, advanced analytics, emergency override
- Default: all enabled (flags only disable)
- Stored in Organization's existing `settings` JSONB field (no migration)
- 7 service tests + 8 frontend tests

## Test plan
- [x] Middleware: 97 suites, 1,975 tests — pass (3 pre-existing health service failures)
- [x] Web: 79 suites, 864 tests — ALL PASS
- [x] Web build succeeds
- [ ] Manual: test Google OAuth with a real Google Client ID
- [ ] Manual: test branding with custom color + logo upload
- [ ] Manual: test disabling a feature flag hides UI elements

## Stats
- 23 files changed, +1,428 / -39 lines
- 15 new backend tests, 8 new frontend tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)