### PR TITLE
fix(mcp): controller paths must NOT include the global prefix (prod 404)

### DIFF
--- a/middleware/src/modules/mcp/admin/mcp-tokens.controller.ts
+++ b/middleware/src/modules/mcp/admin/mcp-tokens.controller.ts
@@ -26,7 +26,10 @@ import { McpTokenService } from '../auth/mcp-token.service';
  * recoverable. Admin must copy it immediately.
  */
 @ApiTags('admin', 'mcp')
-@Controller('api/v1/admin/mcp-tokens')
+// NB: global prefix `api/v1` is auto-prepended by NestJS. The path
+// here is `admin/mcp-tokens` — NOT `api/v1/admin/mcp-tokens` (which
+// would resolve to /api/v1/api/v1/admin/mcp-tokens).
+@Controller('admin/mcp-tokens')
 @UseGuards(JwtAuthGuard, SuperAdminGuard)
 @ApiBearerAuth()
 export class McpTokensAdminController {

--- a/middleware/src/modules/mcp/mcp-controller-paths.spec.ts
+++ b/middleware/src/modules/mcp/mcp-controller-paths.spec.ts
@@ -1,0 +1,27 @@
+import { PATH_METADATA } from '@nestjs/common/constants';
+import { McpController } from './mcp.controller';
+import { McpTokensAdminController } from './admin/mcp-tokens.controller';
+
+/**
+ * Regression: NestJS prepends the global prefix (`api/v1`) at bootstrap
+ * (see middleware/src/main.ts). If a controller's @Controller() path
+ * also includes `api/v1/`, the route resolves to `/api/v1/api/v1/...`
+ * and silently 404s in production. Unit tests on the controller's
+ * methods don't catch this — they don't go through routing.
+ *
+ * These assertions pin the path strings so a future hand-edit that
+ * accidentally re-introduces the prefix fails CI before deploy.
+ */
+describe('MCP controller route paths (regression: no double-prefix)', () => {
+  it('McpController is mounted at "mcp" — global prefix gives /api/v1/mcp', () => {
+    const path = Reflect.getMetadata(PATH_METADATA, McpController);
+    expect(path).toBe('mcp');
+    expect(path).not.toMatch(/^api\/v1\//);
+  });
+
+  it('McpTokensAdminController is mounted at "admin/mcp-tokens" — global prefix gives /api/v1/admin/mcp-tokens', () => {
+    const path = Reflect.getMetadata(PATH_METADATA, McpTokensAdminController);
+    expect(path).toBe('admin/mcp-tokens');
+    expect(path).not.toMatch(/^api\/v1\//);
+  });
+});

--- a/middleware/src/modules/mcp/mcp.controller.ts
+++ b/middleware/src/modules/mcp/mcp.controller.ts
@@ -40,7 +40,10 @@ import { McpService } from './mcp.service';
  * Express-based frameworks.
  */
 @ApiTags('mcp')
-@Controller('api/v1/mcp')
+// NB: NestJS prepends the global prefix (`api/v1`) automatically — the
+// controller path is just `mcp`. Including `api/v1/` here would
+// double-prefix the route to `/api/v1/api/v1/mcp` and silently 404.
+@Controller('mcp')
 @UseGuards(McpAuthGuard, McpRateLimitGuard)
 @UseFilters(McpExceptionFilter)
 @SkipInputSanitize()


### PR DESCRIPTION
## Summary
PR #42 shipped both `McpController` and `McpTokensAdminController` with `@Controller('api/v1/mcp')` / `@Controller('api/v1/admin/mcp-tokens')`. NestJS auto-prepends the global prefix `api/v1` (main.ts:126), so the routes resolved to `/api/v1/api/v1/mcp` and `/api/v1/api/v1/admin/mcp-tokens` — both 404 in prod.

Caught by smoke-testing `POST https://vizora.cloud/api/v1/mcp` post-deploy. Returned NestJS's default Not Found envelope, confirming the route was never registered at the documented path.

## Why unit tests missed it
- Controller-method unit tests instantiate the controller directly and bypass routing.
- The supertest-based `endpoint-smoke.e2e.spec.ts` is gated behind `RUN_E2E_TESTS=true` and isn't part of the default lane.

## Fix
- Strip `api/v1/` from both controller paths (matches every other controller in the codebase, e.g. `@Controller('displays')`).
- Add `mcp-controller-paths.spec.ts` — reads `PATH_METADATA` via `Reflect.getMetadata` and asserts the literal paths. Catches regressions at the unit-test layer without booting the full app.

## Test plan
- [x] `npx jest --testPathPattern="mcp-controller-paths"` — 2/2 pass
- [x] `npx nx build @vizora/middleware` — clean
- [ ] After merge: redeploy + curl `POST /api/v1/mcp` (no auth) → expect 401 with MCP error envelope, not 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)