### PR TITLE
chore(agents): codify Hermes-first rule into scaffolds + agent roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,6 +344,21 @@ Automated deployment readiness checker. Runs 30 validation rules across content,
 **Hermes-driven agents (state):**
 - `vizora-support-triage` — **shadow mode** in cron `*/5 * * * *`. Reads via MCP, scores, appends `/var/log/hermes/vizora-support-triage-shadow.jsonl`. Live-mode skill (`SKILL-live.md`) is built and committed but NOT deployed; cutover is a one-line SCP after the gate below clears.
 
+**Agent migration roadmap (Hermes-first rule)**
+
+Inventory of `scripts/agents/*.ts` and their migration status:
+
+| Agent | Lines | State | Migration plan |
+|-------|-------|-------|----------------|
+| support-triage | 306 | LIVE (PM2 cron, every 5 min) | **Migrated to Hermes shadow.** Cutover gated on shadow-data review. |
+| customer-lifecycle | 463 | LIVE (PM2 cron, every 30 min). Sends real onboarding emails when `LIFECYCLE_LIVE=true`. | **Designed, not built.** See `tasks/feature-backlog.md` → "customer-lifecycle Hermes migration" for the design sketch + MCP tool list. Not started in this autonomous run because the outbound-email blast radius warrants explicit per-step approval. |
+| billing-revenue | 32 | SCAFFOLD (gated off). | Per Hermes-first rule, when implemented build as `hermes-skills/vizora-billing-revenue/SKILL.md`, not TS. |
+| content-intelligence | 32 | SCAFFOLD (gated off). | Per Hermes-first rule, build as `hermes-skills/vizora-content-intelligence/SKILL.md`. |
+| screen-health-customer | 33 | SCAFFOLD (gated off). | Per Hermes-first rule, build as `hermes-skills/vizora-screen-health/SKILL.md`. The `list_displays` MCP tool already exists; only `create_customer_incident` write tool needed. |
+| agent-orchestrator | 33 | SCAFFOLD (gated off). | Per Hermes-first rule, **Hermes IS the orchestrator runtime** — use its built-in `delegate_task` tool to coordinate per-family skills, don't write a custom loop. |
+
+Each scaffold's file header now carries the Hermes-first comment so future implementers see the rule without having to rediscover it.
+
 **Cutover playbook for support-triage (Hermes shadow → live)**
 
 Gate before swapping `SKILL.md`:

--- a/scripts/agents/agent-orchestrator.ts
+++ b/scripts/agents/agent-orchestrator.ts
@@ -9,6 +9,18 @@
  *     — never mutates another agent's state file
  *
  * Gated OFF by default. Set AGENT_ORCHESTRATOR_ENABLED=true to activate.
+ *
+ * **Hermes-first rule (2026-05-04):** Hermes Agent IS the orchestrator
+ * runtime. When this is implemented, do NOT build a custom orchestration
+ * loop in TypeScript — instead, write a Hermes skill at
+ * `hermes-skills/vizora-orchestrator/SKILL.md` that uses Hermes's
+ * built-in `delegate_task` tool to spawn the per-family skills as
+ * sub-agents (parallel where independent, sequential where one's
+ * output drives the next). The MCP server provides cross-family read
+ * tools (`list_open_customer_incidents`, etc — to be added). See
+ * `feedback_hermes_first_for_agents` in user memory and
+ * docs/agents-architecture.md for the dispatcher-first routing rule
+ * that this orchestrator must follow.
  */
 
 import 'dotenv/config';

--- a/scripts/agents/billing-revenue.ts
+++ b/scripts/agents/billing-revenue.ts
@@ -8,6 +8,16 @@
  *   - Never mutates billing state (D1 — read-only)
  *
  * Gated OFF by default. Set BILLING_REVENUE_ENABLED=true to activate.
+ *
+ * **Hermes-first rule (2026-05-04):** when this agent is implemented,
+ * build it as a Hermes skill at
+ * `hermes-skills/vizora-billing-revenue/SKILL.md`, NOT as additional
+ * TypeScript logic in this file. The PM2 cron stays only as a thin
+ * shell scheduling `hermes`; the LLM-driven anomaly reasoning and the
+ * natural-language summary live in the skill prompt. See the
+ * support-triage migration in CLAUDE.md "MCP Server" section as the
+ * reference pattern, and `feedback_hermes_first_for_agents` in user
+ * memory.
  */
 
 import 'dotenv/config';

--- a/scripts/agents/content-intelligence.ts
+++ b/scripts/agents/content-intelligence.ts
@@ -4,10 +4,21 @@
  *
  * Intended scope (not yet implemented):
  *   - Aggregate ContentImpression into per-content perf signals
- *   - Run AgentAI.analyzeContent() for underperforming / time-of-day picks
+ *   - Run analyzeContent() for underperforming / time-of-day picks
  *   - Persist suggestions to ContentRecommendation (org-scoped)
  *
  * Gated OFF by default. Set CONTENT_INTELLIGENCE_ENABLED=true to activate.
+ *
+ * **Hermes-first rule (2026-05-04):** when this agent is implemented,
+ * build it as a Hermes skill at
+ * `hermes-skills/vizora-content-intelligence/SKILL.md`, NOT as
+ * additional TypeScript logic here. The new MCP tools needed will be
+ * read-only (`list_content_performance_signals`, `list_underperforming_content`)
+ * plus one write (`upsert_content_recommendation`). The LLM-driven
+ * "which content to recommend at which time-of-day" reasoning lives
+ * in the skill prompt — this file stays as a thin scheduler shell.
+ * See `feedback_hermes_first_for_agents` and the support-triage
+ * migration in CLAUDE.md as the reference pattern.
  */
 
 import 'dotenv/config';

--- a/scripts/agents/screen-health-customer.ts
+++ b/scripts/agents/screen-health-customer.ts
@@ -9,6 +9,17 @@
  *
  * Gated OFF by default. Set SCREEN_HEALTH_CUSTOMER_ENABLED=true to activate
  * the (currently no-op) cycle.
+ *
+ * **Hermes-first rule (2026-05-04):** when this agent is implemented,
+ * build it as a Hermes skill at
+ * `hermes-skills/vizora-screen-health/SKILL.md`, NOT as additional
+ * TypeScript logic here. The agent already has `list_displays` (with
+ * a `status=offline` filter) on the MCP server today — only the write
+ * tool `create_customer_incident` is missing. The LLM-driven
+ * cluster-detection ("are these offline displays a real outage or one
+ * misconfigured device?") lives in the skill prompt. See
+ * `feedback_hermes_first_for_agents` and the support-triage
+ * migration in CLAUDE.md as the reference pattern.
  */
 
 import 'dotenv/config';

--- a/tasks/feature-backlog.md
+++ b/tasks/feature-backlog.md
@@ -248,3 +248,35 @@ Hardware video-wall controllers (Userful, Datapath, Christie Pandoras Box) handl
 ### Why deferred
 
 No customer ask. The bulk of the "vertical screen" market (menu boards, wayfinding, lobby displays) is solved by today's portrait + DisplayGroups + per-screen playlists. Real video-wall sync serves a much smaller slice (stadium displays, broadcast studios, premium retail) and competes against entrenched hardware-layer players. Build only on a concrete pull.
+
+
+## customer-lifecycle Hermes migration
+
+**What**
+
+Migrate `scripts/agents/customer-lifecycle.ts` (463 lines, runs every 30 min, sends day-1/3/7 onboarding nudges) to a Hermes skill following the same shadow-then-cutover pattern as `vizora-support-triage`.
+
+**Design sketch**
+
+New MCP tools required:
+- `list_onboarding_candidates` (scope `customer:read`) — orgs in last 30d window with incomplete onboarding. Returns structural signals only: `org_id`, `tier`, `days_since_signup`, `milestone_flags` (booleans for welcomed/screenPaired/contentUploaded/playlistCreated/scheduleCreated). NEVER returns admin email or org name. (D13.)
+- `find_org_admin_recipient` (scope `customer:read`) — returns `{ recipient_hash: <sha256-of-email> }` ONLY, never the plaintext. The actual SMTP send happens server-side; agent never sees the address.
+- `mark_onboarding_nudge_sent` (scope `customer:write`) — sets the appropriate `dayN_NudgeSentAt` column. Cross-org guard.
+- `auto_complete_org_onboarding` (scope `customer:write`) — for stale (>30d) signups.
+- `send_lifecycle_nudge_email` (scope `customer:write` — **HIGH BLAST RADIUS**) — server-side SMTP send. Hermes passes `{org_id, nudge_template_key}`, server resolves admin email + sends. Server-side enforces `MAX_EMAILS_PER_RUN=50` circuit breaker, `LIFECYCLE_TEST_EMAILS` allowlist, `LIFECYCLE_LIVE=false` dry-run default. The agent NEVER constructs the email body — only chooses one of the three template keys (`day1-pair-screen` / `day3-upload-content` / `day7-create-schedule`).
+
+**Why deferred from the 2026-05-04 autonomous run**
+
+Outbound email = customer-visible action. Unlike support-triage (which writes internal classifications), this agent sends mail customers SEE. The migration MUST be staged per-step rather than blasted through:
+1. Build the read tools first, ship as a PR.
+2. Build the write tools (especially `send_lifecycle_nudge_email`) as a separate PR with extensive tests + per-tool review.
+3. Hermes shadow-mode skill that ONLY writes to JSONL — no email sends.
+4. Compare shadow against the existing PM2 cron's mark-sent records for ≥7 days.
+5. Live cutover with `LIFECYCLE_LIVE=false` first (dry-run + audit), then enable.
+6. Decommission PM2 cron only after ≥14 days clean Hermes-live.
+
+The Hermes-first rule still applies — when this is built, it lands as a Hermes skill, not new TS in the PM2 script. But the staging cannot be autonomous.
+
+**What triggers a revisit**
+
+User explicit "go" on the staged migration plan, OR Hermes shadow comparison for support-triage shows >85% priority-agreement (a strong signal that Hermes can handle this class of agent reliably and we can apply the same pattern with confidence).


### PR DESCRIPTION
Per the 2026-05-04 "Hermes first" directive: scaffolds carry inline comments so future implementers default to skills, CLAUDE.md gains the agent migration roadmap, customer-lifecycle migration design lands in the backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)