### PR TITLE
fix(mcp): build a fresh McpServer per request, not a singleton

### DIFF
--- a/middleware/src/modules/mcp/mcp.controller.ts
+++ b/middleware/src/modules/mcp/mcp.controller.ts
@@ -85,15 +85,23 @@ export class McpController {
   }
 
   /**
-   * Per-request transport (stateless mode). The auth-info object
-   * carries the per-request `mcpContext` into the SDK so tool
-   * handlers receive the right org / agent / scopes for THIS call.
+   * Per-request transport AND per-request McpServer (stateless mode).
+   * The SDK's `Server.connect()` is single-shot — reusing one server
+   * across requests throws "Already connected to a transport" on the
+   * second call (caught in prod by Hermes hitting `tools/list` after
+   * PR #42 went live). Building both fresh per request pairs their
+   * lifetimes 1:1 and lets GC clean up after `handleRequest` returns.
+   *
+   * The auth-info object carries the per-request `mcpContext` into
+   * the SDK so tool handlers receive the right org / agent / scopes
+   * for THIS call.
    */
   private async handle(req: Request, res: Response): Promise<void> {
+    const server = this.mcp.buildServer();
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined, // stateless
     });
-    await this.mcp.server.connect(transport);
+    await server.connect(transport);
 
     const context = (req as Request & Record<string, unknown>)[
       MCP_CONTEXT_KEY

--- a/middleware/src/modules/mcp/mcp.service.spec.ts
+++ b/middleware/src/modules/mcp/mcp.service.spec.ts
@@ -1,0 +1,48 @@
+import { McpService } from './mcp.service';
+
+/**
+ * Regression: PR #42 shipped a singleton `McpServer` field on McpService
+ * and the controller called `service.server.connect(transport)` per
+ * request. The SDK's `Server.connect()` is single-shot — every request
+ * after the first threw "Already connected to a transport". Caught
+ * end-to-end by Hermes hitting `tools/list` against prod.
+ *
+ * The fix: McpService exposes `buildServer()` which returns a NEW
+ * `McpServer` per call. These tests pin that contract. If a future
+ * refactor reintroduces the singleton, both assertions fail.
+ */
+describe('McpService.buildServer', () => {
+  // Lightweight stubs — the factory itself doesn't call into them; it
+  // only registers the handler closures. Tool execution is covered by
+  // tools/displays.tools.spec.ts.
+  const displays = {} as never;
+  const audit = {} as never;
+
+  it('returns a NEW McpServer instance on every call (REGRESSION: singleton caused "Already connected to a transport" in prod)', () => {
+    const svc = new McpService(displays, audit);
+    const a = svc.buildServer();
+    const b = svc.buildServer();
+    expect(a).toBeDefined();
+    expect(b).toBeDefined();
+    expect(a).not.toBe(b);
+  });
+
+  it('every fresh server has the list_displays tool registered', () => {
+    const svc = new McpService(displays, audit);
+    const server = svc.buildServer();
+    // McpServer.server is the underlying Server instance from the SDK.
+    // Tools live in its `_registeredTools` map (private but stable
+    // across SDK 1.x). Falling back to checking the public `tool` API
+    // would require constructing a Transport — heavier than this
+    // regression needs.
+    const registered = (server as unknown as { _registeredTools?: Record<string, unknown> })._registeredTools
+      ?? (server as unknown as { tools?: { list_displays?: unknown } }).tools;
+    // Either field shape proves registration ran; the assertion is
+    // simply that *some* representation of the tool is present.
+    expect(
+      Boolean(
+        (registered as Record<string, unknown> | undefined)?.list_displays,
+      ),
+    ).toBe(true);
+  });
+});

--- a/middleware/src/modules/mcp/mcp.service.ts
+++ b/middleware/src/modules/mcp/mcp.service.ts
@@ -7,10 +7,15 @@ import { DisplaysService } from '../displays/displays.service';
 import { LIST_DISPLAYS_TOOL } from './tools/displays.tools';
 
 /**
- * Holds a single `McpServer` instance and registers every tool
- * exactly once at startup. The transport is created per-request by
- * `McpController` (stateless mode — no server-side session state) and
- * `connect`-ed against this server.
+ * Builds a fresh `McpServer` per incoming HTTP request. The SDK's
+ * `Server.connect(transport)` is single-shot — calling it twice on the
+ * same instance throws "Already connected to a transport" (we hit this
+ * exact failure in prod after PR #42 / #43 / #44 went live, on the
+ * second authenticated request). The fix is to pair each `transport`
+ * with a fresh `McpServer`; both die together when the request ends.
+ *
+ * Cost: object construction + a few `registerTool` calls (no I/O).
+ * Negligible vs the actual tool work.
  *
  * Tool handlers receive an `extra` arg from the SDK that carries
  * `authInfo`. We populate `authInfo.extra.mcpContext` from the
@@ -21,29 +26,40 @@ import { LIST_DISPLAYS_TOOL } from './tools/displays.tools';
 export class McpService implements OnModuleInit {
   private readonly logger = new Logger(McpService.name);
 
-  /** Singleton MCP server. Tools are registered once at module init. */
-  readonly server = new McpServer(
-    { name: 'vizora-mcp', version: '0.1.0' },
-    { capabilities: { tools: { listChanged: false } } },
-  );
-
   constructor(
     private readonly displays: DisplaysService,
     private readonly audit: McpAuditService,
   ) {}
 
   onModuleInit(): void {
-    this.registerListDisplays();
-    this.logger.log('MCP server initialized — 1 tool registered (list_displays)');
+    // Sanity-check: build a server once at startup so a misconfigured
+    // tool-registration crashes the boot rather than the first user
+    // request. The instance is then discarded.
+    this.buildServer();
+    this.logger.log('MCP server factory ready — 1 tool will be registered per request (list_displays)');
+  }
+
+  /**
+   * Build a fresh MCP server with every tool registered. Called once
+   * per incoming HTTP request by `McpController`. Returning a new
+   * instance each time is what makes the per-request `connect()` safe.
+   */
+  buildServer(): McpServer {
+    const server = new McpServer(
+      { name: 'vizora-mcp', version: '0.1.0' },
+      { capabilities: { tools: { listChanged: false } } },
+    );
+    this.registerListDisplays(server);
+    return server;
   }
 
   /**
    * Wraps tool registration with a uniform try/catch + audit pattern
    * so each tool file stays focused on the tool itself.
    */
-  private registerListDisplays(): void {
+  private registerListDisplays(server: McpServer): void {
     const t = LIST_DISPLAYS_TOOL;
-    this.server.registerTool(
+    server.registerTool(
       t.name,
       {
         description: t.description,


### PR DESCRIPTION
## Summary
PR #42 shipped a singleton `McpServer` on McpService and the controller did `service.server.connect(transport)` per request. The SDK's `Server.connect()` is single-shot — every request after the first threw `500 INTERNAL: Already connected to a transport. Call close() before connecting to a new transport, or use a separate Protocol instance per connection.`

Caught when Hermes Agent (just installed on the prod VPS) called `tools/list` with a valid bearer. The no-auth smoke tests done at deploy time never reached the transport-handle path.

## Fix
`McpService.buildServer()` factory returns a fresh `McpServer` with all tools registered. Called per request by `McpController`, paired 1:1 with the per-request transport. Both die together when `handleRequest` returns.

`onModuleInit` keeps a startup sanity-check (build once, discard) so misconfigured tool registration fails boot, not the first user request.

## Why this slipped through
The existing tool-handler tests (`displays.tools.spec.ts`) call the handler directly, bypassing the McpServer/Transport plumbing. The exception filter and route-resolution specs cover their own slices but not the connect-handle lifecycle. The new `mcp.service.spec.ts` catches the singleton regression at the unit layer without needing to construct a Transport.

## Test plan
- [x] `mcp.service.spec.ts` — 2 new tests: distinct-instance + tool-registered-per-build
- [x] Full suite: 114/114 suites, 2211 tests pass
- [x] `npx nx build @vizora/middleware` clean
- [ ] After deploy: re-run `hermes mcp test vizora` → expect connection success, tools/list returns `list_displays`
- [ ] After deploy: hit `POST /api/v1/mcp` with valid bearer twice in a row, both 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)