### PR TITLE
feat(agents): heuristic-side suggestion logging — true score-vs-score shadow comparison

### DIFF
--- a/scripts/agents/compare-hermes-vs-heuristic.ts
+++ b/scripts/agents/compare-hermes-vs-heuristic.ts
@@ -1,32 +1,30 @@
 #!/usr/bin/env npx tsx
 /**
  * Compare Hermes shadow-mode classifications against the existing
- * heuristic classifier's DB writes.
+ * heuristic classifier's per-ticket suggestions.
  *
- * Reads `/var/log/hermes/vizora-support-triage-shadow.jsonl` (one JSONL
- * row per Hermes cron tick), joins to `support_requests` by id, and
- * reports:
- *   - cron firing rate (heartbeat lines per period)
- *   - per-ticket priority agreement between Hermes-suggested and the
- *     DB-stored priority
+ * Reads two parallel JSONL files:
+ *   - HERMES_SHADOW_LOG     (default /var/log/hermes/vizora-support-
+ *                            triage-shadow.jsonl) — one row per ticket
+ *                            per Hermes cron tick
+ *   - HEURISTIC_LOG         (default /var/log/hermes/vizora-support-
+ *                            triage-heuristic.jsonl) — one row per ticket
+ *                            per PM2 cron tick, written by
+ *                            scripts/agents/support-triage.ts
+ *
+ * Joins by (ticket_id, run_id) and reports:
+ *   - cron firing rate (heartbeats per period)
+ *   - per-ticket priority agreement (Hermes priority vs heuristic priority)
+ *   - per-ticket score divergence (Hermes score vs heuristic score)
  *   - sample disagreements
  *
- * **What this can and cannot tell us**
+ * The earlier version of this script joined to the DB `priority` field,
+ * which mostly reflected the user's submission (not the heuristic's
+ * score). The new heuristic JSONL gives us a true score-vs-score
+ * head-to-head — same input signals, same scoring window, two scoring
+ * implementations.
  *
- * The DB `priority` field reflects the user's original submission
- * unless the heuristic PM2 cron decided the score diverged enough to
- * write back (rank-distance ≥ 2 in scripts/agents/support-triage.ts).
- * Most rows are the user's submission, NOT the heuristic's score-to-
- * priority output. So this script answers:
- *
- *   "Would Hermes have proposed a different priority than what the
- *    user submitted (or what the heuristic occasionally overrode)?"
- *
- * It does NOT answer "Hermes score vs heuristic score" head-to-head.
- * For that we'd need the heuristic cron to also log its score to a
- * parallel file. That's a tracked follow-up — see backlog.md.
- *
- * Run from the VPS (where both the shadow log and the DB live):
+ * Run from the VPS:
  *
  *   ssh root@89.167.55.176 'cd /opt/vizora/app && export $(grep DATABASE_URL .env | xargs) && npx tsx scripts/agents/compare-hermes-vs-heuristic.ts'
  */
@@ -38,6 +36,11 @@ import { prisma } from '@vizora/database';
 const SHADOW_LOG =
   process.env.HERMES_SHADOW_LOG ??
   '/var/log/hermes/vizora-support-triage-shadow.jsonl';
+const HEURISTIC_LOG =
+  process.env.SUPPORT_TRIAGE_HEURISTIC_LOG ??
+  '/var/log/hermes/vizora-support-triage-heuristic.jsonl';
+
+type Priority = 'urgent' | 'high' | 'normal' | 'low';
 
 interface HermesRow {
   timestamp: string;
@@ -45,16 +48,20 @@ interface HermesRow {
   ticket_id: string | null;
   organization_id: string | null;
   hermes_score: number | null;
-  hermes_priority: 'urgent' | 'high' | 'normal' | 'low' | null;
+  hermes_priority: Priority | null;
   hermes_reasoning: string | null;
   input_signals: Record<string, unknown> | null;
 }
 
-interface DisagreementSample {
-  ticket: string;
-  hermes: string;
-  db: string;
-  reason: string | null;
+interface HeuristicRow {
+  timestamp: string;
+  run_id: string;
+  ticket_id: string;
+  organization_id: string;
+  heuristic_score: number;
+  heuristic_priority: Priority;
+  heuristic_reason: string;
+  input_signals: Record<string, unknown>;
 }
 
 function pct(n: number, d: number): string {
@@ -74,135 +81,156 @@ function priorityRank(p: string): number {
     case 'low':
       return 0;
     default:
-      return -1; // unknown / null
+      return -1;
   }
 }
 
-async function main(): Promise<void> {
-  if (!existsSync(SHADOW_LOG)) {
-    console.error(`No shadow log at ${SHADOW_LOG}`);
-    console.error(`Set HERMES_SHADOW_LOG to override the path.`);
-    process.exitCode = 2;
-    return;
-  }
-
-  const text = readFileSync(SHADOW_LOG, 'utf8');
+function readJsonl<T>(path: string): { rows: T[]; malformed: number } {
+  if (!existsSync(path)) return { rows: [], malformed: 0 };
+  const text = readFileSync(path, 'utf8');
   const lines = text.split('\n').filter(Boolean);
-  const rows: HermesRow[] = [];
+  const rows: T[] = [];
   let malformed = 0;
   for (const line of lines) {
     try {
-      rows.push(JSON.parse(line) as HermesRow);
+      rows.push(JSON.parse(line) as T);
     } catch {
       malformed++;
     }
   }
+  return { rows, malformed };
+}
 
-  const heartbeats = rows.filter((r) => r.ticket_id == null);
-  const scored = rows.filter((r) => r.ticket_id != null);
+async function main(): Promise<void> {
+  const { rows: hermesRows, malformed: hermesBad } = readJsonl<HermesRow>(SHADOW_LOG);
+  const { rows: heuristicRows, malformed: heuristicBad } =
+    readJsonl<HeuristicRow>(HEURISTIC_LOG);
 
-  // Cron-firing-rate signal: time span / heartbeat count → expected ~5 min between
+  if (hermesRows.length === 0 && heuristicRows.length === 0) {
+    console.error(`Neither log exists or both empty:\n  ${SHADOW_LOG}\n  ${HEURISTIC_LOG}`);
+    process.exitCode = 2;
+    return;
+  }
+
+  const heartbeats = hermesRows.filter((r) => r.ticket_id == null);
+  const hermesScored = hermesRows.filter((r) => r.ticket_id != null);
+
   let firingRateNote = '';
   if (heartbeats.length >= 2) {
     const first = new Date(heartbeats[0].timestamp).getTime();
     const last = new Date(heartbeats[heartbeats.length - 1].timestamp).getTime();
     const spanMin = (last - first) / 60_000;
-    const ticksPerHour =
-      spanMin > 0 ? (heartbeats.length / spanMin) * 60 : NaN;
+    const ticksPerHour = spanMin > 0 ? (heartbeats.length / spanMin) * 60 : NaN;
     firingRateNote = ` — ~${ticksPerHour.toFixed(1)} ticks/hr (cron is */5 → expected ~12)`;
   }
 
-  console.log('Hermes shadow-mode comparison');
-  console.log('=============================');
-  console.log(`Shadow log:                   ${SHADOW_LOG}`);
-  console.log(`Total log lines:              ${lines.length}`);
-  console.log(`Malformed (skipped):          ${malformed}`);
-  console.log(`Heartbeat rows (cron fires):  ${heartbeats.length}${firingRateNote}`);
-  console.log(`Ticket-scoring rows:          ${scored.length}`);
+  console.log('Hermes vs Heuristic shadow comparison (support-triage)');
+  console.log('======================================================');
+  console.log(`Hermes log:                    ${SHADOW_LOG}`);
+  console.log(`  rows: ${hermesRows.length} (heartbeats: ${heartbeats.length}, scored: ${hermesScored.length}, malformed: ${hermesBad})${firingRateNote}`);
+  console.log(`Heuristic log:                 ${HEURISTIC_LOG}`);
+  console.log(`  rows: ${heuristicRows.length} (malformed: ${heuristicBad})`);
 
-  if (scored.length === 0) {
-    console.log(
-      '\nNo ticket scorings yet. The Hermes cron is firing but the token-scoped org has no open tickets.',
-    );
-    console.log(
-      'Either seed a request in the E2E Test Org, or expand the token to cover an org with traffic.',
-    );
+  if (hermesScored.length === 0 && heuristicRows.length === 0) {
+    console.log('\nNo per-ticket decisions yet from either side. Likely the test orgs have no open tickets.');
     return;
   }
 
-  const ticketIds = [...new Set(scored.map((r) => r.ticket_id!))];
-  const dbTickets = await prisma.supportRequest.findMany({
-    where: { id: { in: ticketIds } },
-    select: { id: true, priority: true, status: true, aiCategory: true },
-  });
-  const byId = new Map(dbTickets.map((t) => [t.id, t]));
+  // Index heuristic rows by composite key. Hermes and heuristic crons
+  // both fire every 5 min; their run_ids may not match exactly (each
+  // computes its own epoch-seconds), but ticket_id alone is a reasonable
+  // join key — most tickets are scored once per cron firing per side.
+  const heuristicByTicket = new Map<string, HeuristicRow[]>();
+  for (const r of heuristicRows) {
+    const arr = heuristicByTicket.get(r.ticket_id) ?? [];
+    arr.push(r);
+    heuristicByTicket.set(r.ticket_id, arr);
+  }
 
-  let agree = 0;
-  let disagree = 0;
+  let agreePri = 0;
+  let disagreePri = 0;
   let unmatched = 0;
-  let rankDiffSum = 0;
-  const samples: DisagreementSample[] = [];
+  let scoreDiffSum = 0;
+  let scoreDiffCount = 0;
+  const samples: Array<{
+    ticket: string;
+    hermesP: string;
+    heuristicP: string;
+    hermesS: number;
+    heuristicS: number;
+    reason: string | null;
+  }> = [];
 
-  for (const r of scored) {
-    const t = byId.get(r.ticket_id!);
-    if (!t) {
+  for (const h of hermesScored) {
+    const hCandidates = heuristicByTicket.get(h.ticket_id!) ?? [];
+    if (hCandidates.length === 0) {
       unmatched++;
       continue;
     }
-    const dbP = (t.priority ?? '').toLowerCase();
-    const hP = (r.hermes_priority ?? '').toLowerCase();
-    if (dbP === hP) {
-      agree++;
+    // Pick the closest-in-time heuristic row (paired by run cadence)
+    const closest = hCandidates.reduce((best, r) =>
+      Math.abs(new Date(r.timestamp).getTime() - new Date(h.timestamp).getTime()) <
+      Math.abs(new Date(best.timestamp).getTime() - new Date(h.timestamp).getTime())
+        ? r
+        : best,
+    );
+
+    const hP = h.hermes_priority ?? '';
+    const cP = closest.heuristic_priority;
+    if (hP === cP) {
+      agreePri++;
     } else {
-      disagree++;
-      const rDb = priorityRank(dbP);
-      const rH = priorityRank(hP);
-      if (rDb >= 0 && rH >= 0) rankDiffSum += Math.abs(rDb - rH);
+      disagreePri++;
       if (samples.length < 10) {
         samples.push({
-          ticket: r.ticket_id!,
-          hermes: hP || '<null>',
-          db: dbP || '<null>',
-          reason: r.hermes_reasoning,
+          ticket: h.ticket_id!,
+          hermesP: hP || '<null>',
+          heuristicP: cP,
+          hermesS: h.hermes_score ?? NaN,
+          heuristicS: closest.heuristic_score,
+          reason: h.hermes_reasoning,
         });
       }
     }
+
+    if (h.hermes_score != null) {
+      scoreDiffSum += Math.abs(h.hermes_score - closest.heuristic_score);
+      scoreDiffCount++;
+    }
   }
 
-  const matched = agree + disagree;
-
-  console.log(`\nTickets joined to DB:         ${matched}`);
-  console.log(`Unmatched (deleted/missing):  ${unmatched}`);
-  console.log(`Priority agreement:           ${agree} (${pct(agree, matched)})`);
-  console.log(`Priority disagreement:        ${disagree} (${pct(disagree, matched)})`);
-  if (disagree > 0) {
-    console.log(
-      `Avg disagreement rank-distance: ${(rankDiffSum / disagree).toFixed(2)} (1 = adjacent tier, 3 = max)`,
-    );
+  const matched = agreePri + disagreePri;
+  console.log(`\nMatched (Hermes ticket joined to heuristic row): ${matched}`);
+  console.log(`Unmatched (heuristic never scored this ticket):  ${unmatched}`);
+  console.log(`Priority agreement:                              ${agreePri} (${pct(agreePri, matched)})`);
+  console.log(`Priority disagreement:                           ${disagreePri} (${pct(disagreePri, matched)})`);
+  if (scoreDiffCount > 0) {
+    console.log(`Mean |Hermes score − heuristic score|:           ${(scoreDiffSum / scoreDiffCount).toFixed(3)}`);
   }
 
   if (samples.length > 0) {
     console.log('\nSample disagreements (first 10):');
     for (const s of samples) {
+      const diff = Math.abs(s.hermesS - s.heuristicS).toFixed(2);
       console.log(
-        `  ${s.ticket.slice(0, 8)}  hermes=${s.hermes.padEnd(7)}  db=${s.db.padEnd(7)}  | ${
-          s.reason ?? '<no reason>'
-        }`,
+        `  ${s.ticket.slice(0, 8)}  hermes=${s.hermesP.padEnd(7)}(${s.hermesS.toFixed(2)})  heuristic=${s.heuristicP.padEnd(7)}(${s.heuristicS.toFixed(2)})  Δ=${diff}  | ${s.reason ?? '<no reason>'}`,
       );
     }
   }
 
-  console.log('\nReminder: DB priority is mostly the user-submitted priority.');
-  console.log('To compare Hermes vs heuristic head-to-head, the existing PM2');
-  console.log('support-triage cron also needs to log its score per cycle to a');
-  console.log("parallel file. Tracked in backlog.md as a follow-up.");
+  // Cutover gate readout
+  console.log('\n— Cutover gate readout —');
+  console.log(`  ≥7 days shadow:               ${heartbeats.length >= 2 ? `${heartbeats.length} heartbeats` : '<2 heartbeats'}`);
+  console.log(`  ≥50 tickets scored:           ${hermesScored.length >= 50 ? '✓ MET' : `✗ have ${hermesScored.length}`}`);
+  console.log(`  ≥80% priority agreement:      ${matched > 0 && agreePri / matched >= 0.8 ? '✓ MET' : `✗ have ${pct(agreePri, matched)}`}`);
+  console.log(`  Sri sign-off:                 (out of band)`);
+
+  // Disconnect even though the script doesn't read the DB anymore — keep
+  // the import for future expansion (e.g., joining to live DB state).
+  await prisma.$disconnect();
 }
 
-main()
-  .catch((err) => {
-    console.error(err);
-    process.exitCode = 2;
-  })
-  .finally(async () => {
-    await prisma.$disconnect();
-  });
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 2;
+});

--- a/scripts/agents/compare-lifecycle-hermes-vs-heuristic.ts
+++ b/scripts/agents/compare-lifecycle-hermes-vs-heuristic.ts
@@ -1,22 +1,26 @@
 #!/usr/bin/env npx tsx
 /**
  * Compare Hermes shadow-mode customer-lifecycle decisions against the
- * existing PM2 cron's mark-sent records.
+ * existing heuristic's per-org suggestions.
  *
- * Reads `/var/log/hermes/vizora-customer-lifecycle-shadow.jsonl`
- * (one JSONL row per Hermes cron tick per candidate org), joins to
- * `organization_onboarding` by id, and reports:
+ * Reads two parallel JSONL files:
+ *   - HERMES_LIFECYCLE_SHADOW_LOG  (default /var/log/hermes/vizora-
+ *                                   customer-lifecycle-shadow.jsonl)
+ *   - CUSTOMER_LIFECYCLE_HEURISTIC_LOG (default /var/log/hermes/
+ *                                       vizora-customer-lifecycle-
+ *                                       heuristic.jsonl) — written by
+ *                                       scripts/agents/customer-lifecycle.ts
+ *
+ * Joins by organization_id (closest-in-time match per org) and reports:
  *   - cron firing rate
- *   - per-org agreement: did Hermes pick the same template the PM2
- *     cron actually marked sent (or 'none' if PM2 didn't act)?
+ *   - per-org template agreement (Hermes template vs heuristic template)
  *   - sample disagreements
  *
- * **Limitation**: PM2's mark-sent record reflects what was SENT, not
- * what its heuristic SUGGESTED. If Hermes suggests `day3` and PM2's
- * heuristic agreed but the ticket failed SMTP, mark-sent is null and
- * we count it as a "disagreement" when it isn't. For a true head-to-
- * head comparison the PM2 cron should also log its suggestion to a
- * parallel file. Tracked in backlog.md.
+ * The earlier version joined to organization_onboarding's mark-sent
+ * timestamps, which conflated SUGGEST with SENT — SMTP failures showed
+ * up as Hermes-disagreements. The new heuristic JSONL gives us true
+ * suggest-vs-suggest comparison: same input signals, two scoring
+ * implementations, no wire-side noise.
  *
  * Run from the VPS:
  *
@@ -30,6 +34,9 @@ import { prisma } from '@vizora/database';
 const SHADOW_LOG =
   process.env.HERMES_LIFECYCLE_SHADOW_LOG ??
   '/var/log/hermes/vizora-customer-lifecycle-shadow.jsonl';
+const HEURISTIC_LOG =
+  process.env.CUSTOMER_LIFECYCLE_HEURISTIC_LOG ??
+  '/var/log/hermes/vizora-customer-lifecycle-heuristic.jsonl';
 
 type Template =
   | 'day1-pair-screen'
@@ -48,51 +55,51 @@ interface HermesRow {
   input_signals: Record<string, unknown> | null;
 }
 
+interface HeuristicRow {
+  timestamp: string;
+  run_id: string;
+  organization_id: string;
+  tier: string;
+  days_since_signup: number;
+  heuristic_template: string;
+  heuristic_action: 'send_nudge' | 'auto_complete' | 'none';
+  heuristic_reason: string;
+  input_signals: Record<string, unknown>;
+}
+
 function pct(n: number, d: number): string {
   return d === 0 ? '0%' : `${Math.round((100 * n) / d)}%`;
 }
 
-/**
- * Map an organization_onboarding row to the most-recently-sent nudge
- * template, or 'none' if no nudge has been sent. Sender precedence is
- * by recency, not by milestone — if PM2 sent day3 yesterday and day7
- * today, return 'day7-create-schedule'.
- */
-function latestNudgeFromOnboarding(ob: {
-  day1NudgeSentAt: Date | null;
-  day3NudgeSentAt: Date | null;
-  day7NudgeSentAt: Date | null;
-}): Template {
-  const sent: Array<{ t: Template; at: Date }> = [];
-  if (ob.day1NudgeSentAt) sent.push({ t: 'day1-pair-screen', at: ob.day1NudgeSentAt });
-  if (ob.day3NudgeSentAt) sent.push({ t: 'day3-upload-content', at: ob.day3NudgeSentAt });
-  if (ob.day7NudgeSentAt) sent.push({ t: 'day7-create-schedule', at: ob.day7NudgeSentAt });
-  if (sent.length === 0) return 'none';
-  sent.sort((a, b) => b.at.getTime() - a.at.getTime());
-  return sent[0].t;
-}
-
-async function main(): Promise<void> {
-  if (!existsSync(SHADOW_LOG)) {
-    console.error(`No shadow log at ${SHADOW_LOG}`);
-    process.exitCode = 2;
-    return;
-  }
-
-  const text = readFileSync(SHADOW_LOG, 'utf8');
+function readJsonl<T>(path: string): { rows: T[]; malformed: number } {
+  if (!existsSync(path)) return { rows: [], malformed: 0 };
+  const text = readFileSync(path, 'utf8');
   const lines = text.split('\n').filter(Boolean);
-  const rows: HermesRow[] = [];
+  const rows: T[] = [];
   let malformed = 0;
   for (const line of lines) {
     try {
-      rows.push(JSON.parse(line) as HermesRow);
+      rows.push(JSON.parse(line) as T);
     } catch {
       malformed++;
     }
   }
+  return { rows, malformed };
+}
 
-  const heartbeats = rows.filter((r) => r.organization_id == null);
-  const decisions = rows.filter((r) => r.organization_id != null);
+async function main(): Promise<void> {
+  const { rows: hermesRows, malformed: hermesBad } = readJsonl<HermesRow>(SHADOW_LOG);
+  const { rows: heuristicRows, malformed: heuristicBad } =
+    readJsonl<HeuristicRow>(HEURISTIC_LOG);
+
+  if (hermesRows.length === 0 && heuristicRows.length === 0) {
+    console.error(`Neither log exists or both empty:\n  ${SHADOW_LOG}\n  ${HEURISTIC_LOG}`);
+    process.exitCode = 2;
+    return;
+  }
+
+  const heartbeats = hermesRows.filter((r) => r.organization_id == null);
+  const hermesDecisions = hermesRows.filter((r) => r.organization_id != null);
 
   let firingRateNote = '';
   if (heartbeats.length >= 2) {
@@ -103,111 +110,95 @@ async function main(): Promise<void> {
     firingRateNote = ` — ~${ticksPerHour.toFixed(1)} ticks/hr (cron is */30 → expected ~2)`;
   }
 
-  console.log('Hermes customer-lifecycle shadow comparison');
-  console.log('===========================================');
-  console.log(`Shadow log:                   ${SHADOW_LOG}`);
-  console.log(`Total log lines:              ${lines.length}`);
-  console.log(`Malformed (skipped):          ${malformed}`);
-  console.log(`Heartbeat rows (cron fires):  ${heartbeats.length}${firingRateNote}`);
-  console.log(`Per-org decision rows:        ${decisions.length}`);
+  console.log('Hermes vs Heuristic shadow comparison (customer-lifecycle)');
+  console.log('==========================================================');
+  console.log(`Hermes log:                   ${SHADOW_LOG}`);
+  console.log(`  rows: ${hermesRows.length} (heartbeats: ${heartbeats.length}, decisions: ${hermesDecisions.length}, malformed: ${hermesBad})${firingRateNote}`);
+  console.log(`Heuristic log:                ${HEURISTIC_LOG}`);
+  console.log(`  rows: ${heuristicRows.length} (malformed: ${heuristicBad})`);
 
-  if (decisions.length === 0) {
-    console.log(
-      '\nNo per-org decisions yet. Either no candidates in the lookback window or the cron just started.',
-    );
+  if (hermesDecisions.length === 0 && heuristicRows.length === 0) {
+    console.log('\nNo per-org decisions yet from either side.');
     return;
   }
 
-  const orgIds = [...new Set(decisions.map((r) => r.organization_id!))];
-  const onboardings = await prisma.organizationOnboarding.findMany({
-    where: { organizationId: { in: orgIds } },
-    select: {
-      organizationId: true,
-      day1NudgeSentAt: true,
-      day3NudgeSentAt: true,
-      day7NudgeSentAt: true,
-      completedAt: true,
-    },
-  });
-  const byOrg = new Map(onboardings.map((o) => [o.organizationId, o]));
+  // Build heuristic index by org_id
+  const heuristicByOrg = new Map<string, HeuristicRow[]>();
+  for (const r of heuristicRows) {
+    const arr = heuristicByOrg.get(r.organization_id) ?? [];
+    arr.push(r);
+    heuristicByOrg.set(r.organization_id, arr);
+  }
 
-  // Decision-by-decision agreement (each Hermes row is a separate event).
-  // Note: Hermes can suggest 'day3' BEFORE PM2 has actually sent day3, so we
-  // also track "Hermes suggested X, PM2 had not sent X yet at time of run"
-  // — treating that as agreement-pending rather than disagreement.
-  let agree = 0;
-  let disagree = 0;
-  let pending = 0;
+  let agreeTpl = 0;
+  let disagreeTpl = 0;
   let unmatched = 0;
   const samples: Array<{
     org: string;
     hermes: string;
-    pm2: string;
+    heuristic: string;
+    days: number;
     reason: string | null;
   }> = [];
 
-  for (const r of decisions) {
-    const ob = byOrg.get(r.organization_id!);
-    if (!ob) {
+  for (const h of hermesDecisions) {
+    const hCandidates = heuristicByOrg.get(h.organization_id!) ?? [];
+    if (hCandidates.length === 0) {
       unmatched++;
       continue;
     }
-    const pm2 = latestNudgeFromOnboarding(ob);
-    const hermes = (r.hermes_template ?? 'none') as Template;
-    if (hermes === pm2) {
-      agree++;
-    } else if (
-      // Hermes suggested a template that PM2 hadn't yet sent at the time
-      // the row was written. Treat as pending — PM2 may catch up.
-      hermes !== 'none' &&
-      pm2 === 'none'
-    ) {
-      pending++;
+    // Pick the closest-in-time heuristic row
+    const closest = hCandidates.reduce((best, r) =>
+      Math.abs(new Date(r.timestamp).getTime() - new Date(h.timestamp).getTime()) <
+      Math.abs(new Date(best.timestamp).getTime() - new Date(h.timestamp).getTime())
+        ? r
+        : best,
+    );
+
+    const hermesT = (h.hermes_template ?? 'none') as Template;
+    const heuristicT = closest.heuristic_template;
+
+    if (hermesT === heuristicT) {
+      agreeTpl++;
     } else {
-      disagree++;
+      disagreeTpl++;
       if (samples.length < 10) {
         samples.push({
-          org: r.organization_id!.slice(0, 8),
-          hermes,
-          pm2,
-          reason: r.hermes_reasoning,
+          org: h.organization_id!.slice(0, 8),
+          hermes: hermesT,
+          heuristic: heuristicT,
+          days: closest.days_since_signup,
+          reason: h.hermes_reasoning,
         });
       }
     }
   }
 
-  const matched = agree + disagree + pending;
-  console.log(`\nDecisions joined to onboarding row: ${matched}`);
-  console.log(`Unmatched (org/onboarding gone):    ${unmatched}`);
-  console.log(`Agreement (template matches):       ${agree} (${pct(agree, matched)})`);
-  console.log(`Pending (Hermes ahead, PM2 hasn't): ${pending} (${pct(pending, matched)})`);
-  console.log(`Disagreement:                       ${disagree} (${pct(disagree, matched)})`);
+  const matched = agreeTpl + disagreeTpl;
+  console.log(`\nMatched (Hermes org joined to heuristic row):    ${matched}`);
+  console.log(`Unmatched (heuristic never scored this org):     ${unmatched}`);
+  console.log(`Template agreement:                              ${agreeTpl} (${pct(agreeTpl, matched)})`);
+  console.log(`Template disagreement:                           ${disagreeTpl} (${pct(disagreeTpl, matched)})`);
 
   if (samples.length > 0) {
     console.log('\nSample disagreements (first 10):');
     for (const s of samples) {
       console.log(
-        `  ${s.org}  hermes=${s.hermes.padEnd(22)}  pm2=${s.pm2.padEnd(22)}  | ${s.reason ?? '<no reason>'}`,
+        `  ${s.org}  age=${String(s.days).padStart(3)}d  hermes=${s.hermes.padEnd(22)}  heuristic=${s.heuristic.padEnd(22)}  | ${s.reason ?? '<no reason>'}`,
       );
     }
   }
 
-  console.log(
-    '\nReminder: PM2 mark-sent reflects SENT, not suggested. SMTP failures',
-  );
-  console.log(
-    'show up here as Hermes-disagree even when both heuristics agreed. Track',
-  );
-  console.log(
-    'PM2-side suggestion logging as a follow-up (see backlog.md).',
-  );
+  console.log('\n— Cutover gate readout —');
+  console.log(`  ≥7 days shadow:               ${heartbeats.length >= 2 ? `${heartbeats.length} heartbeats` : '<2 heartbeats'}`);
+  console.log(`  ≥50 per-org decisions:        ${hermesDecisions.length >= 50 ? '✓ MET' : `✗ have ${hermesDecisions.length}`}`);
+  console.log(`  ≥80% template agreement:      ${matched > 0 && agreeTpl / matched >= 0.8 ? '✓ MET' : `✗ have ${pct(agreeTpl, matched)}`}`);
+  console.log(`  Sri sign-off:                 (out of band)`);
+
+  await prisma.$disconnect();
 }
 
-main()
-  .catch((err) => {
-    console.error(err);
-    process.exitCode = 2;
-  })
-  .finally(async () => {
-    await prisma.$disconnect();
-  });
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 2;
+});

--- a/scripts/agents/customer-lifecycle.ts
+++ b/scripts/agents/customer-lifecycle.ts
@@ -25,6 +25,8 @@
  */
 
 import 'dotenv/config';
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
 import { prisma } from '@vizora/database';
 import type { Organization, OrganizationOnboarding, User } from '@vizora/database';
 import {
@@ -43,6 +45,14 @@ import type {
 
 const AGENT = 'customer-lifecycle';
 const FAMILY = 'customer' as const;
+// Parallel JSONL for shadow comparison against the Hermes-driven
+// vizora-customer-lifecycle skill. Sibling to
+// /var/log/hermes/vizora-customer-lifecycle-shadow.jsonl so
+// scripts/agents/compare-lifecycle-hermes-vs-heuristic.ts can join
+// per-org for true template-vs-template head-to-head.
+const HEURISTIC_LOG_PATH =
+  process.env.CUSTOMER_LIFECYCLE_HEURISTIC_LOG ??
+  '/var/log/hermes/vizora-customer-lifecycle-heuristic.jsonl';
 
 const MAX_EMAILS_PER_RUN = 50;
 const CANDIDATE_LIMIT = 200;
@@ -75,6 +85,53 @@ const NUDGE_SUBJECT: Record<NudgeKey, string> = {
 
 function log(msg: string): void {
   opsLog(AGENT, msg);
+}
+
+/**
+ * Append one JSONL row per org reflecting what the heuristic suggested
+ * THIS cycle. Sibling to the Hermes shadow log so
+ * `compare-lifecycle-hermes-vs-heuristic.ts` can join per-org for
+ * template-vs-template head-to-head.
+ *
+ * Logs every candidate (including 'none' suggestions and stale-org
+ * auto-complete decisions) so the comparison dataset is complete.
+ *
+ * Failures here are non-fatal — the cron's primary job is the email
+ * decision pipeline, not the comparison log.
+ */
+function logHeuristicSuggestion(
+  runId: string,
+  orgId: string,
+  signal: OnboardingSignal,
+  template: string,
+  action: 'send_nudge' | 'auto_complete' | 'none',
+  reason: string,
+): void {
+  try {
+    mkdirSync(dirname(HEURISTIC_LOG_PATH), { recursive: true });
+    const row = {
+      timestamp: new Date().toISOString(),
+      run_id: runId,
+      organization_id: orgId,
+      tier: signal.tier,
+      days_since_signup: signal.daysSinceSignup,
+      heuristic_template: template,
+      heuristic_action: action,
+      heuristic_reason: reason,
+      input_signals: {
+        milestone_flags: {
+          welcomed: signal.milestoneFlags.welcomed,
+          screen_paired: signal.milestoneFlags.screenPaired,
+          content_uploaded: signal.milestoneFlags.contentUploaded,
+          playlist_created: signal.milestoneFlags.playlistCreated,
+          schedule_created: signal.milestoneFlags.scheduleCreated,
+        },
+      },
+    };
+    appendFileSync(HEURISTIC_LOG_PATH, JSON.stringify(row) + '\n');
+  } catch (err) {
+    log(`heuristic log append failed for org=${orgId}: ${err instanceof Error ? err.message : err}`);
+  }
 }
 
 function daysBetween(from: Date, to: Date): number {
@@ -247,6 +304,8 @@ async function fetchCandidates(): Promise<Array<Organization & {
 
 async function main(): Promise<void> {
   const startTime = Date.now();
+  // run_id matches the Hermes shadow's epoch-seconds shape.
+  const runId = String(Math.floor(startTime / 1000));
   log('Starting customer-lifecycle cycle');
 
   // Reset per-run counter at the top of the cycle (persisted state)
@@ -291,6 +350,14 @@ async function main(): Promise<void> {
 
     // Auto-complete stale onboardings (>30d — outside nudge window)
     if (signal.daysSinceSignup >= AUTO_COMPLETE_DAYS) {
+      logHeuristicSuggestion(
+        runId,
+        org.id,
+        signal,
+        'none',
+        'auto_complete',
+        `age=${signal.daysSinceSignup}d >= ${AUTO_COMPLETE_DAYS}d, auto-closing`,
+      );
       try {
         await prisma.organizationOnboarding.upsert({
           where: { organizationId: org.id },
@@ -327,10 +394,38 @@ async function main(): Promise<void> {
       log(`suggestNudge failed for org=${org.id}: ${err instanceof Error ? err.message : err}`);
       continue;
     }
-    if (suggestion.template === 'none') continue;
+    if (suggestion.template === 'none') {
+      logHeuristicSuggestion(
+        runId,
+        org.id,
+        signal,
+        'none',
+        'none',
+        `suggestNudge returned 'none' (age=${signal.daysSinceSignup}d, milestones=${JSON.stringify(signal.milestoneFlags)})`,
+      );
+      continue;
+    }
     const nudgeKey = suggestion.template as NudgeKey;
     const col = NUDGE_COLUMN[nudgeKey];
-    if (!col) continue;
+    if (!col) {
+      logHeuristicSuggestion(
+        runId,
+        org.id,
+        signal,
+        suggestion.template,
+        'none',
+        `unknown nudge key: ${suggestion.template}`,
+      );
+      continue;
+    }
+    logHeuristicSuggestion(
+      runId,
+      org.id,
+      signal,
+      nudgeKey,
+      'send_nudge',
+      `suggestNudge picked ${nudgeKey} (age=${signal.daysSinceSignup}d)`,
+    );
 
     const admin = await findOrgAdmin(org.id);
     if (!admin?.email) {

--- a/scripts/agents/support-triage.ts
+++ b/scripts/agents/support-triage.ts
@@ -21,6 +21,8 @@
  */
 
 import 'dotenv/config';
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
 import { prisma, classifyCategoryV2 } from '@vizora/database';
 import type { SupportRequest, SupportMessage } from '@vizora/database';
 import { readAgentState, writeAgentState } from './lib/state.js';
@@ -37,6 +39,14 @@ import type {
 } from './lib/types.js';
 
 const AGENT = 'support-triage';
+// Parallel JSONL for shadow comparison against the Hermes-driven
+// vizora-support-triage skill. Sibling file to
+// /var/log/hermes/vizora-support-triage-shadow.jsonl so
+// scripts/agents/compare-hermes-vs-heuristic.ts can join by
+// (ticket_id, run_id) for true score-vs-score head-to-head.
+const HEURISTIC_LOG_PATH =
+  process.env.SUPPORT_TRIAGE_HEURISTIC_LOG ??
+  '/var/log/hermes/vizora-support-triage-heuristic.jsonl';
 // Must match middleware/src/modules/agents/agent-state.service.ts AGENT_TO_FAMILY
 const FAMILY = 'ops' as const;
 const BATCH_LIMIT = 20;
@@ -164,6 +174,49 @@ function scoreToPriority(score: number): TicketPriority {
   return 'low';
 }
 
+/**
+ * Append one JSONL row per ticket reflecting what the heuristic
+ * classifier suggested THIS cycle. Sibling to the Hermes shadow log so
+ * `compare-hermes-vs-heuristic.ts` can join by (ticket_id, run_id) for
+ * a true score-vs-score comparison.
+ *
+ * Failures here are non-fatal — the cron's primary job is the DB
+ * mutation, not the comparison log.
+ */
+function logHeuristicSuggestion(
+  runId: string,
+  ticket: TicketRow,
+  score: number,
+  reason: string,
+  signal: TicketSignal,
+): void {
+  try {
+    mkdirSync(dirname(HEURISTIC_LOG_PATH), { recursive: true });
+    const row = {
+      timestamp: new Date().toISOString(),
+      run_id: runId,
+      ticket_id: ticket.id,
+      organization_id: ticket.organizationId,
+      heuristic_score: Number(score.toFixed(4)),
+      heuristic_priority: scoreToPriority(score),
+      heuristic_reason: reason,
+      input_signals: {
+        priority: signal.priority,
+        category: signal.category,
+        ai_category: ticket.aiCategory ?? null,
+        age_minutes: signal.ageMinutes,
+        word_count: signal.wordCount,
+        has_attachment: signal.hasAttachment,
+        message_count: ticket._count.messages,
+        org_tier: signal.orgTier,
+      },
+    };
+    appendFileSync(HEURISTIC_LOG_PATH, JSON.stringify(row) + '\n');
+  } catch (err) {
+    log(`heuristic log append failed for ticket=${ticket.id}: ${err instanceof Error ? err.message : err}`);
+  }
+}
+
 async function writeAiCategory(
   ticket: TicketRow,
   category: TicketCategoryV2,
@@ -209,6 +262,10 @@ async function maybeUpdatePriority(
 
 async function main(): Promise<void> {
   const started = Date.now();
+  // run_id matches the Hermes shadow's epoch-seconds shape so the
+  // comparison script can join rows that were emitted by the same
+  // cron cadence (Hermes also fires every 5 min via hermes cron).
+  const runId = String(Math.floor(started / 1000));
   log('Starting support-triage cycle');
 
   let orgIds: string[];
@@ -251,12 +308,23 @@ async function main(): Promise<void> {
       continue;
     }
 
-    // Index tickets by id for quick lookup
+    // Index tickets and signals by id for quick lookup
     const byId = new Map(tickets.map(t => [t.id, t]));
+    const signalById = new Map(signals.map(s => [s.id, s]));
 
     for (const r of ranked) {
       const ticket = byId.get(r.id);
       if (!ticket) continue;
+      const signal = signalById.get(r.id);
+
+      // Log the heuristic's suggestion BEFORE we mutate. Captures one
+      // JSONL row per ticket per cron firing, regardless of whether
+      // the subsequent writes succeed — keeps the comparison dataset
+      // complete even if writeAgentMessage / maybeUpdatePriority race
+      // with another writer.
+      if (signal) {
+        logHeuristicSuggestion(runId, ticket, r.score, r.reason, signal);
+      }
 
       const msg = await writeAgentMessage(ticket, r.score, r.reason);
       if (msg) triaged++;


### PR DESCRIPTION
Both PM2 cron agents (support-triage + customer-lifecycle) now also append per-decision JSONL rows to a sibling log alongside their Hermes shadow files. Comparison scripts updated to join Hermes-suggest vs heuristic-suggest instead of Hermes-suggest vs DB-mark-sent.

Fixes the caveat I called out in both compare-*.ts scripts ("PM2 mark-sent reflects sent, not suggested — SMTP failures show up as Hermes-disagree even when both heuristics agreed").

## Why now
End-of-session 2026-05-04: OpenRouter credits ran out ~19:30 UTC, killing all subsequent shadow runs (HTTP 402). The shadow infrastructure is currently dead until credits get refilled. Implementing this heuristic logging now means when shadow resumes, we get apples-to-apples comparison data from day-1.

## Scope
- Both PM2 cron scripts log per-decision JSONL
- Both comparison scripts rewritten to join 2 files
- New gate-readout output showing MET/✗ per cutover criterion

## What this PR does NOT do
- Touch PM2 schedules
- Change DB-write semantics
- Any cutover or LIFECYCLE_LIVE flip
- Refill OpenRouter credits (user action required)

## Out-of-band: OpenRouter credits exhausted
Both Hermes crons have been firing since ~19:30 UTC yesterday and getting HTTP 402 every time. The shadow data window is frozen at ~2 hours. Need credits added to resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)