### PR TITLE
fix: resolve playlist:update delivery gaps causing device black screens

### DIFF
--- a/docs/superpowers/specs/2026-03-27-playlist-update-delivery-fixes-design.md
+++ b/docs/superpowers/specs/2026-03-27-playlist-update-delivery-fixes-design.md
@@ -1,0 +1,51 @@
+# Fix playlist:update Delivery Gaps
+
+**Date:** 2026-03-27
+**Status:** Approved
+**Scope:** Realtime service + Middleware
+
+## Problem
+
+Three server-side gaps cause devices to miss `playlist:update` events, resulting in black screens:
+
+1. **Override suppresses playlist** — `sendInitialState()` skips playlist when content override is active. When override expires, device has no playlist to fall back to.
+2. **No offline queue** — `sendPlaylistUpdate()` silently drops updates when device is offline. No Redis queue exists for playlist updates (commands have one).
+3. **Fire-and-forget push** — Middleware's `notifyDisplaysOfPlaylistUpdate()` makes a single HTTP attempt with `Promise.allSettled()`. Transient failures are swallowed.
+
+## Fixes
+
+### Fix 1: Send playlist alongside content override
+
+**File:** `realtime/src/gateways/device.gateway.ts` — `sendInitialState()`
+
+Remove the early return at line 482. Send config (with override info) AND playlist. The TV app handles both events independently (config at line 739, playlist:update at line 746 — no race condition).
+
+### Fix 2: Redis queue for offline playlist updates
+
+**Files:**
+- `realtime/src/services/redis.service.ts` — Add `setPendingPlaylist()` / `getPendingPlaylist()` methods
+- `realtime/src/gateways/device.gateway.ts` — In `sendPlaylistUpdate()`, queue on delivery failure. In `sendInitialState()`, check pending queue (takes priority over DB since it's fresher).
+- `realtime/src/app/app.controller.ts` — Queue when gateway returns `delivered: false`
+
+**Redis key:** `device:pending-playlist:{deviceId}`, 30-min TTL.
+**Priority:** Pending playlist from Redis > DB query in `sendInitialState()`.
+
+### Fix 3: Retry in middleware notification
+
+**File:** `middleware/src/modules/playlists/playlists.service.ts` — `notifyDisplaysOfPlaylistUpdate()`
+
+Add 1 retry with 2s delay per device on HTTP failure. Keep `Promise.allSettled()` wrapper.
+
+## Impact on TV App E2E Tests
+
+| Test | Before | After |
+|------|--------|-------|
+| P-07 (restart) | Black screen | Playlist persisted, content renders from cache |
+| S-06 (offline cache) | Inconclusive | Pending queue delivers playlist on reconnect |
+| S-11 (reconnection) | Inconclusive | sendInitialState sends playlist on reconnect |
+
+## Non-Goals
+
+- No changes to the TV app (Android) — it's already correct.
+- No changes to the web dashboard.
+- No new WebSocket event types.

--- a/middleware/src/modules/playlists/playlists.service.ts
+++ b/middleware/src/modules/playlists/playlists.service.ts
@@ -454,21 +454,29 @@ export class PlaylistsService {
 
     this.logger.log(`Notifying ${displays.length} display(s) of playlist update`);
 
-    // Notify each display via the realtime service
+    // Notify each display via the realtime service (1 retry with 2s delay on failure)
     const url = `${this.realtimeUrl}/api/push/playlist`;
 
     await Promise.allSettled(
       displays.map(async (display) => {
-        try {
-          await firstValueFrom(
-            this.httpService.post(url, {
-              deviceId: display.id,
-              playlist,
-            }, { headers }),
-          );
-          this.logger.log(`Notified display ${display.id} of playlist update`);
-        } catch (error) {
-          this.logger.warn(`Failed to notify display ${display.id}: ${error.message}`);
+        for (let attempt = 1; attempt <= 2; attempt++) {
+          try {
+            await firstValueFrom(
+              this.httpService.post(url, {
+                deviceId: display.id,
+                playlist,
+              }, { headers, timeout: 5000 }),
+            );
+            this.logger.log(`Notified display ${display.id} of playlist update`);
+            return;
+          } catch (error) {
+            if (attempt === 1) {
+              this.logger.warn(`Failed to notify display ${display.id} (attempt 1), retrying in 2s: ${error.message}`);
+              await new Promise((resolve) => setTimeout(resolve, 2000));
+            } else {
+              this.logger.warn(`Failed to notify display ${display.id} after retry: ${error.message}`);
+            }
+          }
         }
       }),
     );

--- a/realtime/src/gateways/device.gateway.ts
+++ b/realtime/src/gateways/device.gateway.ts
@@ -469,15 +469,64 @@ export class DeviceGateway
    */
   private async sendInitialState(client: Socket, deviceId: string, orgId: string): Promise<void> {
     try {
-      // Check if device has an active content override — skip playlist update to prevent flicker
+      // Check if device has an active content override
       const overrideCommandId = await this.redisService.get(`device:override:${deviceId}`);
       if (overrideCommandId) {
-        this.logger.log(`Device ${deviceId} has active override ${overrideCommandId} — skipping playlist update`);
-        // Still send config but skip playlist
+        // We still send the playlist even during an override. The TV app's
+        // updatePlaylist() persists it to Preferences but does NOT interrupt the
+        // active temporary content (guarded by the temporaryContent flag in main.ts).
+        // When the override expires, resumePlaylist() restores savedPlaylistState.
+        // On next restart, the device loads the newest playlist from Preferences.
+        this.logger.log(`Device ${deviceId} has active override ${overrideCommandId} — sending playlist alongside override so device has fallback content`);
+      }
+
+      // Check for a pending playlist queued while the device was offline.
+      // This takes priority over the DB query since it represents a more
+      // recent assignment that the device missed.
+      const pendingPlaylist = await this.redisService.getPendingPlaylist(deviceId);
+      if (pendingPlaylist) {
+        this.logger.log(`Delivering pending playlist to device ${deviceId} (queued while offline)`);
+
+        // Re-queue if the client disconnected between Redis read and now
+        if (!client.connected) {
+          this.logger.warn(`Device ${deviceId} disconnected before pending playlist delivery — re-queuing`);
+          await this.redisService.setPendingPlaylist(deviceId, pendingPlaylist);
+          return;
+        }
+
+        // Resolve layout content for any layout-type items (sendPlaylistUpdate
+        // only does shallow URL resolution, not layout zone expansion).
+        // Note: Zone content is resolved from the DB at reconnect time, so zone
+        // playlists reflect current state, not the queued snapshot. This is an
+        // acceptable trade-off — any zone changes would have been separate pushes.
+        const resolvedItems = await Promise.all(
+          (pendingPlaylist.items || []).map(async (item: any) => {
+            if (item.content?.type === 'layout') {
+              return { ...item, content: await this.resolveLayoutContent(item.content) };
+            }
+            return item;
+          }),
+        );
+
+        // Still need display record for config (qrOverlay etc.)
+        const displayForConfig = await this.databaseService.display.findUnique({
+          where: { id: deviceId },
+          select: { metadata: true },
+        });
+        const configMetadata = (displayForConfig?.metadata as Record<string, any>) || {};
         client.emit('config', {
           heartbeatInterval: 15000,
           cacheSize: 524288000,
           autoUpdate: true,
+          qrOverlay: configMetadata.qrOverlay || null,
+        });
+        // Note: Unlike sendPlaylistUpdate() which uses ack+timeout, this emit
+        // is fire-and-forget. If the socket drops between the connected check
+        // above and this emit, the playlist is lost. The device's next reconnect
+        // will fall through to the DB query path and pick up the current playlist.
+        client.emit('playlist:update', {
+          playlist: { ...pendingPlaylist, items: resolvedItems },
+          timestamp: new Date().toISOString(),
         });
         return;
       }
@@ -932,7 +981,8 @@ export class DeviceGateway
     const sockets = await this.server.in(roomName).fetchSockets();
 
     if (sockets.length === 0) {
-      this.logger.warn(`pushPlaylist: no sockets in room ${roomName} for device ${deviceId}`);
+      this.logger.warn(`pushPlaylist: no sockets in room ${roomName} for device ${deviceId} — queuing for reconnect`);
+      await this.redisService.setPendingPlaylist(deviceId, resolvedPlaylist);
       return { delivered: false, reason: 'no_sockets' };
     }
 
@@ -958,6 +1008,8 @@ export class DeviceGateway
     }
 
     if (!anyAcknowledged) {
+      this.logger.warn(`pushPlaylist: all sockets timed out for device ${deviceId} — queuing for reconnect`);
+      await this.redisService.setPendingPlaylist(deviceId, resolvedPlaylist);
       return { delivered: false, reason: 'ack_timeout' };
     }
 

--- a/realtime/src/services/redis.service.ts
+++ b/realtime/src/services/redis.service.ts
@@ -209,6 +209,39 @@ export class RedisService implements OnModuleDestroy {
   }
 
   /**
+   * Store a pending playlist for an offline device.
+   * When the device reconnects, sendInitialState() delivers this
+   * instead of the DB query (it's fresher — represents a missed update).
+   */
+  async setPendingPlaylist(deviceId: string, playlist: any): Promise<void> {
+    const key = `device:pending-playlist:${deviceId}`;
+    await this.redis.setex(key, 1800, JSON.stringify(playlist)); // 30 minutes
+  }
+
+  /**
+   * Get and consume a pending playlist for a device (atomic read + delete).
+   * Returns null if no pending playlist exists.
+   *
+   * Note: Uses MULTI/EXEC which is atomic on single-node Redis. If migrating
+   * to Redis Cluster, consider replacing with a Lua script for guaranteed
+   * atomicity. On transient Redis errors, EXEC rolls back and the key
+   * survives — the next reconnect attempt will find it.
+   */
+  async getPendingPlaylist(deviceId: string): Promise<any | null> {
+    const key = `device:pending-playlist:${deviceId}`;
+    const multi = this.redis.multi();
+    multi.get(key);
+    multi.del(key);
+    const results = await multi.exec();
+    if (!results || !results[0] || !results[0][1]) return null;
+    try {
+      return JSON.parse(results[0][1] as string);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * Publish event to channel
    */
   async publish<T = unknown>(channel: string, message: T): Promise<void> {


### PR DESCRIPTION
## Summary

Three server-side fixes to ensure Android TV devices always receive their `playlist:update` WebSocket event, resolving black screen issues after restart/reconnect:

- **Fix 1 — Send playlist alongside content override**: Removed early return in `sendInitialState()` that skipped playlist when an override was active. Devices now receive both config and playlist; the TV app's `temporaryContent` flag correctly handles priority.
- **Fix 2 — Redis queue for offline playlist updates**: Added `setPendingPlaylist`/`getPendingPlaylist` methods (30-min TTL). When `sendPlaylistUpdate()` fails (device offline or ack timeout), the playlist is queued in Redis. On reconnect, `sendInitialState()` checks the pending queue first (fresher than DB). Includes disconnect guard with re-queue and layout content resolution.
- **Fix 3 — Retry with timeout in middleware**: Added 1 retry with 2s delay per device in `notifyDisplaysOfPlaylistUpdate()` and a 5s Axios timeout to prevent hanging on unreachable realtime service.

### Files Changed (3 source + 1 spec)

| File | Change |
|------|--------|
| `realtime/src/gateways/device.gateway.ts` | Fix 1 + Fix 2 (pending queue check, queue-on-failure, override behavior) |
| `realtime/src/services/redis.service.ts` | Fix 2 (setPendingPlaylist/getPendingPlaylist with atomic read+delete) |
| `middleware/src/modules/playlists/playlists.service.ts` | Fix 3 (retry loop + Axios timeout) |
| `docs/superpowers/specs/...` | Design spec |

### E2E Impact

| Test | Before | After |
|------|--------|-------|
| P-07 (restart) | Black screen | Playlist persisted, content renders from cache |
| S-06 (offline cache) | Inconclusive | Pending queue delivers playlist on reconnect |
| S-11 (reconnection) | Inconclusive | sendInitialState sends playlist on reconnect |

## Test plan

- [ ] Deploy to staging and verify device receives playlist on initial connect
- [ ] Test override + playlist: device should receive both, override takes visual priority
- [ ] Disconnect device, change playlist assignment, reconnect — verify pending playlist delivered
- [ ] Kill realtime service, trigger playlist update from dashboard, verify middleware retries
- [ ] Verify layout-type playlists have zones resolved correctly on pending delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)