### PR TITLE
feat: Hermes support-triage shadow + MCP write tools (steps 1-4 of migration)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,7 +329,10 @@ Automated deployment readiness checker. Runs 30 validation rules across content,
 
 **Tools today:**
 - `list_displays` — paginated, scope `displays:read`, optional status filter. (PR #42)
-- `list_open_support_requests` — paginated, scope `support:read`, returns triage candidates as **structural signals only** (word_count, has_attachment, message_count, age_minutes, priority, category, ai_category, org_tier). Body and PII NEVER cross the wire. Default WHERE excludes already-triaged requests (D7 reply-loop prevention). First step of the support-triage Hermes migration.
+- `list_open_support_requests` — paginated, scope `support:read`, returns triage candidates as **structural signals only** (word_count, has_attachment, message_count, age_minutes, priority, category, ai_category, org_tier). Body and PII NEVER cross the wire. Default WHERE excludes already-triaged requests (D7 reply-loop prevention).
+- `update_support_request_priority` — scope `support:write`, sets priority on one request (cross-org guard via compound where).
+- `update_support_request_ai_category` — scope `support:write`, sets V2 taxonomy slug. Zod-constrained to the V2 enum.
+- `create_support_message` — scope `support:write`, posts an agent-authored comment. Author identity comes from the bearer-token context, content capped at 2000 chars.
 
 **Pending PRs:**
 - PR-B — remaining 12 tools (display detail, content, playlists, schedules, organizations, audit).

--- a/hermes-skills/vizora-support-triage/SKILL.md
+++ b/hermes-skills/vizora-support-triage/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: vizora-support-triage
+description: Score open Vizora support requests for urgency using structural signals only (no raw ticket body). Reads via the vizora MCP server and appends one JSONL row per ticket to a shadow log for offline comparison against the existing heuristic classifier.
+---
+
+# Vizora Support Triage — Shadow Mode
+
+You are running as a scheduled Vizora support-triage agent. Your only job is to score open support requests for **urgency** and emit one JSONL line per ticket to a shadow log file. **You do NOT write to the Vizora database, send messages, or change priorities.** This is shadow mode — the existing PM2 cron `agent-support-triage` is the source of truth; you are the challenger.
+
+## Hard rules (non-negotiable)
+
+1. **Structural signals only.** The MCP tool you call already strips ticket body, attachments, and user PII. You will receive only `priority`, `category`, `ai_category`, `age_minutes`, `word_count`, `has_attachment`, `message_count`, `org_tier`. **Do NOT ask for, infer, or fabricate ticket content.** Score from these signals alone.
+2. **One MCP call per run.** Call `list_open_support_requests` exactly once with `limit=50`. Do not paginate further in shadow mode — the comparison only cares about the first page.
+3. **Append, don't overwrite.** The shadow log is `/var/log/hermes/vizora-support-triage-shadow.jsonl`. Always append. Never `>` redirect.
+4. **One JSON object per line, no wrapping array.** Each ticket → one line of compact JSON, newline-terminated. Invalid JSON breaks the comparison parser.
+5. **No DB writes, no messaging, no priority changes.** If you find yourself reaching for any tool other than the MCP `list_open_support_requests` and the terminal `tee -a` / `echo >>`, stop.
+
+## Steps to run
+
+### 1. Pull triage candidates
+
+Call the MCP tool from the `vizora` server:
+
+```
+list_open_support_requests({ "limit": 50 })
+```
+
+Expect a response of shape `{ support_requests: [...], total: N, page: 1, limit: 50 }`. If `support_requests` is empty (`total: 0`), still write a single heartbeat line (see step 4) so we can confirm the cron fired.
+
+### 2. Score each ticket
+
+For each `support_request` in the response, compute a `hermes_score` in `[0.0, 1.0]` where higher = more urgent. Use these signal weights:
+
+- **Existing `priority`** — if `urgent` → start at 0.85, if `high` → 0.65, if `normal` → 0.35, if `low` → 0.10. Treat null as 0.35.
+- **`org_tier`** — multiply by 1.20 if `enterprise`, 1.10 if `pro`, 1.00 if `starter` or `free`. (Enterprise SLA matters.)
+- **`age_minutes`** — add 0.05 per hour up to a max of +0.15. (>3 hours stale = +0.15 ceiling.)
+- **`has_attachment`** — add 0.05 if true. (Attachment usually means a real bug report.)
+- **`ai_category`** — high-impact categories add 0.10 each: `device_offline`, `account_access_lost`, `content_storage_limit`. Low-urgency categories subtract 0.05 each: `billing_invoice_question`, `analytics_export_failed`. Other categories: no adjustment.
+- **`message_count`** — if ≥ 3 (back-and-forth in progress), subtract 0.05 (less likely to be net-new urgent).
+
+Clamp the final score to `[0.0, 1.0]`.
+
+### 3. Map score → suggested priority
+
+Match the existing `scoreToPriority` rule in `scripts/agents/support-triage.ts`:
+
+- `score ≥ 0.85` → `urgent`
+- `score ≥ 0.65` → `high`
+- `score ≥ 0.35` → `normal`
+- otherwise → `low`
+
+### 4. Write a JSONL line per ticket
+
+For each ticket, append one line to `/var/log/hermes/vizora-support-triage-shadow.jsonl` in this exact shape (compact, no pretty-printing):
+
+```json
+{"timestamp":"<ISO8601>","run_id":"<short>","ticket_id":"<id>","organization_id":"<org>","hermes_score":0.72,"hermes_priority":"high","hermes_reasoning":"<<=120 chars: which signals drove the score>>","input_signals":{"priority":"normal","category":"bug_report","ai_category":"device_offline","age_minutes":127,"word_count":42,"has_attachment":true,"message_count":2,"org_tier":"pro"}}
+```
+
+**`run_id`**: any short identifier per cron firing. Use the current epoch seconds.
+**`hermes_reasoning`**: a terse human-readable phrase (≤ 120 chars) noting which signals dominated. Example: `"enterprise tier + 3h stale + device_offline category"`. Don't quote any ticket content.
+
+If the response had **zero** tickets, write exactly one heartbeat line:
+
+```json
+{"timestamp":"<ISO8601>","run_id":"<short>","ticket_id":null,"organization_id":null,"hermes_score":null,"hermes_priority":null,"hermes_reasoning":"heartbeat: 0 open requests","input_signals":null}
+```
+
+### 5. Use the terminal tool to append
+
+```bash
+mkdir -p /var/log/hermes
+echo '<the JSONL line>' >> /var/log/hermes/vizora-support-triage-shadow.jsonl
+```
+
+Repeat the `echo >>` for each ticket. Don't accumulate the lines into a variable and write once at the end — incremental appends are easier to debug if a run dies mid-batch.
+
+## What NOT to do
+
+- Don't call `list_displays` — it's not relevant here and burns audit-log noise.
+- Don't try to call any `update_*` or `create_*` MCP tool — the token's scope is read-only for the shadow phase. You'll get a `FORBIDDEN` and waste a turn.
+- Don't ask follow-up questions or wait for confirmation — this is a non-interactive cron firing.
+- Don't write a wrapping JSON array. The file is JSONL (one object per line), not JSON.
+- Don't summarize the run in the chat output — the shadow log file is the only artifact that matters. A one-line stdout like `wrote N rows` is fine.
+
+## Why this exists
+
+Vizora's existing PM2 cron `agent-support-triage` (in `scripts/agents/support-triage.ts`) does the same job today using a heuristic ranker. We want to compare Hermes-driven scoring against the heuristic before cutover. The comparison script is `scripts/agents/compare-hermes-vs-heuristic.ts` in the Vizora repo — it diffs this JSONL against the DB's `priority` field after both classifiers have written. After 1-2 weeks of shadow data, we decide whether Hermes wins.

--- a/middleware/src/modules/mcp/auth/mcp-token.service.spec.ts
+++ b/middleware/src/modules/mcp/auth/mcp-token.service.spec.ts
@@ -116,13 +116,37 @@ describe('McpTokenService', () => {
       expect(JSON.stringify(stored)).not.toContain(out.bearer);
     });
 
-    it('rejects non-read scopes (v1 is read-only)', async () => {
+    it('accepts :read scopes', async () => {
       await expect(
         svc.issue({
           name: 't', organizationId: 'o', agentName: 'a',
-          scopes: ['displays:write'],
+          scopes: ['displays:read'],
         }),
-      ).rejects.toThrow(/read-only/);
+      ).resolves.toMatchObject({ bearer: expect.stringMatching(/^mcp_/) });
+    });
+
+    it('accepts :write scopes (added when support-triage migration needed write tools)', async () => {
+      await expect(
+        svc.issue({
+          name: 't', organizationId: 'o', agentName: 'a',
+          scopes: ['support:write'],
+        }),
+      ).resolves.toMatchObject({ bearer: expect.stringMatching(/^mcp_/) });
+    });
+
+    it('rejects scopes lacking a :read or :write suffix (typo guard)', async () => {
+      await expect(
+        svc.issue({
+          name: 't', organizationId: 'o', agentName: 'a',
+          scopes: ['displays'],
+        }),
+      ).rejects.toThrow(/:read.*:write/);
+      await expect(
+        svc.issue({
+          name: 't', organizationId: 'o', agentName: 'a',
+          scopes: ['displays:admin'],
+        }),
+      ).rejects.toThrow(/:read.*:write/);
     });
 
     it('rejects empty scope list', async () => {

--- a/middleware/src/modules/mcp/auth/mcp-token.service.ts
+++ b/middleware/src/modules/mcp/auth/mcp-token.service.ts
@@ -66,11 +66,14 @@ export class McpTokenService {
     if (input.scopes.length === 0) {
       throw new Error('MCP token must have at least one scope');
     }
-    // Reject any non-read scope until v2 (writes) ships.
+    // Allow `<resource>:read` and `<resource>:write` scopes. Anything
+    // else is a typo — fail loud at issuance rather than silently
+    // letting an unrecognized scope ride along (it would never match
+    // a `hasScope` check, but the operator wouldn't know why).
     for (const s of input.scopes) {
-      if (!s.endsWith(':read')) {
+      if (!/:(read|write)$/.test(s)) {
         throw new Error(
-          `MCP v1 issues read-only tokens; rejected scope '${s}'`,
+          `MCP scope must end in ':read' or ':write'; rejected '${s}'`,
         );
       }
     }

--- a/middleware/src/modules/mcp/mcp.service.ts
+++ b/middleware/src/modules/mcp/mcp.service.ts
@@ -1,12 +1,18 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpServer as McpServerCtor } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { McpRequestContext } from './auth/mcp-context';
 import { McpAuditService } from './audit/mcp-audit.service';
 import { mapExceptionToMcpError } from './lib/error-mapping';
 import { DisplaysService } from '../displays/displays.service';
 import { SupportService } from '../support/support.service';
 import { LIST_DISPLAYS_TOOL } from './tools/displays.tools';
-import { LIST_OPEN_SUPPORT_REQUESTS_TOOL } from './tools/support.tools';
+import {
+  CREATE_SUPPORT_MESSAGE_TOOL,
+  LIST_OPEN_SUPPORT_REQUESTS_TOOL,
+  UPDATE_SUPPORT_REQUEST_AI_CATEGORY_TOOL,
+  UPDATE_SUPPORT_REQUEST_PRIORITY_TOOL,
+} from './tools/support.tools';
 
 /**
  * Builds a fresh `McpServer` per incoming HTTP request. The SDK's
@@ -19,10 +25,9 @@ import { LIST_OPEN_SUPPORT_REQUESTS_TOOL } from './tools/support.tools';
  * Cost: object construction + a few `registerTool` calls (no I/O).
  * Negligible vs the actual tool work.
  *
- * Tool handlers receive an `extra` arg from the SDK that carries
- * `authInfo`. We populate `authInfo.extra.mcpContext` from the
- * controller per-request so each tool sees the right
- * organization/agent/scopes for THIS call.
+ * Tool handlers receive their per-request `McpRequestContext` via
+ * closure capture, NOT via SDK auth-info plumbing — see PR #46 for
+ * why (the SDK silently drops `authInfo.extra` on its way to handlers).
  */
 @Injectable()
 export class McpService implements OnModuleInit {
@@ -40,65 +45,93 @@ export class McpService implements OnModuleInit {
     // request. The instance is then discarded.
     this.buildServer(undefined);
     this.logger.log(
-      'MCP server factory ready — 2 tools will be registered per request (list_displays, list_open_support_requests)',
+      'MCP server factory ready — 5 tools registered per request (list_displays, list_open_support_requests, update_support_request_priority, update_support_request_ai_category, create_support_message)',
     );
   }
 
   /**
    * Build a fresh MCP server with every tool registered, bound to a
-   * specific request context. The handler closures capture `context`
-   * at build time — no reliance on the SDK preserving auth-info
-   * fields through `transport.handleRequest`.
+   * specific request context.
    *
-   * Called once per incoming HTTP request by `McpController`.
    * `context` may be `undefined` only for the onModuleInit
    * sanity-build, which never serves a real request.
    */
   buildServer(context: McpRequestContext | undefined): McpServer {
-    const server = new McpServer(
-      { name: 'vizora-mcp', version: '0.1.0' },
+    const server = new McpServerCtor(
+      { name: 'vizora-mcp', version: '0.2.0' },
       { capabilities: { tools: { listChanged: false } } },
     );
-    this.registerListDisplays(server, context);
-    this.registerListOpenSupportRequests(server, context);
+    this.registerTool(server, LIST_DISPLAYS_TOOL, context, this.displays);
+    this.registerTool(server, LIST_OPEN_SUPPORT_REQUESTS_TOOL, context, this.support);
+    this.registerTool(
+      server,
+      UPDATE_SUPPORT_REQUEST_PRIORITY_TOOL,
+      context,
+      this.support,
+    );
+    this.registerTool(
+      server,
+      UPDATE_SUPPORT_REQUEST_AI_CATEGORY_TOOL,
+      context,
+      this.support,
+    );
+    this.registerTool(server, CREATE_SUPPORT_MESSAGE_TOOL, context, this.support);
     return server;
   }
 
   /**
-   * Wraps tool registration with a uniform try/catch + audit pattern
-   * so each tool file stays focused on the tool itself.
+   * Generic registration wrapper: applies the per-tool input schema,
+   * delegates to the tool's handler, records an `mcp_audit_log` row
+   * for both success and failure, and translates thrown exceptions
+   * into the MCP-spec `isError: true` content shape.
+   *
+   * Generic over the tool registry entry's handler signature — the
+   * handler receives the input, the request context, and a typed
+   * service singleton. The third arg is whatever singleton the tool
+   * needs (DisplaysService, SupportService, etc).
    */
-  private registerListDisplays(
+  private registerTool<TIn, TOut, TService>(
     server: McpServer,
+    tool: {
+      name: string;
+      description: string;
+      inputSchema: { shape: Record<string, unknown> };
+      handler: (
+        input: TIn,
+        context: McpRequestContext,
+        service: TService,
+      ) => Promise<TOut>;
+    },
     context: McpRequestContext | undefined,
+    service: TService,
   ): void {
-    const t = LIST_DISPLAYS_TOOL;
     server.registerTool(
-      t.name,
+      tool.name,
       {
-        description: t.description,
-        inputSchema: t.inputSchema.shape,
+        description: tool.description,
+        inputSchema: tool.inputSchema.shape,
       },
-      async (input) => {
+      async (input: unknown) => {
         const startedAt = Date.now();
         if (!context) {
-          // Should be impossible — controller always sets it. Fail loud.
-          throw new Error('MCP tool invoked without context (controller wiring bug)');
+          throw new Error(
+            'MCP tool invoked without context (controller wiring bug)',
+          );
         }
         try {
-          const result = await t.handler(input, context, this.displays);
+          const result = await tool.handler(input as TIn, context, service);
           await this.audit.record({
             tokenId: context.tokenId,
             agentName: context.agentName,
             organizationId: context.organizationId,
-            tool: t.name,
+            tool: tool.name,
             paramsRaw: input,
             status: 'success',
             latencyMs: Date.now() - startedAt,
           });
           return {
             content: [{ type: 'text', text: JSON.stringify(result) }],
-            structuredContent: result,
+            structuredContent: result as Record<string, unknown>,
           };
         } catch (err) {
           const mapped = mapExceptionToMcpError(err);
@@ -106,72 +139,7 @@ export class McpService implements OnModuleInit {
             tokenId: context.tokenId,
             agentName: context.agentName,
             organizationId: context.organizationId,
-            tool: t.name,
-            paramsRaw: input,
-            status: 'error',
-            errorCode: mapped.code,
-            latencyMs: Date.now() - startedAt,
-          });
-          // Surface as an MCP tool-error result. The SDK converts
-          // thrown exceptions to 'isError: true' content; we follow
-          // the convention so agents see the typed error code in
-          // structuredContent.
-          return {
-            isError: true,
-            content: [{ type: 'text', text: mapped.message }],
-            structuredContent: { error: mapped },
-          };
-        }
-      },
-    );
-  }
-
-  /**
-   * Twin of `registerListDisplays` for the support-triage read tool.
-   * The audit + error-wrap boilerplate is duplicated rather than
-   * extracted because (a) we have only two tools today, and (b) the
-   * audit row carries the tool name as a literal so any helper would
-   * need to thread it through anyway. When PR-B adds the remaining
-   * tools we'll factor a generic `wrapTool(server, t, exec)` helper.
-   */
-  private registerListOpenSupportRequests(
-    server: McpServer,
-    context: McpRequestContext | undefined,
-  ): void {
-    const t = LIST_OPEN_SUPPORT_REQUESTS_TOOL;
-    server.registerTool(
-      t.name,
-      {
-        description: t.description,
-        inputSchema: t.inputSchema.shape,
-      },
-      async (input) => {
-        const startedAt = Date.now();
-        if (!context) {
-          throw new Error('MCP tool invoked without context (controller wiring bug)');
-        }
-        try {
-          const result = await t.handler(input, context, this.support);
-          await this.audit.record({
-            tokenId: context.tokenId,
-            agentName: context.agentName,
-            organizationId: context.organizationId,
-            tool: t.name,
-            paramsRaw: input,
-            status: 'success',
-            latencyMs: Date.now() - startedAt,
-          });
-          return {
-            content: [{ type: 'text', text: JSON.stringify(result) }],
-            structuredContent: result,
-          };
-        } catch (err) {
-          const mapped = mapExceptionToMcpError(err);
-          await this.audit.record({
-            tokenId: context.tokenId,
-            agentName: context.agentName,
-            organizationId: context.organizationId,
-            tool: t.name,
+            tool: tool.name,
             paramsRaw: input,
             status: 'error',
             errorCode: mapped.code,

--- a/middleware/src/modules/mcp/schemas/tool-inputs.ts
+++ b/middleware/src/modules/mcp/schemas/tool-inputs.ts
@@ -30,3 +30,57 @@ export const ListOpenSupportRequestsInput = z.object({
 });
 
 export type ListOpenSupportRequestsInputT = z.infer<typeof ListOpenSupportRequestsInput>;
+
+// ── Write tools (require :write scope) ─────────────────────────────────────
+
+const TICKET_PRIORITY = z.enum(['urgent', 'high', 'normal', 'low']);
+
+// Mirrors the V2_SLUGS list in @vizora/database. Kept inline to avoid a
+// runtime import from the data-package; the union is small and stable.
+const TICKET_CATEGORY_V2 = z.enum([
+  'device_pairing_failed',
+  'device_offline',
+  'device_wrong_content',
+  'device_playback_error',
+  'device_display_config',
+  'content_upload_failed',
+  'content_not_showing',
+  'content_expired',
+  'content_template_broken',
+  'content_storage_limit',
+  'schedule_not_playing',
+  'schedule_timezone_issue',
+  'schedule_conflict',
+  'schedule_coverage_gap',
+  'analytics_missing_data',
+  'analytics_wrong_count',
+  'analytics_export_failed',
+  'account_access_lost',
+  'account_permissions',
+  'billing_invoice_question',
+  'other',
+]);
+
+export const UpdateSupportRequestPriorityInput = z.object({
+  request_id: z.string().min(1).describe('Support request id (cuid).'),
+  priority: TICKET_PRIORITY.describe('New priority. One of urgent | high | normal | low.'),
+});
+export type UpdateSupportRequestPriorityInputT = z.infer<typeof UpdateSupportRequestPriorityInput>;
+
+export const UpdateSupportRequestAiCategoryInput = z.object({
+  request_id: z.string().min(1).describe('Support request id (cuid).'),
+  ai_category: TICKET_CATEGORY_V2.describe(
+    'V2 taxonomy slug. Constrained to the union — unknown slugs are rejected at the wire.',
+  ),
+});
+export type UpdateSupportRequestAiCategoryInputT = z.infer<typeof UpdateSupportRequestAiCategoryInput>;
+
+export const CreateSupportMessageInput = z.object({
+  request_id: z.string().min(1).describe('Support request id (cuid).'),
+  content: z
+    .string()
+    .min(1)
+    .max(2000)
+    .describe('Message body. Templates only — never raw LLM output. Max 2000 chars.'),
+});
+export type CreateSupportMessageInputT = z.infer<typeof CreateSupportMessageInput>;

--- a/middleware/src/modules/mcp/schemas/tool-outputs.ts
+++ b/middleware/src/modules/mcp/schemas/tool-outputs.ts
@@ -68,3 +68,24 @@ export const ListOpenSupportRequestsOutput = z.object({
 });
 
 export type ListOpenSupportRequestsOutputT = z.infer<typeof ListOpenSupportRequestsOutput>;
+
+// ── Write tool outputs ─────────────────────────────────────────────────────
+
+/**
+ * Generic OK/skipped result for the priority + ai_category writers.
+ * `updated=false` means the cross-org guard fired (or the row was
+ * deleted) — agents should NOT retry blindly.
+ */
+export const UpdateSupportRequestResult = z.object({
+  request_id: z.string(),
+  updated: z.boolean(),
+});
+export type UpdateSupportRequestResultT = z.infer<typeof UpdateSupportRequestResult>;
+
+export const CreateSupportMessageResult = z.object({
+  request_id: z.string(),
+  message_id: z.string().nullable(),
+  created_at: z.string().datetime().nullable(),
+  created: z.boolean(),
+});
+export type CreateSupportMessageResultT = z.infer<typeof CreateSupportMessageResult>;

--- a/middleware/src/modules/mcp/tools/support.tools.spec.ts
+++ b/middleware/src/modules/mcp/tools/support.tools.spec.ts
@@ -1,5 +1,10 @@
 import { ForbiddenException } from '@nestjs/common';
-import { listOpenSupportRequestsTool } from './support.tools';
+import {
+  createSupportMessageTool,
+  listOpenSupportRequestsTool,
+  updateSupportRequestAiCategoryTool,
+  updateSupportRequestPriorityTool,
+} from './support.tools';
 import type { McpRequestContext } from '../auth/mcp-context';
 
 function ctx(scopes: string[]): McpRequestContext {
@@ -163,5 +168,176 @@ describe('listOpenSupportRequestsTool', () => {
       makeSupport([{ id: 'r1', createdAt: ts }]) as never,
     );
     expect(out.support_requests[0].created_at).toBe('2026-05-04T12:34:56.000Z');
+  });
+});
+
+describe('updateSupportRequestPriorityTool', () => {
+  it('throws ForbiddenException when support:write scope missing', async () => {
+    const svc = { setRequestPriority: jest.fn() };
+    await expect(
+      updateSupportRequestPriorityTool(
+        { request_id: 'r1', priority: 'high' },
+        ctx(['support:read']), // read-only token cannot write
+        svc as never,
+      ),
+    ).rejects.toThrow(ForbiddenException);
+    expect(svc.setRequestPriority).not.toHaveBeenCalled();
+  });
+
+  it('returns { updated: true } when service confirms the update', async () => {
+    const svc = { setRequestPriority: jest.fn().mockResolvedValue(true) };
+    const out = await updateSupportRequestPriorityTool(
+      { request_id: 'r1', priority: 'urgent' },
+      ctx(['support:write']),
+      svc as never,
+    );
+    expect(out).toEqual({ request_id: 'r1', updated: true });
+    expect(svc.setRequestPriority).toHaveBeenCalledWith('org_1', 'r1', 'urgent');
+  });
+
+  it('returns { updated: false } when no row matched (cross-org guard or deleted)', async () => {
+    const svc = { setRequestPriority: jest.fn().mockResolvedValue(false) };
+    const out = await updateSupportRequestPriorityTool(
+      { request_id: 'r-missing', priority: 'low' },
+      ctx(['support:write']),
+      svc as never,
+    );
+    expect(out).toEqual({ request_id: 'r-missing', updated: false });
+  });
+
+  it('rejects unknown priority values via Zod', async () => {
+    const svc = { setRequestPriority: jest.fn() };
+    await expect(
+      updateSupportRequestPriorityTool(
+        { request_id: 'r1', priority: 'screaming' },
+        ctx(['support:write']),
+        svc as never,
+      ),
+    ).rejects.toThrow();
+    expect(svc.setRequestPriority).not.toHaveBeenCalled();
+  });
+
+  it('passes the calling token org (NOT user-controlled) to the service', async () => {
+    const svc = { setRequestPriority: jest.fn().mockResolvedValue(true) };
+    await updateSupportRequestPriorityTool(
+      { request_id: 'r1', priority: 'high' },
+      ctx(['support:write']),
+      svc as never,
+    );
+    const orgArg = svc.setRequestPriority.mock.calls[0][0];
+    expect(orgArg).toBe('org_1');
+  });
+});
+
+describe('updateSupportRequestAiCategoryTool', () => {
+  it('throws ForbiddenException when support:write scope missing', async () => {
+    const svc = { setRequestAiCategory: jest.fn() };
+    await expect(
+      updateSupportRequestAiCategoryTool(
+        { request_id: 'r1', ai_category: 'device_offline' },
+        ctx(['support:read']),
+        svc as never,
+      ),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('rejects unknown V2 slugs at the Zod wire layer (does NOT reach the service)', async () => {
+    const svc = { setRequestAiCategory: jest.fn() };
+    await expect(
+      updateSupportRequestAiCategoryTool(
+        { request_id: 'r1', ai_category: 'fictional_category_v3' },
+        ctx(['support:write']),
+        svc as never,
+      ),
+    ).rejects.toThrow();
+    expect(svc.setRequestAiCategory).not.toHaveBeenCalled();
+  });
+
+  it('returns { updated: true } and forwards the org from context', async () => {
+    const svc = { setRequestAiCategory: jest.fn().mockResolvedValue(true) };
+    const out = await updateSupportRequestAiCategoryTool(
+      { request_id: 'r1', ai_category: 'billing_invoice_question' },
+      ctx(['support:write']),
+      svc as never,
+    );
+    expect(out).toEqual({ request_id: 'r1', updated: true });
+    expect(svc.setRequestAiCategory).toHaveBeenCalledWith(
+      'org_1',
+      'r1',
+      'billing_invoice_question',
+    );
+  });
+});
+
+describe('createSupportMessageTool', () => {
+  it('throws ForbiddenException when support:write scope missing', async () => {
+    const svc = { createAgentMessage: jest.fn() };
+    await expect(
+      createSupportMessageTool(
+        { request_id: 'r1', content: 'hi' },
+        ctx(['support:read']),
+        svc as never,
+      ),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('returns { created: true } and serializes createdAt to ISO when message lands', async () => {
+    const svc = {
+      createAgentMessage: jest.fn().mockResolvedValue({
+        id: 'msg-123',
+        createdAt: new Date('2026-05-04T13:00:00Z'),
+      }),
+    };
+    const out = await createSupportMessageTool(
+      { request_id: 'r1', content: 'Triage: high urgency, escalating to engineering.' },
+      ctx(['support:write']),
+      svc as never,
+    );
+    expect(out).toEqual({
+      request_id: 'r1',
+      message_id: 'msg-123',
+      created_at: '2026-05-04T13:00:00.000Z',
+      created: true,
+    });
+  });
+
+  it('returns { created: false } and null ids when service refuses (cross-org or missing)', async () => {
+    const svc = { createAgentMessage: jest.fn().mockResolvedValue(null) };
+    const out = await createSupportMessageTool(
+      { request_id: 'r-missing', content: 'hello' },
+      ctx(['support:write']),
+      svc as never,
+    );
+    expect(out).toEqual({
+      request_id: 'r-missing',
+      message_id: null,
+      created_at: null,
+      created: false,
+    });
+  });
+
+  it('rejects empty content via Zod min(1)', async () => {
+    const svc = { createAgentMessage: jest.fn() };
+    await expect(
+      createSupportMessageTool(
+        { request_id: 'r1', content: '' },
+        ctx(['support:write']),
+        svc as never,
+      ),
+    ).rejects.toThrow();
+    expect(svc.createAgentMessage).not.toHaveBeenCalled();
+  });
+
+  it('rejects content over 2000 chars via Zod max(2000)', async () => {
+    const svc = { createAgentMessage: jest.fn() };
+    const huge = 'x'.repeat(2001);
+    await expect(
+      createSupportMessageTool(
+        { request_id: 'r1', content: huge },
+        ctx(['support:write']),
+        svc as never,
+      ),
+    ).rejects.toThrow();
+    expect(svc.createAgentMessage).not.toHaveBeenCalled();
   });
 });

--- a/middleware/src/modules/mcp/tools/support.tools.ts
+++ b/middleware/src/modules/mcp/tools/support.tools.ts
@@ -2,12 +2,22 @@ import { ForbiddenException } from '@nestjs/common';
 import { SupportService } from '../../support/support.service';
 import { hasScope, type McpRequestContext } from '../auth/mcp-context';
 import {
+  CreateSupportMessageInput,
+  type CreateSupportMessageInputT,
   ListOpenSupportRequestsInput,
   type ListOpenSupportRequestsInputT,
+  UpdateSupportRequestAiCategoryInput,
+  type UpdateSupportRequestAiCategoryInputT,
+  UpdateSupportRequestPriorityInput,
+  type UpdateSupportRequestPriorityInputT,
 } from '../schemas/tool-inputs';
 import {
+  CreateSupportMessageResult,
+  type CreateSupportMessageResultT,
   ListOpenSupportRequestsOutput,
   type ListOpenSupportRequestsOutputT,
+  UpdateSupportRequestResult,
+  type UpdateSupportRequestResultT,
 } from '../schemas/tool-outputs';
 
 /**
@@ -93,4 +103,133 @@ export const LIST_OPEN_SUPPORT_REQUESTS_TOOL = {
   inputSchema: ListOpenSupportRequestsInput,
   outputSchema: ListOpenSupportRequestsOutput,
   handler: listOpenSupportRequestsTool,
+};
+
+// ── Write tools (require :write scope) ─────────────────────────────────────
+
+/**
+ * MCP tool: `update_support_request_priority`
+ *
+ * Sets the `priority` of one support request. Cross-org guard via the
+ * service's compound where (id + organizationId).
+ *
+ * Scope required: `support:write`. Returns `{ updated: false }` (NOT an
+ * error) when the row doesn't match — agents should treat that as
+ * "stop, the request is gone or not yours" and not retry.
+ */
+export async function updateSupportRequestPriorityTool(
+  rawInput: unknown,
+  context: McpRequestContext,
+  supportService: SupportService,
+): Promise<UpdateSupportRequestResultT> {
+  if (!hasScope(context, 'support:write')) {
+    throw new ForbiddenException("Token lacks scope 'support:write'");
+  }
+  const input = UpdateSupportRequestPriorityInput.parse(
+    rawInput,
+  ) as UpdateSupportRequestPriorityInputT;
+  const updated = await supportService.setRequestPriority(
+    context.organizationId,
+    input.request_id,
+    input.priority,
+  );
+  return UpdateSupportRequestResult.parse({
+    request_id: input.request_id,
+    updated,
+  });
+}
+
+export const UPDATE_SUPPORT_REQUEST_PRIORITY_TOOL = {
+  name: 'update_support_request_priority',
+  description:
+    "Set the priority of one support request belonging to the calling token's organization. Returns { updated: false } if no row matched (cross-org guard or deleted) — DO NOT retry on false. Priority must be one of urgent | high | normal | low.",
+  scope: 'support:write' as const,
+  inputSchema: UpdateSupportRequestPriorityInput,
+  outputSchema: UpdateSupportRequestResult,
+  handler: updateSupportRequestPriorityTool,
+};
+
+/**
+ * MCP tool: `update_support_request_ai_category`
+ *
+ * Sets the V2 taxonomy slug. The Zod input enum constrains to the
+ * known V2 union — unknown slugs are rejected at the wire, never
+ * reaching the DB.
+ */
+export async function updateSupportRequestAiCategoryTool(
+  rawInput: unknown,
+  context: McpRequestContext,
+  supportService: SupportService,
+): Promise<UpdateSupportRequestResultT> {
+  if (!hasScope(context, 'support:write')) {
+    throw new ForbiddenException("Token lacks scope 'support:write'");
+  }
+  const input = UpdateSupportRequestAiCategoryInput.parse(
+    rawInput,
+  ) as UpdateSupportRequestAiCategoryInputT;
+  const updated = await supportService.setRequestAiCategory(
+    context.organizationId,
+    input.request_id,
+    input.ai_category,
+  );
+  return UpdateSupportRequestResult.parse({
+    request_id: input.request_id,
+    updated,
+  });
+}
+
+export const UPDATE_SUPPORT_REQUEST_AI_CATEGORY_TOOL = {
+  name: 'update_support_request_ai_category',
+  description:
+    'Set the V2-taxonomy aiCategory slug on one support request. The slug is constrained to the V2 enum — unknown values are rejected at the wire. Returns { updated: false } if no row matched. Idempotent for the same value.',
+  scope: 'support:write' as const,
+  inputSchema: UpdateSupportRequestAiCategoryInput,
+  outputSchema: UpdateSupportRequestResult,
+  handler: updateSupportRequestAiCategoryTool,
+};
+
+/**
+ * MCP tool: `create_support_message`
+ *
+ * Posts an agent-authored comment to a support thread. The agent name
+ * comes from the bearer-token context (NOT user-controlled), the
+ * authorType is hardcoded `'agent'`, and the userId is the original
+ * submitter (looked up server-side, not trusted from input).
+ *
+ * Per the architecture rules, callers SHOULD send pre-templated
+ * content here — never raw LLM output. The content cap (2000 chars)
+ * is the hard wall; the discipline is on the agent prompt.
+ */
+export async function createSupportMessageTool(
+  rawInput: unknown,
+  context: McpRequestContext,
+  supportService: SupportService,
+): Promise<CreateSupportMessageResultT> {
+  if (!hasScope(context, 'support:write')) {
+    throw new ForbiddenException("Token lacks scope 'support:write'");
+  }
+  const input = CreateSupportMessageInput.parse(
+    rawInput,
+  ) as CreateSupportMessageInputT;
+  const created = await supportService.createAgentMessage(
+    context.organizationId,
+    input.request_id,
+    input.content,
+  );
+  return CreateSupportMessageResult.parse({
+    request_id: input.request_id,
+    message_id: created?.id ?? null,
+    created_at: created ? created.createdAt.toISOString() : null,
+    created: Boolean(created),
+  });
+}
+
+export const CREATE_SUPPORT_MESSAGE_TOOL = {
+  name: 'create_support_message',
+  description:
+    "Append an agent-authored message to one support request's thread. The author identity is taken from the bearer-token context (NOT user-controlled). Returns { created: false } if the request doesn't exist or belongs to another org. Content is capped at 2000 chars; callers SHOULD send pre-templated text, not raw LLM output.",
+  scope: 'support:write' as const,
+  inputSchema: CreateSupportMessageInput,
+  outputSchema: CreateSupportMessageResult,
+  handler: createSupportMessageTool,
 };

--- a/middleware/src/modules/support/support.service.spec.ts
+++ b/middleware/src/modules/support/support.service.spec.ts
@@ -50,7 +50,9 @@ describe('SupportService', () => {
         create: jest.fn(),
         findMany: jest.fn(),
         findUnique: jest.fn(),
+        findFirst: jest.fn(),
         update: jest.fn(),
+        updateMany: jest.fn(),
         count: jest.fn(),
       },
       supportMessage: {
@@ -837,6 +839,72 @@ describe('SupportService', () => {
       const findCall = db.supportRequest.findMany.mock.calls[0][0];
       expect(findCall.skip).toBe(20);
       expect(findCall.take).toBe(10);
+    });
+  });
+
+  describe('setRequestPriority (write tool)', () => {
+    it('uses updateMany with compound where (id + organizationId) — cross-org guard', async () => {
+      db.supportRequest.updateMany.mockResolvedValueOnce({ count: 1 });
+      const ok = await service.setRequestPriority(orgId, 'r1', 'high');
+      expect(ok).toBe(true);
+      expect(db.supportRequest.updateMany).toHaveBeenCalledWith({
+        where: { id: 'r1', organizationId: orgId },
+        data: { priority: 'high' },
+      });
+    });
+
+    it('returns false when no row matched (wrong org or deleted)', async () => {
+      db.supportRequest.updateMany.mockResolvedValueOnce({ count: 0 });
+      const ok = await service.setRequestPriority(orgId, 'r-missing', 'high');
+      expect(ok).toBe(false);
+    });
+  });
+
+  describe('setRequestAiCategory (write tool)', () => {
+    it('uses updateMany with cross-org guard', async () => {
+      db.supportRequest.updateMany.mockResolvedValueOnce({ count: 1 });
+      const ok = await service.setRequestAiCategory(orgId, 'r1', 'device_offline');
+      expect(ok).toBe(true);
+      expect(db.supportRequest.updateMany).toHaveBeenCalledWith({
+        where: { id: 'r1', organizationId: orgId },
+        data: { aiCategory: 'device_offline' },
+      });
+    });
+
+    it('returns false when no row matched', async () => {
+      db.supportRequest.updateMany.mockResolvedValueOnce({ count: 0 });
+      const ok = await service.setRequestAiCategory(orgId, 'r-missing', 'other');
+      expect(ok).toBe(false);
+    });
+  });
+
+  describe('createAgentMessage (write tool)', () => {
+    it('looks up the request first to verify org, then creates the message attributing to original submitter', async () => {
+      db.supportRequest.findFirst.mockResolvedValueOnce({ id: 'r1', userId: 'u-original' });
+      db.supportMessage.create.mockResolvedValueOnce({
+        id: 'msg-new',
+        createdAt: new Date('2026-05-04T12:00:00Z'),
+      });
+      const out = await service.createAgentMessage(orgId, 'r1', 'Triage: high urgency');
+      expect(out).toEqual({ id: 'msg-new', createdAt: new Date('2026-05-04T12:00:00Z') });
+      expect(db.supportMessage.create).toHaveBeenCalledWith({
+        data: {
+          requestId: 'r1',
+          organizationId: orgId,
+          userId: 'u-original',
+          role: 'assistant',
+          authorType: 'agent',
+          content: 'Triage: high urgency',
+        },
+        select: { id: true, createdAt: true },
+      });
+    });
+
+    it("returns null without writing when the request doesn't exist or belongs to another org (cross-org guard)", async () => {
+      db.supportRequest.findFirst.mockResolvedValueOnce(null);
+      const out = await service.createAgentMessage(orgId, 'r-missing', 'hello');
+      expect(out).toBeNull();
+      expect(db.supportMessage.create).not.toHaveBeenCalled();
     });
   });
 });

--- a/middleware/src/modules/support/support.service.ts
+++ b/middleware/src/modules/support/support.service.ts
@@ -282,6 +282,84 @@ export class SupportService {
   }
 
   /**
+   * Set the `priority` of a support request — agent-driven path.
+   *
+   * Used by Hermes (and the legacy PM2 cron) to escalate or de-escalate
+   * tickets after triage scoring. Cross-org guard via `updateMany`'s
+   * compound where (id + organizationId) ensures a token scoped to one
+   * org cannot mutate a request belonging to another org even if it
+   * gets the id wrong.
+   *
+   * Returns true if exactly one row was updated, false if no row
+   * matched (deleted, wrong org, etc).
+   */
+  async setRequestPriority(
+    organizationId: string,
+    requestId: string,
+    priority: 'urgent' | 'high' | 'normal' | 'low',
+  ): Promise<boolean> {
+    const res = await this.db.supportRequest.updateMany({
+      where: { id: requestId, organizationId },
+      data: { priority },
+    });
+    return res.count === 1;
+  }
+
+  /**
+   * Set the `aiCategory` (V2 taxonomy slug) of a support request.
+   * Idempotent for the same value — Prisma treats no-change updates
+   * as 1-row updates. This matches the existing PM2 cron's behavior.
+   */
+  async setRequestAiCategory(
+    organizationId: string,
+    requestId: string,
+    aiCategory: string,
+  ): Promise<boolean> {
+    const res = await this.db.supportRequest.updateMany({
+      where: { id: requestId, organizationId },
+      data: { aiCategory },
+    });
+    return res.count === 1;
+  }
+
+  /**
+   * Append an agent-authored message to a support request's thread.
+   *
+   * `userId` is the original submitter (kept for attribution + access
+   * control on the messages API). The agent identity rides on
+   * `authorType='agent'`. The MCP tool layer passes the agent name
+   * from the bearer-token context for audit purposes; we do NOT
+   * persist that here — the audit trail lives in `mcp_audit_log`.
+   *
+   * Refuses to write if the request doesn't belong to the named org
+   * (cross-org guard).
+   */
+  async createAgentMessage(
+    organizationId: string,
+    requestId: string,
+    content: string,
+  ): Promise<{ id: string; createdAt: Date } | null> {
+    const req = await this.db.supportRequest.findFirst({
+      where: { id: requestId, organizationId },
+      select: { id: true, userId: true },
+    });
+    if (!req) return null;
+
+    const created = await this.db.supportMessage.create({
+      data: {
+        requestId: req.id,
+        organizationId,
+        userId: req.userId,
+        role: 'assistant',
+        authorType: 'agent',
+        content,
+      },
+      select: { id: true, createdAt: true },
+    });
+    return created;
+  }
+
+  /**
    * Get a single support request with messages
    */
   async findOne(id: string, user: UserInfo) {

--- a/scripts/agents/compare-hermes-vs-heuristic.ts
+++ b/scripts/agents/compare-hermes-vs-heuristic.ts
@@ -1,0 +1,208 @@
+#!/usr/bin/env npx tsx
+/**
+ * Compare Hermes shadow-mode classifications against the existing
+ * heuristic classifier's DB writes.
+ *
+ * Reads `/var/log/hermes/vizora-support-triage-shadow.jsonl` (one JSONL
+ * row per Hermes cron tick), joins to `support_requests` by id, and
+ * reports:
+ *   - cron firing rate (heartbeat lines per period)
+ *   - per-ticket priority agreement between Hermes-suggested and the
+ *     DB-stored priority
+ *   - sample disagreements
+ *
+ * **What this can and cannot tell us**
+ *
+ * The DB `priority` field reflects the user's original submission
+ * unless the heuristic PM2 cron decided the score diverged enough to
+ * write back (rank-distance ≥ 2 in scripts/agents/support-triage.ts).
+ * Most rows are the user's submission, NOT the heuristic's score-to-
+ * priority output. So this script answers:
+ *
+ *   "Would Hermes have proposed a different priority than what the
+ *    user submitted (or what the heuristic occasionally overrode)?"
+ *
+ * It does NOT answer "Hermes score vs heuristic score" head-to-head.
+ * For that we'd need the heuristic cron to also log its score to a
+ * parallel file. That's a tracked follow-up — see backlog.md.
+ *
+ * Run from the VPS (where both the shadow log and the DB live):
+ *
+ *   ssh root@89.167.55.176 'cd /opt/vizora/app && export $(grep DATABASE_URL .env | xargs) && npx tsx scripts/agents/compare-hermes-vs-heuristic.ts'
+ */
+
+import 'dotenv/config';
+import { readFileSync, existsSync } from 'fs';
+import { prisma } from '@vizora/database';
+
+const SHADOW_LOG =
+  process.env.HERMES_SHADOW_LOG ??
+  '/var/log/hermes/vizora-support-triage-shadow.jsonl';
+
+interface HermesRow {
+  timestamp: string;
+  run_id: string;
+  ticket_id: string | null;
+  organization_id: string | null;
+  hermes_score: number | null;
+  hermes_priority: 'urgent' | 'high' | 'normal' | 'low' | null;
+  hermes_reasoning: string | null;
+  input_signals: Record<string, unknown> | null;
+}
+
+interface DisagreementSample {
+  ticket: string;
+  hermes: string;
+  db: string;
+  reason: string | null;
+}
+
+function pct(n: number, d: number): string {
+  return d === 0 ? '0%' : `${Math.round((100 * n) / d)}%`;
+}
+
+function priorityRank(p: string): number {
+  switch (p.toLowerCase()) {
+    case 'urgent':
+    case 'critical':
+      return 3;
+    case 'high':
+      return 2;
+    case 'normal':
+    case 'medium':
+      return 1;
+    case 'low':
+      return 0;
+    default:
+      return -1; // unknown / null
+  }
+}
+
+async function main(): Promise<void> {
+  if (!existsSync(SHADOW_LOG)) {
+    console.error(`No shadow log at ${SHADOW_LOG}`);
+    console.error(`Set HERMES_SHADOW_LOG to override the path.`);
+    process.exitCode = 2;
+    return;
+  }
+
+  const text = readFileSync(SHADOW_LOG, 'utf8');
+  const lines = text.split('\n').filter(Boolean);
+  const rows: HermesRow[] = [];
+  let malformed = 0;
+  for (const line of lines) {
+    try {
+      rows.push(JSON.parse(line) as HermesRow);
+    } catch {
+      malformed++;
+    }
+  }
+
+  const heartbeats = rows.filter((r) => r.ticket_id == null);
+  const scored = rows.filter((r) => r.ticket_id != null);
+
+  // Cron-firing-rate signal: time span / heartbeat count → expected ~5 min between
+  let firingRateNote = '';
+  if (heartbeats.length >= 2) {
+    const first = new Date(heartbeats[0].timestamp).getTime();
+    const last = new Date(heartbeats[heartbeats.length - 1].timestamp).getTime();
+    const spanMin = (last - first) / 60_000;
+    const ticksPerHour =
+      spanMin > 0 ? (heartbeats.length / spanMin) * 60 : NaN;
+    firingRateNote = ` — ~${ticksPerHour.toFixed(1)} ticks/hr (cron is */5 → expected ~12)`;
+  }
+
+  console.log('Hermes shadow-mode comparison');
+  console.log('=============================');
+  console.log(`Shadow log:                   ${SHADOW_LOG}`);
+  console.log(`Total log lines:              ${lines.length}`);
+  console.log(`Malformed (skipped):          ${malformed}`);
+  console.log(`Heartbeat rows (cron fires):  ${heartbeats.length}${firingRateNote}`);
+  console.log(`Ticket-scoring rows:          ${scored.length}`);
+
+  if (scored.length === 0) {
+    console.log(
+      '\nNo ticket scorings yet. The Hermes cron is firing but the token-scoped org has no open tickets.',
+    );
+    console.log(
+      'Either seed a request in the E2E Test Org, or expand the token to cover an org with traffic.',
+    );
+    return;
+  }
+
+  const ticketIds = [...new Set(scored.map((r) => r.ticket_id!))];
+  const dbTickets = await prisma.supportRequest.findMany({
+    where: { id: { in: ticketIds } },
+    select: { id: true, priority: true, status: true, aiCategory: true },
+  });
+  const byId = new Map(dbTickets.map((t) => [t.id, t]));
+
+  let agree = 0;
+  let disagree = 0;
+  let unmatched = 0;
+  let rankDiffSum = 0;
+  const samples: DisagreementSample[] = [];
+
+  for (const r of scored) {
+    const t = byId.get(r.ticket_id!);
+    if (!t) {
+      unmatched++;
+      continue;
+    }
+    const dbP = (t.priority ?? '').toLowerCase();
+    const hP = (r.hermes_priority ?? '').toLowerCase();
+    if (dbP === hP) {
+      agree++;
+    } else {
+      disagree++;
+      const rDb = priorityRank(dbP);
+      const rH = priorityRank(hP);
+      if (rDb >= 0 && rH >= 0) rankDiffSum += Math.abs(rDb - rH);
+      if (samples.length < 10) {
+        samples.push({
+          ticket: r.ticket_id!,
+          hermes: hP || '<null>',
+          db: dbP || '<null>',
+          reason: r.hermes_reasoning,
+        });
+      }
+    }
+  }
+
+  const matched = agree + disagree;
+
+  console.log(`\nTickets joined to DB:         ${matched}`);
+  console.log(`Unmatched (deleted/missing):  ${unmatched}`);
+  console.log(`Priority agreement:           ${agree} (${pct(agree, matched)})`);
+  console.log(`Priority disagreement:        ${disagree} (${pct(disagree, matched)})`);
+  if (disagree > 0) {
+    console.log(
+      `Avg disagreement rank-distance: ${(rankDiffSum / disagree).toFixed(2)} (1 = adjacent tier, 3 = max)`,
+    );
+  }
+
+  if (samples.length > 0) {
+    console.log('\nSample disagreements (first 10):');
+    for (const s of samples) {
+      console.log(
+        `  ${s.ticket.slice(0, 8)}  hermes=${s.hermes.padEnd(7)}  db=${s.db.padEnd(7)}  | ${
+          s.reason ?? '<no reason>'
+        }`,
+      );
+    }
+  }
+
+  console.log('\nReminder: DB priority is mostly the user-submitted priority.');
+  console.log('To compare Hermes vs heuristic head-to-head, the existing PM2');
+  console.log('support-triage cron also needs to log its score per cycle to a');
+  console.log("parallel file. Tracked in backlog.md as a follow-up.");
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 2;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
End-to-end progress on the support-triage Hermes migration: shadow skill running in prod cron, comparison infra ready, MCP write tools shipped (gated on shadow-data review before any live cutover).

## What landed
- **Step 1 — Hermes skill (shadow)**: `hermes-skills/vizora-support-triage/SKILL.md`. Calls `list_open_support_requests`, scores via fixed-weight formula, appends JSONL. D13 enforced in prompt.
- **Step 2 — Cron**: `hermes cron */5 * * * *` registered on prod VPS. `hermes-gateway` systemd unit installed + active.
- **Step 3 — Comparison**: `scripts/agents/compare-hermes-vs-heuristic.ts` reads JSONL + DB and reports priority-agreement rate. Honestly calls out its own limit (DB priority ≠ heuristic-score-derived priority).
- **Step 4 — Write tools**: `update_support_request_priority`, `update_support_request_ai_category`, `create_support_message`, all scope `support:write`. Cross-org guards. Zod enum constraints on V2 slugs. Content capped at 2000 chars.
- **Refactor**: `McpService.buildServer()` extracts a generic `registerTool` helper — going from 2 → 5 tools without 5× copies of the audit/error-wrap boilerplate.
- **Token scope expansion**: `McpTokenService.issue()` now accepts `:read` and `:write` suffixes; rejects others as typos.

## Test plan
- [x] 21 new tests across SupportService, support.tools, mcp-token.service
- [x] 115 suites / 2247 tests pass
- [x] `nx build @vizora/middleware` clean
- [ ] After deploy: psql update token to add `support:write` scope
- [ ] After deploy: Hermes one-shot calling each write tool against a seeded test ticket in E2E Test Org

## What this PR does NOT do
- Step 5 cutover (live writes for production orgs). The shadow skill prompt explicitly forbids calling the new write tools. Cutover playbook lives in CLAUDE.md.
- Touch the existing PM2 cron `agent-support-triage`. Nothing decommissioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)