### PR TITLE
fix(hermes): customer-lifecycle SKILL hard rules — drop stale shell-redirect + read-only claims

### DIFF
--- a/hermes-skills/vizora-customer-lifecycle/SKILL.md
+++ b/hermes-skills/vizora-customer-lifecycle/SKILL.md
@@ -11,9 +11,8 @@ You are running as a scheduled Vizora customer-lifecycle agent in **shadow mode*
 
 1. **Structural signals only.** The MCP read tool already strips org name, admin email, billing detail. You receive only `tier`, `days_since_signup`, `milestone_flags`, `nudges_sent`. **Do NOT fabricate or infer email content.** Score from these signals alone.
 2. **One MCP read call per run.** Call `list_onboarding_candidates` exactly once. Don't paginate further in shadow mode.
-3. **Append, don't overwrite.** Shadow log is `/var/log/hermes/vizora-customer-lifecycle-shadow.jsonl`. Always append (`>>`). Never `>` redirect.
-4. **One JSON object per line.** JSONL, not JSON-array.
-5. **Read-only.** Your token is platform-scope but read-only (`customer:read`). The write tools (`mark_onboarding_nudge_sent`, `send_lifecycle_nudge_email`, `auto_complete_org_onboarding`) don't exist yet — and even if they did, this skill must not call them. The `live` skill is a separate file (`SKILL-live.md`, not yet built).
+3. **Use the `log_shadow_row` MCP tool for the JSONL audit trail.** Do NOT shell out to `echo >>`, `tee -a`, or any terminal-side write. The server-side tool handles atomic append, timestamp + run_id generation, and allowlist-checks the log_name. The old shell-redirect path was deprecated after a smaller LLM truncated the file with `>` and hallucinated timestamps; this is the architectural fix.
+4. **No customer-write actions.** Your token has `customer:read` (for `list_onboarding_candidates`) + `shadow:write` (for `log_shadow_row`). It does NOT have `customer:write`, so the existing write tools (`mark_onboarding_nudge_sent`, `send_lifecycle_nudge_email`, `auto_complete_org_onboarding`) will reject your call with FORBIDDEN. Don't try them. The `live` skill (`SKILL-live.md`) is a separate file with broader scope; do not use its instructions here.
 
 ## Steps to run
 
@@ -45,9 +44,7 @@ For each candidate, pick exactly one of `day1-pair-screen`, `day3-upload-content
 - **`days_since_signup` between 7 and 10 inclusive** AND NOT `schedule_created` AND NOT `nudges_sent.day7` → `day7-create-schedule`.
 - Otherwise → `none` (welcome window, between-window gap, missed-all-windows, or already-completed).
 
-You may use the LLM's reasoning where the heuristic is ambiguous (e.g., to weigh a pro-tier org vs a free-tier org if both fall on the same boundary day). But the output template MUST be one of the four exact strings above. No paraphrasing.
-
-You may use the LLM's reasoning where the heuristic is ambiguous (e.g., to weigh a pro-tier early-stalled org against a free-tier later-stalled one). But the output template MUST be one of the four exact strings above. No paraphrasing.
+You may use the LLM's reasoning where the heuristic is ambiguous (e.g., to weigh a pro-tier org vs a free-tier org on the same boundary day). But the output template MUST be one of the four exact strings above. No paraphrasing.
 
 ### 3. Log a JSONL row per candidate via the MCP tool
 


### PR DESCRIPTION
Caught immediately after deploying log_shadow_row: model still bypassed the new tool because SKILL Hard Rules section retained 2 stale instructions contradicting the updated Steps section. Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)