### PR TITLE
fix(mcp): mark McpController @Public() to bypass global JwtAuthGuard

### DIFF
--- a/middleware/src/modules/mcp/mcp-controller-paths.spec.ts
+++ b/middleware/src/modules/mcp/mcp-controller-paths.spec.ts
@@ -1,6 +1,7 @@
 import { PATH_METADATA } from '@nestjs/common/constants';
 import { McpController } from './mcp.controller';
 import { McpTokensAdminController } from './admin/mcp-tokens.controller';
+import { IS_PUBLIC_KEY } from '../auth/decorators/public.decorator';
 
 /**
  * Regression: NestJS prepends the global prefix (`api/v1`) at bootstrap
@@ -23,5 +24,22 @@ describe('MCP controller route paths (regression: no double-prefix)', () => {
     const path = Reflect.getMetadata(PATH_METADATA, McpTokensAdminController);
     expect(path).toBe('admin/mcp-tokens');
     expect(path).not.toMatch(/^api\/v1\//);
+  });
+
+  // Regression: AuthModule registers JwtAuthGuard as APP_GUARD globally.
+  // Without @Public() on McpController, the global guard intercepts the
+  // request, tries to parse `mcp_<token>` as a user JWT, fails, and
+  // throws a generic 401 — McpAuthGuard never runs and the precise
+  // "Invalid or expired MCP token" message never reaches the wire.
+  it('McpController is marked @Public() so the global JwtAuthGuard skips it (McpAuthGuard handles bearer auth instead)', () => {
+    const isPublic = Reflect.getMetadata(IS_PUBLIC_KEY, McpController);
+    expect(isPublic).toBe(true);
+  });
+
+  // The admin token-issuance endpoints use REAL user JWTs (super-admin
+  // session) — those routes MUST NOT be marked public.
+  it('McpTokensAdminController is NOT marked @Public() — super-admin endpoints require user-session JWT', () => {
+    const isPublic = Reflect.getMetadata(IS_PUBLIC_KEY, McpTokensAdminController);
+    expect(isPublic).toBeFalsy();
   });
 });

--- a/middleware/src/modules/mcp/mcp.controller.ts
+++ b/middleware/src/modules/mcp/mcp.controller.ts
@@ -12,6 +12,7 @@ import type { Request, Response } from 'express';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { SkipEnvelope } from '../common/interceptors/response-envelope.interceptor';
 import { SkipInputSanitize } from '../common/interceptors/sanitize.interceptor';
+import { Public } from '../auth/decorators/public.decorator';
 import { McpAuthGuard } from './auth/mcp-auth.guard';
 import {
   MCP_CONTEXT_KEY,
@@ -44,6 +45,15 @@ import { McpService } from './mcp.service';
 // controller path is just `mcp`. Including `api/v1/` here would
 // double-prefix the route to `/api/v1/api/v1/mcp` and silently 404.
 @Controller('mcp')
+// `@Public()` opts the controller out of the GLOBAL JwtAuthGuard
+// (auth.module.ts registers it as APP_GUARD). MCP uses bearer-token
+// auth via `mcp_<token>` — NOT user-session JWTs. Without this, the
+// global guard intercepts first, fails to validate the MCP bearer as
+// a JWT, and throws a generic UnauthorizedException — McpAuthGuard
+// never runs and the wire message reads "Unauthorized" instead of
+// the MCP-specific "Invalid or expired MCP token". Auth is still
+// enforced — McpAuthGuard runs at the controller level below.
+@Public()
 @UseGuards(McpAuthGuard, McpRateLimitGuard)
 @UseFilters(McpExceptionFilter)
 @SkipInputSanitize()


### PR DESCRIPTION
## Summary
After the route-prefix hotfix (#43), `POST /api/v1/mcp` returns **401** with the MCP wire shape — but the message is `"Unauthorized"` instead of the McpAuthGuard's `"Invalid or expired MCP token"`.

Caused by the global `JwtAuthGuard` registered as `APP_GUARD` in `auth.module.ts:44`. It runs before the controller-level `@UseGuards(McpAuthGuard, ...)`, fails to parse `mcp_<token>` as a JWT, and throws a default `UnauthorizedException`. McpAuthGuard never runs.

## Fix
- Decorate `McpController` with `@Public()` (existing opt-out marker that `JwtAuthGuard` already checks via Reflector).
- `McpTokensAdminController` is NOT marked `@Public()` — those endpoints issue/revoke MCP tokens and MUST stay guarded by the user-session JWT (super-admin only).

## Test plan
- [x] `mcp-controller-paths.spec.ts` extended: 4/4 pass (asserts `IS_PUBLIC_KEY` is `true` on McpController and falsy on McpTokensAdminController)
- [x] `npx nx build @vizora/middleware` clean
- [ ] After deploy: `curl POST /api/v1/mcp` (no auth) → expect `{"error":{"code":"UNAUTHORIZED","message":"Invalid or expired MCP token"}}` (NOT `"Unauthorized"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)