### PR TITLE
Adopt shift-agent / Hermes patterns for Vizora business agents — evaluation + design docs

### DIFF
--- a/docs/agents-architecture.md
+++ b/docs/agents-architecture.md
@@ -291,7 +291,7 @@ From shift-agent §12, adapted:
 |---|---|---|
 | `agent-customer-lifecycle` | Live, single .ts file | Needs DESIGN.md, runbook, dispatcher SKILL pattern, audit |
 | `agent-support-triage` | Live, taxonomy-v2, behind 2026-05-24 Hermes Path B gate | Closest to the discipline — extend it as the reference implementation |
-| `agent-orchestrator` | Scaffold | 30-day ship-or-kill gate (see `tasks/feature-backlog.md`) |
+| `agent-orchestrator` | Scaffold | Design before code — see `tasks/feature-backlog.md` for the open evaluation |
 | `agent-billing-revenue` | Scaffold | Same |
 | `agent-content-intelligence` | Scaffold | Same |
 | `agent-screen-health-customer` | Scaffold | Same |
@@ -302,11 +302,13 @@ From shift-agent §12, adapted:
 
 ## Where to go from here
 
-1. **Read this doc** before designing any new agent.
-2. **For the 4 scaffolds**, write a DESIGN.md (or kill them) by 2026-06-03 — see `tasks/feature-backlog.md`.
-3. **For the 2 live business agents** (`customer-lifecycle`, `support-triage`), retrofit the directory shape (`scripts/agents/<name>/{handler.ts, runbook.md, templates/, config.yaml.template}`) opportunistically — don't block on a big-bang migration.
-4. **Build the Vizora MCP server** (`docs/agents-mcp-server-design.md`) — gives any future business agent a stable read surface without per-agent integration code.
-5. **Add the dead-man + watchdog + heartbeat triad** to `scripts/ops/`. ops-reporter is the reporting layer, not the dead-man layer.
+These are recommendations, not mandates. The framework is proven on shift-agent; the open question is fit for Vizora — see `tasks/feature-backlog.md` for the running evaluation.
+
+1. **Reference this doc** when designing or maintaining a Vizora business agent.
+2. **For the 4 scaffolds**, prefer DESIGN.md before production logic (per the dependency principle in §"Build order"). When the scaffold is ready to become a real agent.
+3. **For the 2 live business agents** (`customer-lifecycle`, `support-triage`), retrofit the directory shape (`scripts/agents/<name>/{handler.ts, runbook.md, templates/, config.yaml.template}`) opportunistically — no big-bang migration.
+4. **Consider building the Vizora MCP server** (`docs/agents-mcp-server-design.md`) — gives any future business agent a stable read surface without per-agent integration code. Independently valuable regardless of whether Vizora itself adopts Hermes.
+5. **Consider adding the dead-man + watchdog + heartbeat triad** to `scripts/ops/`. ops-reporter is the reporting layer, not the dead-man layer.
 
 ---
 

--- a/docs/agents-architecture.md
+++ b/docs/agents-architecture.md
@@ -1,0 +1,319 @@
+# Vizora Business-Agent Architecture
+
+**Status:** Reference doc, written 2026-05-03. Distills the discipline patterns from `shift-agent/DESIGN.md` (979 lines, v2 post-review) into rules Vizora should follow before designing any new business agent.
+
+**Audience:** Anyone designing or maintaining a Vizora business agent (`scripts/agents/`, or — recommended — a future `vizora-business-agents/` Hermes-runtime sidecar).
+
+**Out of scope:** Ops agents (`scripts/ops/`). Those are deterministic cron tasks; they don't carry LLM-shaped risk and most of these patterns don't apply.
+
+---
+
+## The one-line principle
+
+> **The LLM reasons. Scripts enforce invariants. Every state file is validated on read AND on write. Every side-effect is atomic-or-loud. Every failure has a detectable signal AND an out-of-band alert path.**
+
+Quoted from `shift-agent/DESIGN.md §1`. If a proposed agent design violates any of those four clauses, fix the design before writing code.
+
+---
+
+## Architecture shape (what every agent looks like)
+
+```
+External input (webhook, message, cron tick)
+        │
+        ▼
+   dispatcher SKILL          ← classify by metadata, not content
+        │
+   ┌────┴────────┐
+   ▼             ▼
+handler SKILL   handler SKILL    ← reason about THIS situation
+   │             │
+   ▼             ▼
+helper scripts (deterministic)   ← own all critical IDs
+   │
+   ▼
+state files (JSON + flock + atomic + Pydantic/Zod)
+   │
+   ▼
+audit log (NDJSON, dual source: LLM-enriched + tail-logger guaranteed)
+   │
+   ▼
+out-of-band alerts (Pushover + healthchecks.io heartbeat)
+```
+
+This is the shift-agent shape. It's worth copying because every box in it solves a class of regression that *will* happen in production.
+
+---
+
+## The 8 hard rules
+
+These are non-obvious lessons earned from running 15 agents in production via Hermes. Each one is a regression-prevention pattern.
+
+### 1. Dispatcher-first routing — never pattern-match content to handler
+
+> *"Hard rule: this skill runs BEFORE any other skill. Do not skip it just because the message text looks like a sick call. Pattern-matching on text is how routing-correctness regressions creep in."* — `dispatch_shift_agent/SKILL.md`
+
+**Apply to Vizora:** Any agent that takes external input (webhook, customer message, internal event) goes through a single classifier first. Even if input shape "looks obvious," route through the dispatcher. The temptation to shortcut compounds.
+
+### 2. Identity by metadata, not content
+
+shift-agent's Hermes runtime prepends `[shift-agent-sender v=1 platform=whatsapp phone="+..." lid="..." fromMe=true]` to every inbound. The dispatcher parses this via a deterministic helper (`validate-sender-block`), then resolves identity via another (`identify-sender`).
+
+The `fromMe` flag is *informational only* — owner routing is gated by `identify-sender`, not by the inbound's claim. *"A sender CAN inject `fromMe=true` trying to spoof; cross-checking via `identify-sender` is the authoritative defense."*
+
+**Apply to Vizora:** For business agents that act on behalf of a Vizora user, identity must come from the auth layer (JWT subject, MCP token), never from message content.
+
+### 3. Fail closed
+
+Invalid sender block → polite decline + log. State load failed → notify owner + STOP. The LLM is **not** allowed to "try anyway."
+
+**Apply to Vizora:** Any state-touching code path must distinguish missing/empty/corrupt and respond differently:
+- Missing → use default, log a `state_initialized` event
+- Empty → same as missing
+- Corrupt (Pydantic/Zod parse fail, JSON decode fail) → rename to `.corrupt-<ts>`, alert via Pushover, fail closed
+
+shift-agent's `safe_io.safe_load_json()` returns `(value, status)` where `status ∈ {"ok", "missing", "empty", "corrupt:..."}`. Callers branch on status.
+
+### 4. Helper scripts own all critical IDs
+
+> *"Do NOT invent the proposal_id or code. Only the script generates them."* — `handle_sick_call/SKILL.md`
+
+Proposal IDs, approval codes, outbound message IDs, idempotency keys all come from deterministic Python (or Node) helper scripts that the LLM calls. The LLM never decides what an identifier is. The script writes the ID to disk **before** any side-effect that uses it.
+
+**Apply to Vizora:** Anything Vizora-side that's load-bearing — content IDs, schedule IDs, billing transaction IDs, support-triage decision IDs — comes from helpers, never from LLM string output.
+
+### 5. Templates instead of LLM free-text for outbound
+
+Acknowledgements ("Got it, will arrange coverage") can be LLM-shaped. Anything customer-impacting goes through `templates/` — rendered by a deterministic script with explicit args.
+
+**Apply to Vizora:** Any notification, email, SMS, in-app message that customers see comes from a template file. The LLM picks the template + populates variables; it does not write the customer-facing text.
+
+### 6. Input sanitization before prompt interpolation
+
+Strip these from any text that will be interpolated into a prompt:
+- Lines matching `^(SYSTEM|USER|ASSISTANT):/i`
+- Substrings: `IGNORE PREVIOUS`, `DISREGARD`, `OVERRIDE`, `<`, `>`
+- Truncate to 500 chars
+
+Keep raw input for audit; sanitize the prompt copy.
+
+**Apply to Vizora:** Any free-text customer input that reaches an LLM prompt — support tickets, content captions, schedule notes — runs through a sanitizer first.
+
+### 7. Dual-source audit (deterministic backup of LLM-enriched logs)
+
+shift-agent runs **two** audit sources:
+1. **LLM-enriched entries** via helper scripts (`log-decision`, `log-decision-direct`) — rich context, but only if the LLM behavior runs to completion
+2. **Tail-logger timer** every 30s — reads the raw inbound queue, writes guaranteed `raw_inbound` entries to the same `decisions.log`. Independent of LLM behavior. *"Guaranteed via a deterministic tail-logger independent of LLM behavior."*
+
+If the LLM crashes mid-decision, the raw input is still in the audit. Reconciliation can replay it.
+
+**Apply to Vizora:** For any agent whose decisions matter (support-triage classifications, content-intelligence picks, billing actions), there must be a deterministic record of the **input** that's written without the LLM in the loop. Pair with LLM-enriched output.
+
+### 8. Hardened outbound — re-resolve, lock, write-before-POST
+
+shift-agent's `send-coverage-message <proposal_id>` does:
+- Re-resolves candidate phone from the **roster** (don't trust the pending state — it could be stale)
+- Enforces daily cap **under lock**
+- Writes `outbound_attempted` to disk **before** the POST so retries are idempotent
+- Supports `RETRY` on failure
+- Updates state to `outbound_succeeded` or `outbound_failed` with explicit reason
+
+**Apply to Vizora:** Any agent action that has a side-effect on the outside world (Stripe charge, content publish, schedule push, customer email) follows this pattern. Idempotency keys written before the call. Re-resolve from canonical state, never from cached intent.
+
+---
+
+## Per-agent file shape (copy this layout)
+
+shift-agent puts every agent in its own directory under `src/agents/<name>/`:
+
+```
+src/agents/<agent_name>/
+├── __init__.py            (or index.ts)
+├── config.yaml.template   ← per-agent config; populated per customer/env
+├── runbook.md             ← customer-facing-ish ops manual: what alerts mean, how to respond
+├── skills/                ← SKILL.md files (one dir per skill)
+│   ├── dispatch_<agent>/
+│   │   └── SKILL.md       (frontmatter: name + description; body: step-by-step instructions)
+│   ├── handle_<X>/
+│   │   └── SKILL.md
+│   └── handle_<Y>/
+│       └── SKILL.md
+├── scripts/               ← deterministic helper binaries (proposal-id generation, validators)
+├── templates/             ← outbound message templates (NEVER LLM free-text)
+├── systemd/               ← unit files for time-triggered work (or PM2 entries for Vizora)
+└── logrotate/             ← log rotation config per agent
+```
+
+Vizora's `scripts/agents/<name>.ts` is a flat single file. **That's the gap.** Even if Vizora stays TypeScript, each agent should get its own directory with the same companion files.
+
+---
+
+## Shared platform layer (where Vizora is already on-pattern)
+
+shift-agent's `src/platform/`:
+
+| File | Purpose | Vizora equivalent |
+|---|---|---|
+| `safe_io.py` | flock + atomic write + Pydantic validate-on-read | `scripts/ops/lib/state.ts` (partial — has flock, missing schema validation on read) |
+| `schemas.py` | Pydantic models, single source of truth for every state file | Mixed — Prisma covers DB, but state JSON files have ad-hoc TS types |
+| `audit_helpers.py` | NDJSON append helpers | `scripts/ops/lib/state.ts` writes the audit log |
+| `sender_context.py` | Identity resolution | (needed if Vizora business agents take external input) |
+| `qbo_client.py` | External API client (QuickBooks) | `scripts/ops/lib/api-client.ts` (talks to Vizora middleware) |
+| `scripts/validate-sender-block` | Deterministic input validator | (needed) |
+| `scripts/identify-sender` | Identity lookup | (needed) |
+| `scripts/log-decision-direct` | Guaranteed audit write | (needed for business agents) |
+| `scripts/dispatcher-accuracy-report` | Routing-correctness metric | **Missing.** Vizora has no agent-decision-quality metric. |
+
+The `dispatcher-accuracy-report` gap is worth flagging: shift-agent measures whether its dispatcher routes inbound messages to the correct handler. Without an analogous metric, Vizora business agents can quietly drift in quality without anyone noticing.
+
+---
+
+## State file invariants (the `safe_io` pattern, simplified)
+
+Every state-touching code path follows this shape:
+
+```python
+# 1. Lock
+with FileLock(state_dir / "pending.lock"):
+    # 2. Load with explicit failure modes
+    pending, status = safe_load_json(state_dir / "pending.json", default={})
+    if status not in ("ok", "missing", "empty"):
+        notify_owner(f"pending.json {status}")
+        sys.exit(EXIT_STATE_CORRUPT)
+
+    # 3. Validate
+    pending = PendingStore.model_validate(pending)
+
+    # 4. Mutate
+    pending.proposals[proposal_id] = new_proposal
+
+    # 5. Atomic write
+    atomic_write_json(state_dir / "pending.json", pending.model_dump())
+
+    # 6. Audit (under same lock)
+    ndjson_append(decisions_log, json.dumps(audit_entry), lock=current_lock)
+```
+
+For Vizora (TypeScript), the equivalent is:
+- `proper-lockfile` or `node-fcntl` for flock-equivalent
+- Zod schema validation at every boundary
+- `fs.writeFileSync` to a `.tmp-<pid>` then `fs.renameSync` (atomic on POSIX)
+- `fsync` the file AND its directory
+- NDJSON append under the same lock as the state mutation
+
+**This pattern alone prevents an entire class of state-corruption bugs.**
+
+---
+
+## Required out-of-band alerts (don't ship without these)
+
+Per shift-agent's §10 systemd units:
+
+| Signal | Frequency | What it does |
+|---|---|---|
+| **Pushover dead-man** | every 5 min | If health-check fails, Pushover alert to owner's phone. Pushover delivery is the contract. |
+| **healthchecks.io heartbeat** | every 5 min | External "we're alive" ping. If healthchecks.io stops receiving, IT alerts. Two-tier dead-man. |
+| **Health-watchdog** | every 15 min | Detects if health-check timer itself stops firing (e.g., systemd issue). Alerts independently. |
+| **Nightly backup** | 02:00 local | pubkey-GPG tarball of state + config + roster + last 7 days of logs. Pubkey-only mode = compromised VPS can't decrypt prior backups. |
+| **fsck (cross-file invariants)** | 03:00 local | Validates that pending.json + send-counter.json + decisions.log are mutually consistent. Catches drift that any single-file validation misses. |
+| **Boot reconcile** | oneshot at boot | Resets in-flight `reconciling` proposals to a safe terminal state. Detects crashes mid-side-effect. |
+
+**Vizora today has:** ops-reporter every 30 min sends Slack/email aggregated alerts. That's the *reporting* layer, not the *dead-man* layer. The dead-man + watchdog + heartbeat triad is missing.
+
+---
+
+## Build order (the opinionated dependency chain)
+
+shift-agent's §14 prescribes a 26-step build order. The principle: **infra-and-safety first, agent logic last.** No skill ships before its supporting scripts, schemas, and alert paths.
+
+Vizora's order, applied to a new business agent:
+
+1. Define schemas (Zod for state, Prisma for DB if persistent)
+2. Build `safe_io`-equivalent for any new state file
+3. Build `notify-owner`-equivalent (Pushover or Slack alert script) — **REQUIRED before anything else uses it**
+4. Build `log-decision` audit helper
+5. Build deterministic ID generators (`create-<thing>` scripts)
+6. Build state mutators (`update-<thing>-status` scripts)
+7. Build outbound action script (idempotent, hardened per Rule 8)
+8. Build tail-logger timer for guaranteed audit
+9. Build health-check + watchdog timers
+10. Build backup + fsck timers
+11. Build reconcile script (boot-time oneshot)
+12. Build disable / enable scripts (kill-switch first, before code that needs it)
+13. Build smoke-test script
+14. Build deploy script
+15. Write SKILL.md files (dispatcher first, then handlers)
+16. Write systemd units / PM2 entries
+17. Write logrotate config
+18. Write templates
+19. Write runbook.md
+20. **Only then** write the per-agent code
+
+If you find yourself writing code at step 1, you're going to ship regressions.
+
+---
+
+## Testing approach (the staged gate)
+
+shift-agent's §15 stages:
+
+| Stage | Goal | Pass criteria |
+|---|---|---|
+| **0 — schemas parse** | Pydantic / Zod schemas accept example data | All sample files load without error |
+| **1 — unit** | Each helper script behaves correctly | Per-script tests pass |
+| **2 — end-to-end dry-run** | Inputs flow through dispatcher → handlers → state → audit | fsck passes all invariants after a synthetic scenario |
+| **3 — customer roster (real)** | Wire to real customer config + Pushover + healthchecks.io | Test alert reaches phone; missed-ping alert fires |
+| **4 — failure modes** | Kill processes mid-flow; verify dead-man / reconciler / watchdog all fire | Each failure mode has a detected signal within its SLA |
+
+Vizora's existing tests cover Stage 0/1 well. Stage 2/3/4 are the gap for business agents.
+
+---
+
+## Security posture (minimum bar)
+
+From shift-agent §12, adapted:
+
+- Agent process runs as a non-root user, owns its own directory tree, mode 750
+- `.env` mode 600, never world-readable, loaded via systemd `EnvironmentFile=` or PM2 equivalent
+- LLM provider account: spending cap set ON THE PROVIDER DASHBOARD (not just in code)
+- Dedicated provider key per agent surface (don't share keys between business agents and ops)
+- Monthly key rotation reminder (calendar event)
+- Backup encryption: GPG pubkey-only mode (private key OFF the VPS)
+- Prompt injection sanitizer (Rule 6)
+- Audit log tamper-evidence: SHA-256 chain on a `decisions.log.sha256` sidecar
+- Pushover / Slack creds in `.env`; accept that compromised VPS = attacker can spam your alert channel; rotate channel token on suspicion
+
+---
+
+## What this means for Vizora's existing agents
+
+| Agent | Current state | Per shift-agent discipline |
+|---|---|---|
+| `agent-customer-lifecycle` | Live, single .ts file | Needs DESIGN.md, runbook, dispatcher SKILL pattern, audit |
+| `agent-support-triage` | Live, taxonomy-v2, behind 2026-05-24 Hermes Path B gate | Closest to the discipline — extend it as the reference implementation |
+| `agent-orchestrator` | Scaffold | 30-day ship-or-kill gate (see `tasks/feature-backlog.md`) |
+| `agent-billing-revenue` | Scaffold | Same |
+| `agent-content-intelligence` | Scaffold | Same |
+| `agent-screen-health-customer` | Scaffold | Same |
+| 6× `ops-*` | Live cron daemons | **Different shape — these are deterministic cron tasks, not LLM-driven agents.** Most of this doc doesn't apply. They DO benefit from `safe_io` patterns and the dead-man + watchdog + heartbeat triad. |
+| 8× `.claude/agents/*.md` | Dev-time Claude Code subagents | Already in SKILL.md form. Match the pattern by accident. No change needed. |
+
+---
+
+## Where to go from here
+
+1. **Read this doc** before designing any new agent.
+2. **For the 4 scaffolds**, write a DESIGN.md (or kill them) by 2026-06-03 — see `tasks/feature-backlog.md`.
+3. **For the 2 live business agents** (`customer-lifecycle`, `support-triage`), retrofit the directory shape (`scripts/agents/<name>/{handler.ts, runbook.md, templates/, config.yaml.template}`) opportunistically — don't block on a big-bang migration.
+4. **Build the Vizora MCP server** (`docs/agents-mcp-server-design.md`) — gives any future business agent a stable read surface without per-agent integration code.
+5. **Add the dead-man + watchdog + heartbeat triad** to `scripts/ops/`. ops-reporter is the reporting layer, not the dead-man layer.
+
+---
+
+## References
+
+- `shift-agent/DESIGN.md` (979 lines, v2 post-review) — source material for everything in this doc
+- `shift-agent/PLAN.md` — rollout discipline
+- `shift-agent/src/platform/safe_io.py` — copy this pattern (or a TS equivalent)
+- `shift-agent/src/agents/shift/skills/dispatch_shift_agent/SKILL.md` — exemplar dispatcher
+- `shift-agent/src/agents/shift/skills/handle_sick_call/SKILL.md` — exemplar handler

--- a/docs/agents-architecture.md
+++ b/docs/agents-architecture.md
@@ -92,10 +92,13 @@ Acknowledgements ("Got it, will arrange coverage") can be LLM-shaped. Anything c
 
 Strip these from any text that will be interpolated into a prompt:
 - Lines matching `^(SYSTEM|USER|ASSISTANT):/i`
-- Substrings: `IGNORE PREVIOUS`, `DISREGARD`, `OVERRIDE`, `<`, `>`
+- Substrings (case-insensitive): `IGNORE PREVIOUS`, `DISREGARD INSTRUCTIONS`, `OVERRIDE INSTRUCTIONS`
+- Tag-like patterns: `</?(system|user|assistant|prompt|instruction)>` — match the tag form, not bare `<` or `>`
 - Truncate to 500 chars
 
 Keep raw input for audit; sanitize the prompt copy.
+
+> **Important divergence from shift-agent:** shift-agent strips bare `<` and `>` substrings because its inputs are WhatsApp messages where angle brackets are uncommon. Vizora's business-agent inputs (support tickets, content captions, schedule notes) contain legitimate `<` `>` regularly — URLs, code snippets, math expressions, redirected-to symbols. Stripping bare brackets would corrupt input. Match the tag form instead, or HTML-encode at the prompt boundary.
 
 **Apply to Vizora:** Any free-text customer input that reaches an LLM prompt — support tickets, content captions, schedule notes — runs through a sanitizer first.
 
@@ -154,17 +157,19 @@ shift-agent's `src/platform/`:
 
 | File | Purpose | Vizora equivalent |
 |---|---|---|
-| `safe_io.py` | flock + atomic write + Pydantic validate-on-read | `scripts/ops/lib/state.ts` (partial — has flock, missing schema validation on read) |
-| `schemas.py` | Pydantic models, single source of truth for every state file | Mixed — Prisma covers DB, but state JSON files have ad-hoc TS types |
-| `audit_helpers.py` | NDJSON append helpers | `scripts/ops/lib/state.ts` writes the audit log |
-| `sender_context.py` | Identity resolution | (needed if Vizora business agents take external input) |
-| `qbo_client.py` | External API client (QuickBooks) | `scripts/ops/lib/api-client.ts` (talks to Vizora middleware) |
-| `scripts/validate-sender-block` | Deterministic input validator | (needed) |
-| `scripts/identify-sender` | Identity lookup | (needed) |
-| `scripts/log-decision-direct` | Guaranteed audit write | (needed for business agents) |
+| `safe_io.py` | flock + atomic write + Pydantic validate-on-read | **Largely covered** by `middleware/src/modules/agents/agent-state.service.ts` (PR #32, merged 2026-04-19) — async fs/promises, file-locking with timeout (5 s / 50 ms retry / 30 s stale), known-family path safety, anchored secret/PII redaction. `scripts/ops/lib/state.ts` adds flock for cron-side writes. Schema-validate-on-read at the boundary is the remaining gap. |
+| `schemas.py` | Pydantic models, single source of truth for every state file | Prisma covers DB. State JSON files use ad-hoc TS types — would benefit from Zod schemas at agent-state-service boundaries. |
+| `audit_helpers.py` | NDJSON append helpers | `scripts/ops/lib/state.ts` writes the audit log; `AgentStateService` redacts on read |
+| `sender_context.py` | Identity resolution (WhatsApp phone/LID) | **N/A — different auth model.** Vizora business agents authenticate via JWT (user) or MCP token (agent). No external sender block to parse. |
+| `qbo_client.py` | External API client (QuickBooks) | `scripts/ops/lib/api-client.ts` (talks to Vizora middleware); future Hermes sidecar would use `vizora_mcp_client.py` per the MCP server design |
+| `scripts/validate-sender-block` | Deterministic input validator (WhatsApp sender block) | **N/A** — Vizora's auth surface is JWT / MCP token, validated by NestJS guards. Equivalent role is the existing `JwtAuthGuard` + the proposed `McpAuthGuard`. |
+| `scripts/identify-sender` | Identity lookup (phone / LID → role) | **N/A** — JWT subject claim + Prisma user/org lookup is the existing equivalent |
+| `scripts/log-decision-direct` | Guaranteed audit write (LLM-bypass) | (worth building for Vizora business agents — write input to disk before LLM, independent of handler success) |
 | `scripts/dispatcher-accuracy-report` | Routing-correctness metric | **Missing.** Vizora has no agent-decision-quality metric. |
 
 The `dispatcher-accuracy-report` gap is worth flagging: shift-agent measures whether its dispatcher routes inbound messages to the correct handler. Without an analogous metric, Vizora business agents can quietly drift in quality without anyone noticing.
+
+**The `AgentStateService` correction matters because** it changes the action set: Vizora isn't building agent-state I/O from scratch. The discipline rule for new business agents is *use `AgentStateService` for state reads, extend it (don't reimplement) for new families, and add Zod-schema validation at the boundaries it doesn't currently enforce*.
 
 ---
 
@@ -289,8 +294,8 @@ From shift-agent §12, adapted:
 
 | Agent | Current state | Per shift-agent discipline |
 |---|---|---|
-| `agent-customer-lifecycle` | Live, single .ts file | Needs DESIGN.md, runbook, dispatcher SKILL pattern, audit |
-| `agent-support-triage` | Live, taxonomy-v2, behind 2026-05-24 Hermes Path B gate | Closest to the discipline — extend it as the reference implementation |
+| `agent-customer-lifecycle` | Live, single .ts file. State already routed through `AgentStateService` (family: `customer`). | Needs DESIGN.md, runbook, dispatcher SKILL pattern, audit-before-LLM |
+| `agent-support-triage` | Live, taxonomy-v2, behind Hermes Path B gate (2026-05-24, anchored in `tasks/hermes-backlog.md`). State family: `ops`. | Closest to the discipline — extend it as the reference implementation |
 | `agent-orchestrator` | Scaffold | Design before code — see `tasks/feature-backlog.md` for the open evaluation |
 | `agent-billing-revenue` | Scaffold | Same |
 | `agent-content-intelligence` | Scaffold | Same |

--- a/docs/agents-mcp-server-design.md
+++ b/docs/agents-mcp-server-design.md
@@ -1,0 +1,368 @@
+# Vizora MCP Server — Design Sketch
+
+**Status:** Design-only. No code. Written 2026-05-03.
+**Branch:** `docs/business-agents-discipline`
+**Companion docs:** `docs/agents-architecture.md` (the discipline this enables)
+
+---
+
+## Why
+
+Vizora has 20 agents today. Each one that needs Vizora data writes its own glue code: HTTP client, auth, retry, schema. That's reinvention per agent.
+
+**A Vizora MCP server inverts that.** One stable tool surface. Any agent — internal Vizora ops, Claude Code subagents, external Hermes business-agents (the future `vizora-business-agents/` repo per `docs/agents-architecture.md`), eventually customer-built integrations — uses the same tools by name.
+
+It's the same pattern shift-agent uses with `qbo_client.py` for QuickBooks: one client, many callers, one upgrade point. Except MCP makes it standard-protocol instead of bespoke client.
+
+---
+
+## Scope
+
+### In scope (v1)
+
+**Read-only tools.** The agent ecosystem is currently mostly observational (triage, lifecycle, content recommendations). Read tools cover 80% of agent demand and carry zero blast-radius risk.
+
+| Tool | Purpose |
+|---|---|
+| `list_displays(org_id, status?, group?, limit?)` | Fleet snapshot |
+| `get_display(display_id)` | Per-device deep view |
+| `get_display_health(display_id)` | Heartbeat status, last-seen, online/offline transitions |
+| `list_content(org_id, type?, folder?, limit?)` | Content library |
+| `get_content(content_id)` | Per-asset view |
+| `list_playlists(org_id, limit?)` | Playlists |
+| `get_playlist(playlist_id)` | Per-playlist view (items + ordering) |
+| `list_schedules(org_id, active_only?, limit?)` | Schedules |
+| `get_schedule(schedule_id)` | Per-schedule view |
+| `list_organizations(limit?)` | Orgs (admin scope) |
+| `get_org_health(org_id)` | Aggregate org health: display online rate, storage usage, billing status |
+| `list_recent_incidents(org_id, since?)` | Reads from `logs/ops-state.json` — last N ops incidents for this org |
+| `get_audit_trail(resource_type, resource_id, limit?)` | Decision audit log entries for a resource |
+
+### Out of scope (v1)
+
+- **Write tools.** Any tool that mutates state stays out of v1. When agents need to act, they go through existing middleware endpoints (with their existing auth + audit), not through MCP. Reason: MCP write-tools amplify blast radius (one auth lapse → mass mutation). Read-first earns trust before write.
+- **Per-customer config tools.** v1 is for Vizora's internal agents. Customer-facing MCP is a v2 concern.
+- **LLM-mediated routing.** The MCP server is a tool surface, not a router.
+
+---
+
+## Module layout (NestJS)
+
+```
+middleware/src/modules/mcp/
+├── mcp.module.ts                    ← NestJS module wiring
+├── mcp.controller.ts                ← exposes /api/v1/mcp endpoint(s) for transport
+├── mcp.service.ts                   ← MCP server lifecycle, tool registration
+├── transports/
+│   ├── http.transport.ts            ← HTTP/SSE transport (preferred for production)
+│   └── stdio.transport.ts           ← stdio for local dev / CI testing
+├── auth/
+│   ├── mcp-auth.guard.ts            ← validates MCP-specific tokens (not user JWTs — see Auth section)
+│   └── mcp-token.service.ts         ← issue/revoke MCP tokens, scope enforcement
+├── tools/
+│   ├── displays.tools.ts            ← list_displays, get_display, get_display_health
+│   ├── content.tools.ts             ← list_content, get_content
+│   ├── playlists.tools.ts           ← list_playlists, get_playlist
+│   ├── schedules.tools.ts           ← list_schedules, get_schedule
+│   ├── organizations.tools.ts       ← list_organizations, get_org_health
+│   ├── audit.tools.ts               ← list_recent_incidents, get_audit_trail
+│   └── tool-registry.ts             ← exports all tools as a Map<name, ToolDef>
+├── schemas/
+│   ├── tool-inputs.ts               ← Zod schemas for tool parameters
+│   └── tool-outputs.ts              ← Zod schemas for tool return shapes
+├── lib/
+│   ├── pagination.ts                ← shared cursor / limit / offset helpers
+│   └── error-mapping.ts             ← maps NestJS exceptions → MCP error responses
+└── tests/
+    ├── auth.spec.ts
+    ├── tools.spec.ts
+    └── e2e/
+        └── mcp.e2e-spec.ts
+```
+
+Tool implementations are thin: they call the existing NestJS services (`DisplaysService`, `ContentService`, etc.) and project the result into the Zod-defined output schema. **No new business logic in `mcp/`.**
+
+---
+
+## Auth model
+
+### Why not reuse user JWTs
+
+User JWTs are wide-scope (a user can do everything they're allowed to do across the whole app). MCP tokens should be narrow-scope (this token can only call these tools, for this org, until this date).
+
+### MCP token shape
+
+```ts
+type McpToken = {
+  tokenId: string;           // opaque ID for revocation lookup
+  organizationId: string;    // scope: which org's data this token can read
+  scope: string[];           // e.g., ['displays:read', 'content:read', 'audit:read']
+  agentName: string;         // 'support-triage' | 'customer-lifecycle' | etc. — for audit attribution
+  issuedAt: Date;
+  expiresAt: Date;
+  rotatedFrom?: string;      // previous tokenId if this is a rotation
+};
+```
+
+Token storage: new Prisma table `McpToken` with index on `tokenId`. Token *value* is HMAC-signed; the database stores only the hash. Revocation = mark `revokedAt` on the row.
+
+### Authentication flow
+
+1. Agent presents `Authorization: Bearer <mcp-token>` to `/api/v1/mcp`
+2. `McpAuthGuard` parses + verifies HMAC, looks up `tokenId`, checks `expiresAt > now` and `revokedAt is null`
+3. On success, the token's `organizationId`, `scope`, and `agentName` flow into request context
+4. Each tool checks its required scope against the request context's scope set
+5. Every tool call writes an audit entry: `{ tokenId, agentName, tool, params (redacted), result_summary, latency_ms, ts }`
+
+### Token lifecycle
+
+- **Issuance:** admin-only endpoint `POST /api/v1/admin/mcp-tokens` — must specify `organizationId`, `scope`, `agentName`, `expiresAt` (max 90 days)
+- **Rotation:** monthly cron reminder per shift-agent's security posture
+- **Revocation:** admin endpoint or auto-revoke on suspicious activity (configurable threshold of `4xx` per minute)
+
+---
+
+## Tool definition pattern
+
+Each tool is a function + a Zod input schema + a Zod output schema + a required scope:
+
+```ts
+// tools/displays.tools.ts
+import { z } from 'zod';
+import { ToolDef } from './tool-registry';
+
+const ListDisplaysInput = z.object({
+  status: z.enum(['online', 'offline', 'all']).optional().default('all'),
+  group_id: z.string().optional(),
+  limit: z.number().int().min(1).max(100).optional().default(20),
+  cursor: z.string().optional(),
+});
+
+const ListDisplaysOutput = z.object({
+  displays: z.array(z.object({
+    id: z.string(),
+    name: z.string(),
+    organization_id: z.string(),
+    status: z.enum(['online', 'offline', 'unknown']),
+    last_seen_at: z.string().datetime().nullable(),
+    location: z.string().nullable(),
+    current_playlist_id: z.string().nullable(),
+  })),
+  next_cursor: z.string().nullable(),
+});
+
+export const listDisplays: ToolDef<typeof ListDisplaysInput, typeof ListDisplaysOutput> = {
+  name: 'list_displays',
+  description: 'List displays for the current org. Read-only. Returns paginated results.',
+  inputSchema: ListDisplaysInput,
+  outputSchema: ListDisplaysOutput,
+  requiredScope: 'displays:read',
+  handler: async (input, ctx) => {
+    // ctx.organizationId comes from the validated MCP token
+    const result = await ctx.displaysService.findByOrg({
+      orgId: ctx.organizationId,
+      status: input.status === 'all' ? undefined : input.status,
+      groupId: input.group_id,
+      limit: input.limit,
+      cursor: input.cursor,
+    });
+    return ListDisplaysOutput.parse({
+      displays: result.items.map(toMcpShape),
+      next_cursor: result.nextCursor,
+    });
+  },
+};
+```
+
+`tool-registry.ts` collects all tools and exposes them via the MCP `tools/list` and `tools/call` endpoints.
+
+---
+
+## How a Hermes business-agent consumes it
+
+In `vizora-business-agents/src/platform/vizora_mcp_client.py` (modeled after shift-agent's `qbo_client.py`):
+
+```python
+# Pseudo-code
+class VizoraMcpClient:
+    def __init__(self, base_url: str, token: str):
+        self.session = httpx.Client(base_url=base_url, headers={"Authorization": f"Bearer {token}"})
+
+    def list_displays(self, status=None, limit=20):
+        return self._call_tool("list_displays", {"status": status, "limit": limit})
+
+    def _call_tool(self, name, args):
+        r = self.session.post("/api/v1/mcp/tools/call", json={"name": name, "arguments": args})
+        r.raise_for_status()
+        return r.json()["content"]
+```
+
+A SKILL.md in the Hermes side then references:
+
+> *"Call `list_displays` with `status=offline` to find displays needing attention. The tool returns a JSON list with id, name, last_seen_at. Iterate and decide which ones to flag."*
+
+The SKILL doesn't need to know the URL, the auth header shape, or the schema. It just calls a tool by name. **That's the whole point.**
+
+---
+
+## Wiring to existing NestJS services
+
+| MCP tool | Calls into | Existing service file |
+|---|---|---|
+| `list_displays`, `get_display` | `DisplaysService` | `middleware/src/modules/displays/displays.service.ts` |
+| `get_display_health` | `RedisService` (online status) + `DisplaysService` (persisted state) | both |
+| `list_content`, `get_content` | `ContentService` | `middleware/src/modules/content/content.service.ts` |
+| `list_playlists`, `get_playlist` | `PlaylistsService` | `middleware/src/modules/playlists/playlists.service.ts` |
+| `list_schedules`, `get_schedule` | `SchedulesService` | `middleware/src/modules/schedules/schedules.service.ts` |
+| `list_organizations`, `get_org_health` | `OrganizationsService` + new `OrgHealthAggregator` | new aggregator (small) |
+| `list_recent_incidents` | New `OpsStateReader` that reads `logs/ops-state.json` | new (small) |
+| `get_audit_trail` | New `AuditService` over the existing audit-log surface | new (medium) |
+
+**No new business logic.** The MCP layer is a projection over what already exists.
+
+---
+
+## Read-only safety
+
+The `requiredScope` enum is exhaustively `*:read`. There is no `*:write` scope in v1. The `mcp-auth.guard.ts` enforces this by rejecting any token issued with a write scope (until v2 introduces them).
+
+This is a deliberate constraint, not an oversight. Earning the right to write happens after a measurement period (30+ days) of observed read traffic + zero auth incidents.
+
+---
+
+## Pagination
+
+Cursor-based, base64-encoded opaque cursor. Same pattern as Vizora's existing `PaginationDto`. `lib/pagination.ts` wraps the existing helper so MCP tools use it consistently.
+
+Max `limit` = 100 per call. Hard cap at the schema layer.
+
+---
+
+## Error model
+
+MCP-spec-compliant error responses:
+
+```json
+{
+  "error": {
+    "code": "TOOL_NOT_FOUND" | "INVALID_INPUT" | "FORBIDDEN" | "INTERNAL" | "RATE_LIMITED",
+    "message": "Human-readable description",
+    "data": { "details": "..." }
+  }
+}
+```
+
+`error-mapping.ts` maps NestJS exceptions:
+- `NotFoundException` → `INVALID_INPUT` (the resource doesn't exist for this org)
+- `ForbiddenException` → `FORBIDDEN`
+- `BadRequestException` → `INVALID_INPUT`
+- Anything else → `INTERNAL` (with the exception logged but stack trace stripped from the response)
+
+---
+
+## Rate limiting
+
+Per-token rate limit, distinct from the existing user/org rate limiters:
+- 60 calls / minute / token (default)
+- 1000 calls / day / token (default)
+- Configurable per token at issuance time (admin override)
+
+Triggers `RATE_LIMITED` error response with `Retry-After` header.
+
+---
+
+## Observability
+
+| Metric | Why |
+|---|---|
+| `mcp_tool_calls_total{tool, agent, status}` | Per-tool / per-agent volume + success rate |
+| `mcp_tool_latency_ms{tool, p50, p95, p99}` | Per-tool latency |
+| `mcp_auth_failures_total{reason}` | Token validation failures by cause |
+| `mcp_rate_limit_hits_total{token_id}` | Tokens hitting the rate limit |
+| `mcp_active_tokens` | Currently-valid tokens count |
+
+Add to existing Prometheus + Grafana setup (Vizora already has `vizora-overview.json` dashboard — add an `vizora-mcp.json` dashboard).
+
+---
+
+## Testing approach
+
+| Layer | What |
+|---|---|
+| Unit | Each tool handler with mocked services. Verify Zod input/output validation, scope enforcement, error mapping. |
+| Integration | NestJS test app with real Prisma (test DB), real services. Verify tool-call → service-call → DB-query → response shape. |
+| E2E | Spin up the MCP server, issue a real token via admin endpoint, call every tool from a Python or Node MCP client, verify wire shape. |
+| Auth | Forgery / expired / revoked / scope-mismatch — explicit tests for each rejection path. |
+| Rate limit | Burst tests — verify limiter triggers + recovery + headers. |
+| Audit | Verify every successful + failed tool call writes an audit row with `tokenId`, `agentName`, `tool`, `params (redacted)`, `latency_ms`. |
+
+---
+
+## Migration / rollout sequence
+
+Following shift-agent's "infra-and-safety first, agent logic last" build order:
+
+1. Schemas (`tool-inputs.ts`, `tool-outputs.ts`)
+2. Auth (`mcp-auth.guard.ts`, `mcp-token.service.ts`, `McpToken` Prisma table + migration)
+3. Admin endpoint to issue/revoke tokens
+4. Audit + observability hooks (so when tools come online, they're already instrumented)
+5. Rate limiter
+6. One read tool end-to-end (`list_displays`) — exercises the full stack
+7. Remaining read tools, one at a time
+8. Hermes-side `vizora_mcp_client.py` (in `vizora-business-agents/` repo)
+9. First Hermes business-agent migration: `support-triage` (the only live LLM-shaped business agent today)
+10. Measurement period (30 days) — observed read traffic, zero auth incidents → green-light v2 (write tools)
+
+---
+
+## What this unlocks
+
+| Today | After MCP server lands |
+|---|---|
+| Each new agent writes its own HTTP client + auth + retry | Each new agent imports `vizora_mcp_client` and calls tools by name |
+| Per-agent permission management is ad hoc | Per-token scope + revocation is centralized |
+| No agent-decision quality metric | `mcp_tool_calls_total` segmented by `agent` makes per-agent activity visible |
+| Customer integrations need bespoke API contracts | A future v2 customer-facing MCP surface piggybacks on the same code |
+| Hermes sidecar in Python is a 2-week integration project | Hermes sidecar is a thin client over a stable surface |
+
+---
+
+## What this does NOT do
+
+- Doesn't replace the existing REST API. The Vizora dashboard, mobile app, and Electron client continue to use `/api/v1/*` directly. MCP is for agents.
+- Doesn't add LLM capabilities to the middleware. The middleware exposes tools; LLMs live in the agent layer.
+- Doesn't deprecate ops-* agents. Those are deterministic cron tasks; they don't benefit from MCP routing. They can keep calling internal services directly.
+- Doesn't ship in the same PR as the homepage redesign or any other unrelated work. New module, dedicated branch, dedicated review.
+
+---
+
+## Estimated effort
+
+| Phase | Effort | Dependencies |
+|---|---|---|
+| Schemas + auth + admin endpoint + Prisma migration | 1 dev-day | None |
+| Audit + observability + rate limiter | 0.5 dev-day | Existing Prometheus / Grafana |
+| First read tool (`list_displays`) end-to-end + tests | 0.5 dev-day | Phases above |
+| Remaining 12 read tools | 2 dev-days | First tool establishes the pattern |
+| `vizora_mcp_client.py` in `vizora-business-agents/` repo | 0.5 dev-day | MCP server reachable |
+| First Hermes business-agent migration (`support-triage`) | 2 dev-days | shift-agent discipline applied |
+
+**Total: ~6.5 dev-days for the full sequence.** Phases 1–4 (~4 days) deliver the standalone MCP server. Phases 5–6 are the first agent that uses it.
+
+---
+
+## Open questions
+
+1. **Transport choice — HTTP/SSE vs stdio:** HTTP/SSE is the production answer (works across machines, integrates with existing nginx + TLS). stdio is useful for local dev. Both should ship in v1.
+2. **Token storage in Prisma vs Redis:** Prisma for durability + admin queries; Redis for fast revocation lookup with Prisma as source of truth. Lookup pattern: check Redis, miss → Prisma → write-through to Redis.
+3. **`list_recent_incidents` data source:** ops-state.json is local to the VPS; if the middleware runs on a different host eventually, this needs a different source. v1 assumes single-host (matches today).
+4. **Audit log retention:** how long to keep MCP call audits? Suggested: 90 days hot in Postgres, archived to S3 indefinitely. Match existing audit policy (cross-check before shipping).
+
+---
+
+## References
+
+- shift-agent's `src/platform/qbo_client.py` (the QuickBooks integration that proves the cross-language client pattern works)
+- shift-agent's `src/platform/safe_io.py` (the auth-+-state discipline this design draws from)
+- `docs/agents-architecture.md` (the broader discipline this server enables agents to follow)
+- MCP specification: https://modelcontextprotocol.io/specification (the protocol Vizora's server implements)

--- a/docs/agents-mcp-server-design.md
+++ b/docs/agents-mcp-server-design.md
@@ -51,7 +51,7 @@ It's the same pattern shift-agent uses with `qbo_client.py` for QuickBooks: one 
 ```
 middleware/src/modules/mcp/
 ├── mcp.module.ts                    ← NestJS module wiring
-├── mcp.controller.ts                ← exposes /api/v1/mcp endpoint(s) for transport
+├── mcp.controller.ts                ← exposes /api/v1/mcp endpoint(s); uses @SkipEnvelope() (see "Response shape" below)
 ├── mcp.service.ts                   ← MCP server lifecycle, tool registration
 ├── transports/
 │   ├── http.transport.ts            ← HTTP/SSE transport (preferred for production)
@@ -65,7 +65,7 @@ middleware/src/modules/mcp/
 │   ├── playlists.tools.ts           ← list_playlists, get_playlist
 │   ├── schedules.tools.ts           ← list_schedules, get_schedule
 │   ├── organizations.tools.ts       ← list_organizations, get_org_health
-│   ├── audit.tools.ts               ← list_recent_incidents, get_audit_trail
+│   ├── audit.tools.ts               ← list_recent_incidents (calls existing GET /api/v1/health/ops-status), get_audit_trail
 │   └── tool-registry.ts             ← exports all tools as a Map<name, ToolDef>
 ├── schemas/
 │   ├── tool-inputs.ts               ← Zod schemas for tool parameters
@@ -80,9 +80,31 @@ middleware/src/modules/mcp/
         └── mcp.e2e-spec.ts
 ```
 
-Tool implementations are thin: they call the existing NestJS services (`DisplaysService`, `ContentService`, etc.) and project the result into the Zod-defined output schema. **No new business logic in `mcp/`.**
+Tool implementations are thin: they call the existing NestJS services (`DisplaysService`, `ContentService`, etc.) — **including the existing `AgentStateService` from `middleware/src/modules/agents/` and the existing `GET /api/v1/health/ops-status` endpoint** — and project the result into the Zod-defined output schema. **No new business logic in `mcp/`.** No new state I/O paths — reuse what's already battle-hardened by PR #32 review.
 
 ---
+
+## Response shape — interaction with existing global interceptors
+
+Vizora's `ResponseEnvelopeInterceptor` (global, see `CLAUDE.md`) wraps every response in `{ success, data, meta }`. **MCP responses must NOT be enveloped** — the MCP spec requires a specific JSON-RPC shape on the wire, and double-wrapping (`{success, data: {jsonrpc, result, id}, meta}`) breaks every MCP client.
+
+Required:
+- `mcp.controller.ts` decorates every endpoint with `@SkipEnvelope()` so the global interceptor passes the body through verbatim.
+- `mcp.controller.spec.ts` includes a regression test: response body has top-level `jsonrpc` and `result` (or `error`), NOT a `success` field.
+
+Same constraint applies to error responses — MCP errors live at `error.code` / `error.message` / `error.data`, not under `data`.
+
+## Middleware exemptions
+
+Because MCP traffic comes from server-to-server agents (not browsers), several middlewares behave wrong by default:
+
+| Middleware | Default | MCP requirement |
+|---|---|---|
+| `CSRF` (`middleware/src/modules/common/middleware/csrf.middleware.ts`) | Required for cookie-auth endpoints | **Exempt `/api/v1/mcp/*`** — MCP uses bearer tokens, not cookies; no CSRF surface to protect |
+| `ResponseEnvelopeInterceptor` | Wraps everything | **Skipped per endpoint** via `@SkipEnvelope()` (see above) |
+| `SanitizeInterceptor` (XSS) | Sanitizes all response bodies | **Skipped per endpoint** via `@SkipEnvelope()`-equivalent (or use the existing template-field skip mechanism). MCP responses ferry data agents will parse, not HTML to render. |
+| `ThrottlerGuard` (3-tier) | Per-IP user rate limit | Replaced by per-token MCP rate limiter (see "Rate limiting" below); existing throttler stays as a backstop for unauthenticated traffic to the MCP endpoint |
+| `LoggingInterceptor` | Logs all requests | Keep — but ensure token-id (not raw token) is logged |
 
 ## Auth model
 
@@ -119,6 +141,19 @@ Token storage: new Prisma table `McpToken` with index on `tokenId`. Token *value
 - **Issuance:** admin-only endpoint `POST /api/v1/admin/mcp-tokens` — must specify `organizationId`, `scope`, `agentName`, `expiresAt` (max 90 days)
 - **Rotation:** monthly cron reminder per shift-agent's security posture
 - **Revocation:** admin endpoint or auto-revoke on suspicious activity (configurable threshold of `4xx` per minute)
+
+### Required environment variables
+
+Add to `.env.example` (and the env-var doc table in `CLAUDE.md`):
+
+| Var | Purpose | Constraints |
+|---|---|---|
+| `MCP_TOKEN_SECRET` | HMAC signing key for MCP tokens | Min 32 chars; distinct from `JWT_SECRET` and `DEVICE_JWT_SECRET`; rotate via re-issuing all active tokens |
+| `MCP_RATE_LIMIT_PER_MIN` | Optional override for per-token per-minute cap | Default 60 (see "Rate limiting") |
+| `MCP_RATE_LIMIT_PER_DAY` | Optional override for per-token per-day cap | Default 1000 |
+| `MCP_TOKEN_TTL_DAYS` | Max issuance TTL | Default 90 |
+
+Per CLAUDE.md style, the middleware validates each at startup and exits if `MCP_TOKEN_SECRET` is unset or under length — same pattern as `JWT_SECRET` validation.
 
 ---
 
@@ -215,8 +250,10 @@ The SKILL doesn't need to know the URL, the auth header shape, or the schema. It
 | `list_playlists`, `get_playlist` | `PlaylistsService` | `middleware/src/modules/playlists/playlists.service.ts` |
 | `list_schedules`, `get_schedule` | `SchedulesService` | `middleware/src/modules/schedules/schedules.service.ts` |
 | `list_organizations`, `get_org_health` | `OrganizationsService` + new `OrgHealthAggregator` | new aggregator (small) |
-| `list_recent_incidents` | New `OpsStateReader` that reads `logs/ops-state.json` | new (small) |
-| `get_audit_trail` | New `AuditService` over the existing audit-log surface | new (medium) |
+| `list_recent_incidents` | **Existing** `GET /api/v1/health/ops-status` (Redis-cached, see `middleware/src/modules/health/health.controller.ts:169`). Filter the returned status to the requesting org's incidents. | thin tool wrapper over existing endpoint |
+| `get_audit_trail` | **Existing** `AgentStateService.read(family)` from `middleware/src/modules/agents/` (PR #32) — already does the read with secret/PII redaction. Tool wraps it with cursor pagination + per-resource filtering. | thin tool wrapper |
+
+**Why this matters:** earlier draft proposed reading `logs/ops-state.json` directly. That bypasses the approved Redis-cached path on `health.controller.ts` and reimplements the redaction + path-safety logic that `AgentStateService` already enforces. Reusing existing endpoints means MCP inherits the security posture from PR #32's review — no new attack surface to harden.
 
 **No new business logic.** The MCP layer is a projection over what already exists.
 
@@ -245,7 +282,7 @@ MCP-spec-compliant error responses:
 ```json
 {
   "error": {
-    "code": "TOOL_NOT_FOUND" | "INVALID_INPUT" | "FORBIDDEN" | "INTERNAL" | "RATE_LIMITED",
+    "code": "TOOL_NOT_FOUND" | "INVALID_INPUT" | "NOT_FOUND" | "FORBIDDEN" | "UNAUTHORIZED" | "INTERNAL" | "RATE_LIMITED",
     "message": "Human-readable description",
     "data": { "details": "..." }
   }
@@ -253,10 +290,14 @@ MCP-spec-compliant error responses:
 ```
 
 `error-mapping.ts` maps NestJS exceptions:
-- `NotFoundException` → `INVALID_INPUT` (the resource doesn't exist for this org)
-- `ForbiddenException` → `FORBIDDEN`
-- `BadRequestException` → `INVALID_INPUT`
+- `NotFoundException` → **`NOT_FOUND`** (the resource ID is well-formed but no such resource exists for this org). Distinct from `INVALID_INPUT` because agents should *not* retry a NOT_FOUND with the same args — they should fetch fresh state or give up. Conflating the two encourages retry loops.
+- `BadRequestException` → `INVALID_INPUT` (the params themselves are malformed — agent should fix and retry, or escalate)
+- `UnauthorizedException` → `UNAUTHORIZED` (invalid / expired / revoked token — agent should re-auth, not retry)
+- `ForbiddenException` → `FORBIDDEN` (token is valid but lacks the required scope — agent should escalate, not retry)
+- `ThrottlerException` → `RATE_LIMITED` (carries `Retry-After`)
 - Anything else → `INTERNAL` (with the exception logged but stack trace stripped from the response)
+
+The error code carries semantic meaning agents act on. Misclassifying NOT_FOUND as INVALID_INPUT is the difference between an agent backing off vs hammering an endpoint trying to "fix its inputs."
 
 ---
 
@@ -295,6 +336,8 @@ Add to existing Prometheus + Grafana setup (Vizora already has `vizora-overview.
 | Auth | Forgery / expired / revoked / scope-mismatch — explicit tests for each rejection path. |
 | Rate limit | Burst tests — verify limiter triggers + recovery + headers. |
 | Audit | Verify every successful + failed tool call writes an audit row with `tokenId`, `agentName`, `tool`, `params (redacted)`, `latency_ms`. |
+| Envelope/middleware regression | Response body has top-level `jsonrpc` + `result` / `error` (no `success` field — proves `@SkipEnvelope()` + sanitize-skip work). CSRF middleware doesn't reject MCP POSTs without an X-CSRF token. |
+| Error mapping | Each NestJS exception maps to the documented MCP code (NotFoundException → NOT_FOUND, not INVALID_INPUT — explicit regression test for the retry-loop hazard). |
 
 ---
 

--- a/tasks/feature-backlog.md
+++ b/tasks/feature-backlog.md
@@ -6,55 +6,54 @@ Not a sprint tracker — see `todo.md` for in-flight work.
 
 ---
 
-## Business-agent scaffolds — 30-day ship-or-kill gate
+## Adopt shift-agent / Hermes patterns for Vizora business agents (evaluation)
 
 **Opened:** 2026-05-03
-**Status:** Hard gate — **2026-06-03**
-**Decision needed by:** 2026-06-03 (30 days from open)
-**Owner:** Sri
+**Status:** Open evaluation — does this fit Vizora?
+**Trigger to revisit:** Whenever the next business-agent design lands, or when scaling pain on the existing ones forces the question.
 
 ### What this is
 
-`scripts/agents/` contains 6 business-agent entries registered in `ecosystem.config.js`. Today (2026-05-03), only **2 are real**:
+`shift-agent` (Sri's sister project, 15 agents in production on Hermes Agent + Kimi K2 via OpenRouter) demonstrates a mature, opinionated multi-agent architecture with strong maintainability properties:
 
-| Agent | Status | File-header marker |
+- Per-agent directory shape (`skills/`, `scripts/`, `templates/`, `runbook.md`, `config.yaml.template`, `systemd/`)
+- Shared platform layer (`safe_io.py`, `schemas.py`, audit helpers, sender-context resolution)
+- Hard rules: dispatcher-first routing, identity-by-metadata, fail-closed, helper-scripts-own-IDs, templates-not-LLM-text, input sanitization, dual-source audit, hardened outbound
+- Required out-of-band alerts (dead-man + watchdog + heartbeat)
+- Disciplined build order (infra-and-safety first, agent logic last)
+- Heavy doc discipline: PLAN.md → DESIGN.md → runbook.md → code
+
+The framework is proven on the shift-agent side. **The open question is fit:** does Vizora's current agent landscape benefit enough from porting these patterns to justify the work?
+
+### What Vizora has today
+
+| Layer | Count | Pattern fit notes |
 |---|---|---|
-| `agent-customer-lifecycle` | live | (no SCAFFOLD marker) |
-| `agent-support-triage` | live | taxonomy-v2 work, behind Hermes Path B gate |
-| `agent-orchestrator` | **scaffold** | `Vizora Agent System — Orchestrator SCAFFOLD` |
-| `agent-billing-revenue` | **scaffold** | `Vizora Agent System — Billing & Revenue SCAFFOLD (READ-ONLY)` |
-| `agent-content-intelligence` | **scaffold** | `Vizora Agent System — Content Intelligence SCAFFOLD` |
-| `agent-screen-health-customer` | **scaffold** | `Vizora Agent System — Screen Health (Customer-facing) SCAFFOLD` |
+| `.claude/agents/*.md` (dev-time Claude Code subagents) | 8 | Already in SKILL.md shape. Match the pattern by accident. **No change needed.** |
+| `scripts/ops/` (PM2 cron, deterministic) | 6 | Predictable cron jobs. Not LLM-shaped. Most discipline rules don't apply, BUT could benefit from `safe_io` patterns + the dead-man + watchdog + heartbeat triad. |
+| `scripts/agents/` (business agents, mixed) | 6 (2 live, 4 scaffolds) | This is where the patterns would land hardest. The 2 live ones (`customer-lifecycle`, `support-triage`) are doing LLM-shaped work. The 4 scaffolds are unwritten. |
 
-PM2 currently shows all 4 scaffolds in `stopped` state. They consume zero CPU but they are **registered surface area** — visible on the ops dashboard, in deploy scripts, in the mental model of every future agent author. That's the maintenance cost.
+### Companion docs (delivered on this branch)
 
-### The gate
+- `docs/agents-architecture.md` — synthesis of shift-agent's `DESIGN.md` (979 lines, v2 post-review). Distills the 8 hard rules, the per-agent file shape, the `safe_io` pattern, required alerts, build order, testing stages, and security posture. Read when designing or maintaining a Vizora business agent.
+- `docs/agents-mcp-server-design.md` — proposed Vizora MCP server module (`middleware/src/modules/mcp/`). Read-only v1 with 13 tools, token-based auth with per-token scope, rate limiting, audit, observability. Estimate: ~6.5 dev-days for the full server + first agent migration. Would unlock Hermes-side adoption with one stable tool surface, regardless of whether Vizora itself migrates to Hermes.
 
-Each scaffold has one of three resolutions by **2026-06-03**:
+### The decision question
 
-| Resolution | What it requires |
-|---|---|
-| **Ship** | A `DESIGN.md` (shift-agent-style — see `docs/agents-architecture.md`) committed to `docs/agent-designs/` AND production logic landed AND removed from this entry |
-| **Park (re-deferred)** | Move the entry to its own dedicated section here with a clear "trigger to revisit" condition. PM2 entry removed. File moved to `scripts/agents/_parked/`. |
-| **Kill** | Delete the file. Remove the PM2 entry from `ecosystem.config.js`. Note in this entry that it was deleted on date X. |
+Two parts, each independently answerable:
 
-**Default if not addressed by 2026-06-03: kill.** Scaffolds that nobody designed in 30 days are not coming back.
+1. **Should the 4 business-agent scaffolds be designed (per the architecture doc) before any production logic lands?** Sri's instinct says yes — they're proven patterns. Confirm or adjust.
+2. **Should Vizora build the MCP server?** It's the highest-leverage move regardless of whether Vizora itself adopts Hermes — it gives any future agent (Vizora-internal, Hermes-sidecar, customer-built) one stable read surface and removes per-agent integration code.
 
-### Why this gate exists
+### Open considerations
 
-shift-agent (sister project, 15 agents in production via Hermes runtime) does not have scaffolds in production. Each agent there has a complete DESIGN.md, runbook.md, schemas, scripts, templates, and systemd units before it ever ships. Vizora's scaffolds are the opposite pattern — registered before designed. That's the source of the "20 agents to maintain" anxiety: most of them aren't agents, they're empty PM2 entries waving at the future.
+- **Cross-language friction.** Hermes is Python; Vizora is TypeScript/NestJS. Full Hermes adoption means a sidecar repo (`vizora-business-agents/` per the architecture doc), with HTTPS as the boundary. shift-agent already proves this works (it talks to QuickBooks the same way). Cost is mostly the second runtime to operate.
+- **Discipline cost vs payoff.** The shift-agent discipline is heavy — per-agent runbooks, PLAN.md / DESIGN.md before code, build order, staged testing. Worth it when you have 15 agents (shift-agent) or 6+ (Vizora business agents). Maybe overkill if Vizora ends up consolidating to 2–3.
+- **Existing investments.** Vizora's `scripts/ops/lib/` already does some of what `safe_io.py` does. The shift-agent patterns are an extension, not a rewrite.
 
-### Trigger to revisit if parked
+### What would unblock action
 
-For any of the four, "revisit" means:
-- A real customer-driven need surfaces (e.g., a customer asks for revenue cohort analysis → unparks `agent-billing-revenue`)
-- A `DESIGN.md` is written first
-- A `runbook.md` is written before code
-
-### Companion docs (added on this branch)
-
-- `docs/agents-architecture.md` — extracted discipline from shift-agent's `DESIGN.md`. Read this before designing any new agent.
-- `docs/agents-mcp-server-design.md` — proposed Vizora MCP server module. Unlocks Hermes-side adoption with one stable tool surface.
+A decision on the MCP server v1 (yes / no / not yet). The agent-discipline patterns can be adopted incrementally per agent; the MCP server is a focused 6.5-day effort that needs an explicit go.
 
 ---
 

--- a/tasks/feature-backlog.md
+++ b/tasks/feature-backlog.md
@@ -6,6 +6,58 @@ Not a sprint tracker — see `todo.md` for in-flight work.
 
 ---
 
+## Business-agent scaffolds — 30-day ship-or-kill gate
+
+**Opened:** 2026-05-03
+**Status:** Hard gate — **2026-06-03**
+**Decision needed by:** 2026-06-03 (30 days from open)
+**Owner:** Sri
+
+### What this is
+
+`scripts/agents/` contains 6 business-agent entries registered in `ecosystem.config.js`. Today (2026-05-03), only **2 are real**:
+
+| Agent | Status | File-header marker |
+|---|---|---|
+| `agent-customer-lifecycle` | live | (no SCAFFOLD marker) |
+| `agent-support-triage` | live | taxonomy-v2 work, behind Hermes Path B gate |
+| `agent-orchestrator` | **scaffold** | `Vizora Agent System — Orchestrator SCAFFOLD` |
+| `agent-billing-revenue` | **scaffold** | `Vizora Agent System — Billing & Revenue SCAFFOLD (READ-ONLY)` |
+| `agent-content-intelligence` | **scaffold** | `Vizora Agent System — Content Intelligence SCAFFOLD` |
+| `agent-screen-health-customer` | **scaffold** | `Vizora Agent System — Screen Health (Customer-facing) SCAFFOLD` |
+
+PM2 currently shows all 4 scaffolds in `stopped` state. They consume zero CPU but they are **registered surface area** — visible on the ops dashboard, in deploy scripts, in the mental model of every future agent author. That's the maintenance cost.
+
+### The gate
+
+Each scaffold has one of three resolutions by **2026-06-03**:
+
+| Resolution | What it requires |
+|---|---|
+| **Ship** | A `DESIGN.md` (shift-agent-style — see `docs/agents-architecture.md`) committed to `docs/agent-designs/` AND production logic landed AND removed from this entry |
+| **Park (re-deferred)** | Move the entry to its own dedicated section here with a clear "trigger to revisit" condition. PM2 entry removed. File moved to `scripts/agents/_parked/`. |
+| **Kill** | Delete the file. Remove the PM2 entry from `ecosystem.config.js`. Note in this entry that it was deleted on date X. |
+
+**Default if not addressed by 2026-06-03: kill.** Scaffolds that nobody designed in 30 days are not coming back.
+
+### Why this gate exists
+
+shift-agent (sister project, 15 agents in production via Hermes runtime) does not have scaffolds in production. Each agent there has a complete DESIGN.md, runbook.md, schemas, scripts, templates, and systemd units before it ever ships. Vizora's scaffolds are the opposite pattern — registered before designed. That's the source of the "20 agents to maintain" anxiety: most of them aren't agents, they're empty PM2 entries waving at the future.
+
+### Trigger to revisit if parked
+
+For any of the four, "revisit" means:
+- A real customer-driven need surfaces (e.g., a customer asks for revenue cohort analysis → unparks `agent-billing-revenue`)
+- A `DESIGN.md` is written first
+- A `runbook.md` is written before code
+
+### Companion docs (added on this branch)
+
+- `docs/agents-architecture.md` — extracted discipline from shift-agent's `DESIGN.md`. Read this before designing any new agent.
+- `docs/agents-mcp-server-design.md` — proposed Vizora MCP server module. Unlocks Hermes-side adoption with one stable tool surface.
+
+---
+
 ## Atelier Homepage Redesign
 
 **Opened:** 2026-04-30


### PR DESCRIPTION
## Summary

Three documents capturing the evaluation of whether shift-agent's proven Hermes-runtime patterns help Vizora's agent maintainability. **Doc-only PR — no app code touched, nothing in this branch ships to prod even if merged.**

- **\`tasks/feature-backlog.md\`** — new entry: *Adopt shift-agent / Hermes patterns for Vizora business agents (evaluation)*. Frames the open question (does this help Vizora?) and the two-part decision: design discipline for new agents + whether to build the MCP server.
- **\`docs/agents-architecture.md\`** (new) — synthesis of shift-agent's \`DESIGN.md\` (979 lines, v2 post-review). The 8 hard rules, per-agent file shape, \`safe_io\` pattern, required out-of-band alerts, build order, testing stages, security posture. Reference doc for designing or maintaining a Vizora business agent.
- **\`docs/agents-mcp-server-design.md\`** (new) — sketch for \`middleware/src/modules/mcp/\`. Read-only v1, 13 tools, token-based auth with per-token scope, rate limiting, audit, observability. Estimate ~6.5 dev-days for the full server + first agent migration. Independently valuable regardless of whether Vizora itself adopts Hermes — gives any future agent (Vizora-internal, Hermes-sidecar, customer-built) one stable read surface.

## Why now

Sri raised a maintainability concern about Vizora's 20 agents (8 dev-time Claude Code subagents + 6 ops cron + 6 business agents, 4 of which are scaffolds). \`shift-agent\` is Sri's sister project running 15 agents in production via Hermes Agent + Kimi K2 — proven framework with strong discipline. This PR captures what the patterns are and lays out the path if Vizora wants to adopt them.

## Decision asked of reviewers

Two parts, each independently answerable:

1. **Design discipline for new business agents** — should Vizora adopt the per-agent directory shape (\`skills/\`, \`scripts/\`, \`templates/\`, \`runbook.md\`, \`config.yaml.template\`, \`systemd/\`) and the 8 hard rules from \`docs/agents-architecture.md\` for new agents going forward?
2. **MCP server v1** — green-light to build \`middleware/src/modules/mcp/\` per \`docs/agents-mcp-server-design.md\`?

Either can be answered independently of the other. Either can be answered "not yet" without blocking the other.

## Scope deliberately excluded

- No app code changes
- No deadlines or ship-or-kill gates on existing scaffolds (per Sri's reframing)
- Doesn't deprecate or unblock the parked \`feat/design-explorations\` homepage redesign
- Doesn't impose Hermes adoption — the discipline patterns and the MCP server are independently valuable

## Test plan

- [ ] Reviewer reads \`tasks/feature-backlog.md\` entry — does the two-part decision question match Sri's intent?
- [ ] Reviewer skims \`docs/agents-architecture.md\` — 8 hard rules accurate? Vizora-mapping table fair?
- [ ] Reviewer skims \`docs/agents-mcp-server-design.md\` — tool surface covers expected use cases? Auth model reasonable? Effort estimate credible?
- [ ] No accidental cross-references to the parked \`feat/design-explorations\` work (companion safeguard)
- [ ] No app code touched (\`git diff main --stat\` should show only \`tasks/\` and \`docs/\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)