### PR TITLE
feat(mcp): customer-lifecycle Hermes migration — shadow mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,6 +333,11 @@ Automated deployment readiness checker. Runs 30 validation rules across content,
 - `update_support_request_priority` — scope `support:write`, sets priority on one request (cross-org guard via compound where).
 - `update_support_request_ai_category` — scope `support:write`, sets V2 taxonomy slug. Zod-constrained to the V2 enum.
 - `create_support_message` — scope `support:write`, posts an agent-authored comment. Author identity comes from the bearer-token context, content capped at 2000 chars.
+- `list_onboarding_candidates` — **platform-scope** read tool, scope `customer:read`. Returns onboarding candidates across ALL orgs as structural signals only (tier, days_since_signup, milestone_flags, nudges_sent). NEVER returns org name, admin email, or billing detail. Requires a platform-scope token (`organizationId IS NULL` in `mcp_tokens`); per-org tokens are rejected with INVALID_INPUT. Used by the customer-lifecycle Hermes shadow skill.
+
+**Token shapes:**
+- **Per-org token** (`organizationId` is a real org id) — for agents that operate on one org's data. Used by all the `displays:*` and `support:*` tools. The data-access methods compound their WHERE clauses with the token's org id, so the token can never see other orgs' data.
+- **Platform-scope token** (`organizationId IS NULL`) — for cross-org agents like customer-lifecycle and the future agent-orchestrator. Per-org tools reject these with INVALID_INPUT (`requireOrgScope` helper). Platform-scope tools require these (the inverse check in the tool handler). Issued via `McpTokenService.issue({ organizationId: null, ... })`.
 
 **Hermes Agent runtime (prod VPS):**
 - Installed at `/usr/local/lib/hermes-agent`, command at `/usr/local/bin/hermes`.
@@ -343,6 +348,7 @@ Automated deployment readiness checker. Runs 30 validation rules across content,
 
 **Hermes-driven agents (state):**
 - `vizora-support-triage` — **shadow mode** in cron `*/5 * * * *`. Reads via MCP, scores, appends `/var/log/hermes/vizora-support-triage-shadow.jsonl`. Live-mode skill (`SKILL-live.md`) is built and committed but NOT deployed; cutover is a one-line SCP after the gate below clears.
+- `vizora-customer-lifecycle` — **shadow mode** in cron `*/30 * * * *`. Calls `list_onboarding_candidates` (platform-scope), picks template per org via heuristic-matching prompt, appends `/var/log/hermes/vizora-customer-lifecycle-shadow.jsonl`. PM2 cron `agent-customer-lifecycle` continues to send all real emails. Live-mode skill is NOT YET BUILT — the live path needs `mark_onboarding_nudge_sent`, `auto_complete_org_onboarding`, and `send_lifecycle_nudge_email` write tools first (see `tasks/feature-backlog.md`).
 
 **Agent migration roadmap (Hermes-first rule)**
 
@@ -351,7 +357,7 @@ Inventory of `scripts/agents/*.ts` and their migration status:
 | Agent | Lines | State | Migration plan |
 |-------|-------|-------|----------------|
 | support-triage | 306 | LIVE (PM2 cron, every 5 min) | **Migrated to Hermes shadow.** Cutover gated on shadow-data review. |
-| customer-lifecycle | 463 | LIVE (PM2 cron, every 30 min). Sends real onboarding emails when `LIFECYCLE_LIVE=true`. | **Designed, not built.** See `tasks/feature-backlog.md` → "customer-lifecycle Hermes migration" for the design sketch + MCP tool list. Not started in this autonomous run because the outbound-email blast radius warrants explicit per-step approval. |
+| customer-lifecycle | 463 | LIVE (PM2 cron, every 30 min). Sends real onboarding emails when `LIFECYCLE_LIVE=true`. | **Migrated to Hermes shadow.** Read path: `list_onboarding_candidates` (platform-scope MCP tool). Skill: `hermes-skills/vizora-customer-lifecycle/SKILL.md`. Cron: `*/30 * * * *`. Comparison: `scripts/agents/compare-lifecycle-hermes-vs-heuristic.ts`. **Live cutover NOT done** — the write tools (`mark_onboarding_nudge_sent`, `auto_complete_org_onboarding`, `send_lifecycle_nudge_email`) are not yet built; the customer-visible email path stays on the PM2 cron. Backlog entry tracks the staged rollout. |
 | billing-revenue | 32 | SCAFFOLD (gated off). | Per Hermes-first rule, when implemented build as `hermes-skills/vizora-billing-revenue/SKILL.md`, not TS. |
 | content-intelligence | 32 | SCAFFOLD (gated off). | Per Hermes-first rule, build as `hermes-skills/vizora-content-intelligence/SKILL.md`. |
 | screen-health-customer | 33 | SCAFFOLD (gated off). | Per Hermes-first rule, build as `hermes-skills/vizora-screen-health/SKILL.md`. The `list_displays` MCP tool already exists; only `create_customer_incident` write tool needed. |

--- a/hermes-skills/vizora-customer-lifecycle/SKILL.md
+++ b/hermes-skills/vizora-customer-lifecycle/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: vizora-customer-lifecycle
+description: Decide which onboarding nudge (day1 / day3 / day7 / none) each Vizora org should receive at this cron tick, using structural signals only. Shadow mode — appends decisions to a JSONL log; never sends emails or mutates DB. The existing PM2 cron remains the source of truth.
+---
+
+# Vizora Customer Lifecycle — Shadow Mode
+
+You are running as a scheduled Vizora customer-lifecycle agent in **shadow mode**. Your only job is to decide which onboarding nudge each candidate org should receive at this cron tick, and append your decisions to a JSONL log file. **You do NOT send emails. You do NOT mutate the DB.** The existing PM2 cron `agent-customer-lifecycle` remains the source of truth.
+
+## Hard rules (non-negotiable)
+
+1. **Structural signals only.** The MCP read tool already strips org name, admin email, billing detail. You receive only `tier`, `days_since_signup`, `milestone_flags`, `nudges_sent`. **Do NOT fabricate or infer email content.** Score from these signals alone.
+2. **One MCP read call per run.** Call `list_onboarding_candidates` exactly once. Don't paginate further in shadow mode.
+3. **Append, don't overwrite.** Shadow log is `/var/log/hermes/vizora-customer-lifecycle-shadow.jsonl`. Always append (`>>`). Never `>` redirect.
+4. **One JSON object per line.** JSONL, not JSON-array.
+5. **Read-only.** Your token is platform-scope but read-only (`customer:read`). The write tools (`mark_onboarding_nudge_sent`, `send_lifecycle_nudge_email`, `auto_complete_org_onboarding`) don't exist yet — and even if they did, this skill must not call them. The `live` skill is a separate file (`SKILL-live.md`, not yet built).
+
+## Steps to run
+
+### 1. Pull onboarding candidates
+
+```
+list_onboarding_candidates({ "lookback_days": 30, "limit": 200 })
+```
+
+Expect `{ candidates: [...], total: N }`. If empty, write a heartbeat and stop:
+
+```json
+{"timestamp":"<ISO8601>","run_id":"<short>","organization_id":null,"hermes_template":null,"hermes_reasoning":"heartbeat: 0 candidates","input_signals":null}
+```
+
+### 2. Decide template per org
+
+For each candidate, pick exactly one of `day1-pair-screen`, `day3-upload-content`, `day7-create-schedule`, or `none`. Match the existing PM2 cron's heuristic (`scripts/agents/lib/ai.ts` → `heuristic-agent-ai.ts`):
+
+- **`days_since_signup < 1`** → `none` (too early; welcome window).
+- **NOT `screen_paired`** AND `days_since_signup >= 1` AND NOT `nudges_sent.day1` → `day1-pair-screen`.
+- **`screen_paired`** AND NOT `content_uploaded` AND `days_since_signup >= 3` AND NOT `nudges_sent.day3` → `day3-upload-content`.
+- **`content_uploaded`** AND NOT `schedule_created` AND `days_since_signup >= 7` AND NOT `nudges_sent.day7` → `day7-create-schedule`.
+- **`days_since_signup >= 30`** → `none` (will be auto-completed by the PM2 cron; you don't act).
+- Otherwise → `none`.
+
+You may use the LLM's reasoning where the heuristic is ambiguous (e.g., to weigh a pro-tier early-stalled org against a free-tier later-stalled one). But the output template MUST be one of the four exact strings above. No paraphrasing.
+
+### 3. Append a JSONL row per candidate
+
+For each org, append:
+
+```json
+{"timestamp":"<ISO8601>","run_id":"<epoch-seconds>","organization_id":"<id>","tier":"pro","days_since_signup":4,"hermes_template":"day3-upload-content","hermes_reasoning":"<<=120 chars: which signals drove the decision>>","input_signals":{"milestone_flags":{...},"nudges_sent":{...}}}
+```
+
+Use `echo '<line>' >> /var/log/hermes/vizora-customer-lifecycle-shadow.jsonl`. One append per org. Don't accumulate and write once at the end.
+
+`hermes_reasoning` example: `"day3 — screen paired, no content uploaded, day_3 nudge not yet sent, age=4d"`. Don't quote any org name or admin email (you don't have either).
+
+### 4. Stop
+
+After all candidates are processed, exit. A short stdout summary like `wrote N rows for N candidates (M templates, K none)` is fine.
+
+## What NOT to do
+
+- Don't call `list_displays`, `list_open_support_requests`, or any other tool — they're irrelevant here.
+- Don't try to call any `update_*`, `mark_*`, `send_*`, or `create_*` tool. The token's scope is read-only and the relevant write tools don't exist yet anyway.
+- Don't summarize the run by quoting org IDs back to chat. The JSONL is the artifact.
+- Don't fabricate signals. If `nudges_sent.day1` is `true`, the day1 nudge is already done — don't suggest it again.
+
+## Why this exists
+
+Vizora's existing PM2 cron `agent-customer-lifecycle` (in `scripts/agents/customer-lifecycle.ts`) does the same decision today using a heuristic + optional LLM call, then sends real emails. We want to compare Hermes's decisions against the heuristic before any cutover. Compare via `scripts/agents/compare-lifecycle-hermes-vs-heuristic.ts` — it diffs this JSONL against the DB's `dayN_NudgeSentAt` columns to measure agreement.
+
+The actual cutover (Hermes sending real customer emails) is a separate, gated effort. See `tasks/feature-backlog.md` → "customer-lifecycle Hermes migration" for the staged plan.

--- a/middleware/src/modules/mcp/auth/mcp-context.ts
+++ b/middleware/src/modules/mcp/auth/mcp-context.ts
@@ -5,10 +5,15 @@ import { createParamDecorator, ExecutionContext } from '@nestjs/common';
  * is attached to the Express request as `mcpContext`. Tools and
  * audit code read it via this decorator (or directly off the request,
  * which is sometimes necessary inside the SDK callback).
+ *
+ * `organizationId` is **null** for platform-scope tokens (cross-org
+ * agents like customer-lifecycle, agent-orchestrator). Per-org tools
+ * MUST guard against null and reject (use `requireOrgScope` below).
+ * Platform-only tools accept null and operate across all orgs.
  */
 export interface McpRequestContext {
   tokenId: string;
-  organizationId: string;
+  organizationId: string | null;
   agentName: string;
   scopes: string[];
 }
@@ -42,4 +47,26 @@ export function hasScope(
   required: string,
 ): boolean {
   return context.scopes.includes(required);
+}
+
+/**
+ * Per-org tool guard. Throws BadRequest if a platform-scope (null org)
+ * token tries to call a tool that needs to know which org's data to
+ * read or mutate. Returns the non-null orgId on success — designed to
+ * be used as `const orgId = requireOrgScope(context)` inline in tool
+ * handlers.
+ *
+ * The error code maps to MCP `INVALID_INPUT` (not `FORBIDDEN`) because
+ * the issue is the wrong KIND of token, not a scope-level deny.
+ */
+export function requireOrgScope(context: McpRequestContext): string {
+  if (context.organizationId == null) {
+    // Lazy-imported to avoid a circular dep with NestJS's BadRequestException
+    // when this file is consumed from non-Nest contexts (the SDK callback).
+    const { BadRequestException } = require('@nestjs/common');
+    throw new BadRequestException(
+      'This tool requires an org-scoped token. Issue a token with a specific organizationId.',
+    );
+  }
+  return context.organizationId;
 }

--- a/middleware/src/modules/mcp/auth/mcp-token.service.ts
+++ b/middleware/src/modules/mcp/auth/mcp-token.service.ts
@@ -40,7 +40,13 @@ export class McpTokenService {
    */
   async issue(input: {
     name: string;
-    organizationId: string;
+    /**
+     * Org scope. `null` = platform-scope token (cross-org agents like
+     * customer-lifecycle, agent-orchestrator). Per-org tools reject
+     * platform tokens; platform tools reject per-org tokens. The
+     * MCP-side `requireOrgScope`/inverse checks enforce this at runtime.
+     */
+    organizationId: string | null;
     agentName: string;
     scopes: string[];
     expiresInDays?: number;
@@ -49,7 +55,7 @@ export class McpTokenService {
     record: {
       id: string;
       name: string;
-      organizationId: string;
+      organizationId: string | null;
       agentName: string;
       scopes: string[];
       createdAt: Date;
@@ -104,7 +110,7 @@ export class McpTokenService {
     });
 
     this.logger.log(
-      `Issued MCP token id=${created.id} agent=${input.agentName} org=${input.organizationId} scopes=${input.scopes.join(',')} expiresAt=${expiresAt.toISOString()}`,
+      `Issued MCP token id=${created.id} agent=${input.agentName} org=${input.organizationId ?? '<platform>'} scopes=${input.scopes.join(',')} expiresAt=${expiresAt.toISOString()}`,
     );
 
     return { bearer, record: created };
@@ -118,7 +124,7 @@ export class McpTokenService {
    */
   async validate(bearer: string): Promise<{
     id: string;
-    organizationId: string;
+    organizationId: string | null;
     agentName: string;
     scopes: string[];
   } | null> {

--- a/middleware/src/modules/mcp/mcp.module.ts
+++ b/middleware/src/modules/mcp/mcp.module.ts
@@ -3,6 +3,7 @@ import { AdminModule } from '../admin/admin.module';
 import { AuthModule } from '../auth/auth.module';
 import { DatabaseModule } from '../database/database.module';
 import { DisplaysModule } from '../displays/displays.module';
+import { OrganizationsModule } from '../organizations/organizations.module';
 import { SupportModule } from '../support/support.module';
 import { McpAuditService } from './audit/mcp-audit.service';
 import { McpAuthGuard } from './auth/mcp-auth.guard';
@@ -29,7 +30,14 @@ import { McpTokensAdminController } from './admin/mcp-tokens.controller';
  * Companion docs: `docs/agents-mcp-server-design.md`.
  */
 @Module({
-  imports: [DatabaseModule, AuthModule, AdminModule, DisplaysModule, SupportModule],
+  imports: [
+    DatabaseModule,
+    AuthModule,
+    AdminModule,
+    DisplaysModule,
+    OrganizationsModule,
+    SupportModule,
+  ],
   controllers: [McpController, McpTokensAdminController],
   providers: [McpService, McpTokenService, McpAuthGuard, McpRateLimitGuard, McpAuditService],
   exports: [McpService, McpTokenService],

--- a/middleware/src/modules/mcp/mcp.service.spec.ts
+++ b/middleware/src/modules/mcp/mcp.service.spec.ts
@@ -17,10 +17,11 @@ describe('McpService.buildServer', () => {
   // tools/displays.tools.spec.ts and tools/support.tools.spec.ts.
   const displays = {} as never;
   const support = {} as never;
+  const organizations = {} as never;
   const audit = {} as never;
 
   it('returns a NEW McpServer instance on every call (REGRESSION: singleton caused "Already connected to a transport" in prod)', () => {
-    const svc = new McpService(displays, support, audit);
+    const svc = new McpService(displays, support, organizations, audit);
     const a = svc.buildServer(undefined);
     const b = svc.buildServer(undefined);
     expect(a).toBeDefined();
@@ -38,7 +39,8 @@ describe('McpService.buildServer', () => {
     } as never;
     const fakeAudit = { record: jest.fn(async (row) => { captured.push(row); }) } as never;
     const fakeSupport = {} as never;
-    const svc = new McpService(fakeDisplays, fakeSupport, fakeAudit);
+    const fakeOrganizations = {} as never;
+    const svc = new McpService(fakeDisplays, fakeSupport, fakeOrganizations, fakeAudit);
     const ctx = {
       tokenId: 'tok_test',
       organizationId: 'org_test',
@@ -64,7 +66,7 @@ describe('McpService.buildServer', () => {
   });
 
   it('still has list_displays registered on every fresh build', () => {
-    const svc = new McpService(displays, support, audit);
+    const svc = new McpService(displays, support, organizations, audit);
     const server = svc.buildServer(undefined);
     // McpServer.server is the underlying Server instance from the SDK.
     // Tools live in its `_registeredTools` map (private but stable

--- a/middleware/src/modules/mcp/mcp.service.ts
+++ b/middleware/src/modules/mcp/mcp.service.ts
@@ -5,8 +5,10 @@ import type { McpRequestContext } from './auth/mcp-context';
 import { McpAuditService } from './audit/mcp-audit.service';
 import { mapExceptionToMcpError } from './lib/error-mapping';
 import { DisplaysService } from '../displays/displays.service';
+import { OrganizationsService } from '../organizations/organizations.service';
 import { SupportService } from '../support/support.service';
 import { LIST_DISPLAYS_TOOL } from './tools/displays.tools';
+import { LIST_ONBOARDING_CANDIDATES_TOOL } from './tools/organizations.tools';
 import {
   CREATE_SUPPORT_MESSAGE_TOOL,
   LIST_OPEN_SUPPORT_REQUESTS_TOOL,
@@ -36,6 +38,7 @@ export class McpService implements OnModuleInit {
   constructor(
     private readonly displays: DisplaysService,
     private readonly support: SupportService,
+    private readonly organizations: OrganizationsService,
     private readonly audit: McpAuditService,
   ) {}
 
@@ -45,7 +48,7 @@ export class McpService implements OnModuleInit {
     // request. The instance is then discarded.
     this.buildServer(undefined);
     this.logger.log(
-      'MCP server factory ready — 5 tools registered per request (list_displays, list_open_support_requests, update_support_request_priority, update_support_request_ai_category, create_support_message)',
+      'MCP server factory ready — 6 tools registered per request (list_displays, list_open_support_requests, update_support_request_priority, update_support_request_ai_category, create_support_message, list_onboarding_candidates)',
     );
   }
 
@@ -76,6 +79,12 @@ export class McpService implements OnModuleInit {
       this.support,
     );
     this.registerTool(server, CREATE_SUPPORT_MESSAGE_TOOL, context, this.support);
+    this.registerTool(
+      server,
+      LIST_ONBOARDING_CANDIDATES_TOOL,
+      context,
+      this.organizations,
+    );
     return server;
   }
 

--- a/middleware/src/modules/mcp/schemas/tool-inputs.ts
+++ b/middleware/src/modules/mcp/schemas/tool-inputs.ts
@@ -84,3 +84,29 @@ export const CreateSupportMessageInput = z.object({
     .describe('Message body. Templates only — never raw LLM output. Max 2000 chars.'),
 });
 export type CreateSupportMessageInputT = z.infer<typeof CreateSupportMessageInput>;
+
+// ── Customer-lifecycle (platform-scope read tool) ──────────────────────────
+
+export const ListOnboardingCandidatesInput = z.object({
+  lookback_days: z
+    .number()
+    .int()
+    .min(1)
+    .max(90)
+    .optional()
+    .default(30)
+    .describe(
+      'Window for "recently created" orgs whose onboarding may still be in progress. Default 30, matches the existing PM2 cron.',
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(500)
+    .optional()
+    .default(200)
+    .describe(
+      'Max candidates returned. Default 200, matches the existing PM2 cron CANDIDATE_LIMIT.',
+    ),
+});
+export type ListOnboardingCandidatesInputT = z.infer<typeof ListOnboardingCandidatesInput>;

--- a/middleware/src/modules/mcp/schemas/tool-outputs.ts
+++ b/middleware/src/modules/mcp/schemas/tool-outputs.ts
@@ -89,3 +89,39 @@ export const CreateSupportMessageResult = z.object({
   created: z.boolean(),
 });
 export type CreateSupportMessageResultT = z.infer<typeof CreateSupportMessageResult>;
+
+// ── Customer-lifecycle (platform-scope read tool) ──────────────────────────
+
+/**
+ * Onboarding-candidate shape for the customer-lifecycle Hermes skill.
+ *
+ * **Hard contract**: this shape carries NO org name, NO admin email,
+ * NO billing detail. Just structural signals (tier, age, milestone
+ * flags, nudge-sent flags). Adding any free-text field or any
+ * email/name/billing field is a security-sensitive change — call it
+ * out in review.
+ */
+export const OnboardingCandidateShape = z.object({
+  organization_id: z.string(),
+  tier: z.enum(['free', 'starter', 'pro', 'enterprise']),
+  days_since_signup: z.number().int().nonnegative(),
+  milestone_flags: z.object({
+    welcomed: z.boolean(),
+    screen_paired: z.boolean(),
+    content_uploaded: z.boolean(),
+    playlist_created: z.boolean(),
+    schedule_created: z.boolean(),
+  }),
+  nudges_sent: z.object({
+    day1: z.boolean(),
+    day3: z.boolean(),
+    day7: z.boolean(),
+  }),
+});
+
+export const ListOnboardingCandidatesOutput = z.object({
+  candidates: z.array(OnboardingCandidateShape),
+  total: z.number().int().nonnegative(),
+});
+
+export type ListOnboardingCandidatesOutputT = z.infer<typeof ListOnboardingCandidatesOutput>;

--- a/middleware/src/modules/mcp/tools/displays.tools.ts
+++ b/middleware/src/modules/mcp/tools/displays.tools.ts
@@ -1,6 +1,10 @@
 import { ForbiddenException } from '@nestjs/common';
 import { DisplaysService } from '../../displays/displays.service';
-import { hasScope, type McpRequestContext } from '../auth/mcp-context';
+import {
+  hasScope,
+  requireOrgScope,
+  type McpRequestContext,
+} from '../auth/mcp-context';
 import {
   ListDisplaysInput,
   type ListDisplaysInputT,
@@ -32,6 +36,7 @@ export async function listDisplaysTool(
       "Token lacks scope 'displays:read'",
     );
   }
+  const orgId = requireOrgScope(context);
   const input = ListDisplaysInput.parse(rawInput) as ListDisplaysInputT;
 
   // Push the status filter DB-side so `total` reflects the filtered
@@ -39,7 +44,7 @@ export async function listDisplaysTool(
   // but not the count, breaking pagination ratios for any non-'all'
   // status query.
   const result = await displaysService.findAll(
-    context.organizationId,
+    orgId,
     { page: input.page, limit: input.limit },
     input.status === 'all' ? undefined : { status: input.status },
   );

--- a/middleware/src/modules/mcp/tools/organizations.tools.spec.ts
+++ b/middleware/src/modules/mcp/tools/organizations.tools.spec.ts
@@ -1,0 +1,159 @@
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { listOnboardingCandidatesTool } from './organizations.tools';
+import type { McpRequestContext } from '../auth/mcp-context';
+
+function ctx(opts: {
+  scopes: string[];
+  organizationId?: string | null;
+}): McpRequestContext {
+  return {
+    tokenId: 'tok_1',
+    organizationId: opts.organizationId === undefined ? null : opts.organizationId,
+    agentName: 'hermes-customer-lifecycle',
+    scopes: opts.scopes,
+  };
+}
+
+function makeOrgs(rows: Array<Record<string, unknown>>) {
+  return {
+    listOnboardingCandidates: jest.fn().mockResolvedValue(rows),
+  };
+}
+
+describe('listOnboardingCandidatesTool', () => {
+  it('throws ForbiddenException when scope missing', async () => {
+    await expect(
+      listOnboardingCandidatesTool({}, ctx({ scopes: [] }), makeOrgs([]) as never),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('REJECTS per-org tokens with BadRequest (INVALID_INPUT) — platform-only tool', async () => {
+    const orgScopedCtx = ctx({ scopes: ['customer:read'], organizationId: 'org_1' });
+    await expect(
+      listOnboardingCandidatesTool({}, orgScopedCtx, makeOrgs([]) as never),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('accepts platform-scope tokens (organizationId=null)', async () => {
+    const platformCtx = ctx({ scopes: ['customer:read'], organizationId: null });
+    const out = await listOnboardingCandidatesTool(
+      {},
+      platformCtx,
+      makeOrgs([
+        {
+          organizationId: 'o1',
+          tier: 'pro',
+          daysSinceSignup: 5,
+          milestoneFlags: {
+            welcomed: true,
+            screenPaired: false,
+            contentUploaded: false,
+            playlistCreated: false,
+            scheduleCreated: false,
+          },
+          nudgesSent: { day1: false, day3: false, day7: false },
+        },
+      ]) as never,
+    );
+    expect(out.candidates).toHaveLength(1);
+    expect(out.total).toBe(1);
+  });
+
+  it('returns wire-shape (snake_case) with milestone_flags / nudges_sent renamed', async () => {
+    const platformCtx = ctx({ scopes: ['customer:read'], organizationId: null });
+    const out = await listOnboardingCandidatesTool(
+      {},
+      platformCtx,
+      makeOrgs([
+        {
+          organizationId: 'o1',
+          tier: 'enterprise',
+          daysSinceSignup: 3,
+          milestoneFlags: {
+            welcomed: true,
+            screenPaired: true,
+            contentUploaded: false,
+            playlistCreated: false,
+            scheduleCreated: false,
+          },
+          nudgesSent: { day1: true, day3: false, day7: false },
+        },
+      ]) as never,
+    );
+    expect(out.candidates[0]).toEqual({
+      organization_id: 'o1',
+      tier: 'enterprise',
+      days_since_signup: 3,
+      milestone_flags: {
+        welcomed: true,
+        screen_paired: true,
+        content_uploaded: false,
+        playlist_created: false,
+        schedule_created: false,
+      },
+      nudges_sent: { day1: true, day3: false, day7: false },
+    });
+  });
+
+  it('NEVER returns org name, admin email, billing fields, or any free-text — D13 contract enforced at the wire shape', async () => {
+    const platformCtx = ctx({ scopes: ['customer:read'], organizationId: null });
+    // Service tries to leak — Zod schema must strip these
+    const leaky = {
+      listOnboardingCandidates: jest.fn().mockResolvedValue([
+        {
+          organizationId: 'o1',
+          tier: 'pro',
+          daysSinceSignup: 5,
+          milestoneFlags: {
+            welcomed: true,
+            screenPaired: false,
+            contentUploaded: false,
+            playlistCreated: false,
+            scheduleCreated: false,
+          },
+          nudgesSent: { day1: false, day3: false, day7: false },
+          // PII a buggy service might leak
+          name: 'Acme Corp',
+          adminEmail: 'admin@acme.example',
+          subscriptionStatus: 'active',
+          billingAccountId: 'cus_xyz123',
+        },
+      ]),
+    };
+    const out = await listOnboardingCandidatesTool({}, platformCtx, leaky as never);
+    const row = out.candidates[0] as Record<string, unknown>;
+    expect(row).not.toHaveProperty('name');
+    expect(row).not.toHaveProperty('adminEmail');
+    expect(row).not.toHaveProperty('subscription_status');
+    expect(row).not.toHaveProperty('billing_account_id');
+    const serialized = JSON.stringify(out);
+    expect(serialized).not.toContain('Acme Corp');
+    expect(serialized).not.toContain('admin@acme.example');
+    expect(serialized).not.toContain('cus_xyz123');
+  });
+
+  it('forwards lookback_days + limit to the service', async () => {
+    const platformCtx = ctx({ scopes: ['customer:read'], organizationId: null });
+    const svc = makeOrgs([]);
+    await listOnboardingCandidatesTool(
+      { lookback_days: 7, limit: 50 },
+      platformCtx,
+      svc as never,
+    );
+    expect(svc.listOnboardingCandidates).toHaveBeenCalledWith({
+      lookbackDays: 7,
+      limit: 50,
+    });
+  });
+
+  it('rejects lookback_days > 90 via Zod', async () => {
+    const platformCtx = ctx({ scopes: ['customer:read'], organizationId: null });
+    await expect(
+      listOnboardingCandidatesTool(
+        { lookback_days: 365 },
+        platformCtx,
+        makeOrgs([]) as never,
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/middleware/src/modules/mcp/tools/organizations.tools.ts
+++ b/middleware/src/modules/mcp/tools/organizations.tools.ts
@@ -1,0 +1,92 @@
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { OrganizationsService } from '../../organizations/organizations.service';
+import { hasScope, type McpRequestContext } from '../auth/mcp-context';
+import {
+  ListOnboardingCandidatesInput,
+  type ListOnboardingCandidatesInputT,
+} from '../schemas/tool-inputs';
+import {
+  ListOnboardingCandidatesOutput,
+  type ListOnboardingCandidatesOutputT,
+} from '../schemas/tool-outputs';
+
+/**
+ * MCP tool: `list_onboarding_candidates`
+ *
+ * Platform-scope read tool — returns onboarding candidates across ALL
+ * orgs as structural signals only. Used by the customer-lifecycle
+ * Hermes skill (shadow + future live mode).
+ *
+ * **Token shape**: this tool requires a PLATFORM-SCOPE token (i.e.
+ * `organizationId IS NULL` in `mcp_tokens`). A per-org token is the
+ * wrong shape and is rejected with `INVALID_INPUT`. Per-org tokens
+ * never see other orgs' data — this is the security boundary.
+ *
+ * **D13 contract**: returns NO org name, NO admin email, NO billing
+ * detail. Structural signals only. The wire-shape Zod schema strips
+ * unknown keys, so a future buggy service that leaks PII can't push
+ * it past this boundary.
+ *
+ * Scope required: `customer:read`.
+ */
+export async function listOnboardingCandidatesTool(
+  rawInput: unknown,
+  context: McpRequestContext,
+  organizationsService: OrganizationsService,
+): Promise<ListOnboardingCandidatesOutputT> {
+  if (!hasScope(context, 'customer:read')) {
+    throw new ForbiddenException("Token lacks scope 'customer:read'");
+  }
+  // The opposite of `requireOrgScope` — this tool is platform-only
+  // and rejects per-org tokens.
+  if (context.organizationId != null) {
+    throw new BadRequestException(
+      'list_onboarding_candidates requires a platform-scope token (organizationId=null). Per-org tokens are rejected.',
+    );
+  }
+  const input = ListOnboardingCandidatesInput.parse(
+    rawInput,
+  ) as ListOnboardingCandidatesInputT;
+
+  const candidates = await organizationsService.listOnboardingCandidates({
+    lookbackDays: input.lookback_days,
+    limit: input.limit,
+  });
+
+  return ListOnboardingCandidatesOutput.parse({
+    candidates: candidates.map(toCandidateShape),
+    total: candidates.length,
+  });
+}
+
+function toCandidateShape(c: Record<string, unknown>) {
+  const flags = c.milestoneFlags as Record<string, boolean>;
+  const nudges = c.nudgesSent as Record<string, boolean>;
+  return {
+    organization_id: c.organizationId as string,
+    tier: c.tier as 'free' | 'starter' | 'pro' | 'enterprise',
+    days_since_signup: c.daysSinceSignup as number,
+    milestone_flags: {
+      welcomed: Boolean(flags.welcomed),
+      screen_paired: Boolean(flags.screenPaired),
+      content_uploaded: Boolean(flags.contentUploaded),
+      playlist_created: Boolean(flags.playlistCreated),
+      schedule_created: Boolean(flags.scheduleCreated),
+    },
+    nudges_sent: {
+      day1: Boolean(nudges.day1),
+      day3: Boolean(nudges.day3),
+      day7: Boolean(nudges.day7),
+    },
+  };
+}
+
+export const LIST_ONBOARDING_CANDIDATES_TOOL = {
+  name: 'list_onboarding_candidates',
+  description:
+    "Platform-scope read tool. Returns onboarding candidates across ALL orgs as structural signals only — tier, days since signup, milestone flags, nudge-sent flags. NEVER returns org name, admin email, or billing detail. REQUIRES a platform-scope token (organizationId=null) — per-org tokens are rejected with INVALID_INPUT. Used by the customer-lifecycle Hermes skill.",
+  scope: 'customer:read' as const,
+  inputSchema: ListOnboardingCandidatesInput,
+  outputSchema: ListOnboardingCandidatesOutput,
+  handler: listOnboardingCandidatesTool,
+};

--- a/middleware/src/modules/mcp/tools/support.tools.ts
+++ b/middleware/src/modules/mcp/tools/support.tools.ts
@@ -1,6 +1,10 @@
 import { ForbiddenException } from '@nestjs/common';
 import { SupportService } from '../../support/support.service';
-import { hasScope, type McpRequestContext } from '../auth/mcp-context';
+import {
+  hasScope,
+  requireOrgScope,
+  type McpRequestContext,
+} from '../auth/mcp-context';
 import {
   CreateSupportMessageInput,
   type CreateSupportMessageInputT,
@@ -44,12 +48,13 @@ export async function listOpenSupportRequestsTool(
   if (!hasScope(context, 'support:read')) {
     throw new ForbiddenException("Token lacks scope 'support:read'");
   }
+  const orgId = requireOrgScope(context);
   const input = ListOpenSupportRequestsInput.parse(
     rawInput,
   ) as ListOpenSupportRequestsInputT;
 
   const result = await supportService.listTriageCandidates(
-    context.organizationId,
+    orgId,
     {
       page: input.page,
       limit: input.limit,
@@ -125,11 +130,12 @@ export async function updateSupportRequestPriorityTool(
   if (!hasScope(context, 'support:write')) {
     throw new ForbiddenException("Token lacks scope 'support:write'");
   }
+  const orgId = requireOrgScope(context);
   const input = UpdateSupportRequestPriorityInput.parse(
     rawInput,
   ) as UpdateSupportRequestPriorityInputT;
   const updated = await supportService.setRequestPriority(
-    context.organizationId,
+    orgId,
     input.request_id,
     input.priority,
   );
@@ -164,11 +170,12 @@ export async function updateSupportRequestAiCategoryTool(
   if (!hasScope(context, 'support:write')) {
     throw new ForbiddenException("Token lacks scope 'support:write'");
   }
+  const orgId = requireOrgScope(context);
   const input = UpdateSupportRequestAiCategoryInput.parse(
     rawInput,
   ) as UpdateSupportRequestAiCategoryInputT;
   const updated = await supportService.setRequestAiCategory(
-    context.organizationId,
+    orgId,
     input.request_id,
     input.ai_category,
   );
@@ -208,11 +215,12 @@ export async function createSupportMessageTool(
   if (!hasScope(context, 'support:write')) {
     throw new ForbiddenException("Token lacks scope 'support:write'");
   }
+  const orgId = requireOrgScope(context);
   const input = CreateSupportMessageInput.parse(
     rawInput,
   ) as CreateSupportMessageInputT;
   const created = await supportService.createAgentMessage(
-    context.organizationId,
+    orgId,
     input.request_id,
     input.content,
   );

--- a/middleware/src/modules/organizations/organizations.service.ts
+++ b/middleware/src/modules/organizations/organizations.service.ts
@@ -62,6 +62,94 @@ export class OrganizationsService {
     return new PaginatedResponse(data.map(org => this.sanitizeOrg(org)), total, page, limit);
   }
 
+  /**
+   * List onboarding candidates for the customer-lifecycle agent — orgs
+   * created within the last `lookbackDays` whose onboarding hasn't
+   * completed yet.
+   *
+   * Returns precomputed STRUCTURAL SIGNALS ONLY: org id, tier, days
+   * since signup, and a milestone-flags map (booleans for welcomed /
+   * screenPaired / contentUploaded / playlistCreated / scheduleCreated).
+   * NO org name, NO admin email, NO billing detail. The structural-only
+   * contract is enforced here so an LLM-driven downstream agent (Hermes
+   * customer-lifecycle skill) can safely consume the output without
+   * violating D13 (no raw user data into LLM prompts).
+   *
+   * Cross-org by design — this method takes no org filter. The MCP tool
+   * layer guards this with a platform-scope-only token check.
+   */
+  async listOnboardingCandidates(
+    options: { lookbackDays?: number; limit?: number } = {},
+  ) {
+    const { lookbackDays = 30, limit = 200 } = options;
+    const since = new Date();
+    since.setDate(since.getDate() - lookbackDays);
+
+    const rows = await this.db.organization.findMany({
+      where: {
+        createdAt: { gte: since },
+        OR: [
+          { onboarding: null },
+          { onboarding: { completedAt: null } },
+        ],
+      },
+      orderBy: { createdAt: 'asc' },
+      take: limit,
+      select: {
+        id: true,
+        subscriptionTier: true,
+        createdAt: true,
+        onboarding: {
+          select: {
+            welcomeEmailSentAt: true,
+            firstScreenPairedAt: true,
+            firstContentUploadedAt: true,
+            firstPlaylistCreatedAt: true,
+            firstScheduleCreatedAt: true,
+            day1NudgeSentAt: true,
+            day3NudgeSentAt: true,
+            day7NudgeSentAt: true,
+            completedAt: true,
+          },
+        },
+      },
+    });
+
+    const now = Date.now();
+    return rows.map((org) => {
+      const ob = org.onboarding;
+      return {
+        organizationId: org.id,
+        tier: this.coerceTier(org.subscriptionTier),
+        daysSinceSignup: Math.floor(
+          (now - org.createdAt.getTime()) / (24 * 60 * 60 * 1000),
+        ),
+        milestoneFlags: {
+          welcomed: ob?.welcomeEmailSentAt != null,
+          screenPaired: ob?.firstScreenPairedAt != null,
+          contentUploaded: ob?.firstContentUploadedAt != null,
+          playlistCreated: ob?.firstPlaylistCreatedAt != null,
+          scheduleCreated: ob?.firstScheduleCreatedAt != null,
+        },
+        nudgesSent: {
+          day1: ob?.day1NudgeSentAt != null,
+          day3: ob?.day3NudgeSentAt != null,
+          day7: ob?.day7NudgeSentAt != null,
+        },
+      };
+    });
+  }
+
+  /**
+   * Same coercion the customer-lifecycle PM2 cron uses. Kept inline so
+   * this service doesn't depend on agent-side types.
+   */
+  private coerceTier(tier: string | null | undefined): 'free' | 'starter' | 'pro' | 'enterprise' {
+    const v = (tier ?? '').toLowerCase();
+    if (v === 'starter' || v === 'pro' || v === 'enterprise') return v;
+    return 'free';
+  }
+
   async findOne(id: string) {
     const organization = await this.db.organization.findUnique({
       where: { id },

--- a/packages/database/prisma/migrations/20260504120000_mcp_token_org_nullable/migration.sql
+++ b/packages/database/prisma/migrations/20260504120000_mcp_token_org_nullable/migration.sql
@@ -1,0 +1,22 @@
+-- Make `organizationId` nullable on `mcp_tokens` to support platform-scope
+-- agents (customer-lifecycle, agent-orchestrator) that work across orgs.
+--
+-- Per-org tools (list_displays, list_open_support_requests, etc) must
+-- reject null-org tokens. Platform-only tools accept null and operate
+-- across all orgs. See middleware/src/modules/mcp/auth/mcp-context.ts
+-- and the per-tool handlers for the runtime checks.
+--
+-- Existing tokens are unaffected — only future issuances may set null.
+
+-- DropForeignKey
+ALTER TABLE "mcp_tokens" DROP CONSTRAINT "mcp_tokens_organizationId_fkey";
+
+-- AlterColumn: organizationId TEXT NOT NULL -> TEXT NULL
+ALTER TABLE "mcp_tokens" ALTER COLUMN "organizationId" DROP NOT NULL;
+
+-- ReAddForeignKey (same shape, but the column is now nullable so the FK
+-- itself becomes effectively conditional — null orgId means no FK row)
+ALTER TABLE "mcp_tokens"
+    ADD CONSTRAINT "mcp_tokens_organizationId_fkey"
+    FOREIGN KEY ("organizationId") REFERENCES "organizations"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -867,9 +867,13 @@ model McpToken {
   tokenHash      String       @unique
   // Human-readable label (e.g. "support-triage prod 2026-Q2"). Free-form.
   name           String
-  // Scope: which org's data this token can read.
-  organizationId String
-  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  // Scope: which org's data this token can read. NULL = platform-scope
+  // token (cross-org agents like customer-lifecycle, agent-orchestrator).
+  // Per-org tools must reject null-org tokens; platform-only tools must
+  // accept null and operate across all orgs. The Organization relation
+  // is `onDelete: Cascade` so revoking an org cleans up its tokens.
+  organizationId String?
+  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   // Which agent the token was issued for — used in audit attribution.
   agentName      String
   // Tool-scope strings (e.g. ["displays:read", "content:read"]).

--- a/scripts/agents/compare-lifecycle-hermes-vs-heuristic.ts
+++ b/scripts/agents/compare-lifecycle-hermes-vs-heuristic.ts
@@ -1,0 +1,213 @@
+#!/usr/bin/env npx tsx
+/**
+ * Compare Hermes shadow-mode customer-lifecycle decisions against the
+ * existing PM2 cron's mark-sent records.
+ *
+ * Reads `/var/log/hermes/vizora-customer-lifecycle-shadow.jsonl`
+ * (one JSONL row per Hermes cron tick per candidate org), joins to
+ * `organization_onboarding` by id, and reports:
+ *   - cron firing rate
+ *   - per-org agreement: did Hermes pick the same template the PM2
+ *     cron actually marked sent (or 'none' if PM2 didn't act)?
+ *   - sample disagreements
+ *
+ * **Limitation**: PM2's mark-sent record reflects what was SENT, not
+ * what its heuristic SUGGESTED. If Hermes suggests `day3` and PM2's
+ * heuristic agreed but the ticket failed SMTP, mark-sent is null and
+ * we count it as a "disagreement" when it isn't. For a true head-to-
+ * head comparison the PM2 cron should also log its suggestion to a
+ * parallel file. Tracked in backlog.md.
+ *
+ * Run from the VPS:
+ *
+ *   ssh root@89.167.55.176 'cd /opt/vizora/app && export $(grep DATABASE_URL .env | xargs) && npx tsx scripts/agents/compare-lifecycle-hermes-vs-heuristic.ts'
+ */
+
+import 'dotenv/config';
+import { readFileSync, existsSync } from 'fs';
+import { prisma } from '@vizora/database';
+
+const SHADOW_LOG =
+  process.env.HERMES_LIFECYCLE_SHADOW_LOG ??
+  '/var/log/hermes/vizora-customer-lifecycle-shadow.jsonl';
+
+type Template =
+  | 'day1-pair-screen'
+  | 'day3-upload-content'
+  | 'day7-create-schedule'
+  | 'none';
+
+interface HermesRow {
+  timestamp: string;
+  run_id: string;
+  organization_id: string | null;
+  tier?: string;
+  days_since_signup?: number;
+  hermes_template: Template | null;
+  hermes_reasoning: string | null;
+  input_signals: Record<string, unknown> | null;
+}
+
+function pct(n: number, d: number): string {
+  return d === 0 ? '0%' : `${Math.round((100 * n) / d)}%`;
+}
+
+/**
+ * Map an organization_onboarding row to the most-recently-sent nudge
+ * template, or 'none' if no nudge has been sent. Sender precedence is
+ * by recency, not by milestone — if PM2 sent day3 yesterday and day7
+ * today, return 'day7-create-schedule'.
+ */
+function latestNudgeFromOnboarding(ob: {
+  day1NudgeSentAt: Date | null;
+  day3NudgeSentAt: Date | null;
+  day7NudgeSentAt: Date | null;
+}): Template {
+  const sent: Array<{ t: Template; at: Date }> = [];
+  if (ob.day1NudgeSentAt) sent.push({ t: 'day1-pair-screen', at: ob.day1NudgeSentAt });
+  if (ob.day3NudgeSentAt) sent.push({ t: 'day3-upload-content', at: ob.day3NudgeSentAt });
+  if (ob.day7NudgeSentAt) sent.push({ t: 'day7-create-schedule', at: ob.day7NudgeSentAt });
+  if (sent.length === 0) return 'none';
+  sent.sort((a, b) => b.at.getTime() - a.at.getTime());
+  return sent[0].t;
+}
+
+async function main(): Promise<void> {
+  if (!existsSync(SHADOW_LOG)) {
+    console.error(`No shadow log at ${SHADOW_LOG}`);
+    process.exitCode = 2;
+    return;
+  }
+
+  const text = readFileSync(SHADOW_LOG, 'utf8');
+  const lines = text.split('\n').filter(Boolean);
+  const rows: HermesRow[] = [];
+  let malformed = 0;
+  for (const line of lines) {
+    try {
+      rows.push(JSON.parse(line) as HermesRow);
+    } catch {
+      malformed++;
+    }
+  }
+
+  const heartbeats = rows.filter((r) => r.organization_id == null);
+  const decisions = rows.filter((r) => r.organization_id != null);
+
+  let firingRateNote = '';
+  if (heartbeats.length >= 2) {
+    const first = new Date(heartbeats[0].timestamp).getTime();
+    const last = new Date(heartbeats[heartbeats.length - 1].timestamp).getTime();
+    const spanMin = (last - first) / 60_000;
+    const ticksPerHour = spanMin > 0 ? (heartbeats.length / spanMin) * 60 : NaN;
+    firingRateNote = ` — ~${ticksPerHour.toFixed(1)} ticks/hr (cron is */30 → expected ~2)`;
+  }
+
+  console.log('Hermes customer-lifecycle shadow comparison');
+  console.log('===========================================');
+  console.log(`Shadow log:                   ${SHADOW_LOG}`);
+  console.log(`Total log lines:              ${lines.length}`);
+  console.log(`Malformed (skipped):          ${malformed}`);
+  console.log(`Heartbeat rows (cron fires):  ${heartbeats.length}${firingRateNote}`);
+  console.log(`Per-org decision rows:        ${decisions.length}`);
+
+  if (decisions.length === 0) {
+    console.log(
+      '\nNo per-org decisions yet. Either no candidates in the lookback window or the cron just started.',
+    );
+    return;
+  }
+
+  const orgIds = [...new Set(decisions.map((r) => r.organization_id!))];
+  const onboardings = await prisma.organizationOnboarding.findMany({
+    where: { organizationId: { in: orgIds } },
+    select: {
+      organizationId: true,
+      day1NudgeSentAt: true,
+      day3NudgeSentAt: true,
+      day7NudgeSentAt: true,
+      completedAt: true,
+    },
+  });
+  const byOrg = new Map(onboardings.map((o) => [o.organizationId, o]));
+
+  // Decision-by-decision agreement (each Hermes row is a separate event).
+  // Note: Hermes can suggest 'day3' BEFORE PM2 has actually sent day3, so we
+  // also track "Hermes suggested X, PM2 had not sent X yet at time of run"
+  // — treating that as agreement-pending rather than disagreement.
+  let agree = 0;
+  let disagree = 0;
+  let pending = 0;
+  let unmatched = 0;
+  const samples: Array<{
+    org: string;
+    hermes: string;
+    pm2: string;
+    reason: string | null;
+  }> = [];
+
+  for (const r of decisions) {
+    const ob = byOrg.get(r.organization_id!);
+    if (!ob) {
+      unmatched++;
+      continue;
+    }
+    const pm2 = latestNudgeFromOnboarding(ob);
+    const hermes = (r.hermes_template ?? 'none') as Template;
+    if (hermes === pm2) {
+      agree++;
+    } else if (
+      // Hermes suggested a template that PM2 hadn't yet sent at the time
+      // the row was written. Treat as pending — PM2 may catch up.
+      hermes !== 'none' &&
+      pm2 === 'none'
+    ) {
+      pending++;
+    } else {
+      disagree++;
+      if (samples.length < 10) {
+        samples.push({
+          org: r.organization_id!.slice(0, 8),
+          hermes,
+          pm2,
+          reason: r.hermes_reasoning,
+        });
+      }
+    }
+  }
+
+  const matched = agree + disagree + pending;
+  console.log(`\nDecisions joined to onboarding row: ${matched}`);
+  console.log(`Unmatched (org/onboarding gone):    ${unmatched}`);
+  console.log(`Agreement (template matches):       ${agree} (${pct(agree, matched)})`);
+  console.log(`Pending (Hermes ahead, PM2 hasn't): ${pending} (${pct(pending, matched)})`);
+  console.log(`Disagreement:                       ${disagree} (${pct(disagree, matched)})`);
+
+  if (samples.length > 0) {
+    console.log('\nSample disagreements (first 10):');
+    for (const s of samples) {
+      console.log(
+        `  ${s.org}  hermes=${s.hermes.padEnd(22)}  pm2=${s.pm2.padEnd(22)}  | ${s.reason ?? '<no reason>'}`,
+      );
+    }
+  }
+
+  console.log(
+    '\nReminder: PM2 mark-sent reflects SENT, not suggested. SMTP failures',
+  );
+  console.log(
+    'show up here as Hermes-disagree even when both heuristics agreed. Track',
+  );
+  console.log(
+    'PM2-side suggestion logging as a follow-up (see backlog.md).',
+  );
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 2;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
Shadow-mode migration for the only remaining LIVE business agent. Read path goes through MCP, decisions logged to JSONL, comparison script ready. Live-mode (write tools + email cutover) deferred to a separate gated effort.

## Schema
`mcp_tokens.organizationId` is now nullable. NULL = platform-scope token (cross-org agents). Per-org tools reject null via `requireOrgScope`; platform tools require null.

## New MCP tool
`list_onboarding_candidates` (platform-scope, `customer:read`). Structural signals only — D13 enforced at the wire-shape Zod layer.

## Hermes skill
`hermes-skills/vizora-customer-lifecycle/SKILL.md`. Heuristic-matching prompt, JSONL output to `/var/log/hermes/vizora-customer-lifecycle-shadow.jsonl`. Read-only — won't call any write tool even if scope was given.

## Comparison
`scripts/agents/compare-lifecycle-hermes-vs-heuristic.ts`. Diffs Hermes decisions against PM2 mark-sent timestamps. Honestly notes its own limitation re: SMTP failures.

## Test plan
- [x] 116 suites / 2254 tests pass (was 115/2247; +7 new)
- [x] `nx build @vizora/middleware` clean
- [ ] After deploy: `prisma migrate deploy` + `prisma generate` on prod
- [ ] After deploy: issue platform-scope MCP token (psql, organizationId=null) for `hermes-customer-lifecycle` agent
- [ ] After deploy: `hermes mcp test vizora` should show 6 tools
- [ ] After deploy: schedule `hermes cron */30 * * * * --skill vizora-customer-lifecycle`
- [ ] After deploy: verify JSONL gets heartbeat / decision rows on first firing

## NOT in this PR
- Write tools (`mark_onboarding_nudge_sent` etc) — separate PR
- Live cutover — gated on shadow data + Sri sign-off
- Decommission of PM2 cron — stays as source of truth

🤖 Generated with [Claude Code](https://claude.com/claude-code)