### PR TITLE
fix(agents): resolve lock timeout and stale prisma client

### DIFF
--- a/packages/database/project.json
+++ b/packages/database/project.json
@@ -1,0 +1,20 @@
+{
+  "name": "@vizora/database",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/database/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/dist"],
+      "options": {
+        "cwd": "packages/database",
+        "parallel": false,
+        "commands": [
+          "pnpm exec tsc -p tsconfig.lib.json",
+          "node -e \"require('node:fs').cpSync('src/generated','dist/generated',{recursive:true})\""
+        ]
+      }
+    }
+  }
+}

--- a/scripts/agents/lib/state.ts
+++ b/scripts/agents/lib/state.ts
@@ -43,6 +43,10 @@ async function sleep(ms: number): Promise<void> {
 }
 
 async function acquireLock(family: AgentFamily): Promise<void> {
+  // Ensure STATE_DIR exists before attempting the lock; otherwise openSync throws
+  // ENOENT (not EEXIST), existsSync(lockFile) stays false, and we retry for the
+  // full LOCK_TIMEOUT_MS on every first run where the dir hasn't been created.
+  if (!existsSync(STATE_DIR)) mkdirSync(STATE_DIR, { recursive: true });
   const lockFile = lockFileFor(family);
   const deadline = Date.now() + LOCK_TIMEOUT_MS;
   while (Date.now() < deadline) {


### PR DESCRIPTION
## Summary
Fixes two production bugs found in the newly-deployed agent system:

1. **state.ts acquireLock ENOENT loop** — when `logs/agent-state/` didn't exist, `openSync(lockFile, 'wx')` threw ENOENT (not EEXIST). The catch branch checked `existsSync(lockFile)` which stayed false, so retries never made progress. `agent-customer-lifecycle` cron hit this on every run (23x since first deploy).
2. **Stale `dist/generated/` prisma client** — `nx build @vizora/database` only runs tsc against `src/**/*.ts`. The `postbuild` lifecycle in `package.json` is never invoked by nx's `@nx/js/typescript` plugin, so `dist/generated/` remained at 2026-04-15. Runtime `@vizora/database` imports resolved to the stale client, which lacked the `authorType` field from the 20260417 migration; `agent-support-triage` failed with `Unknown argument authorType` on every cron.

## Fixes
- `scripts/agents/lib/state.ts`: `acquireLock` now `mkdirSync(STATE_DIR, {recursive:true})` before the first lock attempt.
- `packages/database/project.json` (new): overrides the inferred build target with `nx:run-commands` that runs `tsc -p tsconfig.lib.json` then `cpSync('src/generated','dist/generated',{recursive:true})`.

## Test plan
- [x] Local `npx nx build @vizora/database` — dist/generated/prisma/index.d.ts has 41 `authorType` refs (was 0)
- [ ] Deploy to prod, trigger next customer-lifecycle cron → expect no `acquireLock timeout`
- [ ] Trigger next support-triage cron → expect no `Unknown argument authorType`