### PR TITLE
fix(mcp): pass request context via closure capture, not SDK authInfo.extra

### DIFF
--- a/middleware/src/modules/mcp/mcp.controller.ts
+++ b/middleware/src/modules/mcp/mcp.controller.ts
@@ -97,39 +97,28 @@ export class McpController {
    * for THIS call.
    */
   private async handle(req: Request, res: Response): Promise<void> {
-    const server = this.mcp.buildServer();
+    const context = (req as Request & Record<string, unknown>)[
+      MCP_CONTEXT_KEY
+    ] as McpRequestContext | undefined;
+
+    // The McpServer is built WITH the context — tool handler closures
+    // capture it at build time. We previously tried to plumb context
+    // through the SDK via `transport.handleRequest(..., extra: {
+    // authInfo: { extra: { mcpContext } } })`, but the SDK doesn't
+    // forward `authInfo.extra` to tool handlers in v1.x — handlers
+    // received `undefined` and threw "MCP tool invoked without
+    // context". Closure capture is reliable and SDK-version-agnostic.
+    const server = this.mcp.buildServer(context);
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined, // stateless
     });
     await server.connect(transport);
 
-    const context = (req as Request & Record<string, unknown>)[
-      MCP_CONTEXT_KEY
-    ] as McpRequestContext | undefined;
-
     // Pass NestJS's pre-parsed body straight through. Per the SDK
     // example: `transport.handleRequest(req, res, req.body)`.
-    // The SDK's `MessageExtraInfo.authInfo.extra` is how we ferry
-    // the per-request mcpContext to the tool handler — the registered
-    // tool reads it via `extra.authInfo.extra.mcpContext`.
-    const extra = context
-      ? {
-          authInfo: {
-            // The SDK's AuthInfo type requires a `token`. We don't
-            // re-leak the bearer; pass the token id instead — it's
-            // already in `mcpContext.tokenId`.
-            token: context.tokenId,
-            clientId: context.agentName,
-            scopes: context.scopes,
-            extra: { mcpContext: context },
-          },
-        }
-      : {};
-
-    await transport.handleRequest(req, res, req.body, extra);
+    await transport.handleRequest(req, res, req.body);
 
     // The transport closes itself when the client disconnects; the
-    // McpServer's `connect()` is per-transport so there's nothing to
-    // explicitly tear down here.
+    // McpServer is per-request so it dies with this scope.
   }
 }

--- a/middleware/src/modules/mcp/mcp.service.spec.ts
+++ b/middleware/src/modules/mcp/mcp.service.spec.ts
@@ -20,16 +20,50 @@ describe('McpService.buildServer', () => {
 
   it('returns a NEW McpServer instance on every call (REGRESSION: singleton caused "Already connected to a transport" in prod)', () => {
     const svc = new McpService(displays, audit);
-    const a = svc.buildServer();
-    const b = svc.buildServer();
+    const a = svc.buildServer(undefined);
+    const b = svc.buildServer(undefined);
     expect(a).toBeDefined();
     expect(b).toBeDefined();
     expect(a).not.toBe(b);
   });
 
-  it('every fresh server has the list_displays tool registered', () => {
+  it('captures the request context in tool-handler closures (REGRESSION: previously plumbed through SDK extra.authInfo.extra and the SDK silently dropped it — every tool call threw "MCP tool invoked without context")', async () => {
+    const captured: unknown[] = [];
+    const fakeDisplays = {
+      findAll: jest.fn().mockResolvedValue({
+        data: [],
+        meta: { page: 1, limit: 20, total: 0, totalPages: 0 },
+      }),
+    } as never;
+    const fakeAudit = { record: jest.fn(async (row) => { captured.push(row); }) } as never;
+    const svc = new McpService(fakeDisplays, fakeAudit);
+    const ctx = {
+      tokenId: 'tok_test',
+      organizationId: 'org_test',
+      agentName: 'unit-test-agent',
+      scopes: ['displays:read'],
+    };
+    const server = svc.buildServer(ctx);
+    // Pull out the registered handler closure and invoke it directly.
+    // The McpServer SDK 1.x stores it at _registeredTools[name].handler.
+    const handler = (server as unknown as {
+      _registeredTools: Record<string, { handler: (input: unknown) => Promise<unknown> }>;
+    })._registeredTools.list_displays.handler;
+    await handler({});
+    // Audit row must show the captured context's org + agent — this is
+    // the proof that the closure picked up the per-request ctx, not a
+    // stale singleton or undefined.
+    expect(fakeAudit.record).toHaveBeenCalledTimes(1);
+    expect(captured[0]).toMatchObject({
+      tokenId: 'tok_test',
+      agentName: 'unit-test-agent',
+      organizationId: 'org_test',
+    });
+  });
+
+  it('still has list_displays registered on every fresh build', () => {
     const svc = new McpService(displays, audit);
-    const server = svc.buildServer();
+    const server = svc.buildServer(undefined);
     // McpServer.server is the underlying Server instance from the SDK.
     // Tools live in its `_registeredTools` map (private but stable
     // across SDK 1.x). Falling back to checking the public `tool` API

--- a/middleware/src/modules/mcp/mcp.service.ts
+++ b/middleware/src/modules/mcp/mcp.service.ts
@@ -35,21 +35,26 @@ export class McpService implements OnModuleInit {
     // Sanity-check: build a server once at startup so a misconfigured
     // tool-registration crashes the boot rather than the first user
     // request. The instance is then discarded.
-    this.buildServer();
+    this.buildServer(undefined);
     this.logger.log('MCP server factory ready — 1 tool will be registered per request (list_displays)');
   }
 
   /**
-   * Build a fresh MCP server with every tool registered. Called once
-   * per incoming HTTP request by `McpController`. Returning a new
-   * instance each time is what makes the per-request `connect()` safe.
+   * Build a fresh MCP server with every tool registered, bound to a
+   * specific request context. The handler closures capture `context`
+   * at build time — no reliance on the SDK preserving auth-info
+   * fields through `transport.handleRequest`.
+   *
+   * Called once per incoming HTTP request by `McpController`.
+   * `context` may be `undefined` only for the onModuleInit
+   * sanity-build, which never serves a real request.
    */
-  buildServer(): McpServer {
+  buildServer(context: McpRequestContext | undefined): McpServer {
     const server = new McpServer(
       { name: 'vizora-mcp', version: '0.1.0' },
       { capabilities: { tools: { listChanged: false } } },
     );
-    this.registerListDisplays(server);
+    this.registerListDisplays(server, context);
     return server;
   }
 
@@ -57,7 +62,10 @@ export class McpService implements OnModuleInit {
    * Wraps tool registration with a uniform try/catch + audit pattern
    * so each tool file stays focused on the tool itself.
    */
-  private registerListDisplays(server: McpServer): void {
+  private registerListDisplays(
+    server: McpServer,
+    context: McpRequestContext | undefined,
+  ): void {
     const t = LIST_DISPLAYS_TOOL;
     server.registerTool(
       t.name,
@@ -65,10 +73,8 @@ export class McpService implements OnModuleInit {
         description: t.description,
         inputSchema: t.inputSchema.shape,
       },
-      async (input, extra) => {
+      async (input) => {
         const startedAt = Date.now();
-        const mcp = (extra.authInfo?.extra ?? {}) as { mcpContext?: McpRequestContext };
-        const context = mcp.mcpContext;
         if (!context) {
           // Should be impossible — controller always sets it. Fail loud.
           throw new Error('MCP tool invoked without context (controller wiring bug)');


### PR DESCRIPTION
## Summary
After PR #45 fixed the singleton-server bug and Hermes was able to call `tools/list`, **tool execution** still failed with:

> MCP tool invoked without context (controller wiring bug)

Root cause: PR #42 plumbed the per-request `McpRequestContext` through `transport.handleRequest(req, res, body, { authInfo: { extra: { mcpContext } } })`. The MCP SDK 1.x silently drops `authInfo.extra` before reaching tool handlers — `mcpContext` was always undefined.

Unit tests bypassed the SDK plumbing (called the handler directly with a hand-constructed context), so the bug shipped silently.

## Fix
Capture `context` in the tool-handler closure at `buildServer(context)` time. No reliance on the SDK forwarding custom fields. Reliable across SDK versions and simpler.

## Regression test
`mcp.service.spec.ts` now pins:
1. Fresh McpServer per `buildServer()` call (existing)
2. **Closure capture** — invoke the handler directly via `_registeredTools.list_displays.handler` and assert the audit row carries the captured `tokenId`/`agentName`/`organizationId`. If anyone reverts to SDK-extra plumbing, this fails.
3. `list_displays` still registered

## Test plan
- [x] 114/114 suites, 2212 tests pass
- [x] `nx build @vizora/middleware` clean
- [ ] After deploy: `hermes -z "Use the vizora MCP server. Call list_displays..."` → expect successful tool result, not "MCP tool invoked without context"

🤖 Generated with [Claude Code](https://claude.com/claude-code)