### PR TITLE
feat(mcp): list_open_support_requests — first step of support-triage Hermes migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,8 +327,9 @@ Automated deployment readiness checker. Runs 30 validation rules across content,
 - `GET  /api/v1/admin/mcp-tokens` — list tokens (no plaintext).
 - `DELETE /api/v1/admin/mcp-tokens/:id` — revoke (idempotent).
 
-**Tools today (PR-A — `feat/mcp-server-foundation`):**
-- `list_displays` — paginated, scope `displays:read`, optional status filter.
+**Tools today:**
+- `list_displays` — paginated, scope `displays:read`, optional status filter. (PR #42)
+- `list_open_support_requests` — paginated, scope `support:read`, returns triage candidates as **structural signals only** (word_count, has_attachment, message_count, age_minutes, priority, category, ai_category, org_tier). Body and PII NEVER cross the wire. Default WHERE excludes already-triaged requests (D7 reply-loop prevention). First step of the support-triage Hermes migration.
 
 **Pending PRs:**
 - PR-B — remaining 12 tools (display detail, content, playlists, schedules, organizations, audit).

--- a/middleware/src/modules/mcp/mcp.module.ts
+++ b/middleware/src/modules/mcp/mcp.module.ts
@@ -3,6 +3,7 @@ import { AdminModule } from '../admin/admin.module';
 import { AuthModule } from '../auth/auth.module';
 import { DatabaseModule } from '../database/database.module';
 import { DisplaysModule } from '../displays/displays.module';
+import { SupportModule } from '../support/support.module';
 import { McpAuditService } from './audit/mcp-audit.service';
 import { McpAuthGuard } from './auth/mcp-auth.guard';
 import { McpRateLimitGuard } from './auth/mcp-rate-limit.guard';
@@ -21,12 +22,14 @@ import { McpTokensAdminController } from './admin/mcp-tokens.controller';
  *   - GET  /api/v1/admin/mcp-tokens        (list)
  *   - DELETE /api/v1/admin/mcp-tokens/:id  (revoke)
  *
- * Tools registered: `list_displays` (read-only, scope `displays:read`)
+ * Tools registered:
+ *   - `list_displays`                 (scope `displays:read`)
+ *   - `list_open_support_requests`    (scope `support:read`, structural-only)
  *
  * Companion docs: `docs/agents-mcp-server-design.md`.
  */
 @Module({
-  imports: [DatabaseModule, AuthModule, AdminModule, DisplaysModule],
+  imports: [DatabaseModule, AuthModule, AdminModule, DisplaysModule, SupportModule],
   controllers: [McpController, McpTokensAdminController],
   providers: [McpService, McpTokenService, McpAuthGuard, McpRateLimitGuard, McpAuditService],
   exports: [McpService, McpTokenService],

--- a/middleware/src/modules/mcp/mcp.service.spec.ts
+++ b/middleware/src/modules/mcp/mcp.service.spec.ts
@@ -14,12 +14,13 @@ import { McpService } from './mcp.service';
 describe('McpService.buildServer', () => {
   // Lightweight stubs — the factory itself doesn't call into them; it
   // only registers the handler closures. Tool execution is covered by
-  // tools/displays.tools.spec.ts.
+  // tools/displays.tools.spec.ts and tools/support.tools.spec.ts.
   const displays = {} as never;
+  const support = {} as never;
   const audit = {} as never;
 
   it('returns a NEW McpServer instance on every call (REGRESSION: singleton caused "Already connected to a transport" in prod)', () => {
-    const svc = new McpService(displays, audit);
+    const svc = new McpService(displays, support, audit);
     const a = svc.buildServer(undefined);
     const b = svc.buildServer(undefined);
     expect(a).toBeDefined();
@@ -36,7 +37,8 @@ describe('McpService.buildServer', () => {
       }),
     } as never;
     const fakeAudit = { record: jest.fn(async (row) => { captured.push(row); }) } as never;
-    const svc = new McpService(fakeDisplays, fakeAudit);
+    const fakeSupport = {} as never;
+    const svc = new McpService(fakeDisplays, fakeSupport, fakeAudit);
     const ctx = {
       tokenId: 'tok_test',
       organizationId: 'org_test',
@@ -62,7 +64,7 @@ describe('McpService.buildServer', () => {
   });
 
   it('still has list_displays registered on every fresh build', () => {
-    const svc = new McpService(displays, audit);
+    const svc = new McpService(displays, support, audit);
     const server = svc.buildServer(undefined);
     // McpServer.server is the underlying Server instance from the SDK.
     // Tools live in its `_registeredTools` map (private but stable

--- a/middleware/src/modules/mcp/mcp.service.ts
+++ b/middleware/src/modules/mcp/mcp.service.ts
@@ -4,7 +4,9 @@ import type { McpRequestContext } from './auth/mcp-context';
 import { McpAuditService } from './audit/mcp-audit.service';
 import { mapExceptionToMcpError } from './lib/error-mapping';
 import { DisplaysService } from '../displays/displays.service';
+import { SupportService } from '../support/support.service';
 import { LIST_DISPLAYS_TOOL } from './tools/displays.tools';
+import { LIST_OPEN_SUPPORT_REQUESTS_TOOL } from './tools/support.tools';
 
 /**
  * Builds a fresh `McpServer` per incoming HTTP request. The SDK's
@@ -28,6 +30,7 @@ export class McpService implements OnModuleInit {
 
   constructor(
     private readonly displays: DisplaysService,
+    private readonly support: SupportService,
     private readonly audit: McpAuditService,
   ) {}
 
@@ -36,7 +39,9 @@ export class McpService implements OnModuleInit {
     // tool-registration crashes the boot rather than the first user
     // request. The instance is then discarded.
     this.buildServer(undefined);
-    this.logger.log('MCP server factory ready — 1 tool will be registered per request (list_displays)');
+    this.logger.log(
+      'MCP server factory ready — 2 tools will be registered per request (list_displays, list_open_support_requests)',
+    );
   }
 
   /**
@@ -55,6 +60,7 @@ export class McpService implements OnModuleInit {
       { capabilities: { tools: { listChanged: false } } },
     );
     this.registerListDisplays(server, context);
+    this.registerListOpenSupportRequests(server, context);
     return server;
   }
 
@@ -110,6 +116,67 @@ export class McpService implements OnModuleInit {
           // thrown exceptions to 'isError: true' content; we follow
           // the convention so agents see the typed error code in
           // structuredContent.
+          return {
+            isError: true,
+            content: [{ type: 'text', text: mapped.message }],
+            structuredContent: { error: mapped },
+          };
+        }
+      },
+    );
+  }
+
+  /**
+   * Twin of `registerListDisplays` for the support-triage read tool.
+   * The audit + error-wrap boilerplate is duplicated rather than
+   * extracted because (a) we have only two tools today, and (b) the
+   * audit row carries the tool name as a literal so any helper would
+   * need to thread it through anyway. When PR-B adds the remaining
+   * tools we'll factor a generic `wrapTool(server, t, exec)` helper.
+   */
+  private registerListOpenSupportRequests(
+    server: McpServer,
+    context: McpRequestContext | undefined,
+  ): void {
+    const t = LIST_OPEN_SUPPORT_REQUESTS_TOOL;
+    server.registerTool(
+      t.name,
+      {
+        description: t.description,
+        inputSchema: t.inputSchema.shape,
+      },
+      async (input) => {
+        const startedAt = Date.now();
+        if (!context) {
+          throw new Error('MCP tool invoked without context (controller wiring bug)');
+        }
+        try {
+          const result = await t.handler(input, context, this.support);
+          await this.audit.record({
+            tokenId: context.tokenId,
+            agentName: context.agentName,
+            organizationId: context.organizationId,
+            tool: t.name,
+            paramsRaw: input,
+            status: 'success',
+            latencyMs: Date.now() - startedAt,
+          });
+          return {
+            content: [{ type: 'text', text: JSON.stringify(result) }],
+            structuredContent: result,
+          };
+        } catch (err) {
+          const mapped = mapExceptionToMcpError(err);
+          await this.audit.record({
+            tokenId: context.tokenId,
+            agentName: context.agentName,
+            organizationId: context.organizationId,
+            tool: t.name,
+            paramsRaw: input,
+            status: 'error',
+            errorCode: mapped.code,
+            latencyMs: Date.now() - startedAt,
+          });
           return {
             isError: true,
             content: [{ type: 'text', text: mapped.message }],

--- a/middleware/src/modules/mcp/schemas/tool-inputs.ts
+++ b/middleware/src/modules/mcp/schemas/tool-inputs.ts
@@ -17,3 +17,16 @@ export const ListDisplaysInput = z.object({
 });
 
 export type ListDisplaysInputT = z.infer<typeof ListDisplaysInput>;
+
+export const ListOpenSupportRequestsInput = z.object({
+  limit: z.number().int().min(1).max(100).optional().default(20)
+    .describe('Page size, 1-100.'),
+  page: z.number().int().min(1).optional().default(1)
+    .describe('1-indexed page number.'),
+  include_already_triaged: z.boolean().optional().default(false)
+    .describe(
+      'When false (default), excludes any request that already has an agent-authored message in its thread (D7 reply-loop prevention). Set true to see every open request regardless of triage state.',
+    ),
+});
+
+export type ListOpenSupportRequestsInputT = z.infer<typeof ListOpenSupportRequestsInput>;

--- a/middleware/src/modules/mcp/schemas/tool-outputs.ts
+++ b/middleware/src/modules/mcp/schemas/tool-outputs.ts
@@ -34,3 +34,37 @@ export const ListDisplaysOutput = z.object({
 });
 
 export type ListDisplaysOutputT = z.infer<typeof ListDisplaysOutput>;
+
+/**
+ * Triage-candidate shape — the output of `list_open_support_requests`.
+ *
+ * **Hard contract**: this shape NEVER carries `description`,
+ * `consoleErrors`, or any user-PII (name/email). It is structural
+ * signals only, computed server-side, so an LLM-driven agent can
+ * safely consume it without violating D13 (no raw user data in LLM
+ * prompts). Adding any free-text body field here is a security-sensitive
+ * change — call it out in review.
+ */
+export const TriageCandidateShape = z.object({
+  id: z.string(),
+  organization_id: z.string(),
+  status: z.string(),
+  priority: z.string().nullable(),
+  category: z.string().nullable(),
+  ai_category: z.string().nullable(),
+  created_at: z.string().datetime(),
+  age_minutes: z.number().int().nonnegative(),
+  word_count: z.number().int().nonnegative(),
+  has_attachment: z.boolean(),
+  message_count: z.number().int().nonnegative(),
+  org_tier: z.string(),
+});
+
+export const ListOpenSupportRequestsOutput = z.object({
+  support_requests: z.array(TriageCandidateShape),
+  page: z.number().int(),
+  limit: z.number().int(),
+  total: z.number().int(),
+});
+
+export type ListOpenSupportRequestsOutputT = z.infer<typeof ListOpenSupportRequestsOutput>;

--- a/middleware/src/modules/mcp/tools/support.tools.spec.ts
+++ b/middleware/src/modules/mcp/tools/support.tools.spec.ts
@@ -1,0 +1,167 @@
+import { ForbiddenException } from '@nestjs/common';
+import { listOpenSupportRequestsTool } from './support.tools';
+import type { McpRequestContext } from '../auth/mcp-context';
+
+function ctx(scopes: string[]): McpRequestContext {
+  return {
+    tokenId: 'tok_1',
+    organizationId: 'org_1',
+    agentName: 'hermes-support-triage',
+    scopes,
+  };
+}
+
+function makeSupport(
+  rows: Array<Partial<{
+    id: string;
+    status: string;
+    priority: string | null;
+    category: string | null;
+    aiCategory: string | null;
+    createdAt: Date;
+    ageMinutes: number;
+    wordCount: number;
+    hasAttachment: boolean;
+    messageCount: number;
+    orgTier: string;
+  }>>,
+) {
+  return {
+    listTriageCandidates: jest.fn().mockResolvedValue({
+      data: rows.map((r) => ({
+        id: r.id,
+        organizationId: 'org_1',
+        status: r.status ?? 'open',
+        priority: r.priority ?? 'normal',
+        category: r.category ?? 'bug_report',
+        aiCategory: r.aiCategory ?? null,
+        createdAt: r.createdAt ?? new Date('2026-05-01T00:00:00Z'),
+        ageMinutes: r.ageMinutes ?? 30,
+        wordCount: r.wordCount ?? 12,
+        hasAttachment: r.hasAttachment ?? false,
+        messageCount: r.messageCount ?? 1,
+        orgTier: r.orgTier ?? 'free',
+      })),
+      meta: { page: 1, limit: 20, total: rows.length, totalPages: 1 },
+    }),
+  };
+}
+
+describe('listOpenSupportRequestsTool', () => {
+  it('throws ForbiddenException when scope missing', async () => {
+    await expect(
+      listOpenSupportRequestsTool({}, ctx([]), makeSupport([]) as never),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('returns wire-shape (snake_case) when scope present', async () => {
+    const out = await listOpenSupportRequestsTool(
+      {},
+      ctx(['support:read']),
+      makeSupport([{ id: 'r1' }, { id: 'r2' }]) as never,
+    );
+    expect(out.support_requests).toHaveLength(2);
+    expect(out.support_requests[0]).toMatchObject({
+      id: 'r1',
+      organization_id: 'org_1',
+      status: 'open',
+      priority: 'normal',
+      category: 'bug_report',
+      ai_category: null,
+      age_minutes: 30,
+      word_count: 12,
+      has_attachment: false,
+      message_count: 1,
+      org_tier: 'free',
+    });
+    expect(out.support_requests[0].created_at).toBe('2026-05-01T00:00:00.000Z');
+    expect(out.total).toBe(2);
+  });
+
+  it('NEVER returns description, consoleErrors, or user fields — D13 contract enforced at the wire shape', async () => {
+    // Simulate a misbehaving service that leaks the body. The Zod
+    // outputSchema MUST strip-or-reject — we don't trust the service
+    // to never leak. (zod .parse strips unknown keys by default.)
+    const leaky = {
+      listTriageCandidates: jest.fn().mockResolvedValue({
+        data: [
+          {
+            id: 'r1',
+            organizationId: 'org_1',
+            status: 'open',
+            priority: 'normal',
+            category: 'bug_report',
+            aiCategory: null,
+            createdAt: new Date('2026-05-01T00:00:00Z'),
+            ageMinutes: 30,
+            wordCount: 12,
+            hasAttachment: false,
+            messageCount: 1,
+            orgTier: 'free',
+            // fields a buggy service might accidentally leak
+            description: 'CUSTOMER PII LEAKED — phone 555-1234',
+            consoleErrors: 'private stack trace',
+            user: { email: 'leak@example.com', firstName: 'Leak' },
+          },
+        ],
+        meta: { page: 1, limit: 20, total: 1, totalPages: 1 },
+      }),
+    };
+    const out = await listOpenSupportRequestsTool(
+      {},
+      ctx(['support:read']),
+      leaky as never,
+    );
+    const row = out.support_requests[0] as Record<string, unknown>;
+    expect(row).not.toHaveProperty('description');
+    expect(row).not.toHaveProperty('consoleErrors');
+    expect(row).not.toHaveProperty('user');
+    // Be paranoid — also verify the leaked PII isn't anywhere in the wire payload
+    const serialized = JSON.stringify(out);
+    expect(serialized).not.toContain('phone 555-1234');
+    expect(serialized).not.toContain('leak@example.com');
+    expect(serialized).not.toContain('private stack trace');
+  });
+
+  it('passes the calling token org to listTriageCandidates (NOT user-controlled)', async () => {
+    const svc = makeSupport([]);
+    await listOpenSupportRequestsTool({}, ctx(['support:read']), svc as never);
+    expect(svc.listTriageCandidates).toHaveBeenCalledWith(
+      'org_1',
+      { page: 1, limit: 20, includeAlreadyTriaged: false },
+    );
+  });
+
+  it('forwards include_already_triaged through to the service', async () => {
+    const svc = makeSupport([]);
+    await listOpenSupportRequestsTool(
+      { include_already_triaged: true },
+      ctx(['support:read']),
+      svc as never,
+    );
+    expect(svc.listTriageCandidates).toHaveBeenCalledWith(
+      'org_1',
+      { page: 1, limit: 20, includeAlreadyTriaged: true },
+    );
+  });
+
+  it('rejects invalid limit via Zod (>100)', async () => {
+    await expect(
+      listOpenSupportRequestsTool(
+        { limit: 999 },
+        ctx(['support:read']),
+        makeSupport([]) as never,
+      ),
+    ).rejects.toThrow(/100/);
+  });
+
+  it('serializes Date createdAt as ISO string on the wire', async () => {
+    const ts = new Date('2026-05-04T12:34:56Z');
+    const out = await listOpenSupportRequestsTool(
+      {},
+      ctx(['support:read']),
+      makeSupport([{ id: 'r1', createdAt: ts }]) as never,
+    );
+    expect(out.support_requests[0].created_at).toBe('2026-05-04T12:34:56.000Z');
+  });
+});

--- a/middleware/src/modules/mcp/tools/support.tools.ts
+++ b/middleware/src/modules/mcp/tools/support.tools.ts
@@ -1,0 +1,96 @@
+import { ForbiddenException } from '@nestjs/common';
+import { SupportService } from '../../support/support.service';
+import { hasScope, type McpRequestContext } from '../auth/mcp-context';
+import {
+  ListOpenSupportRequestsInput,
+  type ListOpenSupportRequestsInputT,
+} from '../schemas/tool-inputs';
+import {
+  ListOpenSupportRequestsOutput,
+  type ListOpenSupportRequestsOutputT,
+} from '../schemas/tool-outputs';
+
+/**
+ * MCP tool: `list_open_support_requests`
+ *
+ * Returns triage candidates for the calling token's organization as
+ * STRUCTURAL SIGNALS ONLY — word count, has-attachment, message count,
+ * age, org tier. No description body, no user PII. The LLM-driven
+ * agent on the other side of this tool can safely consume the output
+ * without risking D13 (no raw user data into LLM prompts).
+ *
+ * Default WHERE excludes already-triaged requests (D7 reply-loop
+ * prevention) — pass `include_already_triaged: true` to override.
+ *
+ * Scope required: `support:read`. Scope failure throws
+ * `ForbiddenException` which the error mapper translates to MCP
+ * `FORBIDDEN`.
+ */
+export async function listOpenSupportRequestsTool(
+  rawInput: unknown,
+  context: McpRequestContext,
+  supportService: SupportService,
+): Promise<ListOpenSupportRequestsOutputT> {
+  if (!hasScope(context, 'support:read')) {
+    throw new ForbiddenException("Token lacks scope 'support:read'");
+  }
+  const input = ListOpenSupportRequestsInput.parse(
+    rawInput,
+  ) as ListOpenSupportRequestsInputT;
+
+  const result = await supportService.listTriageCandidates(
+    context.organizationId,
+    {
+      page: input.page,
+      limit: input.limit,
+      includeAlreadyTriaged: input.include_already_triaged,
+    },
+  );
+
+  return ListOpenSupportRequestsOutput.parse({
+    support_requests: result.data.map(toTriageShape),
+    page: input.page,
+    limit: input.limit,
+    total: result.meta?.total ?? result.data.length,
+  });
+}
+
+/**
+ * Project a service-layer triage row into the MCP wire shape.
+ * camelCase → snake_case is the only translation. The service layer
+ * has already enforced the no-body / no-PII contract.
+ */
+function toTriageShape(r: Record<string, unknown>) {
+  return {
+    id: r.id as string,
+    organization_id: r.organizationId as string,
+    status: r.status as string,
+    priority: (r.priority as string | null) ?? null,
+    category: (r.category as string | null) ?? null,
+    ai_category: (r.aiCategory as string | null) ?? null,
+    created_at:
+      r.createdAt instanceof Date
+        ? r.createdAt.toISOString()
+        : (r.createdAt as string),
+    age_minutes: r.ageMinutes as number,
+    word_count: r.wordCount as number,
+    has_attachment: Boolean(r.hasAttachment),
+    message_count: r.messageCount as number,
+    org_tier: r.orgTier as string,
+  };
+}
+
+/**
+ * Registry entry for MCP tool registration in McpService. Lives next
+ * to the implementation so input/output schemas can't drift from the
+ * handler.
+ */
+export const LIST_OPEN_SUPPORT_REQUESTS_TOOL = {
+  name: 'list_open_support_requests',
+  description:
+    "List open support requests for the calling token's organization as triage candidates. Returns structural signals ONLY (word_count, has_attachment, message_count, age_minutes, priority, category, ai_category, org_tier) — NEVER the description body or any user PII. By default excludes already-triaged requests (those with an agent-authored message). Read-only. Paginated.",
+  scope: 'support:read' as const,
+  inputSchema: ListOpenSupportRequestsInput,
+  outputSchema: ListOpenSupportRequestsOutput,
+  handler: listOpenSupportRequestsTool,
+};

--- a/middleware/src/modules/support/support.service.spec.ts
+++ b/middleware/src/modules/support/support.service.spec.ts
@@ -757,4 +757,86 @@ describe('SupportService', () => {
       expect(firstCall.where.organizationId).toBeUndefined();
     });
   });
+
+  describe('listTriageCandidates', () => {
+    const triageRow = {
+      id: 'r1',
+      organizationId: orgId,
+      status: 'open',
+      priority: 'high',
+      category: 'bug_report',
+      aiCategory: null,
+      createdAt: new Date(Date.now() - 5 * 60_000), // 5 min old
+      description: 'two   three  four words   here',
+      consoleErrors: 'Error: foo at line 3',
+      organization: { subscriptionTier: 'pro' },
+      _count: { messages: 2 },
+    };
+
+    beforeEach(() => {
+      db.supportRequest.findMany.mockResolvedValue([triageRow]);
+      db.supportRequest.count.mockResolvedValue(1);
+    });
+
+    it('always scopes to the given orgId — does NOT honor a super-admin escape (MCP tokens are per-org)', async () => {
+      await service.listTriageCandidates(orgId);
+
+      const findCall = db.supportRequest.findMany.mock.calls[0][0];
+      const countCall = db.supportRequest.count.mock.calls[0][0];
+      expect(findCall.where.organizationId).toBe(orgId);
+      expect(countCall.where.organizationId).toBe(orgId);
+    });
+
+    it('excludes already-triaged requests by default (D7 reply-loop prevention)', async () => {
+      await service.listTriageCandidates(orgId);
+
+      const findCall = db.supportRequest.findMany.mock.calls[0][0];
+      expect(findCall.where.messages).toEqual({ none: { authorType: 'agent' } });
+    });
+
+    it('omits the messages-none filter when includeAlreadyTriaged=true', async () => {
+      await service.listTriageCandidates(orgId, { includeAlreadyTriaged: true });
+
+      const findCall = db.supportRequest.findMany.mock.calls[0][0];
+      expect(findCall.where.messages).toBeUndefined();
+    });
+
+    it('returns precomputed structural signals — NEVER the description body or consoleErrors (D13)', async () => {
+      const out = await service.listTriageCandidates(orgId);
+      expect(out.data).toHaveLength(1);
+      const row = out.data[0] as Record<string, unknown>;
+      expect(row.id).toBe('r1');
+      expect(row.wordCount).toBe(5); // "two three four words here"
+      expect(row.hasAttachment).toBe(true); // consoleErrors present
+      expect(row.messageCount).toBe(2);
+      expect(row.orgTier).toBe('pro');
+      expect(row.ageMinutes).toBeGreaterThanOrEqual(4);
+      expect(row.ageMinutes).toBeLessThanOrEqual(6);
+      // CRITICAL: body and PII fields MUST NOT be on the wire shape
+      expect(row).not.toHaveProperty('description');
+      expect(row).not.toHaveProperty('consoleErrors');
+      expect(row).not.toHaveProperty('user');
+    });
+
+    it('falls back to "free" tier when organization is missing', async () => {
+      db.supportRequest.findMany.mockResolvedValueOnce([
+        { ...triageRow, organization: null },
+      ]);
+      const out = await service.listTriageCandidates(orgId);
+      expect((out.data[0] as Record<string, unknown>).orgTier).toBe('free');
+    });
+
+    it('returns paginated meta', async () => {
+      db.supportRequest.count.mockResolvedValueOnce(45);
+      const out = await service.listTriageCandidates(orgId, { page: 2, limit: 10 });
+      expect(out.meta).toEqual({ page: 2, limit: 10, total: 45, totalPages: 5 });
+    });
+
+    it('skips correctly for pagination (page 3, limit 10 → skip 20)', async () => {
+      await service.listTriageCandidates(orgId, { page: 3, limit: 10 });
+      const findCall = db.supportRequest.findMany.mock.calls[0][0];
+      expect(findCall.skip).toBe(20);
+      expect(findCall.take).toBe(10);
+    });
+  });
 });

--- a/middleware/src/modules/support/support.service.ts
+++ b/middleware/src/modules/support/support.service.ts
@@ -191,6 +191,97 @@ export class SupportService {
   }
 
   /**
+   * List open support requests as TRIAGE CANDIDATES — returns precomputed
+   * structural signals only (word count, has-attachment, message count,
+   * age, org tier). The description body and any user PII NEVER cross
+   * this method's return boundary, so a downstream LLM-driven agent
+   * (Hermes / MCP tool) can safely consume the output without violating
+   * D13 (no raw user data into LLM prompts — see scripts/agents/lib/
+   * types.ts for the original constraint).
+   *
+   * Different from `findAll`:
+   *  - Always scoped to one orgId (no super-admin escape; MCP tokens are
+   *    per-org-scoped at issuance, this method matches that contract).
+   *  - Default WHERE excludes any request that already has an
+   *    `authorType='agent'` message (D7 reply-loop prevention) — the
+   *    same exclusion the existing `support-triage` cron uses.
+   *  - Returns NO `description`, NO `consoleErrors`, NO user joins.
+   *  - Word count + has_attachment computed server-side.
+   */
+  async listTriageCandidates(
+    organizationId: string,
+    options: {
+      page?: number;
+      limit?: number;
+      includeAlreadyTriaged?: boolean;
+    } = {},
+  ) {
+    const { page = 1, limit = 20, includeAlreadyTriaged = false } = options;
+    const skip = (page - 1) * limit;
+
+    const where: Prisma.SupportRequestWhereInput = {
+      organizationId,
+      status: 'open',
+    };
+    if (!includeAlreadyTriaged) {
+      where.messages = { none: { authorType: 'agent' } };
+    }
+
+    const [rows, total] = await Promise.all([
+      this.db.supportRequest.findMany({
+        where,
+        skip,
+        take: limit,
+        orderBy: { createdAt: 'desc' },
+        select: {
+          id: true,
+          organizationId: true,
+          status: true,
+          priority: true,
+          category: true,
+          aiCategory: true,
+          createdAt: true,
+          // Selected purely to compute structural signals server-side —
+          // these fields are stripped before returning.
+          description: true,
+          consoleErrors: true,
+          organization: { select: { subscriptionTier: true } },
+          _count: { select: { messages: true } },
+        },
+      }),
+      this.db.supportRequest.count({ where }),
+    ]);
+
+    const now = Date.now();
+    const data = rows.map((r) => ({
+      id: r.id,
+      organizationId: r.organizationId,
+      status: r.status,
+      priority: r.priority,
+      category: r.category,
+      aiCategory: r.aiCategory,
+      createdAt: r.createdAt,
+      ageMinutes: Math.floor((now - r.createdAt.getTime()) / 60_000),
+      // Structural signals only — body never on the wire.
+      wordCount: (r.description ?? '').trim().split(/\s+/).filter(Boolean)
+        .length,
+      hasAttachment: Boolean(r.consoleErrors && r.consoleErrors.length > 0),
+      messageCount: r._count.messages,
+      orgTier: r.organization?.subscriptionTier ?? 'free',
+    }));
+
+    return {
+      data,
+      meta: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  /**
    * Get a single support request with messages
    */
   async findOne(id: string, user: UserInfo) {


### PR DESCRIPTION
## Summary
Second MCP tool, scope `support:read`. Returns open support requests as triage candidates with **structural signals only** — `word_count`, `has_attachment`, `message_count`, `age_minutes`, `priority`, `category`, `ai_category`, `org_tier`. The description body and any user PII NEVER cross the wire.

This is what the Hermes-side support-triage skill will call once we point it at Vizora. Mirrors the existing PM2 cron's `fetchTicketsForOrg` + `buildSignals` shape, with the same WHERE clause (status='open' AND no agent message yet, D7 reply-loop prevention).

## D13 enforcement (no raw user data into LLM prompts)
Two layers:
1. **Service layer** — `listTriageCandidates` selects `description`/`consoleErrors` to compute word-count and has-attachment, then DROPS them before returning. Body never leaves the data-access layer.
2. **Wire layer** — `TriageCandidateShape` Zod schema whitelists every output field. `parse()` strips unknown keys, so even a future buggy service that leaks the body cannot push it past the tool boundary. Test asserts this directly via JSON-stringified payload check.

## Test plan
- [x] 7 new SupportService.listTriageCandidates tests (per-org scoping, D7 exclude, structural-only output, pagination)
- [x] 7 new tool tests (scope-rejection, wire shape, D13 paranoia-test feeding a leaky service, org-from-token enforcement, includeAlreadyTriaged forwarding, Zod limit validation, ISO date)
- [x] 115/115 suites, 2226/2226 tests pass (was 113/2212; +14 new)
- [x] `npx nx build @vizora/middleware` clean
- [ ] After deploy: `UPDATE mcp_tokens SET scopes = ARRAY['displays:read', 'support:read'] WHERE name = 'hermes-support-triage-shadow';`
- [ ] After deploy: `hermes -z` prompt invoking `list_open_support_requests` against E2E Test Org

## Next steps after this lands
- Add `support:read` scope to the `hermes-support-triage-shadow` token (psql UPDATE; no migration)
- Verify round trip from Hermes
- Write the Hermes-side support-triage skill (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)