### PR TITLE
fix(hermes): rewrite SKILL prompts with imperative tool-invocation framing

### DIFF
--- a/hermes-skills/vizora-customer-lifecycle/SKILL-live.md
+++ b/hermes-skills/vizora-customer-lifecycle/SKILL-live.md
@@ -15,7 +15,7 @@ This file is named `SKILL-live.md` in the repo. The cutover is performed by scp'
 2. **Structural signals only for scoring.** The MCP read tool already strips org name, admin email, and billing detail. You receive only `tier`, `days_since_signup`, `milestone_flags`, `nudges_sent`. Do NOT fabricate or infer email content.
 3. **One MCP read call per cron firing.** Call `list_onboarding_candidates` exactly once. Don't paginate.
 4. **One write per ticket per cron firing.** For each candidate, you make at most ONE of: `send_lifecycle_nudge_email`, OR `auto_complete_org_onboarding`, OR no write (template = `none`). Do NOT call both for the same org in the same firing.
-5. **Audit: log via the `log_shadow_row` MCP tool.** Every decision (including `none` and dry-run results) gets one row written via `log_shadow_row({ log_name: "vizora-customer-lifecycle-live", fields: {...} })`. Server prepends `timestamp` + `run_id`. The mcp_audit_log is the server-side trail; the JSONL the tool writes is the agent-side trail.
+5. **Audit: invoke the `log_shadow_row` MCP tool per decision.** Every decision (including `none` and dry-run results) gets one tool invocation: pass `log_name: "vizora-customer-lifecycle-live"` and a `fields` object with the decision details. Tool invocation only — do NOT echo or shell-redirect. Server prepends `timestamp` + `run_id`. The mcp_audit_log is the server-side trail; the JSONL the tool writes is the agent-side trail.
 6. **Trust the server's `LIFECYCLE_LIVE` gate.** If the server returns `reason: "dry_run"`, that means `LIFECYCLE_LIVE` is unset on the server — emails were intentionally NOT sent. Log it and move on. Do not retry.
 7. **Trust the server's dedup.** If the server returns `reason: "already_sent"`, the dayN_NudgeSentAt column was already set. Don't try to re-send via a different tool.
 
@@ -29,7 +29,7 @@ Use the `vizora-platform` MCP server (NOT the `vizora` server — that one carri
 list_onboarding_candidates({ "lookback_days": 30, "limit": 200 })
 ```
 
-If the response is empty, log a heartbeat row via `log_shadow_row({ log_name: "vizora-customer-lifecycle-live", fields: { "organization_id": null, "action": "none", "hermes_reasoning": "heartbeat: 0 candidates" } })` and stop. Do NOT call any write tool.
+If the response is empty, **invoke the `log_shadow_row` MCP tool** with `log_name: "vizora-customer-lifecycle-live"` and `fields: { "organization_id": null, "action": "none", "hermes_reasoning": "heartbeat: 0 candidates" }`, then stop. Do NOT call any other write tool. Tool invocation only, no shell redirect.
 
 ### 2. For each candidate, decide the action
 
@@ -78,12 +78,12 @@ No tool call other than the audit log (next step).
 
 ### 4. Log a JSONL audit row per candidate via the MCP tool
 
-For every candidate (including `action == 'none'`), call:
+For every candidate (including `action == 'none'`), **invoke the `log_shadow_row` MCP tool** with these arguments:
 
-```
-log_shadow_row({
-  "log_name": "vizora-customer-lifecycle-live",
-  "fields": {
+- `log_name`: `"vizora-customer-lifecycle-live"` (NOT `-shadow` — this is the live skill)
+- `fields`: a JSON object with the per-org result:
+  ```json
+  {
     "organization_id": "<id>",
     "tier": "pro",
     "days_since_signup": 4,
@@ -92,10 +92,9 @@ log_shadow_row({
     "tool_result": { "sent": true, "reason": "sent", "recipient_count": 1, "recipient_hashes": ["abcd1234..."] },
     "hermes_reasoning": "<≤120 chars>"
   }
-})
-```
+  ```
 
-Server prepends `timestamp` + `run_id`. log_name MUST be `vizora-customer-lifecycle-live` (not `-shadow`) for the live skill.
+This is a tool INVOCATION — call the function via the MCP transport. Do NOT use `echo`, `tee`, or any shell redirect. Server prepends `timestamp` + `run_id`.
 
 For `action == 'none'`: `tool_result: null`, reasoning explains why (e.g., `"day=15 stalled at content-upload but day3 nudge already sent"`).
 

--- a/hermes-skills/vizora-customer-lifecycle/SKILL.md
+++ b/hermes-skills/vizora-customer-lifecycle/SKILL.md
@@ -24,16 +24,12 @@ Use the `vizora-platform` MCP server (NOT the `vizora` server — that one carri
 list_onboarding_candidates({ "lookback_days": 30, "limit": 200 })
 ```
 
-Expect `{ candidates: [...], total: N }`. If empty, log a heartbeat row via the MCP tool and stop:
+Expect `{ candidates: [...], total: N }`. If empty, **invoke the `log_shadow_row` MCP tool** (provided by the `vizora-platform` server) with these arguments, then stop:
 
-```
-log_shadow_row({
-  "log_name": "vizora-customer-lifecycle-shadow",
-  "fields": { "organization_id": null, "hermes_template": null, "hermes_reasoning": "heartbeat: 0 candidates", "input_signals": null }
-})
-```
+- `log_name`: `"vizora-customer-lifecycle-shadow"`
+- `fields`: `{ "organization_id": null, "hermes_template": null, "hermes_reasoning": "heartbeat: 0 candidates", "input_signals": null }`
 
-The server prepends `timestamp` and `run_id` automatically — don't include them in `fields`.
+This is a tool INVOCATION — call the function via the MCP transport, do NOT echo the JSON to a file. The server prepends `timestamp` and `run_id` automatically — don't include them in `fields`. The tool returns `{ written, line_count, timestamp, run_id }`; use the response to confirm the write.
 
 ### 2. Decide template per org
 
@@ -48,12 +44,12 @@ You may use the LLM's reasoning where the heuristic is ambiguous (e.g., to weigh
 
 ### 3. Log a JSONL row per candidate via the MCP tool
 
-For each org, call:
+For each org, **invoke the `log_shadow_row` MCP tool** (provided by the `vizora-platform` server) with these arguments:
 
-```
-log_shadow_row({
-  "log_name": "vizora-customer-lifecycle-shadow",
-  "fields": {
+- `log_name`: `"vizora-customer-lifecycle-shadow"`
+- `fields`: a JSON object with the per-org decision details:
+  ```json
+  {
     "organization_id": "<id>",
     "tier": "pro",
     "days_since_signup": 4,
@@ -61,8 +57,9 @@ log_shadow_row({
     "hermes_reasoning": "<≤120 chars — which signals drove the decision>",
     "input_signals": { "milestone_flags": {...}, "nudges_sent": {...} }
   }
-})
-```
+  ```
+
+This is a tool INVOCATION — call the function via the MCP transport. Do NOT use `echo`, `tee`, or any shell redirect. There is no fallback path; the tool is the only way to write the row.
 
 **Server-side guarantees** — these are the reason this tool exists, you don't need to manage them:
 - `timestamp` (ISO-8601 UTC) and `run_id` (epoch-seconds) are prepended by the server. Do NOT supply them in `fields`.

--- a/hermes-skills/vizora-support-triage/SKILL-live.md
+++ b/hermes-skills/vizora-support-triage/SKILL-live.md
@@ -92,12 +92,14 @@ create_support_message({
 
 ### 4. Log a JSONL audit row per ticket via the MCP tool
 
-Even though the support-write calls themselves are tracked in `mcp_audit_log` (server-side), keep a local JSONL trail for ops review:
+Even though the support-write calls themselves are tracked in `mcp_audit_log` (server-side), keep a local JSONL trail for ops review.
 
-```
-log_shadow_row({
-  "log_name": "vizora-support-triage-live",
-  "fields": {
+For each ticket, **invoke the `log_shadow_row` MCP tool** with these arguments:
+
+- `log_name`: `"vizora-support-triage-live"` (NOT `-shadow` — this is the live skill)
+- `fields`: a JSON object with the per-ticket result:
+  ```json
+  {
     "ticket_id": "<id>",
     "organization_id": "<org>",
     "hermes_score": 0.72,
@@ -107,10 +109,9 @@ log_shadow_row({
     "message_posted": true,
     "input_signals": { /* same shape as shadow */ }
   }
-})
-```
+  ```
 
-Server prepends `timestamp` + `run_id`. log_name MUST be `vizora-support-triage-live` (not `-shadow`) for the live skill.
+This is a tool INVOCATION — call the function via the MCP transport. Do NOT use `echo`, `tee`, or any shell redirect. Server prepends `timestamp` + `run_id`.
 
 ## What NOT to do
 

--- a/hermes-skills/vizora-support-triage/SKILL.md
+++ b/hermes-skills/vizora-support-triage/SKILL.md
@@ -50,12 +50,12 @@ Match the existing `scoreToPriority` rule in `scripts/agents/support-triage.ts`:
 
 ### 4. Log a JSONL row per ticket via the MCP tool
 
-For each ticket, call:
+For each ticket, **invoke the `log_shadow_row` MCP tool** (provided by the `vizora` server) with these arguments:
 
-```
-log_shadow_row({
-  "log_name": "vizora-support-triage-shadow",
-  "fields": {
+- `log_name`: `"vizora-support-triage-shadow"`
+- `fields`: a JSON object with the per-ticket score:
+  ```json
+  {
     "ticket_id": "<id>",
     "organization_id": "<org>",
     "hermes_score": 0.72,
@@ -67,8 +67,9 @@ log_shadow_row({
       "message_count": 2, "org_tier": "pro"
     }
   }
-})
-```
+  ```
+
+This is a tool INVOCATION — call the function via the MCP transport. Do NOT use `echo`, `tee`, or any shell redirect. There is no fallback; the tool is the only way to write the row.
 
 **Server-side guarantees** — these are why the tool exists:
 - `timestamp` (ISO-8601 UTC) and `run_id` (epoch-seconds) are prepended by the server. Do NOT supply them in `fields`.
@@ -78,16 +79,12 @@ log_shadow_row({
 
 `hermes_reasoning`: a terse human-readable phrase noting which signals dominated. Example: `"enterprise tier + 3h stale + device_offline category"`. Don't quote any ticket content.
 
-If the response had **zero** tickets, log a single heartbeat row instead:
+If the response had **zero** tickets, invoke `log_shadow_row` once with `fields` set to the heartbeat shape:
 
-```
-log_shadow_row({
-  "log_name": "vizora-support-triage-shadow",
-  "fields": { "ticket_id": null, "organization_id": null, "hermes_score": null, "hermes_priority": null, "hermes_reasoning": "heartbeat: 0 open requests", "input_signals": null }
-})
-```
+- `log_name`: `"vizora-support-triage-shadow"`
+- `fields`: `{ "ticket_id": null, "organization_id": null, "hermes_score": null, "hermes_priority": null, "hermes_reasoning": "heartbeat: 0 open requests", "input_signals": null }`
 
-One MCP call per ticket. Don't accumulate and call once at the end.
+One MCP invocation per ticket. Don't accumulate and call once at the end.
 
 ## What NOT to do
 


### PR DESCRIPTION
After PR #56/#57 the model still bypassed log_shadow_row because the SKILL syntax `log_shadow_row({...})` reads as JSON-to-echo rather than tool-to-invoke. One-shot test with imperative phrasing worked end-to-end. Rewrote all 4 SKILL files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)