### PR TITLE
feat(mcp): PR-A — foundation + list_displays tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -166,6 +166,21 @@ BACKUP_RETENTION_DAYS=7
 # BACKUP_S3_BUCKET=s3://my-vizora-backups
 
 # =============================================================================
+# MCP Server (Model Context Protocol) — read-only tool surface for agents
+# =============================================================================
+# Bearer tokens are sha256-hashed before storage. Plaintext is shown to admin
+# ONCE on issue and never recoverable. See docs/agents-mcp-server-design.md.
+
+# Maximum issuance TTL in days. Tokens default to this if no expiresInDays is
+# supplied at issue time. Min: 1.
+MCP_TOKEN_TTL_DAYS=90
+
+# Per-token rate limits (in-memory; ~2× the configured cap effective in PM2
+# cluster mode — set to half the desired global ceiling if strict).
+MCP_RATE_LIMIT_PER_MIN=60
+MCP_RATE_LIMIT_PER_DAY=1000
+
+# =============================================================================
 # Continuous Monitoring (Tier 1 Validator)
 # =============================================================================
 # Service account for automated validation runs (every 15min via PM2)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,14 @@ HEALTHCHECKS_HEALTH_GUARDIAN_URL  # External heartbeat for the ops dead-man (see
 EMAIL_FROM              # Default sender for transactional mail
 ```
 
+### MCP Server (see also `docs/agents-mcp-server-design.md`)
+
+```
+MCP_TOKEN_TTL_DAYS                # Max issuance TTL in days. Default 90. Min 1.
+MCP_RATE_LIMIT_PER_MIN            # Per-token per-minute cap. Default 60.
+MCP_RATE_LIMIT_PER_DAY            # Per-token per-day cap. Default 1000.
+```
+
 ### Agent System (business agents — see also `docs/agents-architecture.md`)
 
 ```
@@ -201,12 +209,16 @@ OPENWEATHER_API_KEY     # Optional — OpenWeatherMap API key for weather widget
 middleware/src/modules/    # NestJS modules:
                            #   admin, agents, analytics, api-keys, auth, billing,
                            #   common, config, content, database, display-groups,
-                           #   displays, fleet, folders, health, mail, metrics,
+                           #   displays, fleet, folders, health, mail, mcp, metrics,
                            #   notifications, organizations, playlists, redis,
                            #   schedules, storage, support, template-library, users
 middleware/src/modules/agents/  # Business-agent infrastructure (PR #32, 2026-04-19):
                                 #   AgentStateService, agent-state.schema, controllers
                                 #   for /api/v1/agents/* — see docs/agents-architecture.md
+middleware/src/modules/mcp/     # Model Context Protocol server — read-only tool surface
+                                # for agents (Vizora-internal + future Hermes sidecar).
+                                # See docs/agents-mcp-server-design.md and the "MCP
+                                # Server" section below.
 middleware/src/modules/common/  # Shared guards (csrf), interceptors (logging, sanitize, response-envelope), middleware (csrf)
 middleware/test/           # E2E test specs (*.e2e-spec.ts)
 packages/database/prisma/schema.prisma  # Data model: Organization, User, Display, Content, Playlist, Schedule, DisplayGroup, Tag
@@ -303,6 +315,34 @@ Automated deployment readiness checker. Runs 30 validation rules across content,
 **Dashboard:** `GET /api/v1/health/ops-status` — Redis-cached ops status for web dashboard at `/dashboard/ops`. Prefer this over reading `ops-state.json` directly from new callers.
 
 **Design:** `docs/plans/2026-02-28-autonomous-ops-design.md`
+
+## MCP Server
+
+`middleware/src/modules/mcp/` — Vizora's Model Context Protocol server. Read-only tool surface that agents (Vizora-internal cron, Claude Code subagents, future Hermes sidecar, eventually customer integrations) call instead of hitting per-domain REST endpoints.
+
+**Endpoints:**
+- `POST /api/v1/mcp` — MCP transport (JSON-RPC over HTTP). Bearer-token auth.
+- `GET  /api/v1/mcp` — MCP transport SSE leg.
+- `POST /api/v1/admin/mcp-tokens` — issue token (super-admin only). Returns plaintext bearer ONCE.
+- `GET  /api/v1/admin/mcp-tokens` — list tokens (no plaintext).
+- `DELETE /api/v1/admin/mcp-tokens/:id` — revoke (idempotent).
+
+**Tools today (PR-A — `feat/mcp-server-foundation`):**
+- `list_displays` — paginated, scope `displays:read`, optional status filter.
+
+**Pending PRs:**
+- PR-B — remaining 12 tools (display detail, content, playlists, schedules, organizations, audit).
+- PR-C — Hermes sidecar `vizora_mcp_client.py` + first agent migration (`support-triage`).
+
+**Key behaviors to know:**
+- Bearer tokens are sha256-hashed; plaintext shown once at issuance, never persisted.
+- `@SkipEnvelope()` on every MCP endpoint — global response envelope is bypassed so MCP JSON-RPC reaches the wire unwrapped.
+- CSRF middleware exempts the entire `/api/v1/mcp` tree (bearer auth, no cookie surface).
+- Per-token rate limit (default 60/min, 1000/day). In-memory; ~2× effective limit in PM2 cluster mode (documented in code).
+- Audit row written to `mcp_audit_log` for every tool call (success or error). Inputs redacted via the same anchored regex `AgentStateService` uses.
+- Errors map to MCP-spec codes: `NOT_FOUND` (resource missing), `INVALID_INPUT` (params bad), `UNAUTHORIZED` (token issue), `FORBIDDEN` (scope), `RATE_LIMITED`, `INTERNAL`. **Distinction matters** — `NOT_FOUND` tells agents to back off, `INVALID_INPUT` invites retry.
+
+**Design doc:** `docs/agents-mcp-server-design.md`.
 
 ## Agent Architecture (business agents)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,7 +221,7 @@ middleware/src/modules/mcp/     # Model Context Protocol server — read-only to
                                 # Server" section below.
 middleware/src/modules/common/  # Shared guards (csrf), interceptors (logging, sanitize, response-envelope), middleware (csrf)
 middleware/test/           # E2E test specs (*.e2e-spec.ts)
-packages/database/prisma/schema.prisma  # Data model: Organization, User, Display, Content, Playlist, Schedule, DisplayGroup, Tag
+packages/database/prisma/schema.prisma  # Data model: Organization, User, Display, Content, Playlist, Schedule, DisplayGroup, Tag, AuditLog, AdminAuditLog, McpToken, McpAuditLog, ContentRecommendation, CustomerIncident, ...
 web/src/app/               # Next.js App Router: (auth)/, dashboard/, api/, product/
 web/src/lib/hooks/          # useSocket, useRealtimeEvents for WebSocket integration
 realtime/src/gateways/     # device.gateway.ts — main WebSocket handler

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -94,6 +94,7 @@
     }
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@nestjs/axios": "^4.0.0",
     "@nestjs/common": "^11.0.0",
     "@nestjs/config": "^4.0.2",

--- a/middleware/src/app/app.module.ts
+++ b/middleware/src/app/app.module.ts
@@ -31,6 +31,7 @@ import { MailModule } from '../modules/mail/mail.module';
 import { SupportModule } from '../modules/support/support.module';
 import { FleetModule } from '../modules/fleet/fleet.module';
 import { AgentsModule } from '../modules/agents/agents.module';
+import { McpModule } from '../modules/mcp/mcp.module';
 
 @Module({
   imports: [
@@ -117,6 +118,7 @@ import { AgentsModule } from '../modules/agents/agents.module';
     SupportModule,
     FleetModule,
     AgentsModule,
+    McpModule,
   ],
   controllers: [AppController],
   providers: [

--- a/middleware/src/modules/common/interceptors/sanitize.interceptor.ts
+++ b/middleware/src/modules/common/interceptors/sanitize.interceptor.ts
@@ -14,6 +14,16 @@ export const SKIP_OUTPUT_SANITIZE_KEY = 'skipOutputSanitize';
 export const SkipOutputSanitize = () => SetMetadata(SKIP_OUTPUT_SANITIZE_KEY, true);
 
 /**
+ * Skip *input* sanitization on this handler/controller. Use when the
+ * incoming body is not a string-bag-of-form-fields and the
+ * sanitize-html pass would corrupt structured data — e.g. MCP's
+ * JSON-RPC envelope where `params` carries typed tool inputs that
+ * are validated by Zod, not sanitized as HTML.
+ */
+export const SKIP_INPUT_SANITIZE_KEY = 'skipInputSanitize';
+export const SkipInputSanitize = () => SetMetadata(SKIP_INPUT_SANITIZE_KEY, true);
+
+/**
  * Interceptor to sanitize all string inputs in request body
  * and all string outputs in response data.
  * Prevents XSS attacks by stripping dangerous HTML.
@@ -68,22 +78,29 @@ export class SanitizeInterceptor implements NestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
     const request = context.switchToHttp().getRequest();
 
-    if (request.body && typeof request.body === 'object') {
-      request.body = this.sanitizeObject(request.body);
-    }
+    const skipInput = this.reflector?.getAllAndOverride<boolean>(
+      SKIP_INPUT_SANITIZE_KEY,
+      [context.getHandler(), context.getClass()],
+    );
 
-    if (request.query && typeof request.query === 'object') {
-      const sanitizedQuery = this.sanitizeObject(request.query);
-      Object.keys(sanitizedQuery).forEach(key => {
-        request.query[key] = sanitizedQuery[key];
-      });
-    }
+    if (!skipInput) {
+      if (request.body && typeof request.body === 'object') {
+        request.body = this.sanitizeObject(request.body);
+      }
 
-    if (request.params && typeof request.params === 'object') {
-      const sanitizedParams = this.sanitizeObject(request.params);
-      Object.keys(sanitizedParams).forEach(key => {
-        request.params[key] = sanitizedParams[key];
-      });
+      if (request.query && typeof request.query === 'object') {
+        const sanitizedQuery = this.sanitizeObject(request.query);
+        Object.keys(sanitizedQuery).forEach(key => {
+          request.query[key] = sanitizedQuery[key];
+        });
+      }
+
+      if (request.params && typeof request.params === 'object') {
+        const sanitizedParams = this.sanitizeObject(request.params);
+        Object.keys(sanitizedParams).forEach(key => {
+          request.params[key] = sanitizedParams[key];
+        });
+      }
     }
 
     // Check if output sanitization should be skipped

--- a/middleware/src/modules/common/middleware/csrf.middleware.spec.ts
+++ b/middleware/src/modules/common/middleware/csrf.middleware.spec.ts
@@ -170,6 +170,57 @@ describe('CsrfMiddleware', () => {
     });
   });
 
+  describe('MCP route exemption', () => {
+    it('should skip CSRF for /api/v1/mcp (exact match)', () => {
+      mockRequest.method = 'POST';
+      (mockRequest as Request).originalUrl = '/api/v1/mcp';
+      mockRequest.cookies = {};
+      mockRequest.headers = {};
+
+      middleware.use(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+      expect(mockResponse.status).not.toHaveBeenCalled();
+    });
+
+    it('should skip CSRF for /api/v1/mcp/* (subpaths)', () => {
+      mockRequest.method = 'POST';
+      (mockRequest as Request).originalUrl = '/api/v1/mcp/tools/list';
+      mockRequest.cookies = {};
+      mockRequest.headers = {};
+
+      middleware.use(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+      expect(mockResponse.status).not.toHaveBeenCalled();
+    });
+
+    it('should NOT skip CSRF for sibling routes that share the /api/v1/mcp prefix (REGRESSION: previously bare startsWith would also exempt /api/v1/mcp-admin etc)', () => {
+      mockRequest.method = 'POST';
+      (mockRequest as Request).originalUrl = '/api/v1/mcp-admin';
+      mockRequest.cookies = {};
+      mockRequest.headers = {};
+
+      middleware.use(mockRequest as Request, mockResponse as Response, mockNext);
+
+      // No CSRF cookie → should be rejected with 403
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(mockResponse.status).toHaveBeenCalledWith(403);
+    });
+
+    it('should ignore query string when matching MCP exemption (a malicious ?path=/api/v1/mcp must not bypass CSRF)', () => {
+      mockRequest.method = 'POST';
+      (mockRequest as Request).originalUrl = '/api/v1/something?path=/api/v1/mcp';
+      mockRequest.cookies = {};
+      mockRequest.headers = {};
+
+      middleware.use(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(mockResponse.status).toHaveBeenCalledWith(403);
+    });
+  });
+
   describe('CSRF token validation', () => {
     beforeEach(() => {
       mockRequest.method = 'POST';

--- a/middleware/src/modules/common/middleware/csrf.middleware.ts
+++ b/middleware/src/modules/common/middleware/csrf.middleware.ts
@@ -67,7 +67,13 @@ export class CsrfMiddleware implements NestMiddleware {
     // server-to-server by agents (no browser, no CSRF surface). Exempt
     // the entire /api/v1/mcp tree from CSRF validation. Auth on these
     // routes is enforced by McpAuthGuard.
-    const isMcpRoute = fullPath.includes('/api/v1/mcp');
+    //
+    // Use startsWith — `includes()` would also exempt URLs like
+    // `/api/v1/something?ref=/api/v1/mcp` which is a real bypass.
+    // pathname() strips the query string so a manipulated query
+    // parameter cannot match.
+    const pathname = fullPath.split('?')[0];
+    const isMcpRoute = pathname.startsWith('/api/v1/mcp');
 
     const isExempt = csrfExemptSuffixes.some(suffix => fullPath.endsWith(suffix))
       || fullPath.match(/\/devices\/pairing\/status\/[A-Za-z0-9]+$/)

--- a/middleware/src/modules/common/middleware/csrf.middleware.ts
+++ b/middleware/src/modules/common/middleware/csrf.middleware.ts
@@ -63,8 +63,15 @@ export class CsrfMiddleware implements NestMiddleware {
       '/webhooks/razorpay',
     ];
 
+    // MCP endpoints use bearer-token auth (not cookies) and are called
+    // server-to-server by agents (no browser, no CSRF surface). Exempt
+    // the entire /api/v1/mcp tree from CSRF validation. Auth on these
+    // routes is enforced by McpAuthGuard.
+    const isMcpRoute = fullPath.includes('/api/v1/mcp');
+
     const isExempt = csrfExemptSuffixes.some(suffix => fullPath.endsWith(suffix))
-      || fullPath.match(/\/devices\/pairing\/status\/[A-Za-z0-9]+$/);
+      || fullPath.match(/\/devices\/pairing\/status\/[A-Za-z0-9]+$/)
+      || isMcpRoute;
 
     if (isExempt) {
       return next();

--- a/middleware/src/modules/common/middleware/csrf.middleware.ts
+++ b/middleware/src/modules/common/middleware/csrf.middleware.ts
@@ -65,15 +65,16 @@ export class CsrfMiddleware implements NestMiddleware {
 
     // MCP endpoints use bearer-token auth (not cookies) and are called
     // server-to-server by agents (no browser, no CSRF surface). Exempt
-    // the entire /api/v1/mcp tree from CSRF validation. Auth on these
-    // routes is enforced by McpAuthGuard.
+    // the /api/v1/mcp tree from CSRF validation. Auth on these routes
+    // is enforced by McpAuthGuard.
     //
-    // Use startsWith — `includes()` would also exempt URLs like
-    // `/api/v1/something?ref=/api/v1/mcp` which is a real bypass.
-    // pathname() strips the query string so a manipulated query
-    // parameter cannot match.
+    // Match `/api/v1/mcp` exactly OR `/api/v1/mcp/*` — bare startsWith
+    // would also exempt sibling routes like `/api/v1/mcp-admin` or
+    // `/api/v1/mcpwhatever` if they ever exist. Query string is
+    // stripped so a manipulated `?` parameter cannot match.
     const pathname = fullPath.split('?')[0];
-    const isMcpRoute = pathname.startsWith('/api/v1/mcp');
+    const isMcpRoute =
+      pathname === '/api/v1/mcp' || pathname.startsWith('/api/v1/mcp/');
 
     const isExempt = csrfExemptSuffixes.some(suffix => fullPath.endsWith(suffix))
       || fullPath.match(/\/devices\/pairing\/status\/[A-Za-z0-9]+$/)

--- a/middleware/src/modules/displays/displays.service.ts
+++ b/middleware/src/modules/displays/displays.service.ts
@@ -86,13 +86,27 @@ export class DisplaysService {
     this.eventEmitter.emit(`display.${action}`, { action, entityType: 'display', entityId, organizationId });
   }
 
-  async findAll(organizationId: string, pagination: PaginationDto) {
+  /**
+   * @param filters Optional filters applied DB-side. `status` lets MCP
+   *   tools (and future REST callers) filter without bringing the
+   *   filter client-side and breaking pagination totals — the
+   *   reported `total` always matches the filtered result set.
+   */
+  async findAll(
+    organizationId: string,
+    pagination: PaginationDto,
+    filters?: { status?: 'online' | 'offline' | 'pairing' | 'error' },
+  ) {
     const { page = 1, limit = 10 } = pagination;
     const skip = (page - 1) * limit;
+    const where = {
+      organizationId,
+      ...(filters?.status ? { status: filters.status } : {}),
+    };
 
     const [data, total] = await Promise.all([
       this.db.display.findMany({
-        where: { organizationId },
+        where,
         skip,
         take: limit,
         orderBy: { createdAt: 'desc' },
@@ -104,7 +118,7 @@ export class DisplaysService {
           },
         },
       }),
-      this.db.display.count({ where: { organizationId } }),
+      this.db.display.count({ where }),
     ]);
 
     return new PaginatedResponse(data, total, page, limit);

--- a/middleware/src/modules/mcp/admin/mcp-tokens.controller.ts
+++ b/middleware/src/modules/mcp/admin/mcp-tokens.controller.ts
@@ -1,0 +1,67 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { SuperAdminGuard } from '../../admin/guards/super-admin.guard';
+import { McpTokenService } from '../auth/mcp-token.service';
+
+/**
+ * Admin endpoints for issuing, listing, and revoking MCP tokens.
+ *
+ * Auth: super-admin only (Vizora platform admins, NOT org admins).
+ * Issuing a token grants access to ALL data within the named org —
+ * an org-admin should not be able to issue a bearer that bypasses
+ * their own scope checks.
+ *
+ * The plaintext bearer is returned ONCE on issue and never
+ * recoverable. Admin must copy it immediately.
+ */
+@ApiTags('admin', 'mcp')
+@Controller('api/v1/admin/mcp-tokens')
+@UseGuards(JwtAuthGuard, SuperAdminGuard)
+@ApiBearerAuth()
+export class McpTokensAdminController {
+  constructor(private readonly tokens: McpTokenService) {}
+
+  @Post()
+  @HttpCode(201)
+  @ApiOperation({
+    summary: 'Issue a new MCP token. Plaintext returned ONCE.',
+  })
+  async issue(
+    @Body()
+    body: {
+      name: string;
+      organizationId: string;
+      agentName: string;
+      scopes: string[];
+      expiresInDays?: number;
+    },
+  ) {
+    return this.tokens.issue(body);
+  }
+
+  @Get()
+  @ApiOperation({
+    summary: 'List MCP tokens. Optional org filter via ?organizationId=',
+  })
+  async list(@Query('organizationId') organizationId?: string) {
+    return this.tokens.list(organizationId);
+  }
+
+  @Delete(':id')
+  @HttpCode(204)
+  @ApiOperation({ summary: 'Revoke an MCP token. Idempotent.' })
+  async revoke(@Param('id') id: string): Promise<void> {
+    await this.tokens.revoke(id);
+  }
+}

--- a/middleware/src/modules/mcp/audit/mcp-audit.service.ts
+++ b/middleware/src/modules/mcp/audit/mcp-audit.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { DatabaseService } from '../../database/database.service';
+import { redactSecrets } from '../lib/redact';
+
+/**
+ * Append-only audit log for every MCP tool call. Persists to the
+ * `mcp_audit_log` Prisma table. Best-effort — if the audit write
+ * fails we log + swallow rather than fail the user-visible request
+ * (the call itself already happened or didn't; flagging it via
+ * stdout is the right fallback).
+ *
+ * Inputs are passed through `redactSecrets` (same anchored regex as
+ * `AgentStateService`) before persistence — no `password` /
+ * `apiKey` / etc. ever lands in the audit row.
+ */
+@Injectable()
+export class McpAuditService {
+  private readonly logger = new Logger(McpAuditService.name);
+
+  constructor(private readonly db: DatabaseService) {}
+
+  async record(entry: {
+    tokenId: string | null;
+    agentName: string;
+    organizationId: string | null;
+    tool: string | null;
+    paramsRaw: unknown;
+    status: 'success' | 'error';
+    errorCode?: string;
+    latencyMs: number;
+  }): Promise<void> {
+    try {
+      await this.db.mcpAuditLog.create({
+        data: {
+          tokenId: entry.tokenId,
+          agentName: entry.agentName,
+          organizationId: entry.organizationId,
+          tool: entry.tool,
+          paramsRedacted: redactSecrets(entry.paramsRaw) as object | null,
+          status: entry.status,
+          errorCode: entry.errorCode,
+          latencyMs: entry.latencyMs,
+        },
+      });
+    } catch (err) {
+      this.logger.error(
+        `Failed to write MCP audit row (agent=${entry.agentName} tool=${entry.tool}): ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+}

--- a/middleware/src/modules/mcp/auth/mcp-auth.guard.spec.ts
+++ b/middleware/src/modules/mcp/auth/mcp-auth.guard.spec.ts
@@ -1,0 +1,58 @@
+import { UnauthorizedException, ExecutionContext } from '@nestjs/common';
+import { McpAuthGuard } from './mcp-auth.guard';
+import { McpTokenService } from './mcp-token.service';
+import { MCP_CONTEXT_KEY } from './mcp-context';
+
+function makeCtx(headers: Record<string, string | undefined> = {}) {
+  const req: Record<string, unknown> = { headers };
+  return {
+    ctx: {
+      switchToHttp: () => ({ getRequest: () => req }),
+    } as unknown as ExecutionContext,
+    req,
+  };
+}
+
+describe('McpAuthGuard', () => {
+  let guard: McpAuthGuard;
+  let tokens: jest.Mocked<Pick<McpTokenService, 'validate'>>;
+
+  beforeEach(() => {
+    tokens = { validate: jest.fn() } as never;
+    guard = new McpAuthGuard(tokens as never);
+  });
+
+  it('rejects when Authorization header is missing', async () => {
+    const { ctx } = makeCtx({});
+    await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('rejects when Authorization header is not Bearer', async () => {
+    const { ctx } = makeCtx({ authorization: 'Basic abc' });
+    await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('rejects with the GENERIC message when token validation fails (no info leak)', async () => {
+    tokens.validate.mockResolvedValue(null);
+    const { ctx } = makeCtx({ authorization: 'Bearer mcp_anything' });
+    await expect(guard.canActivate(ctx)).rejects.toThrow(/Invalid or expired/);
+  });
+
+  it('attaches mcpContext to the request on success', async () => {
+    tokens.validate.mockResolvedValue({
+      id: 'tok_1',
+      organizationId: 'org_1',
+      agentName: 'support-triage',
+      scopes: ['displays:read'],
+    });
+    const { ctx, req } = makeCtx({ authorization: 'Bearer mcp_xyz' });
+    const ok = await guard.canActivate(ctx);
+    expect(ok).toBe(true);
+    expect(req[MCP_CONTEXT_KEY]).toEqual({
+      tokenId: 'tok_1',
+      organizationId: 'org_1',
+      agentName: 'support-triage',
+      scopes: ['displays:read'],
+    });
+  });
+});

--- a/middleware/src/modules/mcp/auth/mcp-auth.guard.spec.ts
+++ b/middleware/src/modules/mcp/auth/mcp-auth.guard.spec.ts
@@ -22,20 +22,27 @@ describe('McpAuthGuard', () => {
     guard = new McpAuthGuard(tokens as never);
   });
 
-  it('rejects when Authorization header is missing', async () => {
+  // The wire-facing message MUST be identical for every failure path
+  // — distinguishing missing-header from invalid-token from expired
+  // is an info-disclosure invitation. The tests below assert a single
+  // generic message; the guard's own logger carries the precise
+  // server-side reason.
+  const REJECTION_MESSAGE = 'Invalid or expired MCP token';
+
+  it('rejects with generic message when Authorization header is missing', async () => {
     const { ctx } = makeCtx({});
-    await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
+    await expect(guard.canActivate(ctx)).rejects.toThrow(REJECTION_MESSAGE);
   });
 
-  it('rejects when Authorization header is not Bearer', async () => {
+  it('rejects with generic message when Authorization header is not Bearer', async () => {
     const { ctx } = makeCtx({ authorization: 'Basic abc' });
-    await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
+    await expect(guard.canActivate(ctx)).rejects.toThrow(REJECTION_MESSAGE);
   });
 
-  it('rejects with the GENERIC message when token validation fails (no info leak)', async () => {
+  it('rejects with the SAME generic message when token validation fails', async () => {
     tokens.validate.mockResolvedValue(null);
     const { ctx } = makeCtx({ authorization: 'Bearer mcp_anything' });
-    await expect(guard.canActivate(ctx)).rejects.toThrow(/Invalid or expired/);
+    await expect(guard.canActivate(ctx)).rejects.toThrow(REJECTION_MESSAGE);
   });
 
   it('attaches mcpContext to the request on success', async () => {

--- a/middleware/src/modules/mcp/auth/mcp-auth.guard.ts
+++ b/middleware/src/modules/mcp/auth/mcp-auth.guard.ts
@@ -30,14 +30,22 @@ export class McpAuthGuard implements CanActivate {
   async canActivate(ctx: ExecutionContext): Promise<boolean> {
     const req = ctx.switchToHttp().getRequest<Request>();
     const auth = req.headers.authorization;
+
+    // Single user-facing message for every failure path — distinguishing
+    // "missing header" from "invalid token" from "expired" is an info-
+    // disclosure invitation. The server-side log carries the precise
+    // reason for ops; the wire response does not.
+    const REJECTION = 'Invalid or expired MCP token';
+
     if (!auth || typeof auth !== 'string' || !auth.startsWith('Bearer ')) {
-      throw new UnauthorizedException('Missing or malformed Authorization header');
+      this.logger.debug('MCP auth rejected: missing or malformed Authorization header');
+      throw new UnauthorizedException(REJECTION);
     }
     const bearer = auth.slice('Bearer '.length).trim();
     const context = await this.tokens.validate(bearer);
     if (!context) {
-      // Generic message — see class docstring
-      throw new UnauthorizedException('Invalid or expired MCP token');
+      this.logger.debug('MCP auth rejected: token validation failed');
+      throw new UnauthorizedException(REJECTION);
     }
     const ctxValue: McpRequestContext = {
       tokenId: context.id,

--- a/middleware/src/modules/mcp/auth/mcp-auth.guard.ts
+++ b/middleware/src/modules/mcp/auth/mcp-auth.guard.ts
@@ -1,0 +1,51 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
+import type { Request } from 'express';
+import { MCP_CONTEXT_KEY, type McpRequestContext } from './mcp-context';
+import { McpTokenService } from './mcp-token.service';
+
+/**
+ * Bearer-token guard for the MCP transport endpoint. Extracts the
+ * `Authorization: Bearer <token>` header, validates via
+ * `McpTokenService.validate`, and on success attaches the resolved
+ * context to `req[MCP_CONTEXT_KEY]` for downstream consumers (tool
+ * handlers, audit interceptor).
+ *
+ * On any failure: throw `UnauthorizedException` with a generic message.
+ * Don't leak which check failed (missing header vs expired vs revoked
+ * vs unknown hash) — that's an info-disclosure invitation. The token
+ * service logs the precise reason for ops.
+ */
+@Injectable()
+export class McpAuthGuard implements CanActivate {
+  private readonly logger = new Logger(McpAuthGuard.name);
+
+  constructor(private readonly tokens: McpTokenService) {}
+
+  async canActivate(ctx: ExecutionContext): Promise<boolean> {
+    const req = ctx.switchToHttp().getRequest<Request>();
+    const auth = req.headers.authorization;
+    if (!auth || typeof auth !== 'string' || !auth.startsWith('Bearer ')) {
+      throw new UnauthorizedException('Missing or malformed Authorization header');
+    }
+    const bearer = auth.slice('Bearer '.length).trim();
+    const context = await this.tokens.validate(bearer);
+    if (!context) {
+      // Generic message — see class docstring
+      throw new UnauthorizedException('Invalid or expired MCP token');
+    }
+    const ctxValue: McpRequestContext = {
+      tokenId: context.id,
+      organizationId: context.organizationId,
+      agentName: context.agentName,
+      scopes: context.scopes,
+    };
+    (req as Request & Record<string, unknown>)[MCP_CONTEXT_KEY] = ctxValue;
+    return true;
+  }
+}

--- a/middleware/src/modules/mcp/auth/mcp-context.ts
+++ b/middleware/src/modules/mcp/auth/mcp-context.ts
@@ -1,0 +1,45 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+/**
+ * After `McpAuthGuard` validates a bearer, the resolved token context
+ * is attached to the Express request as `mcpContext`. Tools and
+ * audit code read it via this decorator (or directly off the request,
+ * which is sometimes necessary inside the SDK callback).
+ */
+export interface McpRequestContext {
+  tokenId: string;
+  organizationId: string;
+  agentName: string;
+  scopes: string[];
+}
+
+/**
+ * Internal symbol used to attach the context to the request. Exported
+ * so the SDK callback path (which doesn't go through Nest's DI) can
+ * read it.
+ */
+export const MCP_CONTEXT_KEY = '__mcpContext';
+
+export const McpContext = createParamDecorator<McpRequestContext>(
+  (_, ctx: ExecutionContext) => {
+    const req = ctx.switchToHttp().getRequest();
+    const value = req[MCP_CONTEXT_KEY];
+    if (!value) {
+      throw new Error(
+        'McpContext used on a route that did not pass McpAuthGuard',
+      );
+    }
+    return value as McpRequestContext;
+  },
+);
+
+/**
+ * Scope-check helper used by tools. Pure function — easy to unit test.
+ * @returns true when the context's scopes include `required`.
+ */
+export function hasScope(
+  context: McpRequestContext,
+  required: string,
+): boolean {
+  return context.scopes.includes(required);
+}

--- a/middleware/src/modules/mcp/auth/mcp-rate-limit.guard.spec.ts
+++ b/middleware/src/modules/mcp/auth/mcp-rate-limit.guard.spec.ts
@@ -1,0 +1,51 @@
+import { ThrottlerException } from '@nestjs/throttler';
+import { ExecutionContext } from '@nestjs/common';
+import { McpRateLimitGuard, MCP_RATE_LIMIT_DEFAULTS } from './mcp-rate-limit.guard';
+import { MCP_CONTEXT_KEY, type McpRequestContext } from './mcp-context';
+
+function makeCtx(mcp?: McpRequestContext): ExecutionContext {
+  const req = {} as Record<string, unknown>;
+  if (mcp) req[MCP_CONTEXT_KEY] = mcp;
+  return {
+    switchToHttp: () => ({ getRequest: () => req }),
+  } as unknown as ExecutionContext;
+}
+
+describe('McpRateLimitGuard', () => {
+  let guard: McpRateLimitGuard;
+  const ctx: McpRequestContext = {
+    tokenId: 'tok_1',
+    organizationId: 'org_1',
+    agentName: 'support-triage',
+    scopes: ['displays:read'],
+  };
+
+  beforeEach(() => {
+    guard = new McpRateLimitGuard();
+  });
+
+  it('allows the first call', () => {
+    expect(guard.canActivate(makeCtx(ctx))).toBe(true);
+  });
+
+  it('throws ThrottlerException after per-min limit', () => {
+    for (let i = 0; i < MCP_RATE_LIMIT_DEFAULTS.perMin; i++) {
+      guard.canActivate(makeCtx(ctx));
+    }
+    expect(() => guard.canActivate(makeCtx(ctx))).toThrow(ThrottlerException);
+  });
+
+  it('two distinct tokens have independent buckets', () => {
+    const ctxB: McpRequestContext = { ...ctx, tokenId: 'tok_2' };
+    for (let i = 0; i < MCP_RATE_LIMIT_DEFAULTS.perMin; i++) {
+      guard.canActivate(makeCtx(ctx));
+    }
+    // tok_1 is now at the limit; tok_2 should still pass
+    expect(() => guard.canActivate(makeCtx(ctx))).toThrow(ThrottlerException);
+    expect(guard.canActivate(makeCtx(ctxB))).toBe(true);
+  });
+
+  it('throws when McpAuthGuard did not run first (defense-in-depth)', () => {
+    expect(() => guard.canActivate(makeCtx(undefined))).toThrow(ThrottlerException);
+  });
+});

--- a/middleware/src/modules/mcp/auth/mcp-rate-limit.guard.ts
+++ b/middleware/src/modules/mcp/auth/mcp-rate-limit.guard.ts
@@ -1,0 +1,140 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  HttpStatus,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
+import { ThrottlerException } from '@nestjs/throttler';
+import type { Request } from 'express';
+import { MCP_CONTEXT_KEY, type McpRequestContext } from './mcp-context';
+
+const DEFAULT_PER_MIN = Number(process.env.MCP_RATE_LIMIT_PER_MIN ?? 60);
+const DEFAULT_PER_DAY = Number(process.env.MCP_RATE_LIMIT_PER_DAY ?? 1000);
+
+interface Bucket {
+  minuteCount: number;
+  minuteResetAt: number;
+  dayCount: number;
+  dayResetAt: number;
+}
+
+/**
+ * Per-token rate limit (in-memory). MUST run AFTER `McpAuthGuard` so
+ * `req[MCP_CONTEXT_KEY]` is populated.
+ *
+ * **Cluster caveat:** the Vizora middleware runs PM2 cluster mode
+ * (×2 in prod). Each instance has its own in-memory bucket, so the
+ * effective per-token limit is ~2× the configured value. This is
+ * documented and accepted for v1; if it bites, the bucket store
+ * moves to Redis (Phase 2). Until then, set `MCP_RATE_LIMIT_PER_MIN`
+ * to half of the desired global ceiling if you want a strict cap.
+ *
+ * The bucket Map grows with the number of distinct tokens. We sweep
+ * stale buckets opportunistically on each call (cheap; runs once per
+ * request anyway). At ~hundreds of tokens this is fine.
+ */
+@Injectable()
+export class McpRateLimitGuard implements CanActivate {
+  private readonly logger = new Logger(McpRateLimitGuard.name);
+  private readonly buckets = new Map<string, Bucket>();
+  private lastSweepAt = 0;
+
+  canActivate(ctx: ExecutionContext): boolean {
+    const req = ctx.switchToHttp().getRequest<Request>();
+    const mcp = (req as Request & Record<string, unknown>)[MCP_CONTEXT_KEY] as
+      | McpRequestContext
+      | undefined;
+    if (!mcp) {
+      // Defense-in-depth: this guard should never run before McpAuthGuard.
+      // If it does, fail closed.
+      throw new ThrottlerException(
+        'rate-limit guard ran before auth — check guard ordering',
+      );
+    }
+
+    this.maybeSweep();
+
+    const now = Date.now();
+    const bucket = this.buckets.get(mcp.tokenId) ?? this.fresh(now);
+
+    if (now >= bucket.minuteResetAt) {
+      bucket.minuteCount = 0;
+      bucket.minuteResetAt = now + 60_000;
+    }
+    if (now >= bucket.dayResetAt) {
+      bucket.dayCount = 0;
+      bucket.dayResetAt = now + 24 * 60 * 60 * 1000;
+    }
+
+    if (bucket.minuteCount >= DEFAULT_PER_MIN) {
+      this.logger.warn(
+        `Rate limit (per-min) hit for token ${mcp.tokenId} agent=${mcp.agentName}`,
+      );
+      throw new ThrottlerException(
+        `MCP rate limit exceeded: ${DEFAULT_PER_MIN}/min`,
+      );
+    }
+    if (bucket.dayCount >= DEFAULT_PER_DAY) {
+      this.logger.warn(
+        `Rate limit (per-day) hit for token ${mcp.tokenId} agent=${mcp.agentName}`,
+      );
+      throw new ThrottlerException(
+        `MCP rate limit exceeded: ${DEFAULT_PER_DAY}/day`,
+      );
+    }
+
+    bucket.minuteCount++;
+    bucket.dayCount++;
+    this.buckets.set(mcp.tokenId, bucket);
+    return true;
+  }
+
+  private fresh(now: number): Bucket {
+    return {
+      minuteCount: 0,
+      minuteResetAt: now + 60_000,
+      dayCount: 0,
+      dayResetAt: now + 24 * 60 * 60 * 1000,
+    };
+  }
+
+  /**
+   * Drop buckets whose day window has long passed. O(n) sweep capped
+   * to once per minute so it doesn't dominate hot paths.
+   */
+  private maybeSweep(): void {
+    const now = Date.now();
+    if (now - this.lastSweepAt < 60_000) return;
+    this.lastSweepAt = now;
+    const cutoff = now - 24 * 60 * 60 * 1000;
+    for (const [tokenId, bucket] of this.buckets) {
+      if (bucket.dayResetAt < cutoff) {
+        this.buckets.delete(tokenId);
+      }
+    }
+  }
+
+  /** For tests: clear in-memory state. */
+  reset(): void {
+    this.buckets.clear();
+    this.lastSweepAt = 0;
+  }
+}
+
+export const MCP_RATE_LIMIT_DEFAULTS = {
+  perMin: DEFAULT_PER_MIN,
+  perDay: DEFAULT_PER_DAY,
+};
+
+// Re-export ThrottlerException so consumers don't need a second import
+export { ThrottlerException };
+
+/** Header set on rate-limit responses (Retry-After in seconds). */
+export const RATE_LIMIT_RETRY_AFTER_SECONDS = 60;
+
+/**
+ * Stub for HTTP code mapping; the controller layer translates
+ * ThrottlerException → 429. Re-exported here for documentation.
+ */
+export const HTTP_RATE_LIMITED = HttpStatus.TOO_MANY_REQUESTS;

--- a/middleware/src/modules/mcp/auth/mcp-rate-limit.guard.ts
+++ b/middleware/src/modules/mcp/auth/mcp-rate-limit.guard.ts
@@ -7,10 +7,23 @@ import {
 } from '@nestjs/common';
 import { ThrottlerException } from '@nestjs/throttler';
 import type { Request } from 'express';
+import { parsePositiveInt } from '../lib/parse-env';
 import { MCP_CONTEXT_KEY, type McpRequestContext } from './mcp-context';
 
-const DEFAULT_PER_MIN = Number(process.env.MCP_RATE_LIMIT_PER_MIN ?? 60);
-const DEFAULT_PER_DAY = Number(process.env.MCP_RATE_LIMIT_PER_DAY ?? 1000);
+// Validated at module load. A typo (e.g. MCP_RATE_LIMIT_PER_MIN=sixty)
+// would silently turn the rate-limit check into a no-op via NaN under
+// the bare-Number() pattern — parsePositiveInt warns and falls back so
+// the guard always has a sane positive integer.
+const DEFAULT_PER_MIN = parsePositiveInt(
+  process.env.MCP_RATE_LIMIT_PER_MIN,
+  60,
+  'MCP_RATE_LIMIT_PER_MIN',
+);
+const DEFAULT_PER_DAY = parsePositiveInt(
+  process.env.MCP_RATE_LIMIT_PER_DAY,
+  1000,
+  'MCP_RATE_LIMIT_PER_DAY',
+);
 
 interface Bucket {
   minuteCount: number;
@@ -100,16 +113,17 @@ export class McpRateLimitGuard implements CanActivate {
   }
 
   /**
-   * Drop buckets whose day window has long passed. O(n) sweep capped
-   * to once per minute so it doesn't dominate hot paths.
+   * Drop buckets whose day window has expired. O(n) sweep capped to
+   * once per minute so it doesn't dominate hot paths. The previous
+   * cutoff was `now - 24h`, which keeps buckets for ~48h after their
+   * day window ended; correct comparison is against `now` directly.
    */
   private maybeSweep(): void {
     const now = Date.now();
     if (now - this.lastSweepAt < 60_000) return;
     this.lastSweepAt = now;
-    const cutoff = now - 24 * 60 * 60 * 1000;
     for (const [tokenId, bucket] of this.buckets) {
-      if (bucket.dayResetAt < cutoff) {
+      if (bucket.dayResetAt < now) {
         this.buckets.delete(tokenId);
       }
     }

--- a/middleware/src/modules/mcp/auth/mcp-token.service.spec.ts
+++ b/middleware/src/modules/mcp/auth/mcp-token.service.spec.ts
@@ -1,0 +1,213 @@
+import { McpTokenService } from './mcp-token.service';
+import { createHash } from 'node:crypto';
+
+interface TokenRow {
+  id: string;
+  tokenHash: string;
+  name: string;
+  organizationId: string;
+  agentName: string;
+  scopes: string[];
+  createdAt: Date;
+  expiresAt: Date | null;
+  revokedAt: Date | null;
+  lastUsedAt: Date | null;
+}
+
+/**
+ * In-memory fake DatabaseService. Avoids a real Prisma client in
+ * unit tests but still exercises the service end-to-end.
+ */
+function makeFakeDb() {
+  const rows = new Map<string, TokenRow>();
+  let idCounter = 0;
+  return {
+    rows,
+    mcpToken: {
+      async create({ data, select }: { data: Partial<TokenRow>; select?: Partial<Record<keyof TokenRow, true>> }) {
+        const id = `tok_${++idCounter}`;
+        const row: TokenRow = {
+          id,
+          tokenHash: data.tokenHash!,
+          name: data.name!,
+          organizationId: data.organizationId!,
+          agentName: data.agentName!,
+          scopes: data.scopes ?? [],
+          createdAt: new Date(),
+          expiresAt: data.expiresAt ?? null,
+          revokedAt: null,
+          lastUsedAt: null,
+        };
+        rows.set(id, row);
+        return project(row, select);
+      },
+      async findUnique({ where, select }: { where: { tokenHash?: string; id?: string }; select?: Partial<Record<keyof TokenRow, true>> }) {
+        for (const row of rows.values()) {
+          if (where.tokenHash && row.tokenHash === where.tokenHash) return project(row, select);
+          if (where.id && row.id === where.id) return project(row, select);
+        }
+        return null;
+      },
+      async update({ where, data }: { where: { id: string }; data: Partial<TokenRow> }) {
+        const row = rows.get(where.id);
+        if (!row) throw new Error('not found');
+        Object.assign(row, data);
+        return row;
+      },
+      async updateMany({ where, data }: { where: { id: string; revokedAt: null }; data: Partial<TokenRow> }) {
+        const row = rows.get(where.id);
+        if (!row || row.revokedAt !== null) return { count: 0 };
+        Object.assign(row, data);
+        return { count: 1 };
+      },
+      async findMany({ where, select }: { where?: { organizationId?: string }; select?: Partial<Record<keyof TokenRow, true>>; orderBy?: unknown }) {
+        const all = Array.from(rows.values());
+        const filtered = where?.organizationId
+          ? all.filter((r) => r.organizationId === where.organizationId)
+          : all;
+        return filtered.map((r) => project(r, select));
+      },
+    },
+  };
+}
+
+function project(row: TokenRow, select?: Partial<Record<keyof TokenRow, true>>): unknown {
+  if (!select) return row;
+  const out: Partial<TokenRow> = {};
+  for (const key of Object.keys(select) as (keyof TokenRow)[]) {
+    (out as Record<string, unknown>)[key] = row[key];
+  }
+  return out;
+}
+
+describe('McpTokenService', () => {
+  let svc: McpTokenService;
+  let db: ReturnType<typeof makeFakeDb>;
+
+  beforeEach(() => {
+    db = makeFakeDb();
+    svc = new McpTokenService(db as never);
+  });
+
+  describe('issue', () => {
+    it('returns plaintext bearer + record without hash field', async () => {
+      const out = await svc.issue({
+        name: 'test',
+        organizationId: 'org_1',
+        agentName: 'support-triage',
+        scopes: ['displays:read'],
+      });
+      expect(out.bearer).toMatch(/^mcp_[A-Za-z0-9_-]{43}$/);
+      expect(out.record).toHaveProperty('id');
+      expect(out.record).not.toHaveProperty('tokenHash');
+    });
+
+    it('persists sha256(bearer) — never plaintext', async () => {
+      const out = await svc.issue({
+        name: 'test',
+        organizationId: 'org_1',
+        agentName: 'support-triage',
+        scopes: ['displays:read'],
+      });
+      const stored = Array.from(db.rows.values())[0];
+      const expectedHash = createHash('sha256').update(out.bearer).digest('hex');
+      expect(stored.tokenHash).toBe(expectedHash);
+      // Confirm plaintext is NOT in the stored row
+      expect(JSON.stringify(stored)).not.toContain(out.bearer);
+    });
+
+    it('rejects non-read scopes (v1 is read-only)', async () => {
+      await expect(
+        svc.issue({
+          name: 't', organizationId: 'o', agentName: 'a',
+          scopes: ['displays:write'],
+        }),
+      ).rejects.toThrow(/read-only/);
+    });
+
+    it('rejects empty scope list', async () => {
+      await expect(
+        svc.issue({ name: 't', organizationId: 'o', agentName: 'a', scopes: [] }),
+      ).rejects.toThrow(/at least one scope/);
+    });
+
+    it('caps TTL at MCP_TOKEN_TTL_DAYS even when caller asks for more', async () => {
+      const original = process.env.MCP_TOKEN_TTL_DAYS;
+      process.env.MCP_TOKEN_TTL_DAYS = '7';
+      try {
+        const svc2 = new McpTokenService(db as never);
+        const out = await svc2.issue({
+          name: 't', organizationId: 'o', agentName: 'a',
+          scopes: ['displays:read'],
+          expiresInDays: 9999,
+        });
+        const ms = out.record.expiresAt!.getTime() - out.record.createdAt.getTime();
+        expect(ms).toBeLessThanOrEqual(7 * 24 * 60 * 60 * 1000 + 5_000);
+      } finally {
+        if (original) process.env.MCP_TOKEN_TTL_DAYS = original;
+        else delete process.env.MCP_TOKEN_TTL_DAYS;
+      }
+    });
+  });
+
+  describe('validate', () => {
+    it('returns context for a valid live bearer', async () => {
+      const issued = await svc.issue({
+        name: 't', organizationId: 'org_X', agentName: 'support-triage',
+        scopes: ['displays:read'],
+      });
+      const ctx = await svc.validate(issued.bearer);
+      expect(ctx).toEqual({
+        id: issued.record.id,
+        organizationId: 'org_X',
+        agentName: 'support-triage',
+        scopes: ['displays:read'],
+      });
+    });
+
+    it('returns null for a fabricated bearer that has the right prefix', async () => {
+      const ctx = await svc.validate('mcp_' + 'A'.repeat(43));
+      expect(ctx).toBeNull();
+    });
+
+    it('returns null for missing/empty/wrong-shape bearer', async () => {
+      expect(await svc.validate('')).toBeNull();
+      expect(await svc.validate('Bearer foo')).toBeNull();
+      expect(await svc.validate('foo')).toBeNull();
+    });
+
+    it('returns null for a revoked token', async () => {
+      const issued = await svc.issue({
+        name: 't', organizationId: 'o', agentName: 'a',
+        scopes: ['displays:read'],
+      });
+      await svc.revoke(issued.record.id);
+      expect(await svc.validate(issued.bearer)).toBeNull();
+    });
+
+    it('returns null for an expired token', async () => {
+      const issued = await svc.issue({
+        name: 't', organizationId: 'o', agentName: 'a',
+        scopes: ['displays:read'],
+      });
+      const stored = Array.from(db.rows.values()).find((r) => r.id === issued.record.id)!;
+      stored.expiresAt = new Date(Date.now() - 1_000);
+      expect(await svc.validate(issued.bearer)).toBeNull();
+    });
+  });
+
+  describe('revoke', () => {
+    it('is idempotent — second revoke of the same id is a no-op', async () => {
+      const issued = await svc.issue({
+        name: 't', organizationId: 'o', agentName: 'a',
+        scopes: ['displays:read'],
+      });
+      await svc.revoke(issued.record.id);
+      await expect(svc.revoke(issued.record.id)).resolves.toBeUndefined();
+    });
+
+    it('revoking an unknown id is a no-op (not an error)', async () => {
+      await expect(svc.revoke('nonexistent')).resolves.toBeUndefined();
+    });
+  });
+});

--- a/middleware/src/modules/mcp/auth/mcp-token.service.ts
+++ b/middleware/src/modules/mcp/auth/mcp-token.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { createHash, randomBytes } from 'node:crypto';
 import { DatabaseService } from '../../database/database.service';
+import { parsePositiveInt } from '../lib/parse-env';
 
 /**
  * Issue, validate, and revoke MCP bearer tokens.
@@ -17,8 +18,12 @@ import { DatabaseService } from '../../database/database.service';
 export class McpTokenService {
   private readonly logger = new Logger(McpTokenService.name);
 
-  /** Configurable max issuance TTL (default 90 days). */
-  private readonly maxTtlDays = Number(process.env.MCP_TOKEN_TTL_DAYS ?? 90);
+  /** Configurable max issuance TTL (default 90 days). Validated at startup. */
+  private readonly maxTtlDays = parsePositiveInt(
+    process.env.MCP_TOKEN_TTL_DAYS,
+    90,
+    'MCP_TOKEN_TTL_DAYS',
+  );
 
   constructor(private readonly db: DatabaseService) {}
 

--- a/middleware/src/modules/mcp/auth/mcp-token.service.ts
+++ b/middleware/src/modules/mcp/auth/mcp-token.service.ts
@@ -1,0 +1,188 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { createHash, randomBytes } from 'node:crypto';
+import { DatabaseService } from '../../database/database.service';
+
+/**
+ * Issue, validate, and revoke MCP bearer tokens.
+ *
+ * **Plaintext is shown to admin once at issuance and never persisted.**
+ * The DB stores only `tokenHash` (sha256 hex). Lookup hashes the
+ * incoming bearer and compares. Never compare plaintext to plaintext.
+ *
+ * This avoids the entire class of "leaked DB row → working token"
+ * vulnerabilities — a stolen `mcp_tokens` row gives the attacker a
+ * hash, not a usable bearer.
+ */
+@Injectable()
+export class McpTokenService {
+  private readonly logger = new Logger(McpTokenService.name);
+
+  /** Configurable max issuance TTL (default 90 days). */
+  private readonly maxTtlDays = Number(process.env.MCP_TOKEN_TTL_DAYS ?? 90);
+
+  constructor(private readonly db: DatabaseService) {}
+
+  private hash(plaintext: string): string {
+    return createHash('sha256').update(plaintext).digest('hex');
+  }
+
+  /**
+   * Generate a new bearer token. Returns the plaintext bearer ONCE +
+   * the persisted record (without `tokenHash` for safety).
+   *
+   * The bearer format is `mcp_<43 base64url chars>` — recognizable
+   * prefix for log redaction tools, ~256 bits of entropy.
+   */
+  async issue(input: {
+    name: string;
+    organizationId: string;
+    agentName: string;
+    scopes: string[];
+    expiresInDays?: number;
+  }): Promise<{
+    bearer: string;
+    record: {
+      id: string;
+      name: string;
+      organizationId: string;
+      agentName: string;
+      scopes: string[];
+      createdAt: Date;
+      expiresAt: Date | null;
+    };
+  }> {
+    const ttlDays = Math.min(
+      input.expiresInDays ?? this.maxTtlDays,
+      this.maxTtlDays,
+    );
+    if (ttlDays < 1) {
+      throw new Error('MCP token TTL must be at least 1 day');
+    }
+    if (input.scopes.length === 0) {
+      throw new Error('MCP token must have at least one scope');
+    }
+    // Reject any non-read scope until v2 (writes) ships.
+    for (const s of input.scopes) {
+      if (!s.endsWith(':read')) {
+        throw new Error(
+          `MCP v1 issues read-only tokens; rejected scope '${s}'`,
+        );
+      }
+    }
+
+    // 32 bytes → 43 base64url chars without padding
+    const bearer = `mcp_${randomBytes(32).toString('base64url')}`;
+    const tokenHash = this.hash(bearer);
+    const expiresAt = new Date(Date.now() + ttlDays * 24 * 60 * 60 * 1000);
+
+    const created = await this.db.mcpToken.create({
+      data: {
+        tokenHash,
+        name: input.name,
+        organizationId: input.organizationId,
+        agentName: input.agentName,
+        scopes: input.scopes,
+        expiresAt,
+      },
+      select: {
+        id: true,
+        name: true,
+        organizationId: true,
+        agentName: true,
+        scopes: true,
+        createdAt: true,
+        expiresAt: true,
+      },
+    });
+
+    this.logger.log(
+      `Issued MCP token id=${created.id} agent=${input.agentName} org=${input.organizationId} scopes=${input.scopes.join(',')} expiresAt=${expiresAt.toISOString()}`,
+    );
+
+    return { bearer, record: created };
+  }
+
+  /**
+   * Validate an incoming bearer. Returns the token row on success or
+   * null on any failure (missing/expired/revoked). On success, also
+   * touches `lastUsedAt` (best-effort — failure to update is logged
+   * but doesn't fail validation).
+   */
+  async validate(bearer: string): Promise<{
+    id: string;
+    organizationId: string;
+    agentName: string;
+    scopes: string[];
+  } | null> {
+    if (!bearer || typeof bearer !== 'string' || !bearer.startsWith('mcp_')) {
+      return null;
+    }
+    const tokenHash = this.hash(bearer);
+    const row = await this.db.mcpToken.findUnique({
+      where: { tokenHash },
+      select: {
+        id: true,
+        organizationId: true,
+        agentName: true,
+        scopes: true,
+        expiresAt: true,
+        revokedAt: true,
+      },
+    });
+    if (!row) return null;
+    if (row.revokedAt) return null;
+    if (row.expiresAt && row.expiresAt.getTime() < Date.now()) return null;
+
+    // Best-effort lastUsedAt update — fire and forget.
+    this.db.mcpToken
+      .update({
+        where: { id: row.id },
+        data: { lastUsedAt: new Date() },
+      })
+      .catch((err: unknown) => {
+        this.logger.warn(
+          `Failed to update lastUsedAt for token ${row.id}: ${err instanceof Error ? err.message : err}`,
+        );
+      });
+
+    return {
+      id: row.id,
+      organizationId: row.organizationId,
+      agentName: row.agentName,
+      scopes: row.scopes,
+    };
+  }
+
+  /** Mark a token as revoked. Idempotent. */
+  async revoke(id: string): Promise<void> {
+    const updated = await this.db.mcpToken.updateMany({
+      where: { id, revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
+    if (updated.count === 0) {
+      // Either not found or already revoked — log and continue
+      this.logger.log(`Revoke no-op for token id=${id} (not found or already revoked)`);
+    } else {
+      this.logger.log(`Revoked MCP token id=${id}`);
+    }
+  }
+
+  /** Admin listing — never returns the hash. */
+  async list(organizationId?: string) {
+    return this.db.mcpToken.findMany({
+      where: organizationId ? { organizationId } : undefined,
+      select: {
+        id: true,
+        name: true,
+        organizationId: true,
+        agentName: true,
+        scopes: true,
+        createdAt: true,
+        expiresAt: true,
+        revokedAt: true,
+        lastUsedAt: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+}

--- a/middleware/src/modules/mcp/lib/error-mapping.spec.ts
+++ b/middleware/src/modules/mcp/lib/error-mapping.spec.ts
@@ -1,0 +1,67 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  HttpException,
+  HttpStatus,
+  InternalServerErrorException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ThrottlerException } from '@nestjs/throttler';
+import { mapExceptionToMcpError } from './error-mapping';
+
+describe('mapExceptionToMcpError', () => {
+  it('maps NotFoundException → NOT_FOUND (not INVALID_INPUT — the retry-loop hazard)', () => {
+    const r = mapExceptionToMcpError(new NotFoundException('display abc not found'));
+    expect(r.code).toBe('NOT_FOUND');
+    expect(r.message).toContain('display abc not found');
+  });
+
+  it('maps BadRequestException → INVALID_INPUT', () => {
+    const r = mapExceptionToMcpError(new BadRequestException('bad'));
+    expect(r.code).toBe('INVALID_INPUT');
+  });
+
+  it('maps UnauthorizedException → UNAUTHORIZED', () => {
+    const r = mapExceptionToMcpError(new UnauthorizedException());
+    expect(r.code).toBe('UNAUTHORIZED');
+  });
+
+  it('maps ForbiddenException → FORBIDDEN', () => {
+    const r = mapExceptionToMcpError(new ForbiddenException());
+    expect(r.code).toBe('FORBIDDEN');
+  });
+
+  it('maps ThrottlerException → RATE_LIMITED', () => {
+    const r = mapExceptionToMcpError(new ThrottlerException('too many'));
+    expect(r.code).toBe('RATE_LIMITED');
+  });
+
+  it('maps unknown 4xx HttpException → INVALID_INPUT', () => {
+    const r = mapExceptionToMcpError(
+      new HttpException('teapot', HttpStatus.I_AM_A_TEAPOT),
+    );
+    expect(r.code).toBe('INVALID_INPUT');
+  });
+
+  it('maps 5xx HttpException → INTERNAL with generic message (no leak)', () => {
+    const r = mapExceptionToMcpError(
+      new InternalServerErrorException('database panic at line 47'),
+    );
+    expect(r.code).toBe('INTERNAL');
+    expect(r.message).toBe('Internal server error');
+    expect(r.message).not.toContain('database panic');
+  });
+
+  it('maps a plain Error → INTERNAL with generic message', () => {
+    const r = mapExceptionToMcpError(new Error('boom'));
+    expect(r.code).toBe('INTERNAL');
+    expect(r.message).toBe('Internal server error');
+  });
+
+  it('maps a non-error value → INTERNAL', () => {
+    expect(mapExceptionToMcpError('string').code).toBe('INTERNAL');
+    expect(mapExceptionToMcpError(null).code).toBe('INTERNAL');
+    expect(mapExceptionToMcpError(undefined).code).toBe('INTERNAL');
+  });
+});

--- a/middleware/src/modules/mcp/lib/error-mapping.spec.ts
+++ b/middleware/src/modules/mcp/lib/error-mapping.spec.ts
@@ -37,11 +37,17 @@ describe('mapExceptionToMcpError', () => {
     expect(r.code).toBe('RATE_LIMITED');
   });
 
-  it('maps unknown 4xx HttpException → INVALID_INPUT', () => {
+  it('maps unknown 4xx HttpException → INVALID_INPUT with GENERIC message (does NOT leak internal detail like SQL errors or record IDs that controllers may have placed in the message)', () => {
     const r = mapExceptionToMcpError(
-      new HttpException('teapot', HttpStatus.I_AM_A_TEAPOT),
+      new HttpException(
+        'duplicate key violates unique constraint pg_unique_42 on table users',
+        HttpStatus.CONFLICT,
+      ),
     );
     expect(r.code).toBe('INVALID_INPUT');
+    expect(r.message).toBe('Invalid request');
+    expect(r.message).not.toContain('pg_unique_42');
+    expect(r.message).not.toContain('users');
   });
 
   it('maps 5xx HttpException → INTERNAL with generic message (no leak)', () => {

--- a/middleware/src/modules/mcp/lib/error-mapping.ts
+++ b/middleware/src/modules/mcp/lib/error-mapping.ts
@@ -1,0 +1,80 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  HttpException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ThrottlerException } from '@nestjs/throttler';
+
+/**
+ * MCP wire error shape:
+ *
+ *   { error: { code: <enum>, message: <human>, data?: <object> } }
+ *
+ * The code is what agents act on. NOT_FOUND vs INVALID_INPUT is a
+ * meaningful distinction — INVALID_INPUT signals "fix your params and
+ * retry," NOT_FOUND signals "this resource is gone, refresh your state
+ * or stop." Conflating them encourages retry loops on missing data.
+ */
+export type McpErrorCode =
+  | 'TOOL_NOT_FOUND'
+  | 'INVALID_INPUT'
+  | 'NOT_FOUND'
+  | 'UNAUTHORIZED'
+  | 'FORBIDDEN'
+  | 'RATE_LIMITED'
+  | 'INTERNAL';
+
+export interface McpErrorPayload {
+  code: McpErrorCode;
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Map a NestJS-thrown exception (including Throttler) to the MCP error
+ * code agents will see on the wire. INTERNAL is the fallback — it never
+ * leaks the exception's stack or message verbatim.
+ */
+export function mapExceptionToMcpError(err: unknown): McpErrorPayload {
+  if (err instanceof NotFoundException) {
+    return {
+      code: 'NOT_FOUND',
+      message: err.message || 'Resource not found',
+    };
+  }
+  if (err instanceof BadRequestException) {
+    return {
+      code: 'INVALID_INPUT',
+      message: err.message || 'Invalid input',
+    };
+  }
+  if (err instanceof UnauthorizedException) {
+    return {
+      code: 'UNAUTHORIZED',
+      message: err.message || 'Token missing, invalid, expired, or revoked',
+    };
+  }
+  if (err instanceof ForbiddenException) {
+    return {
+      code: 'FORBIDDEN',
+      message: err.message || 'Token lacks the required scope',
+    };
+  }
+  if (err instanceof ThrottlerException) {
+    return {
+      code: 'RATE_LIMITED',
+      message: 'Rate limit exceeded for this token. Retry after the cooldown.',
+    };
+  }
+  if (err instanceof HttpException) {
+    // Other HTTP exceptions land in INVALID_INPUT (4xx) or INTERNAL (5xx)
+    const status = err.getStatus();
+    if (status >= 400 && status < 500) {
+      return { code: 'INVALID_INPUT', message: err.message };
+    }
+  }
+  // Anything else → INTERNAL with the message stripped
+  return { code: 'INTERNAL', message: 'Internal server error' };
+}

--- a/middleware/src/modules/mcp/lib/error-mapping.ts
+++ b/middleware/src/modules/mcp/lib/error-mapping.ts
@@ -69,10 +69,16 @@ export function mapExceptionToMcpError(err: unknown): McpErrorPayload {
     };
   }
   if (err instanceof HttpException) {
-    // Other HTTP exceptions land in INVALID_INPUT (4xx) or INTERNAL (5xx)
+    // Other HTTP exception subtypes (Conflict, Gone, Teapot, Payload-
+    // Too-Large, etc) land here. We map 4xx → INVALID_INPUT but DO NOT
+    // pass the exception's own message through — controllers may have
+    // attached internal detail (record IDs, SQL error text, hostnames)
+    // expecting NestJS's default envelope to wrap it. The MCP wire is
+    // an external surface; treat anything we haven't whitelisted above
+    // as opaque.
     const status = err.getStatus();
     if (status >= 400 && status < 500) {
-      return { code: 'INVALID_INPUT', message: err.message };
+      return { code: 'INVALID_INPUT', message: 'Invalid request' };
     }
   }
   // Anything else → INTERNAL with the message stripped

--- a/middleware/src/modules/mcp/lib/parse-env.spec.ts
+++ b/middleware/src/modules/mcp/lib/parse-env.spec.ts
@@ -1,0 +1,52 @@
+import { parsePositiveInt } from './parse-env';
+
+describe('parsePositiveInt', () => {
+  let warn: jest.SpyInstance;
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it.each([
+    ['60', 60],
+    ['1', 1],
+    ['1000', 1000],
+    [' 30 ', 30],
+  ])('parses valid value %s → %d', (input, expected) => {
+    expect(parsePositiveInt(input, 99, 'TEST')).toBe(expected);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, '', null as unknown as undefined])(
+    'returns fallback (no warn) when value is %p',
+    (input) => {
+      expect(parsePositiveInt(input as string | undefined, 99, 'TEST')).toBe(99);
+      expect(warn).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    'sixty',          // textual word — the actual reviewer scenario
+    '60abc',          // trailing junk
+    'abc60',          // leading junk
+    '60.5',           // float
+    '0',              // zero is non-positive
+    '-1',             // negative
+    '-60',            // negative with sign
+    '1e3',            // scientific notation
+    '0x40',           // hex
+    'NaN',            // literal NaN string
+    'Infinity',
+  ])('falls back + warns when value is %s', (input) => {
+    expect(parsePositiveInt(input, 99, 'TEST_VAR')).toBe(99);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('TEST_VAR');
+    expect(warn.mock.calls[0][0]).toContain(input);
+  });
+
+  it('returns the parsed integer (not the fallback) for a normal valid input — sanity', () => {
+    expect(parsePositiveInt('42', 99, 'X')).toBe(42);
+  });
+});

--- a/middleware/src/modules/mcp/lib/parse-env.ts
+++ b/middleware/src/modules/mcp/lib/parse-env.ts
@@ -1,0 +1,46 @@
+/**
+ * Parse a positive integer from an environment-variable value.
+ *
+ * The bare `Number(process.env.X ?? default)` pattern silently
+ * disables downstream guards when an operator typos a value:
+ * `Number("sixty")` → `NaN`, and `count >= NaN` is always `false`,
+ * so a rate-limit check or TTL clamp turns into a no-op without any
+ * log line. That is a security-control failure mode.
+ *
+ * This helper:
+ *   - Returns the fallback if `value` is undefined / empty
+ *   - Parses as integer (rejects floats and trailing junk)
+ *   - Returns the fallback + writes a `console.warn` line if the
+ *     parse fails or the value is non-positive
+ *   - Always returns a finite positive integer
+ *
+ * Use at module load time. Don't repeat the parse on every call —
+ * fail fast (or fall back fast) on startup so misconfiguration is
+ * obvious in the boot logs.
+ */
+export function parsePositiveInt(
+  value: string | undefined,
+  fallback: number,
+  varName: string,
+): number {
+  if (value === undefined || value === null || value === '') {
+    return fallback;
+  }
+  // Reject floats / trailing junk: '60' OK, '60.5' / '60abc' NOT OK
+  if (!/^\d+$/.test(value.trim())) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[parse-env] ${varName}='${value}' is not a positive integer; falling back to ${fallback}`,
+    );
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[parse-env] ${varName}='${value}' parsed to ${parsed}; falling back to ${fallback}`,
+    );
+    return fallback;
+  }
+  return parsed;
+}

--- a/middleware/src/modules/mcp/lib/redact.spec.ts
+++ b/middleware/src/modules/mcp/lib/redact.spec.ts
@@ -1,0 +1,52 @@
+import { redactSecrets } from './redact';
+
+describe('redactSecrets', () => {
+  it.each([
+    'token', 'secret', 'password', 'apiKey', 'api_key', 'webhook',
+    'jwt', 'credential', 'cookie', 'sessionId', 'privateKey',
+    'accessToken', 'refreshToken', 'authHeader', 'authorization',
+    'email', 'phone', 'address', 'fullName',
+  ])('redacts top-level key %s', (key) => {
+    const out = redactSecrets({ [key]: 'sensitive', safe: 'ok' }) as Record<string, unknown>;
+    expect(out[key]).toBe('[REDACTED]');
+    expect(out.safe).toBe('ok');
+  });
+
+  it.each(['apiToken', 'clientSecret', 'authorType', 'monkey', 'key'])(
+    'does NOT redact non-allowlisted key %s (anchored regex)',
+    (key) => {
+      const out = redactSecrets({ [key]: 'kept' }) as Record<string, unknown>;
+      expect(out[key]).toBe('kept');
+    },
+  );
+
+  it('redacts recursively inside nested objects', () => {
+    const out = redactSecrets({ a: { b: { password: 'p', ok: 1 } } }) as {
+      a: { b: { password: string; ok: number } };
+    };
+    expect(out.a.b.password).toBe('[REDACTED]');
+    expect(out.a.b.ok).toBe(1);
+  });
+
+  it('redacts forbidden keys inside arrays of objects', () => {
+    const out = redactSecrets({ items: [{ secret: 'a' }, { secret: 'b' }, { ok: 'c' }] }) as {
+      items: Array<Record<string, unknown>>;
+    };
+    expect(out.items[0].secret).toBe('[REDACTED]');
+    expect(out.items[1].secret).toBe('[REDACTED]');
+    expect(out.items[2].ok).toBe('c');
+  });
+
+  it('leaves primitives untouched', () => {
+    expect(redactSecrets(42)).toBe(42);
+    expect(redactSecrets('hello')).toBe('hello');
+    expect(redactSecrets(null)).toBe(null);
+    expect(redactSecrets(true)).toBe(true);
+  });
+
+  it('matches case-insensitively (PASSWORD == password)', () => {
+    const out = redactSecrets({ PASSWORD: 'p', Token: 't' }) as Record<string, unknown>;
+    expect(out.PASSWORD).toBe('[REDACTED]');
+    expect(out.Token).toBe('[REDACTED]');
+  });
+});

--- a/middleware/src/modules/mcp/lib/redact.ts
+++ b/middleware/src/modules/mcp/lib/redact.ts
@@ -1,0 +1,28 @@
+/**
+ * Recursive redaction of secret/PII fields before audit-logging tool inputs.
+ *
+ * Mirrors the anchored regex in `AgentStateService.FORBIDDEN_KEY_REGEX`
+ * (PR #32, R4-HIGH1) so MCP audit logs apply the exact same secret/PII
+ * policy as the agent-state I/O surface. Anchored on `^...$/i` — only
+ * EXACT key matches are redacted; `apiToken` / `clientSecret` / `key` /
+ * `authorType` are intentionally NOT redacted (they were false-positive
+ * substring matches in the older unanchored regex this regex replaced).
+ */
+const FORBIDDEN_KEY_REGEX =
+  /^(token|secret|password|passphrase|apiKey|api_key|webhook|webhookUrl|jwt|credential|cookie|sessionId|session_token|privateKey|private_key|accessToken|access_token|refreshToken|refresh_token|authHeader|authorization|email|emailAddress|recipient|phone|phoneNumber|address|fullName)$/i;
+
+export function redactSecrets(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((v) => redactSecrets(v));
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (FORBIDDEN_KEY_REGEX.test(k)) {
+        out[k] = '[REDACTED]';
+      } else {
+        out[k] = redactSecrets(v);
+      }
+    }
+    return out;
+  }
+  return value;
+}

--- a/middleware/src/modules/mcp/mcp-exception.filter.spec.ts
+++ b/middleware/src/modules/mcp/mcp-exception.filter.spec.ts
@@ -9,20 +9,21 @@ import {
 import { ThrottlerException } from '@nestjs/throttler';
 import { McpExceptionFilter } from './mcp-exception.filter';
 
-function makeHost(): {
+function makeHost(preexistingHeaders: Record<string, string | number> = {}): {
   filter: McpExceptionFilter;
-  res: { statusCode: number | null; body: unknown; headers: Record<string, string> };
+  res: { statusCode: number | null; body: unknown; headers: Record<string, string | number> };
   host: Parameters<McpExceptionFilter['catch']>[1];
 } {
-  const recorded: { statusCode: number | null; body: unknown; headers: Record<string, string> } = {
+  const recorded: { statusCode: number | null; body: unknown; headers: Record<string, string | number> } = {
     statusCode: null,
     body: null,
-    headers: {},
+    headers: { ...preexistingHeaders },
   };
   const res = {
     status(code: number) { recorded.statusCode = code; return this; },
     json(body: unknown) { recorded.body = body; return this; },
-    setHeader(key: string, value: string) { recorded.headers[key] = value; },
+    setHeader(key: string, value: string | number) { recorded.headers[key] = value; },
+    getHeader(key: string) { return recorded.headers[key]; },
   };
   const req = { method: 'POST', originalUrl: '/api/v1/mcp', url: '/api/v1/mcp' };
   const host = {
@@ -52,10 +53,16 @@ describe('McpExceptionFilter', () => {
     expect(res.body).not.toHaveProperty('statusCode');
   });
 
-  it('sets Retry-After header on RATE_LIMITED responses', () => {
+  it('sets Retry-After=60 on RATE_LIMITED when no upstream value is present', () => {
     const { filter, res, host } = makeHost();
     filter.catch(new ThrottlerException('too many'), host);
     expect(res.headers['Retry-After']).toBe('60');
+  });
+
+  it('PRESERVES an existing Retry-After header (e.g. from ThrottlerGuard) instead of overwriting with 60 — REGRESSION: previously clobbered the throttler-set TTL', () => {
+    const { filter, res, host } = makeHost({ 'Retry-After': '7' });
+    filter.catch(new ThrottlerException('too many'), host);
+    expect(res.headers['Retry-After']).toBe('7');
   });
 
   it('does NOT leak the underlying error message for INTERNAL', () => {

--- a/middleware/src/modules/mcp/mcp-exception.filter.spec.ts
+++ b/middleware/src/modules/mcp/mcp-exception.filter.spec.ts
@@ -1,0 +1,69 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  HttpStatus,
+  InternalServerErrorException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ThrottlerException } from '@nestjs/throttler';
+import { McpExceptionFilter } from './mcp-exception.filter';
+
+function makeHost(): {
+  filter: McpExceptionFilter;
+  res: { statusCode: number | null; body: unknown; headers: Record<string, string> };
+  host: Parameters<McpExceptionFilter['catch']>[1];
+} {
+  const recorded: { statusCode: number | null; body: unknown; headers: Record<string, string> } = {
+    statusCode: null,
+    body: null,
+    headers: {},
+  };
+  const res = {
+    status(code: number) { recorded.statusCode = code; return this; },
+    json(body: unknown) { recorded.body = body; return this; },
+    setHeader(key: string, value: string) { recorded.headers[key] = value; },
+  };
+  const req = { method: 'POST', originalUrl: '/api/v1/mcp', url: '/api/v1/mcp' };
+  const host = {
+    switchToHttp: () => ({ getResponse: () => res, getRequest: () => req }),
+  } as unknown as Parameters<McpExceptionFilter['catch']>[1];
+  return { filter: new McpExceptionFilter(), res: recorded, host };
+}
+
+describe('McpExceptionFilter', () => {
+  it.each<[Error, number, string]>([
+    [new UnauthorizedException(),   HttpStatus.UNAUTHORIZED,         'UNAUTHORIZED'],
+    [new ForbiddenException(),      HttpStatus.FORBIDDEN,            'FORBIDDEN'],
+    [new NotFoundException('x'),    HttpStatus.NOT_FOUND,            'NOT_FOUND'],
+    [new BadRequestException('x'),  HttpStatus.BAD_REQUEST,          'INVALID_INPUT'],
+    [new ThrottlerException('x'),   HttpStatus.TOO_MANY_REQUESTS,    'RATE_LIMITED'],
+    [new InternalServerErrorException('boom'), HttpStatus.INTERNAL_SERVER_ERROR, 'INTERNAL'],
+    [new Error('plain'),            HttpStatus.INTERNAL_SERVER_ERROR, 'INTERNAL'],
+  ])('maps %s → HTTP %d / code %s, body shape { error: { code, message } }', (err, status, code) => {
+    const { filter, res, host } = makeHost();
+    filter.catch(err, host);
+    expect(res.statusCode).toBe(status);
+    expect(res.body).toMatchObject({
+      error: { code, message: expect.any(String) },
+    });
+    // Critical: response is NOT wrapped in NestJS's { statusCode, message, error }
+    // envelope. The top-level shape is the MCP error contract.
+    expect(res.body).not.toHaveProperty('statusCode');
+  });
+
+  it('sets Retry-After header on RATE_LIMITED responses', () => {
+    const { filter, res, host } = makeHost();
+    filter.catch(new ThrottlerException('too many'), host);
+    expect(res.headers['Retry-After']).toBe('60');
+  });
+
+  it('does NOT leak the underlying error message for INTERNAL', () => {
+    const { filter, res, host } = makeHost();
+    filter.catch(new InternalServerErrorException('database connection refused at line 47'), host);
+    const body = res.body as { error: { code: string; message: string } };
+    expect(body.error.code).toBe('INTERNAL');
+    expect(body.error.message).toBe('Internal server error');
+    expect(body.error.message).not.toContain('database');
+  });
+});

--- a/middleware/src/modules/mcp/mcp-exception.filter.ts
+++ b/middleware/src/modules/mcp/mcp-exception.filter.ts
@@ -1,0 +1,70 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { ThrottlerException } from '@nestjs/throttler';
+import type { Request, Response } from 'express';
+import { mapExceptionToMcpError, type McpErrorCode } from './lib/error-mapping';
+
+/**
+ * Catches every exception thrown on /api/v1/mcp/* (including those
+ * raised by `McpAuthGuard` and `McpRateLimitGuard`) and serializes
+ * them in the MCP wire-error shape clients expect:
+ *
+ *   { error: { code: <enum>, message: <human>, data?: <object> } }
+ *
+ * Without this filter, NestJS's default exception handler emits its
+ * own envelope (`{ statusCode, message, error }`) which agents have
+ * to special-case. With this filter, transport-level failures and
+ * tool-handler failures look the same on the wire.
+ *
+ * HTTP status codes still match the MCP code (401 / 403 / 404 / 429
+ * / 400 / 500) so an MCP client that triages on status alone still
+ * works.
+ */
+@Catch()
+export class McpExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(McpExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const res = ctx.getResponse<Response>();
+    const req = ctx.getRequest<Request>();
+
+    const mapped = mapExceptionToMcpError(exception);
+    const status = httpStatusFor(mapped.code);
+
+    // Surface the precise reason in our own logs, never to the client.
+    this.logger.warn(
+      `MCP ${req.method} ${req.originalUrl ?? req.url} → ${status} ${mapped.code}: ${
+        exception instanceof Error ? exception.message : String(exception)
+      }`,
+    );
+
+    if (mapped.code === 'RATE_LIMITED') {
+      res.setHeader('Retry-After', '60');
+    }
+
+    res.status(status).json({ error: mapped });
+  }
+}
+
+function httpStatusFor(code: McpErrorCode): number {
+  switch (code) {
+    case 'UNAUTHORIZED':   return HttpStatus.UNAUTHORIZED;
+    case 'FORBIDDEN':      return HttpStatus.FORBIDDEN;
+    case 'NOT_FOUND':      return HttpStatus.NOT_FOUND;
+    case 'INVALID_INPUT':  return HttpStatus.BAD_REQUEST;
+    case 'RATE_LIMITED':   return HttpStatus.TOO_MANY_REQUESTS;
+    case 'TOOL_NOT_FOUND': return HttpStatus.NOT_FOUND;
+    case 'INTERNAL':       return HttpStatus.INTERNAL_SERVER_ERROR;
+    default:               return HttpStatus.INTERNAL_SERVER_ERROR;
+  }
+}
+
+// Re-export to avoid a second import in the controller
+export { ThrottlerException, HttpException };

--- a/middleware/src/modules/mcp/mcp-exception.filter.ts
+++ b/middleware/src/modules/mcp/mcp-exception.filter.ts
@@ -46,7 +46,15 @@ export class McpExceptionFilter implements ExceptionFilter {
     );
 
     if (mapped.code === 'RATE_LIMITED') {
-      res.setHeader('Retry-After', '60');
+      // The throttler may have already set Retry-After to the actual
+      // bucket-reset TTL (in seconds). Honour that if present —
+      // overwriting it with a hardcoded 60 makes clients back off for
+      // longer than they need to. Only fall back to 60 when no upstream
+      // value exists.
+      const existing = res.getHeader('Retry-After');
+      if (existing === undefined || existing === null || existing === '') {
+        res.setHeader('Retry-After', '60');
+      }
     }
 
     res.status(status).json({ error: mapped });

--- a/middleware/src/modules/mcp/mcp.controller.ts
+++ b/middleware/src/modules/mcp/mcp.controller.ts
@@ -1,0 +1,109 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Req,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import type { Request, Response } from 'express';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { SkipEnvelope } from '../common/interceptors/response-envelope.interceptor';
+import { McpAuthGuard } from './auth/mcp-auth.guard';
+import {
+  MCP_CONTEXT_KEY,
+  type McpRequestContext,
+} from './auth/mcp-context';
+import { McpRateLimitGuard } from './auth/mcp-rate-limit.guard';
+import { McpService } from './mcp.service';
+
+/**
+ * MCP transport endpoint. Every method is decorated with:
+ *
+ *   - `@SkipEnvelope()`     — bypass the global response envelope so
+ *                              MCP's JSON-RPC payload reaches the wire
+ *                              unwrapped (otherwise agents receive
+ *                              `{success, data: {jsonrpc, ...}, meta}`
+ *                              and every MCP client breaks)
+ *   - `@UseGuards(McpAuthGuard, McpRateLimitGuard)` — auth FIRST so
+ *                              the rate-limit guard has a populated
+ *                              tokenId on the request
+ *
+ * Each request creates a fresh `StreamableHTTPServerTransport` in
+ * stateless mode (no session id) and calls `transport.handleRequest`,
+ * passing the body NestJS already parsed — the SDK accepts a
+ * pre-parsed body, which avoids the double-parse foot-gun common with
+ * Express-based frameworks.
+ */
+@ApiTags('mcp')
+@Controller('api/v1/mcp')
+@UseGuards(McpAuthGuard, McpRateLimitGuard)
+@ApiBearerAuth()
+export class McpController {
+  constructor(private readonly mcp: McpService) {}
+
+  /** Tools/list and tools/call live on POST per MCP spec. */
+  @Post()
+  @SkipEnvelope()
+  async post(@Req() req: Request, @Res() res: Response): Promise<void> {
+    await this.handle(req, res);
+  }
+
+  /** GET supports SSE streaming for long-running tools. v1 has none, */
+  /** but the spec requires the endpoint exist on the same path.       */
+  @Get()
+  @SkipEnvelope()
+  async get(@Req() req: Request, @Res() res: Response): Promise<void> {
+    await this.handle(req, res);
+  }
+
+  /** DELETE for closing a session. Stateless mode = nothing to close, */
+  /** but we keep the route for spec compliance.                       */
+  @Post('close')
+  @SkipEnvelope()
+  async close(@Req() req: Request, @Res() res: Response): Promise<void> {
+    await this.handle(req, res);
+  }
+
+  /**
+   * Per-request transport (stateless mode). The auth-info object
+   * carries the per-request `mcpContext` into the SDK so tool
+   * handlers receive the right org / agent / scopes for THIS call.
+   */
+  private async handle(req: Request, res: Response): Promise<void> {
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined, // stateless
+    });
+    await this.mcp.server.connect(transport);
+
+    const context = (req as Request & Record<string, unknown>)[
+      MCP_CONTEXT_KEY
+    ] as McpRequestContext | undefined;
+
+    // Pass NestJS's pre-parsed body straight through. Per the SDK
+    // example: `transport.handleRequest(req, res, req.body)`.
+    // The SDK's `MessageExtraInfo.authInfo.extra` is how we ferry
+    // the per-request mcpContext to the tool handler — the registered
+    // tool reads it via `extra.authInfo.extra.mcpContext`.
+    const extra = context
+      ? {
+          authInfo: {
+            // The SDK's AuthInfo type requires a `token`. We don't
+            // re-leak the bearer; pass the token id instead — it's
+            // already in `mcpContext.tokenId`.
+            token: context.tokenId,
+            clientId: context.agentName,
+            scopes: context.scopes,
+            extra: { mcpContext: context },
+          },
+        }
+      : {};
+
+    await transport.handleRequest(req, res, req.body, extra);
+
+    // The transport closes itself when the client disconnects; the
+    // McpServer's `connect()` is per-transport so there's nothing to
+    // explicitly tear down here.
+  }
+}

--- a/middleware/src/modules/mcp/mcp.controller.ts
+++ b/middleware/src/modules/mcp/mcp.controller.ts
@@ -4,18 +4,21 @@ import {
   Post,
   Req,
   Res,
+  UseFilters,
   UseGuards,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import type { Request, Response } from 'express';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { SkipEnvelope } from '../common/interceptors/response-envelope.interceptor';
+import { SkipInputSanitize } from '../common/interceptors/sanitize.interceptor';
 import { McpAuthGuard } from './auth/mcp-auth.guard';
 import {
   MCP_CONTEXT_KEY,
   type McpRequestContext,
 } from './auth/mcp-context';
 import { McpRateLimitGuard } from './auth/mcp-rate-limit.guard';
+import { McpExceptionFilter } from './mcp-exception.filter';
 import { McpService } from './mcp.service';
 
 /**
@@ -39,6 +42,8 @@ import { McpService } from './mcp.service';
 @ApiTags('mcp')
 @Controller('api/v1/mcp')
 @UseGuards(McpAuthGuard, McpRateLimitGuard)
+@UseFilters(McpExceptionFilter)
+@SkipInputSanitize()
 @ApiBearerAuth()
 export class McpController {
   constructor(private readonly mcp: McpService) {}

--- a/middleware/src/modules/mcp/mcp.module.ts
+++ b/middleware/src/modules/mcp/mcp.module.ts
@@ -1,0 +1,34 @@
+import { Module } from '@nestjs/common';
+import { AdminModule } from '../admin/admin.module';
+import { AuthModule } from '../auth/auth.module';
+import { DatabaseModule } from '../database/database.module';
+import { DisplaysModule } from '../displays/displays.module';
+import { McpAuditService } from './audit/mcp-audit.service';
+import { McpAuthGuard } from './auth/mcp-auth.guard';
+import { McpRateLimitGuard } from './auth/mcp-rate-limit.guard';
+import { McpTokenService } from './auth/mcp-token.service';
+import { McpController } from './mcp.controller';
+import { McpService } from './mcp.service';
+import { McpTokensAdminController } from './admin/mcp-tokens.controller';
+
+/**
+ * Vizora MCP server module.
+ *
+ * Exposes:
+ *   - POST /api/v1/mcp                     (MCP transport — auth required)
+ *   - GET  /api/v1/mcp                     (MCP transport SSE leg)
+ *   - POST /api/v1/admin/mcp-tokens        (issue, super-admin only)
+ *   - GET  /api/v1/admin/mcp-tokens        (list)
+ *   - DELETE /api/v1/admin/mcp-tokens/:id  (revoke)
+ *
+ * Tools registered: `list_displays` (read-only, scope `displays:read`)
+ *
+ * Companion docs: `docs/agents-mcp-server-design.md`.
+ */
+@Module({
+  imports: [DatabaseModule, AuthModule, AdminModule, DisplaysModule],
+  controllers: [McpController, McpTokensAdminController],
+  providers: [McpService, McpTokenService, McpAuthGuard, McpRateLimitGuard, McpAuditService],
+  exports: [McpService, McpTokenService],
+})
+export class McpModule {}

--- a/middleware/src/modules/mcp/mcp.service.ts
+++ b/middleware/src/modules/mcp/mcp.service.ts
@@ -1,0 +1,100 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpRequestContext } from './auth/mcp-context';
+import { McpAuditService } from './audit/mcp-audit.service';
+import { mapExceptionToMcpError } from './lib/error-mapping';
+import { DisplaysService } from '../displays/displays.service';
+import { LIST_DISPLAYS_TOOL } from './tools/displays.tools';
+
+/**
+ * Holds a single `McpServer` instance and registers every tool
+ * exactly once at startup. The transport is created per-request by
+ * `McpController` (stateless mode — no server-side session state) and
+ * `connect`-ed against this server.
+ *
+ * Tool handlers receive an `extra` arg from the SDK that carries
+ * `authInfo`. We populate `authInfo.extra.mcpContext` from the
+ * controller per-request so each tool sees the right
+ * organization/agent/scopes for THIS call.
+ */
+@Injectable()
+export class McpService implements OnModuleInit {
+  private readonly logger = new Logger(McpService.name);
+
+  /** Singleton MCP server. Tools are registered once at module init. */
+  readonly server = new McpServer(
+    { name: 'vizora-mcp', version: '0.1.0' },
+    { capabilities: { tools: { listChanged: false } } },
+  );
+
+  constructor(
+    private readonly displays: DisplaysService,
+    private readonly audit: McpAuditService,
+  ) {}
+
+  onModuleInit(): void {
+    this.registerListDisplays();
+    this.logger.log('MCP server initialized — 1 tool registered (list_displays)');
+  }
+
+  /**
+   * Wraps tool registration with a uniform try/catch + audit pattern
+   * so each tool file stays focused on the tool itself.
+   */
+  private registerListDisplays(): void {
+    const t = LIST_DISPLAYS_TOOL;
+    this.server.registerTool(
+      t.name,
+      {
+        description: t.description,
+        inputSchema: t.inputSchema.shape,
+      },
+      async (input, extra) => {
+        const startedAt = Date.now();
+        const mcp = (extra.authInfo?.extra ?? {}) as { mcpContext?: McpRequestContext };
+        const context = mcp.mcpContext;
+        if (!context) {
+          // Should be impossible — controller always sets it. Fail loud.
+          throw new Error('MCP tool invoked without context (controller wiring bug)');
+        }
+        try {
+          const result = await t.handler(input, context, this.displays);
+          await this.audit.record({
+            tokenId: context.tokenId,
+            agentName: context.agentName,
+            organizationId: context.organizationId,
+            tool: t.name,
+            paramsRaw: input,
+            status: 'success',
+            latencyMs: Date.now() - startedAt,
+          });
+          return {
+            content: [{ type: 'text', text: JSON.stringify(result) }],
+            structuredContent: result,
+          };
+        } catch (err) {
+          const mapped = mapExceptionToMcpError(err);
+          await this.audit.record({
+            tokenId: context.tokenId,
+            agentName: context.agentName,
+            organizationId: context.organizationId,
+            tool: t.name,
+            paramsRaw: input,
+            status: 'error',
+            errorCode: mapped.code,
+            latencyMs: Date.now() - startedAt,
+          });
+          // Surface as an MCP tool-error result. The SDK converts
+          // thrown exceptions to 'isError: true' content; we follow
+          // the convention so agents see the typed error code in
+          // structuredContent.
+          return {
+            isError: true,
+            content: [{ type: 'text', text: mapped.message }],
+            structuredContent: { error: mapped },
+          };
+        }
+      },
+    );
+  }
+}

--- a/middleware/src/modules/mcp/schemas/tool-inputs.ts
+++ b/middleware/src/modules/mcp/schemas/tool-inputs.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+/**
+ * Input schemas for MCP tools. One per tool. Re-exported through
+ * `tools/tool-registry.ts` so handlers can `parse()` once.
+ */
+
+export const ListDisplaysInput = z.object({
+  status: z.enum(['online', 'offline', 'pairing', 'error', 'all'])
+    .optional()
+    .default('all')
+    .describe('Filter by display status. "all" returns every status.'),
+  limit: z.number().int().min(1).max(100).optional().default(20)
+    .describe('Page size, 1-100.'),
+  page: z.number().int().min(1).optional().default(1)
+    .describe('1-indexed page number.'),
+});
+
+export type ListDisplaysInputT = z.infer<typeof ListDisplaysInput>;

--- a/middleware/src/modules/mcp/schemas/tool-outputs.ts
+++ b/middleware/src/modules/mcp/schemas/tool-outputs.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+/**
+ * Output schemas for MCP tools. The MCP SDK validates output against
+ * these before sending — a tool that returns a shape that fails
+ * validation surfaces as an INTERNAL error to the caller (and a loud
+ * server-side log), which is what we want.
+ *
+ * Field naming: snake_case for the wire (consistent with MCP convention),
+ * regardless of Vizora's internal camelCase Prisma fields. Translation
+ * happens at the projection step in each tool.
+ */
+
+export const DisplayShape = z.object({
+  id: z.string(),
+  organization_id: z.string(),
+  device_identifier: z.string(),
+  nickname: z.string().nullable(),
+  location: z.string().nullable(),
+  status: z.enum(['online', 'offline', 'pairing', 'error']),
+  orientation: z.enum(['landscape', 'portrait']),
+  resolution: z.string().nullable(),
+  last_heartbeat: z.string().datetime().nullable(),
+  current_playlist_id: z.string().nullable(),
+  is_disabled: z.boolean(),
+  created_at: z.string().datetime(),
+});
+
+export const ListDisplaysOutput = z.object({
+  displays: z.array(DisplayShape),
+  page: z.number().int(),
+  limit: z.number().int(),
+  total: z.number().int(),
+});
+
+export type ListDisplaysOutputT = z.infer<typeof ListDisplaysOutput>;

--- a/middleware/src/modules/mcp/tools/displays.tools.spec.ts
+++ b/middleware/src/modules/mcp/tools/displays.tools.spec.ts
@@ -59,18 +59,54 @@ describe('listDisplaysTool', () => {
     expect(out.total).toBe(2);
   });
 
-  it('client-side filters by status when not "all"', async () => {
+  it('passes the status filter through to DisplaysService.findAll (DB-side, not client-side)', async () => {
     const displaysSvc = makeDisplays([
       { id: 'd1', status: 'online' },
-      { id: 'd2', status: 'offline' },
-      { id: 'd3', status: 'online' },
+      { id: 'd2', status: 'online' },
     ]);
     const out = await listDisplaysTool(
       { status: 'online' },
       ctx(['displays:read']),
       displaysSvc as never,
     );
-    expect(out.displays.map((d) => d.id)).toEqual(['d1', 'd3']);
+    expect(displaysSvc.findAll).toHaveBeenCalledWith(
+      'org_1',
+      { page: 1, limit: 20 },
+      { status: 'online' },
+    );
+    expect(out.displays.map((d) => d.id)).toEqual(['d1', 'd2']);
+  });
+
+  it("does NOT pass a filter when status='all'", async () => {
+    const displaysSvc = makeDisplays([{ id: 'd1' }]);
+    await listDisplaysTool({}, ctx(['displays:read']), displaysSvc as never);
+    expect(displaysSvc.findAll).toHaveBeenCalledWith(
+      'org_1',
+      { page: 1, limit: 20 },
+      undefined,
+    );
+  });
+
+  it('reports the DB-filtered total — pagination ratios match (REGRESSION: was previously the unfiltered count)', async () => {
+    // Simulate DisplaysService.findAll with status filter applied:
+    // total reflects the FILTERED count, not the org-wide count.
+    const displaysSvc = {
+      findAll: jest.fn().mockResolvedValue({
+        data: [
+          { id: 'd1', organizationId: 'org_1', deviceIdentifier: 'a', nickname: null, location: null, status: 'offline', orientation: 'landscape', resolution: null, lastHeartbeat: null, currentPlaylistId: null, isDisabled: false, createdAt: new Date('2026-05-01T00:00:00Z') },
+          { id: 'd2', organizationId: 'org_1', deviceIdentifier: 'b', nickname: null, location: null, status: 'offline', orientation: 'landscape', resolution: null, lastHeartbeat: null, currentPlaylistId: null, isDisabled: false, createdAt: new Date('2026-05-01T00:00:00Z') },
+        ],
+        // 7 offline displays exist across all pages, 100 total in the org
+        meta: { page: 1, limit: 20, total: 7, totalPages: 1 },
+      }),
+    };
+    const out = await listDisplaysTool(
+      { status: 'offline' },
+      ctx(['displays:read']),
+      displaysSvc as never,
+    );
+    expect(out.total).toBe(7);
+    expect(out.displays).toHaveLength(2);
   });
 
   it('rejects invalid limit via Zod (>100)', async () => {
@@ -86,7 +122,11 @@ describe('listDisplaysTool', () => {
   it('passes the calling token org to DisplaysService.findAll (not user-controlled)', async () => {
     const displaysSvc = makeDisplays([]);
     await listDisplaysTool({}, ctx(['displays:read']), displaysSvc as never);
-    expect(displaysSvc.findAll).toHaveBeenCalledWith('org_1', { page: 1, limit: 20 });
+    expect(displaysSvc.findAll).toHaveBeenCalledWith(
+      'org_1',
+      { page: 1, limit: 20 },
+      undefined,
+    );
   });
 
   it('lastHeartbeat as Date is serialized to ISO string', async () => {

--- a/middleware/src/modules/mcp/tools/displays.tools.spec.ts
+++ b/middleware/src/modules/mcp/tools/displays.tools.spec.ts
@@ -1,0 +1,101 @@
+import { ForbiddenException } from '@nestjs/common';
+import { listDisplaysTool } from './displays.tools';
+import type { McpRequestContext } from '../auth/mcp-context';
+
+function ctx(scopes: string[]): McpRequestContext {
+  return {
+    tokenId: 'tok_1',
+    organizationId: 'org_1',
+    agentName: 'support-triage',
+    scopes,
+  };
+}
+
+function makeDisplays(rows: Array<Partial<{ id: string; status: string; nickname: string | null; isDisabled: boolean; lastHeartbeat: Date | null }>>) {
+  return {
+    findAll: jest.fn().mockResolvedValue({
+      data: rows.map((r) => ({
+        id: r.id,
+        organizationId: 'org_1',
+        deviceIdentifier: `dev-${r.id}`,
+        nickname: r.nickname ?? null,
+        location: null,
+        status: r.status ?? 'online',
+        orientation: 'landscape',
+        resolution: null,
+        lastHeartbeat: r.lastHeartbeat ?? null,
+        currentPlaylistId: null,
+        isDisabled: r.isDisabled ?? false,
+        createdAt: new Date('2026-05-01T00:00:00Z'),
+      })),
+      meta: { page: 1, limit: 20, total: rows.length, totalPages: 1 },
+    }),
+  };
+}
+
+describe('listDisplaysTool', () => {
+  it('throws ForbiddenException when scope missing', async () => {
+    await expect(
+      listDisplaysTool({}, ctx([]), makeDisplays([]) as never),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('returns wire-shape (snake_case) when scope present', async () => {
+    const out = await listDisplaysTool(
+      {},
+      ctx(['displays:read']),
+      makeDisplays([{ id: 'd1' }, { id: 'd2' }]) as never,
+    );
+    expect(out.displays).toHaveLength(2);
+    expect(out.displays[0]).toMatchObject({
+      id: 'd1',
+      organization_id: 'org_1',
+      device_identifier: 'dev-d1',
+      status: 'online',
+      orientation: 'landscape',
+      is_disabled: false,
+    });
+    expect(out.displays[0].created_at).toBe('2026-05-01T00:00:00.000Z');
+    expect(out.total).toBe(2);
+  });
+
+  it('client-side filters by status when not "all"', async () => {
+    const displaysSvc = makeDisplays([
+      { id: 'd1', status: 'online' },
+      { id: 'd2', status: 'offline' },
+      { id: 'd3', status: 'online' },
+    ]);
+    const out = await listDisplaysTool(
+      { status: 'online' },
+      ctx(['displays:read']),
+      displaysSvc as never,
+    );
+    expect(out.displays.map((d) => d.id)).toEqual(['d1', 'd3']);
+  });
+
+  it('rejects invalid limit via Zod (>100)', async () => {
+    await expect(
+      listDisplaysTool(
+        { limit: 999 },
+        ctx(['displays:read']),
+        makeDisplays([]) as never,
+      ),
+    ).rejects.toThrow(/100/);
+  });
+
+  it('passes the calling token org to DisplaysService.findAll (not user-controlled)', async () => {
+    const displaysSvc = makeDisplays([]);
+    await listDisplaysTool({}, ctx(['displays:read']), displaysSvc as never);
+    expect(displaysSvc.findAll).toHaveBeenCalledWith('org_1', { page: 1, limit: 20 });
+  });
+
+  it('lastHeartbeat as Date is serialized to ISO string', async () => {
+    const ts = new Date('2026-05-04T12:34:56Z');
+    const out = await listDisplaysTool(
+      {},
+      ctx(['displays:read']),
+      makeDisplays([{ id: 'd1', lastHeartbeat: ts }]) as never,
+    );
+    expect(out.displays[0].last_heartbeat).toBe('2026-05-04T12:34:56.000Z');
+  });
+});

--- a/middleware/src/modules/mcp/tools/displays.tools.ts
+++ b/middleware/src/modules/mcp/tools/displays.tools.ts
@@ -1,0 +1,92 @@
+import { ForbiddenException } from '@nestjs/common';
+import { DisplaysService } from '../../displays/displays.service';
+import { hasScope, type McpRequestContext } from '../auth/mcp-context';
+import {
+  ListDisplaysInput,
+  type ListDisplaysInputT,
+} from '../schemas/tool-inputs';
+import {
+  ListDisplaysOutput,
+  type ListDisplaysOutputT,
+} from '../schemas/tool-outputs';
+
+/**
+ * MCP tool: `list_displays`
+ *
+ * Read-only listing of displays for the calling token's organization.
+ * Wraps `DisplaysService.findAll` and projects each Prisma row into
+ * the wire-shape declared in `ListDisplaysOutput`. No new business
+ * logic.
+ *
+ * Scope required: `displays:read`. Scope failure throws
+ * `ForbiddenException` which the error mapper translates to MCP
+ * `FORBIDDEN`.
+ */
+export async function listDisplaysTool(
+  rawInput: unknown,
+  context: McpRequestContext,
+  displaysService: DisplaysService,
+): Promise<ListDisplaysOutputT> {
+  if (!hasScope(context, 'displays:read')) {
+    throw new ForbiddenException(
+      "Token lacks scope 'displays:read'",
+    );
+  }
+  const input = ListDisplaysInput.parse(rawInput) as ListDisplaysInputT;
+
+  const result = await displaysService.findAll(context.organizationId, {
+    page: input.page,
+    limit: input.limit,
+  });
+
+  // Filter by status client-side — DisplaysService.findAll doesn't
+  // accept a status filter today and we don't want to widen its
+  // signature for an MCP-only concern. At ≤100 rows per page the cost
+  // is negligible.
+  const filtered = (result.data as Array<Record<string, unknown>>).filter(
+    (d) => input.status === 'all' || d.status === input.status,
+  );
+
+  return ListDisplaysOutput.parse({
+    displays: filtered.map(toDisplayShape),
+    page: input.page,
+    limit: input.limit,
+    total: result.meta?.total ?? filtered.length,
+  });
+}
+
+function toDisplayShape(d: Record<string, unknown>) {
+  return {
+    id: d.id as string,
+    organization_id: d.organizationId as string,
+    device_identifier: d.deviceIdentifier as string,
+    nickname: (d.nickname as string | null) ?? null,
+    location: (d.location as string | null) ?? null,
+    status: d.status as 'online' | 'offline' | 'pairing' | 'error',
+    orientation: d.orientation as 'landscape' | 'portrait',
+    resolution: (d.resolution as string | null) ?? null,
+    last_heartbeat: d.lastHeartbeat instanceof Date
+      ? d.lastHeartbeat.toISOString()
+      : (d.lastHeartbeat as string | null) ?? null,
+    current_playlist_id: (d.currentPlaylistId as string | null) ?? null,
+    is_disabled: Boolean(d.isDisabled),
+    created_at: d.createdAt instanceof Date
+      ? d.createdAt.toISOString()
+      : (d.createdAt as string),
+  };
+}
+
+/**
+ * Registry entry shape for MCP tool registration. Lives next to the
+ * implementation so we can't lose track of the input/output schemas
+ * vs the handler.
+ */
+export const LIST_DISPLAYS_TOOL = {
+  name: 'list_displays',
+  description:
+    'List displays for the calling token\'s organization. Read-only. Paginated. Optional status filter (online | offline | pairing | error | all).',
+  scope: 'displays:read' as const,
+  inputSchema: ListDisplaysInput,
+  outputSchema: ListDisplaysOutput,
+  handler: listDisplaysTool,
+};

--- a/middleware/src/modules/mcp/tools/displays.tools.ts
+++ b/middleware/src/modules/mcp/tools/displays.tools.ts
@@ -34,24 +34,23 @@ export async function listDisplaysTool(
   }
   const input = ListDisplaysInput.parse(rawInput) as ListDisplaysInputT;
 
-  const result = await displaysService.findAll(context.organizationId, {
-    page: input.page,
-    limit: input.limit,
-  });
-
-  // Filter by status client-side — DisplaysService.findAll doesn't
-  // accept a status filter today and we don't want to widen its
-  // signature for an MCP-only concern. At ≤100 rows per page the cost
-  // is negligible.
-  const filtered = (result.data as Array<Record<string, unknown>>).filter(
-    (d) => input.status === 'all' || d.status === input.status,
+  // Push the status filter DB-side so `total` reflects the filtered
+  // result set. The previous client-side filter narrowed the page
+  // but not the count, breaking pagination ratios for any non-'all'
+  // status query.
+  const result = await displaysService.findAll(
+    context.organizationId,
+    { page: input.page, limit: input.limit },
+    input.status === 'all' ? undefined : { status: input.status },
   );
 
+  const rows = result.data as Array<Record<string, unknown>>;
+
   return ListDisplaysOutput.parse({
-    displays: filtered.map(toDisplayShape),
+    displays: rows.map(toDisplayShape),
     page: input.page,
     limit: input.limit,
-    total: result.meta?.total ?? filtered.length,
+    total: result.meta?.total ?? rows.length,
   });
 }
 

--- a/packages/database/prisma/migrations/20260504000000_add_mcp_token_and_audit_log/migration.sql
+++ b/packages/database/prisma/migrations/20260504000000_add_mcp_token_and_audit_log/migration.sql
@@ -1,0 +1,61 @@
+-- CreateTable: mcp_tokens
+CREATE TABLE "mcp_tokens" (
+    "id" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "agentName" TEXT NOT NULL,
+    "scopes" TEXT[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "lastUsedAt" TIMESTAMP(3),
+
+    CONSTRAINT "mcp_tokens_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "mcp_tokens_tokenHash_key" ON "mcp_tokens"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "mcp_tokens_organizationId_idx" ON "mcp_tokens"("organizationId");
+
+-- CreateIndex
+CREATE INDEX "mcp_tokens_agentName_idx" ON "mcp_tokens"("agentName");
+
+-- AddForeignKey
+ALTER TABLE "mcp_tokens"
+    ADD CONSTRAINT "mcp_tokens_organizationId_fkey"
+    FOREIGN KEY ("organizationId") REFERENCES "organizations"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateTable: mcp_audit_log
+CREATE TABLE "mcp_audit_log" (
+    "id" TEXT NOT NULL,
+    "tokenId" TEXT,
+    "agentName" TEXT NOT NULL,
+    "organizationId" TEXT,
+    "tool" TEXT,
+    "paramsRedacted" JSONB,
+    "status" TEXT NOT NULL,
+    "errorCode" TEXT,
+    "latencyMs" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "mcp_audit_log_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "mcp_audit_log_tokenId_createdAt_idx" ON "mcp_audit_log"("tokenId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "mcp_audit_log_agentName_createdAt_idx" ON "mcp_audit_log"("agentName", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "mcp_audit_log_organizationId_createdAt_idx" ON "mcp_audit_log"("organizationId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "mcp_audit_log"
+    ADD CONSTRAINT "mcp_audit_log_tokenId_fkey"
+    FOREIGN KEY ("tokenId") REFERENCES "mcp_tokens"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -15,47 +15,48 @@ datasource db {
 // ============================================================================
 
 model Organization {
-  id                     String   @id @default(uuid())
+  id                     String    @id @default(uuid())
   name                   String
-  slug                   String   @unique
+  slug                   String    @unique
   logoUrl                String?
-  subscriptionTier       String   @default("free") // free, basic, pro, enterprise
-  screenQuota            Int      @default(5)
-  stripeCustomerId       String?  @unique
+  subscriptionTier       String    @default("free") // free, basic, pro, enterprise
+  screenQuota            Int       @default(5)
+  stripeCustomerId       String?   @unique
   stripeSubscriptionId   String?
-  razorpayCustomerId     String?  @unique
+  razorpayCustomerId     String?   @unique
   razorpaySubscriptionId String?
-  paymentProvider        String?  // 'stripe' | 'razorpay'
-  country                String?  // ISO 3166-1 alpha-2 (e.g., 'US', 'IN')
-  gstin                  String?  // GST Identification Number (India only)
+  paymentProvider        String? // 'stripe' | 'razorpay'
+  country                String? // ISO 3166-1 alpha-2 (e.g., 'US', 'IN')
+  gstin                  String? // GST Identification Number (India only)
   billingEmail           String?
   trialEndsAt            DateTime?
-  subscriptionStatus     String   @default("trial") // trial, active, past_due, canceled
-  storageUsedBytes       BigInt   @default(0)           // Current storage usage in bytes
-  storageQuotaBytes      BigInt   @default(1073741824)  // 1GB default quota in bytes (trial)
-  settings               Json?    @db.JsonB
-  createdAt              DateTime @default(now())
-  updatedAt              DateTime @updatedAt
+  subscriptionStatus     String    @default("trial") // trial, active, past_due, canceled
+  storageUsedBytes       BigInt    @default(0) // Current storage usage in bytes
+  storageQuotaBytes      BigInt    @default(1073741824) // 1GB default quota in bytes (trial)
+  settings               Json?     @db.JsonB
+  createdAt              DateTime  @default(now())
+  updatedAt              DateTime  @updatedAt
 
-  users               User[]
-  displays            Display[]
-  content             Content[]
-  playlists           Playlist[]
-  schedules           Schedule[]
-  tags                Tag[]
-  displayGroups       DisplayGroup[]
-  auditLogs           AuditLog[]
-  contentFolders      ContentFolder[]
-  notifications       Notification[]
-  apiKeys             ApiKey[]
-  billingTransactions BillingTransaction[]
-  impressions         ContentImpression[]
-  promotionRedemptions PromotionRedemption[]
-  supportRequests      SupportRequest[]
-  supportMessages      SupportMessage[] @relation("OrgSupportMessages")
-  onboarding           OrganizationOnboarding?
-  customerIncidents    CustomerIncident[]
+  users                  User[]
+  displays               Display[]
+  content                Content[]
+  playlists              Playlist[]
+  schedules              Schedule[]
+  tags                   Tag[]
+  displayGroups          DisplayGroup[]
+  auditLogs              AuditLog[]
+  contentFolders         ContentFolder[]
+  notifications          Notification[]
+  apiKeys                ApiKey[]
+  billingTransactions    BillingTransaction[]
+  impressions            ContentImpression[]
+  promotionRedemptions   PromotionRedemption[]
+  supportRequests        SupportRequest[]
+  supportMessages        SupportMessage[]        @relation("OrgSupportMessages")
+  onboarding             OrganizationOnboarding?
+  customerIncidents      CustomerIncident[]
   contentRecommendations ContentRecommendation[]
+  mcpTokens              McpToken[]
 
   @@index([slug])
   @@index([stripeCustomerId])
@@ -64,29 +65,29 @@ model Organization {
 }
 
 model User {
-  id             String   @id @default(uuid())
-  email          String   @unique
-  passwordHash   String?  // nullable if using Clerk
-  clerkUserId    String?  @unique
-  firstName      String
-  lastName       String
-  role           String   @default("viewer") // admin, manager, viewer
-  avatar         String?
-  isActive       Boolean  @default(true)
-  isSuperAdmin   Boolean  @default(false) // Vizora platform admin (separate from org admin)
-  lastLoginAt    DateTime?
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
+  id           String    @id @default(uuid())
+  email        String    @unique
+  passwordHash String? // nullable if using Clerk
+  clerkUserId  String?   @unique
+  firstName    String
+  lastName     String
+  role         String    @default("viewer") // admin, manager, viewer
+  avatar       String?
+  isActive     Boolean   @default(true)
+  isSuperAdmin Boolean   @default(false) // Vizora platform admin (separate from org admin)
+  lastLoginAt  DateTime?
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
 
   organizationId String
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
-  auditLogs      AuditLog[]
-  notifications  Notification[]
-  apiKeys        ApiKey[]
-  passwordResetTokens PasswordResetToken[]
-  supportRequests          SupportRequest[] @relation("SupportRequestUser")
-  resolvedSupportRequests  SupportRequest[] @relation("SupportRequestResolver")
+  auditLogs               AuditLog[]
+  notifications           Notification[]
+  apiKeys                 ApiKey[]
+  passwordResetTokens     PasswordResetToken[]
+  supportRequests         SupportRequest[]     @relation("SupportRequestUser")
+  resolvedSupportRequests SupportRequest[]     @relation("SupportRequestResolver")
 
   @@index([organizationId])
   @@index([email])
@@ -114,38 +115,38 @@ model PasswordResetToken {
 // ============================================================================
 
 model Display {
-  id                    String   @id @default(uuid())
-  organizationId        String
-  organization          Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  deviceIdentifier      String   @unique // MAC address or unique hardware ID
-  nickname              String?
-  description           String?
-  location              String?
-  pairingCode           String?
-  pairingCodeExpiresAt  DateTime?
-  jwtToken              String?  @db.Text
-  socketId              String?
-  status                String   @default("offline") // online, offline, pairing, error
-  orientation           String   @default("landscape") // landscape, portrait
-  resolution            String?  // e.g., "1920x1080"
-  lastHeartbeat         DateTime?
-  metadata              Json?    @db.JsonB // OS, model, version, etc.
-  timezone              String   @default("UTC")
-  lastScreenshot        String?  // URL to last captured screenshot
-  lastScreenshotAt      DateTime? // When screenshot was taken
-  isDisabled            Boolean   @default(false)
-  currentPlaylistId     String?  // Direct playlist assignment for simple cases
-  currentPlaylist       Playlist? @relation("DisplayCurrentPlaylist", fields: [currentPlaylistId], references: [id], onDelete: SetNull)
-  createdAt             DateTime @default(now())
-  updatedAt             DateTime @updatedAt
-  pairedAt              DateTime?
-  unpairedAt            DateTime?
+  id                   String       @id @default(uuid())
+  organizationId       String
+  organization         Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  deviceIdentifier     String       @unique // MAC address or unique hardware ID
+  nickname             String?
+  description          String?
+  location             String?
+  pairingCode          String?
+  pairingCodeExpiresAt DateTime?
+  jwtToken             String?      @db.Text
+  socketId             String?
+  status               String       @default("offline") // online, offline, pairing, error
+  orientation          String       @default("landscape") // landscape, portrait
+  resolution           String? // e.g., "1920x1080"
+  lastHeartbeat        DateTime?
+  metadata             Json?        @db.JsonB // OS, model, version, etc.
+  timezone             String       @default("UTC")
+  lastScreenshot       String? // URL to last captured screenshot
+  lastScreenshotAt     DateTime? // When screenshot was taken
+  isDisabled           Boolean      @default(false)
+  currentPlaylistId    String? // Direct playlist assignment for simple cases
+  currentPlaylist      Playlist?    @relation("DisplayCurrentPlaylist", fields: [currentPlaylistId], references: [id], onDelete: SetNull)
+  createdAt            DateTime     @default(now())
+  updatedAt            DateTime     @updatedAt
+  pairedAt             DateTime?
+  unpairedAt           DateTime?
 
-  schedules             Schedule[]
-  tags                  DisplayTag[]
-  groups                DisplayGroupMember[]
-  auditLogs             AuditLog[]
-  impressions           ContentImpression[]
+  schedules   Schedule[]
+  tags        DisplayTag[]
+  groups      DisplayGroupMember[]
+  auditLogs   AuditLog[]
+  impressions ContentImpression[]
 
   @@index([organizationId])
   @@index([deviceIdentifier])
@@ -165,8 +166,8 @@ model DisplayGroup {
   organizationId String
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
-  displays    DisplayGroupMember[]
-  schedules   Schedule[]
+  displays  DisplayGroupMember[]
+  schedules Schedule[]
 
   @@index([organizationId])
 }
@@ -175,8 +176,8 @@ model DisplayGroupMember {
   id        String   @id @default(cuid())
   createdAt DateTime @default(now())
 
-  displayId      String
-  display        Display @relation(fields: [displayId], references: [id], onDelete: Cascade)
+  displayId String
+  display   Display @relation(fields: [displayId], references: [id], onDelete: Cascade)
 
   displayGroupId String
   displayGroup   DisplayGroup @relation(fields: [displayGroupId], references: [id], onDelete: Cascade)
@@ -191,43 +192,43 @@ model DisplayGroupMember {
 // ============================================================================
 
 model Content {
-  id          String   @id @default(cuid())
-  name        String
-  description String?
-  type        String   // image, video, url, html
-  url         String   // URL to the content or embed URL
-  thumbnail   String?
-  duration    Int      @default(10) // Duration in seconds
-  fileSize    Int?     // Size in bytes
-  mimeType    String?
-  metadata    Json?    @db.JsonB
-  status      String   @default("active") // active, archived, expired
-  isGlobal    Boolean  @default(false)    // true for template library items (available to all orgs)
-  templateOrientation  String?  // 'landscape' | 'portrait' | 'both' for template filtering
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id                  String   @id @default(cuid())
+  name                String
+  description         String?
+  type                String // image, video, url, html
+  url                 String // URL to the content or embed URL
+  thumbnail           String?
+  duration            Int      @default(10) // Duration in seconds
+  fileSize            Int? // Size in bytes
+  mimeType            String?
+  metadata            Json?    @db.JsonB
+  status              String   @default("active") // active, archived, expired
+  isGlobal            Boolean  @default(false) // true for template library items (available to all orgs)
+  templateOrientation String? // 'landscape' | 'portrait' | 'both' for template filtering
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
 
   // Content expiration feature
-  expiresAt            DateTime?  // When this content should expire
-  replacementContentId String?    // Content to replace with when expired
-  replacementContent   Content?   @relation("ContentReplacement", fields: [replacementContentId], references: [id], onDelete: SetNull)
-  replacedBy           Content[]  @relation("ContentReplacement")
+  expiresAt            DateTime? // When this content should expire
+  replacementContentId String? // Content to replace with when expired
+  replacementContent   Content?  @relation("ContentReplacement", fields: [replacementContentId], references: [id], onDelete: SetNull)
+  replacedBy           Content[] @relation("ContentReplacement")
 
   // Version history for file replacement
-  previousVersionId    String?    // Reference to the previous version
-  previousVersion      Content?   @relation("ContentVersions", fields: [previousVersionId], references: [id], onDelete: SetNull)
-  newerVersions        Content[]  @relation("ContentVersions")
-  versionNumber        Int        @default(1)
+  previousVersionId String? // Reference to the previous version
+  previousVersion   Content?  @relation("ContentVersions", fields: [previousVersionId], references: [id], onDelete: SetNull)
+  newerVersions     Content[] @relation("ContentVersions")
+  versionNumber     Int       @default(1)
 
   organizationId String
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
-  folderId       String?
-  folder         ContentFolder? @relation(fields: [folderId], references: [id], onDelete: SetNull)
+  folderId String?
+  folder   ContentFolder? @relation(fields: [folderId], references: [id], onDelete: SetNull)
 
-  playlistItems  PlaylistItem[]
-  tags           ContentTag[]
-  impressions    ContentImpression[]
+  playlistItems PlaylistItem[]
+  tags          ContentTag[]
+  impressions   ContentImpression[]
 
   @@index([organizationId])
   @@index([type])
@@ -249,10 +250,10 @@ model Playlist {
   organizationId String
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
-  items              PlaylistItem[]
-  schedules          Schedule[]
-  assignedDisplays   Display[]      @relation("DisplayCurrentPlaylist")
-  impressions        ContentImpression[]
+  items            PlaylistItem[]
+  schedules        Schedule[]
+  assignedDisplays Display[]           @relation("DisplayCurrentPlaylist")
+  impressions      ContentImpression[]
 
   @@index([organizationId])
   @@index([organizationId, updatedAt])
@@ -261,14 +262,14 @@ model Playlist {
 model PlaylistItem {
   id        String   @id @default(cuid())
   order     Int      @default(0)
-  duration  Int?     // Override content duration if needed
+  duration  Int? // Override content duration if needed
   createdAt DateTime @default(now())
 
   playlistId String
   playlist   Playlist @relation(fields: [playlistId], references: [id], onDelete: Cascade)
 
-  contentId  String
-  content    Content @relation(fields: [contentId], references: [id], onDelete: Cascade)
+  contentId String
+  content   Content @relation(fields: [contentId], references: [id], onDelete: Cascade)
 
   @@unique([playlistId, order])
   @@index([playlistId])
@@ -280,15 +281,15 @@ model PlaylistItem {
 // ============================================================================
 
 model ContentImpression {
-  id                   String    @id @default(cuid())
+  id                   String   @id @default(cuid())
   organizationId       String
   contentId            String
   displayId            String
   playlistId           String?
   duration             Int?
   completionPercentage Int?
-  timestamp            DateTime  @default(now())
-  date                 DateTime  @db.Date
+  timestamp            DateTime @default(now())
+  date                 DateTime @db.Date
   hour                 Int
 
   organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
@@ -307,18 +308,18 @@ model ContentImpression {
 // ============================================================================
 
 model Schedule {
-  id          String   @id @default(cuid())
+  id          String    @id @default(cuid())
   name        String
   description String?
   startDate   DateTime
   endDate     DateTime?
-  startTime   Int?     // Minutes from midnight (0-1439)
-  endTime     Int?     // Minutes from midnight (0-1439)
-  daysOfWeek  Int[]    // 0-6 (Sunday-Saturday)
-  priority    Int      @default(0)
-  isActive    Boolean  @default(true)
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  startTime   Int? // Minutes from midnight (0-1439)
+  endTime     Int? // Minutes from midnight (0-1439)
+  daysOfWeek  Int[] // 0-6 (Sunday-Saturday)
+  priority    Int       @default(0)
+  isActive    Boolean   @default(true)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
 
   organizationId String
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
@@ -326,8 +327,8 @@ model Schedule {
   playlistId String
   playlist   Playlist @relation(fields: [playlistId], references: [id], onDelete: Cascade)
 
-  displayId      String?
-  display        Display? @relation(fields: [displayId], references: [id], onDelete: Cascade)
+  displayId String?
+  display   Display? @relation(fields: [displayId], references: [id], onDelete: Cascade)
 
   displayGroupId String?
   displayGroup   DisplayGroup? @relation(fields: [displayGroupId], references: [id], onDelete: Cascade)
@@ -356,8 +357,8 @@ model Tag {
   organizationId String
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
-  content   ContentTag[]
-  displays  DisplayTag[]
+  content  ContentTag[]
+  displays DisplayTag[]
 
   @@unique([organizationId, name])
   @@index([organizationId])
@@ -370,8 +371,8 @@ model ContentTag {
   contentId String
   content   Content @relation(fields: [contentId], references: [id], onDelete: Cascade)
 
-  tagId     String
-  tag       Tag @relation(fields: [tagId], references: [id], onDelete: Cascade)
+  tagId String
+  tag   Tag    @relation(fields: [tagId], references: [id], onDelete: Cascade)
 
   @@unique([contentId, tagId])
   @@index([contentId])
@@ -385,8 +386,8 @@ model DisplayTag {
   displayId String
   display   Display @relation(fields: [displayId], references: [id], onDelete: Cascade)
 
-  tagId     String
-  tag       Tag @relation(fields: [tagId], references: [id], onDelete: Cascade)
+  tagId String
+  tag   Tag    @relation(fields: [tagId], references: [id], onDelete: Cascade)
 
   @@unique([displayId, tagId])
   @@index([displayId])
@@ -398,23 +399,23 @@ model DisplayTag {
 // ============================================================================
 
 model AuditLog {
-  id          String   @id @default(cuid())
-  action      String   // create, update, delete, etc.
-  entityType  String   // display, content, schedule, etc.
-  entityId    String
-  changes     Json?    @db.JsonB
-  ipAddress   String?
-  userAgent   String?
-  createdAt   DateTime @default(now())
+  id         String   @id @default(cuid())
+  action     String // create, update, delete, etc.
+  entityType String // display, content, schedule, etc.
+  entityId   String
+  changes    Json?    @db.JsonB
+  ipAddress  String?
+  userAgent  String?
+  createdAt  DateTime @default(now())
 
-  userId         String?
-  user           User? @relation(fields: [userId], references: [id], onDelete: SetNull)
+  userId String?
+  user   User?   @relation(fields: [userId], references: [id], onDelete: SetNull)
 
   organizationId String
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
-  displayId      String?
-  display        Display? @relation(fields: [displayId], references: [id], onDelete: SetNull)
+  displayId String?
+  display   Display? @relation(fields: [displayId], references: [id], onDelete: SetNull)
 
   @@index([organizationId])
   @@index([userId])
@@ -427,17 +428,17 @@ model AuditLog {
 // ============================================================================
 
 model ContentFolder {
-  id             String   @id @default(cuid())
+  id             String          @id @default(cuid())
   name           String
   parentId       String?
   parent         ContentFolder?  @relation("FolderHierarchy", fields: [parentId], references: [id], onDelete: SetNull)
   children       ContentFolder[] @relation("FolderHierarchy")
   organizationId String
-  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
+  organization   Organization    @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
 
-  content        Content[]
+  content Content[]
 
   @@unique([organizationId, name, parentId])
   @@index([organizationId])
@@ -450,20 +451,20 @@ model ContentFolder {
 // ============================================================================
 
 model Notification {
-  id             String    @id @default(cuid())
-  type           String    // device_offline, device_online, content_expired, system
+  id             String       @id @default(cuid())
+  type           String // device_offline, device_online, content_expired, system
   title          String
   message        String
-  severity       String    @default("info") // info, warning, critical
-  read           Boolean   @default(false)
+  severity       String       @default("info") // info, warning, critical
+  read           Boolean      @default(false)
   dismissedAt    DateTime?
-  metadata       Json?     @db.JsonB
+  metadata       Json?        @db.JsonB
   organizationId String
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   userId         String?
-  user           User?     @relation(fields: [userId], references: [id], onDelete: SetNull)
-  createdAt      DateTime  @default(now())
-  updatedAt      DateTime  @updatedAt
+  user           User?        @relation(fields: [userId], references: [id], onDelete: SetNull)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@index([organizationId, read])
   @@index([organizationId, createdAt])
@@ -476,21 +477,21 @@ model Notification {
 // ============================================================================
 
 model ApiKey {
-  id             String    @id @default(cuid())
-  name           String    // User-friendly name
-  prefix         String    // First 8 chars for identification (e.g., "vz_live_")
-  hashedKey      String    @unique // SHA-256 hash of full key
-  lastUsedAt     DateTime?
-  expiresAt      DateTime?
-  revokedAt      DateTime?
-  scopes         String[]  // ['read:content', 'write:playlists', etc.]
-  createdAt      DateTime  @default(now())
+  id         String    @id @default(cuid())
+  name       String // User-friendly name
+  prefix     String // First 8 chars for identification (e.g., "vz_live_")
+  hashedKey  String    @unique // SHA-256 hash of full key
+  lastUsedAt DateTime?
+  expiresAt  DateTime?
+  revokedAt  DateTime?
+  scopes     String[] // ['read:content', 'write:playlists', etc.]
+  createdAt  DateTime  @default(now())
 
   organizationId String
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
-  createdById    String?
-  createdBy      User?     @relation(fields: [createdById], references: [id], onDelete: SetNull)
+  createdById String?
+  createdBy   User?   @relation(fields: [createdById], references: [id], onDelete: SetNull)
 
   @@index([organizationId])
   @@index([prefix])
@@ -503,19 +504,19 @@ model ApiKey {
 // ============================================================================
 
 model BillingTransaction {
-  id                    String   @id @default(cuid())
+  id                    String       @id @default(cuid())
   organizationId        String
   organization          Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  provider              String   // 'stripe' | 'razorpay'
+  provider              String // 'stripe' | 'razorpay'
   providerTransactionId String
-  type                  String   // 'subscription', 'one_time', 'refund'
-  status                String   // 'pending', 'succeeded', 'failed'
-  amount                Int      // cents/paise
-  currency              String   // 'usd', 'inr'
+  type                  String // 'subscription', 'one_time', 'refund'
+  status                String // 'pending', 'succeeded', 'failed'
+  amount                Int // cents/paise
+  currency              String // 'usd', 'inr'
   description           String?
-  metadata              Json?    @db.JsonB
-  createdAt             DateTime @default(now())
-  updatedAt             DateTime @updatedAt
+  metadata              Json?        @db.JsonB
+  createdAt             DateTime     @default(now())
+  updatedAt             DateTime     @updatedAt
 
   @@unique([provider, providerTransactionId])
   @@index([organizationId])
@@ -528,42 +529,42 @@ model BillingTransaction {
 // ============================================================================
 
 model Plan {
-  id                     String   @id @default(cuid())
-  slug                   String   @unique  // 'free', 'basic', 'pro', 'enterprise'
-  name                   String
-  description            String?
+  id          String  @id @default(cuid())
+  slug        String  @unique // 'free', 'basic', 'pro', 'enterprise'
+  name        String
+  description String?
 
   // Quotas
-  screenQuota            Int      // -1 for unlimited
-  storageQuotaMb         Int      @default(5000)  // Storage limit in MB
-  apiRateLimit           Int      @default(1000)  // Requests per hour
+  screenQuota    Int // -1 for unlimited
+  storageQuotaMb Int @default(5000) // Storage limit in MB
+  apiRateLimit   Int @default(1000) // Requests per hour
 
   // Pricing (cents/paise, -1 for custom)
-  priceUsdMonthly        Int
-  priceUsdYearly         Int
-  priceInrMonthly        Int
-  priceInrYearly         Int
+  priceUsdMonthly Int
+  priceUsdYearly  Int
+  priceInrMonthly Int
+  priceInrYearly  Int
 
   // Payment provider IDs
-  stripePriceIdMonthly   String?
-  stripePriceIdYearly    String?
-  razorpayPlanIdMonthly  String?
-  razorpayPlanIdYearly   String?
+  stripePriceIdMonthly  String?
+  stripePriceIdYearly   String?
+  razorpayPlanIdMonthly String?
+  razorpayPlanIdYearly  String?
 
   // Features
-  features               String[]  // ['analytics', 'api_access', 'priority_support']
-  featureFlags           Json?     @db.JsonB  // Detailed feature config
+  features     String[] // ['analytics', 'api_access', 'priority_support']
+  featureFlags Json?    @db.JsonB // Detailed feature config
 
   // Display
-  isActive               Boolean   @default(true)
-  isPublic               Boolean   @default(true)  // Show on pricing page
-  sortOrder              Int       @default(0)
-  highlightText          String?   // "Most Popular", "Best Value"
+  isActive      Boolean @default(true)
+  isPublic      Boolean @default(true) // Show on pricing page
+  sortOrder     Int     @default(0)
+  highlightText String? // "Most Popular", "Best Value"
 
-  createdAt              DateTime  @default(now())
-  updatedAt              DateTime  @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-  promotions             PlanPromotion[]
+  promotions PlanPromotion[]
 
   @@index([isActive, isPublic])
   @@index([slug])
@@ -575,36 +576,36 @@ model Plan {
 // ============================================================================
 
 model Promotion {
-  id                   String    @id @default(cuid())
-  code                 String    @unique  // 'LAUNCH50', 'DIWALI2026'
-  name                 String
-  description          String?
+  id          String  @id @default(cuid())
+  code        String  @unique // 'LAUNCH50', 'DIWALI2026'
+  name        String
+  description String?
 
   // Discount configuration
-  discountType         String    // 'percentage' | 'fixed_amount' | 'free_months'
-  discountValue        Int       // 50 for 50%, or cents/paise, or months
-  currency             String?   // null for percentage, 'usd'/'inr' for fixed
+  discountType  String // 'percentage' | 'fixed_amount' | 'free_months'
+  discountValue Int // 50 for 50%, or cents/paise, or months
+  currency      String? // null for percentage, 'usd'/'inr' for fixed
 
   // Limits
-  maxRedemptions       Int?      // null for unlimited
-  maxPerCustomer       Int       @default(1)
-  currentRedemptions   Int       @default(0)
-  minPurchaseAmount    Int?      // Minimum cart value
+  maxRedemptions     Int? // null for unlimited
+  maxPerCustomer     Int  @default(1)
+  currentRedemptions Int  @default(0)
+  minPurchaseAmount  Int? // Minimum cart value
 
   // Validity
-  startsAt             DateTime
-  expiresAt            DateTime?
-  isActive             Boolean   @default(true)
+  startsAt  DateTime
+  expiresAt DateTime?
+  isActive  Boolean   @default(true)
 
   // Tracking
-  createdBy            String?   // Admin user ID
-  metadata             Json?     @db.JsonB  // Campaign tracking, UTM, etc.
+  createdBy String? // Admin user ID
+  metadata  Json?   @db.JsonB // Campaign tracking, UTM, etc.
 
-  createdAt            DateTime  @default(now())
-  updatedAt            DateTime  @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-  applicablePlans      PlanPromotion[]
-  redemptions          PromotionRedemption[]
+  applicablePlans PlanPromotion[]
+  redemptions     PromotionRedemption[]
 
   @@index([code])
   @@index([isActive, startsAt, expiresAt])
@@ -612,24 +613,24 @@ model Promotion {
 }
 
 model PlanPromotion {
-  id           String    @id @default(cuid())
-  planId       String
-  plan         Plan      @relation(fields: [planId], references: [id], onDelete: Cascade)
-  promotionId  String
-  promotion    Promotion @relation(fields: [promotionId], references: [id], onDelete: Cascade)
+  id          String    @id @default(cuid())
+  planId      String
+  plan        Plan      @relation(fields: [planId], references: [id], onDelete: Cascade)
+  promotionId String
+  promotion   Promotion @relation(fields: [promotionId], references: [id], onDelete: Cascade)
 
   @@unique([planId, promotionId])
   @@map("plan_promotions")
 }
 
 model PromotionRedemption {
-  id              String    @id @default(cuid())
+  id              String       @id @default(cuid())
   promotionId     String
-  promotion       Promotion @relation(fields: [promotionId], references: [id], onDelete: Cascade)
+  promotion       Promotion    @relation(fields: [promotionId], references: [id], onDelete: Cascade)
   organizationId  String
   organization    Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  discountApplied Int       // Actual discount in cents/paise
-  redeemedAt      DateTime  @default(now())
+  discountApplied Int // Actual discount in cents/paise
+  redeemedAt      DateTime     @default(now())
 
   @@index([promotionId])
   @@index([organizationId])
@@ -644,12 +645,12 @@ model SystemConfig {
   id          String   @id @default(cuid())
   key         String   @unique
   value       Json     @db.JsonB
-  dataType    String   @default("string")  // string, number, boolean, json
+  dataType    String   @default("string") // string, number, boolean, json
   category    String   @default("general") // general, security, limits, features
   description String?
-  isSecret    Boolean  @default(false)  // Hide value in UI
+  isSecret    Boolean  @default(false) // Hide value in UI
   updatedAt   DateTime @updatedAt
-  updatedBy   String?  // Admin user ID
+  updatedBy   String? // Admin user ID
 
   @@index([category])
   @@map("system_configs")
@@ -660,15 +661,15 @@ model SystemConfig {
 // ============================================================================
 
 model AdminAuditLog {
-  id             String   @id @default(cuid())
-  adminUserId    String
-  action         String   // 'plan.create', 'org.suspend', 'user.impersonate'
-  targetType     String?  // 'organization', 'user', 'plan', 'promotion'
-  targetId       String?
-  details        Json?    @db.JsonB  // Action-specific details
-  ipAddress      String?
-  userAgent      String?
-  createdAt      DateTime @default(now())
+  id          String   @id @default(cuid())
+  adminUserId String
+  action      String // 'plan.create', 'org.suspend', 'user.impersonate'
+  targetType  String? // 'organization', 'user', 'plan', 'promotion'
+  targetId    String?
+  details     Json?    @db.JsonB // Action-specific details
+  ipAddress   String?
+  userAgent   String?
+  createdAt   DateTime @default(now())
 
   @@index([adminUserId])
   @@index([action])
@@ -685,9 +686,9 @@ model SystemAnnouncement {
   id             String    @id @default(cuid())
   title          String
   message        String    @db.Text
-  type           String    @default("info")  // info, warning, critical, maintenance
-  targetAudience String    @default("all")   // all, admins, specific_plans
-  targetPlans    String[]  // If targetAudience is specific_plans
+  type           String    @default("info") // info, warning, critical, maintenance
+  targetAudience String    @default("all") // all, admins, specific_plans
+  targetPlans    String[] // If targetAudience is specific_plans
   startsAt       DateTime
   expiresAt      DateTime?
   isActive       Boolean   @default(true)
@@ -707,13 +708,13 @@ model SystemAnnouncement {
 // ============================================================================
 
 model IpBlocklist {
-  id          String    @id @default(cuid())
-  ipAddress   String    // Can be single IP or CIDR range
-  reason      String?
-  blockedBy   String?   // Admin user ID
-  expiresAt   DateTime?
-  isActive    Boolean   @default(true)
-  createdAt   DateTime  @default(now())
+  id        String    @id @default(cuid())
+  ipAddress String // Can be single IP or CIDR range
+  reason    String?
+  blockedBy String? // Admin user ID
+  expiresAt DateTime?
+  isActive  Boolean   @default(true)
+  createdAt DateTime  @default(now())
 
   @@unique([ipAddress])
   @@index([isActive])
@@ -725,35 +726,35 @@ model IpBlocklist {
 // ============================================================================
 
 model SupportRequest {
-  id               String    @id @default(uuid())
-  organizationId   String
-  userId           String
+  id             String @id @default(uuid())
+  organizationId String
+  userId         String
 
-  category         String    // bug_report, feature_request, help_question, template_request, feedback, urgent_issue, account_issue
-  priority         String    @default("medium") // critical, high, medium, low
-  status           String    @default("open")   // open, in_progress, resolved, closed, wont_fix
+  category String // bug_report, feature_request, help_question, template_request, feedback, urgent_issue, account_issue
+  priority String @default("medium") // critical, high, medium, low
+  status   String @default("open") // open, in_progress, resolved, closed, wont_fix
 
-  title            String?   @db.VarChar(255)
-  description      String
-  aiSummary        String?
+  title             String? @db.VarChar(255)
+  description       String
+  aiSummary         String?
   aiSuggestedAction String?
-  aiCategory       String?   // TicketCategoryV2 slug — see docs/hermes/ticket-categories-2026-04-24.md
+  aiCategory        String? // TicketCategoryV2 slug — see docs/hermes/ticket-categories-2026-04-24.md
 
-  pageUrl          String?   @db.VarChar(500)
-  browserInfo      String?   @db.VarChar(255)
-  consoleErrors    String?
+  pageUrl       String? @db.VarChar(500)
+  browserInfo   String? @db.VarChar(255)
+  consoleErrors String?
 
-  resolutionNotes  String?
-  resolvedById     String?
-  resolvedAt       DateTime?
+  resolutionNotes String?
+  resolvedById    String?
+  resolvedAt      DateTime?
 
-  createdAt        DateTime  @default(now())
-  updatedAt        DateTime  @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-  organization     Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  user             User         @relation("SupportRequestUser", fields: [userId], references: [id], onDelete: Cascade)
-  resolvedBy       User?        @relation("SupportRequestResolver", fields: [resolvedById], references: [id], onDelete: SetNull)
-  messages         SupportMessage[]
+  organization Organization     @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  user         User             @relation("SupportRequestUser", fields: [userId], references: [id], onDelete: Cascade)
+  resolvedBy   User?            @relation("SupportRequestResolver", fields: [resolvedById], references: [id], onDelete: SetNull)
+  messages     SupportMessage[]
 
   @@index([organizationId])
   @@index([status])
@@ -765,19 +766,19 @@ model SupportRequest {
 }
 
 model SupportMessage {
-  id               String    @id @default(uuid())
-  requestId        String
-  organizationId   String
-  userId           String
+  id             String @id @default(uuid())
+  requestId      String
+  organizationId String
+  userId         String
 
-  role             String    // 'user', 'assistant', 'admin' — conversation role
-  authorType       String    @default("user") // 'user' | 'admin' | 'agent' — source (agent = automation)
-  content          String
+  role       String // 'user', 'assistant', 'admin' — conversation role
+  authorType String @default("user") // 'user' | 'admin' | 'agent' — source (agent = automation)
+  content    String
 
-  createdAt        DateTime  @default(now())
+  createdAt DateTime @default(now())
 
-  request          SupportRequest @relation(fields: [requestId], references: [id], onDelete: Cascade)
-  organization     Organization   @relation("OrgSupportMessages", fields: [organizationId], references: [id], onDelete: Cascade)
+  request      SupportRequest @relation(fields: [requestId], references: [id], onDelete: Cascade)
+  organization Organization   @relation("OrgSupportMessages", fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@index([requestId])
   @@index([organizationId])
@@ -790,44 +791,44 @@ model SupportMessage {
 // ============================================================================
 
 model OrganizationOnboarding {
-  id                        String   @id @default(cuid())
-  organizationId            String   @unique
-  organization              Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  id             String       @id @default(cuid())
+  organizationId String       @unique
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
-  welcomeEmailSentAt        DateTime?
-  firstScreenPairedAt       DateTime?
-  firstContentUploadedAt    DateTime?
-  firstPlaylistCreatedAt    DateTime?
-  firstScheduleCreatedAt    DateTime?
+  welcomeEmailSentAt     DateTime?
+  firstScreenPairedAt    DateTime?
+  firstContentUploadedAt DateTime?
+  firstPlaylistCreatedAt DateTime?
+  firstScheduleCreatedAt DateTime?
 
-  day1NudgeSentAt           DateTime?
-  day3NudgeSentAt           DateTime?
-  day7NudgeSentAt           DateTime?
+  day1NudgeSentAt DateTime?
+  day3NudgeSentAt DateTime?
+  day7NudgeSentAt DateTime?
 
-  completedAt               DateTime?
-  createdAt                 DateTime @default(now())
-  updatedAt                 DateTime @updatedAt
+  completedAt DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
 
   @@map("organization_onboarding")
 }
 
 model CustomerIncident {
-  id              String   @id @default(cuid())
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  id             String       @id @default(cuid())
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
-  agent           String   // e.g. 'screen-health-customer', 'billing-revenue'
-  type            String   // e.g. 'cluster-offline', 'failed-payment-retry-exhausted'
-  severity        String   // 'critical' | 'warning' | 'info'
-  target          String
-  targetId        String
-  message         String   @db.Text
-  remediation     String?  @db.Text
+  agent       String // e.g. 'screen-health-customer', 'billing-revenue'
+  type        String // e.g. 'cluster-offline', 'failed-payment-retry-exhausted'
+  severity    String // 'critical' | 'warning' | 'info'
+  target      String
+  targetId    String
+  message     String  @db.Text
+  remediation String? @db.Text
 
-  status          String   @default("open") // 'open' | 'resolved' | 'escalated'
-  detectedAt      DateTime @default(now())
-  resolvedAt      DateTime?
-  notifiedAt      DateTime?
+  status     String    @default("open") // 'open' | 'resolved' | 'escalated'
+  detectedAt DateTime  @default(now())
+  resolvedAt DateTime?
+  notifiedAt DateTime?
 
   @@index([organizationId, status])
   @@index([agent, type])
@@ -835,21 +836,82 @@ model CustomerIncident {
 }
 
 model ContentRecommendation {
-  id              String   @id @default(cuid())
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  id             String       @id @default(cuid())
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
-  kind            String   // 'time-of-day' | 'underperforming' | 'rotation-frequency'
-  contentId       String?
-  playlistId      String?
+  kind       String // 'time-of-day' | 'underperforming' | 'rotation-frequency'
+  contentId  String?
+  playlistId String?
 
-  summary         String   @db.Text
-  details         Json
-  confidence      Float
+  summary    String @db.Text
+  details    Json
+  confidence Float
 
-  createdAt       DateTime @default(now())
-  dismissedAt     DateTime?
+  createdAt   DateTime  @default(now())
+  dismissedAt DateTime?
 
   @@index([organizationId, createdAt])
   @@map("content_recommendations")
+}
+
+// ============================================================================
+// MCP Server (Model Context Protocol) — read-only tool surface for agents
+// ============================================================================
+
+model McpToken {
+  id             String       @id @default(cuid())
+  // SHA-256 hex of the bearer token. Plaintext is shown to admin once at
+  // issuance and never persisted. Lookup compares hashes — never compare
+  // plaintext to plaintext.
+  tokenHash      String       @unique
+  // Human-readable label (e.g. "support-triage prod 2026-Q2"). Free-form.
+  name           String
+  // Scope: which org's data this token can read.
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  // Which agent the token was issued for — used in audit attribution.
+  agentName      String
+  // Tool-scope strings (e.g. ["displays:read", "content:read"]).
+  scopes         String[]
+  createdAt      DateTime     @default(now())
+  // Nullable = no expiry. Recommend setting one (max 90d) for admin-issued tokens.
+  expiresAt      DateTime?
+  // Set when revoked. Null = active.
+  revokedAt      DateTime?
+  // Updated each successful auth. Useful for "when did this token last work."
+  lastUsedAt     DateTime?
+
+  auditEntries McpAuditLog[]
+
+  @@index([organizationId])
+  @@index([agentName])
+  @@map("mcp_tokens")
+}
+
+model McpAuditLog {
+  id             String    @id @default(cuid())
+  // FK to the token used. Null if the call failed auth (no valid token).
+  tokenId        String?
+  token          McpToken? @relation(fields: [tokenId], references: [id], onDelete: SetNull)
+  // Denormalized for queryability when the token is later deleted.
+  agentName      String
+  organizationId String?
+  // Tool name (e.g. "list_displays"). Null if request failed before tool dispatch.
+  tool           String?
+  // Redacted input arguments (secrets stripped per AgentStateService's
+  // FORBIDDEN_KEY_REGEX precedent). JSON for queryability.
+  paramsRedacted Json?     @db.JsonB
+  // 'success' | 'error'
+  status         String
+  // Wire-level MCP error code if status='error'. e.g. NOT_FOUND, INVALID_INPUT.
+  errorCode      String?
+  // Time spent inside the tool handler.
+  latencyMs      Int
+  createdAt      DateTime  @default(now())
+
+  @@index([tokenId, createdAt])
+  @@index([agentName, createdAt])
+  @@index([organizationId, createdAt])
+  @@map("mcp_audit_log")
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,9 @@ importers:
 
   middleware:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@3.25.76)
       '@nestjs/axios':
         specifier: ^4.0.0
         version: 4.0.1(@nestjs/common@11.1.12(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(axios@1.13.6)(rxjs@7.8.2)
@@ -677,7 +680,7 @@ importers:
         version: 10.1.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
+        version: 29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -689,7 +692,7 @@ importers:
         version: 3.4.19(tsx@4.21.0)(yaml@2.8.2)
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(jest-util@30.2.0)(jest@29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(jest-util@30.2.0)(jest@29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -1896,6 +1899,12 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -2412,6 +2421,16 @@ packages:
 
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@module-federation/bridge-react-webpack-plugin@0.21.6':
     resolution: {integrity: sha512-lJMmdhD4VKVkeg8RHb+Jwe6Ou9zKVgjtb1inEURDG/sSS2ksdZA8pVKLYbRPRbdmjr193Y8gJfqFbI2dqoyc/g==}
@@ -6545,6 +6564,14 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -6572,6 +6599,12 @@ packages:
   expect@30.2.0:
     resolution: {integrity: sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  express-rate-limit@8.4.1:
+    resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
 
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
@@ -7049,6 +7082,10 @@ packages:
   homedir-polyfill@1.0.3:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
+
+  hono@4.12.16:
+    resolution: {integrity: sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==}
+    engines: {node: '>=16.9.0'}
 
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
@@ -7736,6 +7773,9 @@ packages:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -7790,6 +7830,9 @@ packages:
 
   json-schema-typed@7.0.3:
     resolution: {integrity: sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -8826,6 +8869,10 @@ packages:
 
   piscina@4.9.2:
     resolution: {integrity: sha512-Fq0FERJWFEUpB4eSY59wSNwXD4RYqR+nR/WiEVcZW8IWfVBxJJafcgTEZDQo8k3w0sUarJ8RyVbbUF4GQ2LGbQ==}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
@@ -11073,6 +11120,11 @@ packages:
     resolution: {integrity: sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==}
     engines: {node: '>= 10'}
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -12411,6 +12463,10 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
+  '@hono/node-server@1.19.14(hono@4.12.16)':
+    dependencies:
+      hono: 4.12.16
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -13158,6 +13214,28 @@ snapshots:
   '@marijn/find-cluster-break@1.0.2': {}
 
   '@microsoft/tsdoc@0.16.0': {}
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.16)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.4.1(express@5.2.1)
+      hono: 4.12.16
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@module-federation/bridge-react-webpack-plugin@0.21.6':
     dependencies:
@@ -18166,6 +18244,12 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -18205,6 +18289,11 @@ snapshots:
       jest-message-util: 30.2.0
       jest-mock: 30.2.0
       jest-util: 30.2.0
+
+  express-rate-limit@8.4.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
 
   express@4.22.1:
     dependencies:
@@ -18822,6 +18911,8 @@ snapshots:
   homedir-polyfill@1.0.3:
     dependencies:
       parse-passwd: 1.0.0
+
+  hono@4.12.16: {}
 
   hosted-git-info@4.1.0:
     dependencies:
@@ -20112,6 +20203,8 @@ snapshots:
 
   jiti@2.4.2: {}
 
+  jose@6.2.3: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.2:
@@ -20200,6 +20293,8 @@ snapshots:
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@7.0.3: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -21215,6 +21310,8 @@ snapshots:
   piscina@4.9.2:
     optionalDependencies:
       '@napi-rs/nice': 1.1.1
+
+  pkce-challenge@5.0.1: {}
 
   pkg-dir@4.2.0:
     dependencies:
@@ -23798,6 +23895,10 @@ snapshots:
       archiver-utils: 3.0.4
       compress-commons: 4.1.2
       readable-stream: 3.6.2
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
PR-A of the staged Vizora MCP server build (per `docs/agents-mcp-server-design.md` and the discussion thread on PR #37). Foundation + ONE tool end-to-end so the loop is proven; remaining 12 tools are PR-B; Hermes-side client + first agent migration is PR-C.

## What this PR delivers

**Module layout (new):** `middleware/src/modules/mcp/`

- `mcp.module.ts` — wires controllers / services / guards / providers into `AppModule`
- `mcp.controller.ts` — `POST/GET /api/v1/mcp` + `POST /api/v1/mcp/close`. Each method `@SkipEnvelope()`. Per-request `StreamableHTTPServerTransport` (stateless mode), passes NestJS's pre-parsed body straight through (`transport.handleRequest(req, res, req.body)` per the SDK example — avoids the double-parse foot-gun).
- `mcp.service.ts` — singleton `McpServer` (SDK), tool registration in `onModuleInit`. Each registered tool wraps the handler with the audit + error-mapping pattern; consistent across tools.
- `auth/mcp-token.service.ts` — issue/validate/revoke. **Plaintext bearer shown ONCE on issue and never persisted** — DB stores `tokenHash` (sha256 hex), lookup compares hashes. Cap on TTL (`MCP_TOKEN_TTL_DAYS`, default 90). Rejects non-`:read` scopes (v1 is read-only).
- `auth/mcp-auth.guard.ts` — bearer extraction + validation. Generic `UnauthorizedException` message on every failure (no info-leak about WHY).
- `auth/mcp-rate-limit.guard.ts` — per-token in-memory bucket. Documented cluster caveat (~2× effective limit in PM2 cluster). Defense-in-depth: throws if `McpAuthGuard` didn't run first.
- `auth/mcp-context.ts` — `McpContext` decorator + `MCP_CONTEXT_KEY` for ferrying the per-request token context.
- `audit/mcp-audit.service.ts` — append-only Prisma write per tool call. Best-effort (logs and swallows on failure). Inputs redacted via the same anchored regex `AgentStateService` uses.
- `lib/redact.ts` — extracted `FORBIDDEN_KEY_REGEX` from `AgentStateService` so the MCP audit applies the exact same secret/PII policy.
- `lib/error-mapping.ts` — NestJS exceptions → MCP error codes. Critically: `NotFoundException → NOT_FOUND` (not `INVALID_INPUT`). Distinct codes are agent-actionable signals.
- `schemas/tool-inputs.ts` + `tool-outputs.ts` — Zod schemas. Output uses snake_case for the wire (MCP convention) regardless of internal camelCase.
- `tools/displays.tools.ts` — `list_displays` tool (read-only, scope `displays:read`, paginated, optional status filter). Wraps `DisplaysService.findAll`. **No new business logic** in `mcp/`.
- `admin/mcp-tokens.controller.ts` — `POST/GET/DELETE /api/v1/admin/mcp-tokens`. `JwtAuthGuard + SuperAdminGuard`. Plaintext bearer returned ONCE on POST.

**Schema migration:** `packages/database/prisma/migrations/20260504000000_add_mcp_token_and_audit_log/`

- `mcp_tokens` — `id, tokenHash UNIQUE, name, organizationId FK, agentName, scopes TEXT[], createdAt, expiresAt?, revokedAt?, lastUsedAt?`. Indexed on `organizationId` and `agentName`.
- `mcp_audit_log` — `id, tokenId FK SET NULL, agentName, organizationId?, tool?, paramsRedacted JSONB, status, errorCode?, latencyMs, createdAt`. Composite indexes for the common queries `(tokenId, createdAt)`, `(agentName, createdAt)`, `(organizationId, createdAt)`.
- All required columns committed in this initial migration (per the lock-down — adding columns later is a migration, getting them now is free).

**Wiring:**

- `app.module.ts` — `McpModule` added.
- `csrf.middleware.ts` — `/api/v1/mcp` tree exempted (bearer auth, no cookie surface).
- `.env.example` — `MCP_TOKEN_TTL_DAYS`, `MCP_RATE_LIMIT_PER_MIN`, `MCP_RATE_LIMIT_PER_DAY`.
- `CLAUDE.md` — new "MCP Server" section + module added to Project Structure + env vars in the consolidated env-vars block.

**Tests (6 spec files, 63 new tests):**

- `lib/redact.spec.ts` (10 tests) — anchored regex behavior, recursive redaction, primitives untouched, case-insensitive matching.
- `lib/error-mapping.spec.ts` (8 tests) — every exception → expected code, including the `NotFoundException → NOT_FOUND` regression test, and `5xx HttpException → INTERNAL` strips the message.
- `auth/mcp-token.service.spec.ts` (12 tests) — issuance returns plaintext + record (no hash field), persisted row contains sha256, rejects non-read scopes, rejects empty scopes, caps TTL, validate returns null on revoked / expired / unknown / malformed bearers.
- `auth/mcp-rate-limit.guard.spec.ts` (4 tests) — first call passes, throws after limit, distinct tokens have independent buckets, defense-in-depth fails closed without `mcpContext`.
- `auth/mcp-auth.guard.spec.ts` (4 tests) — missing/non-Bearer header rejected, generic message on failure (no info leak), context attached to request on success.
- `tools/displays.tools.spec.ts` (5 tests) — scope check throws Forbidden, snake_case wire shape, client-side status filter, Zod rejects out-of-range limit, calling token's org is enforced (not user-controlled), Date → ISO serialization.

## Verification

- `npx jest --testPathPattern=modules/mcp` → **63/63 pass**
- `npx jest` (full middleware suite) → **2170/2170 pass, 110/110 suites** — zero regressions
- `npx nx build @vizora/middleware` → clean build (8 pre-existing webpack warnings, none new)
- Migration SQL hand-written (Docker Desktop unavailable in this dev env to auto-generate via `prisma migrate dev`). Schema matches the Prisma models. Reviewer can apply via `npx prisma migrate deploy` on prod or any env with Postgres up.

## Lock-downs from PR #37 review thread — all honored

| # | Lock-down | Where |
|---|---|---|
| 1 | StreamableHTTPServerTransport, raw body delegated (pre-parsed body OK) | `mcp.controller.ts:handle()` |
| 2 | Token storage = sha256 hash; full column set in initial migration | `mcp-token.service.ts:hash()`, `migration.sql` |
| 3 | Per-token rate limit | `mcp-rate-limit.guard.ts` |
| 4 | Audit destination = Prisma table | `mcp_audit_log`, `mcp-audit.service.ts` |
| 5 | `@SkipEnvelope()` on every endpoint | `mcp.controller.ts` |

Plus: CSRF middleware exempts `/api/v1/mcp` tree (the additional middleware-exemption call-out from the PR #37 review).

## Out of scope (deliberate — punted to PR-B and PR-C)

- Remaining 12 tools (display detail, content, playlists, schedules, organizations, audit) — patterns established here, fast follow.
- Hermes-side `vizora_mcp_client.py` and the first agent migration (`support-triage`).
- Redis-backed rate limit (in-memory v1 documented cluster caveat — Phase 2 if it bites).
- Write tools — v1 is strictly read-only by design (token service rejects non-`:read` scopes at issuance).
- E2E test that wires the full HTTP path through a real MCP client — covered by per-layer unit + integration tests for now; full e2e arrives with PR-B.

## Test plan

- [ ] `cd middleware && npx jest --testPathPattern=modules/mcp` → 63 pass
- [ ] `cd middleware && npx jest` → 2170 pass, no new failures
- [ ] Apply migration on a test DB: `cd packages/database && npx prisma migrate deploy`
- [ ] Smoke test by hand: start middleware → issue a token via `POST /api/v1/admin/mcp-tokens` (super-admin JWT required) → use the bearer to call `POST /api/v1/mcp` with an MCP `tools/call` for `list_displays`
- [ ] Verify `mcp_audit_log` row written with `paramsRedacted` actually redacted (try a param with key `password`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
