### PR TITLE
fix(mcp): implement empty resources/prompts spec handlers (stops Hermes probe loops)

### DIFF
--- a/middleware/src/modules/mcp/mcp.service.spec.ts
+++ b/middleware/src/modules/mcp/mcp.service.spec.ts
@@ -85,4 +85,70 @@ describe('McpService.buildServer', () => {
       ),
     ).toBe(true);
   });
+
+  describe('MCP-spec method stubs (resources/prompts) — REGRESSION: Hermes auto-probed these and looped on Method-not-found responses, exhausting gpt-4o-mini\'s 60-turn budget on the customer-lifecycle cron', () => {
+    function build() {
+      const svc = new McpService(displays, support, organizations, audit, shadowLog);
+      const server = svc.buildServer(undefined);
+      // The underlying low-level Server stores method handlers in
+      // `_requestHandlers`. Stable across SDK 1.x; verified by
+      // grepping node_modules.
+      const handlers = (server.server as unknown as {
+        _requestHandlers: Map<string, (req: unknown, extra: unknown) => unknown>;
+      })._requestHandlers;
+      return handlers;
+    }
+
+    it('declares resources + prompts capabilities (so clients know to call list_*)', () => {
+      const svc = new McpService(displays, support, organizations, audit, shadowLog);
+      const server = svc.buildServer(undefined);
+      // Server exposes its capabilities via the underlying low-level
+      // Server's _capabilities private field.
+      const caps = (server.server as unknown as {
+        _capabilities: { tools?: object; resources?: object; prompts?: object };
+      })._capabilities;
+      expect(caps.tools).toBeDefined();
+      expect(caps.resources).toBeDefined();
+      expect(caps.prompts).toBeDefined();
+    });
+
+    it('returns empty arrays for resources/list, resources/templates/list, prompts/list (NOT Method-not-found — that\'s what caused the loop)', async () => {
+      const handlers = build();
+      const listResources = handlers.get('resources/list');
+      const listResourceTemplates = handlers.get('resources/templates/list');
+      const listPrompts = handlers.get('prompts/list');
+      expect(listResources).toBeDefined();
+      expect(listResourceTemplates).toBeDefined();
+      expect(listPrompts).toBeDefined();
+      const r = await listResources!({ params: {}, method: 'resources/list' }, {});
+      const rt = await listResourceTemplates!(
+        { params: {}, method: 'resources/templates/list' },
+        {},
+      );
+      const p = await listPrompts!({ params: {}, method: 'prompts/list' }, {});
+      expect(r).toEqual({ resources: [] });
+      expect(rt).toEqual({ resourceTemplates: [] });
+      expect(p).toEqual({ prompts: [] });
+    });
+
+    it('throws spec-compliant InvalidParams for resources/read and prompts/get (NOT Method-not-found — gives client clean signal "your URI is wrong" so it stops retrying)', async () => {
+      const handlers = build();
+      const readResource = handlers.get('resources/read');
+      const getPrompt = handlers.get('prompts/get');
+      expect(readResource).toBeDefined();
+      expect(getPrompt).toBeDefined();
+      await expect(
+        readResource!(
+          { params: { uri: 'file:///nope' }, method: 'resources/read' },
+          {},
+        ),
+      ).rejects.toMatchObject({ code: -32602 }); // InvalidParams
+      await expect(
+        getPrompt!(
+          { params: { name: 'nope' }, method: 'prompts/get' },
+          {},
+        ),
+      ).rejects.toMatchObject({ code: -32602 });
+    });
+  });
 });

--- a/middleware/src/modules/mcp/mcp.service.ts
+++ b/middleware/src/modules/mcp/mcp.service.ts
@@ -1,6 +1,15 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { McpServer as McpServerCtor } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  ErrorCode,
+  GetPromptRequestSchema,
+  ListPromptsRequestSchema,
+  ListResourceTemplatesRequestSchema,
+  ListResourcesRequestSchema,
+  McpError,
+  ReadResourceRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
 import type { McpRequestContext } from './auth/mcp-context';
 import { McpAuditService } from './audit/mcp-audit.service';
 import { ShadowLogService } from './audit/shadow-log.service';
@@ -69,9 +78,26 @@ export class McpService implements OnModuleInit {
    */
   buildServer(context: McpRequestContext | undefined): McpServer {
     const server = new McpServerCtor(
-      { name: 'vizora-mcp', version: '0.2.0' },
-      { capabilities: { tools: { listChanged: false } } },
+      { name: 'vizora-mcp', version: '0.3.0' },
+      {
+        capabilities: {
+          tools: { listChanged: false },
+          // Declare resources + prompts capabilities even though we
+          // expose zero of each. Hermes auto-wraps the spec methods
+          // (resources/list, resources/read, resources/templates/list,
+          // prompts/list, prompts/get) into agent-callable tools and
+          // probes them when an LLM is uncertain about which tool to
+          // use. Without these handlers the server returns "Method not
+          // found" — which gpt-4o-mini-class models handled by
+          // retrying in a loop until max-turns. Empty handlers + a
+          // proper "not found" on read/get gives clients a clean
+          // signal to stop probing.
+          resources: { listChanged: false },
+          prompts: { listChanged: false },
+        },
+      },
     );
+    this.registerSpecMethodStubs(server);
     this.registerTool(server, LIST_DISPLAYS_TOOL, context, this.displays);
     this.registerTool(server, LIST_OPEN_SUPPORT_REQUESTS_TOOL, context, this.support);
     this.registerTool(
@@ -113,6 +139,54 @@ export class McpService implements OnModuleInit {
     );
     this.registerTool(server, LOG_SHADOW_ROW_TOOL, context, this.shadowLog);
     return server;
+  }
+
+  /**
+   * Register empty handlers for the MCP-spec resources/prompts methods.
+   *
+   * Why: Hermes (and any spec-compliant MCP client) auto-discovers
+   * available tools by calling these methods at session start, and
+   * smaller LLMs reach for them again whenever they're uncertain
+   * which tool to use. Returning "Method not found" causes retry
+   * loops and ate gpt-4o-mini's full 60-turn budget on the
+   * customer-lifecycle cron. Empty arrays + spec-compliant
+   * "no such resource" errors stop the loops.
+   *
+   * Invariant: this server exposes ZERO resources, ZERO resource
+   * templates, ZERO prompts. The capability declaration in
+   * `buildServer()` advertises the surface; these handlers honor it
+   * with empty bodies. If we ever expose actual resources/prompts,
+   * THIS is the place to add them — not via a parallel handler.
+   */
+  private registerSpecMethodStubs(server: McpServer): void {
+    server.server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+      resources: [],
+    }));
+    server.server.setRequestHandler(
+      ListResourceTemplatesRequestSchema,
+      async () => ({ resourceTemplates: [] }),
+    );
+    server.server.setRequestHandler(ListPromptsRequestSchema, async () => ({
+      prompts: [],
+    }));
+    server.server.setRequestHandler(
+      ReadResourceRequestSchema,
+      async (req) => {
+        // Spec-compliant "no such resource" — InvalidParams (-32602)
+        // tells the client "your URI is wrong/unknown", which is
+        // unambiguous (NOT "method not found") and stops the loop.
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          `No resource at uri '${req.params.uri}'. This server exposes zero resources; use the registered tools instead.`,
+        );
+      },
+    );
+    server.server.setRequestHandler(GetPromptRequestSchema, async (req) => {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `No prompt named '${req.params.name}'. This server exposes zero prompts; use the registered tools instead.`,
+      );
+    });
   }
 
   /**


### PR DESCRIPTION
Real root cause of the customer-lifecycle cron loops: our MCP server returns 'Method not found' for spec methods (resources/list, prompts/list, etc.) that the MCP SDK auto-wraps and Hermes auto-probes. gpt-4o-mini retried in a loop until max_turns. Claude Opus had enough discipline to ignore them; smaller models don't.

The model was right to retry — our server was ambiguous. Fix the server, any model works. No claude-haiku-4.5 swap needed.

## Test plan
- [x] 3 new spec-stub tests, 118/118 suites pass
- [x] nx build clean
- [ ] Deploy + force a customer-lifecycle cron firing — expect single-pass completion, audit log shows log_shadow_row call, JSONL gets a properly-formed row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)