### PR TITLE
feat(hermes): switch shadow agents from hermes-cron to PM2-cron-driven `hermes -z`

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -375,6 +375,64 @@ module.exports = {
       out_file: './logs/agent-support-triage-out.log',
       merge_logs: true,
     },
+    // -------- Hermes-driven shadow agents --------
+    // PM2 fires the runner script which invokes `hermes -z` with an explicit
+    // action prompt. We previously used `hermes cron` directly but the model
+    // produced different (worse) behavior in cron-firing context vs `-z`
+    // invocation: probe loops on get_prompt/read_resource and chat-text
+    // outputs instead of MCP tool calls. The runner+`-z` path
+    // demonstrably works end-to-end (audit log + JSONL both populate).
+    //
+    // The corresponding `hermes cron` jobs MUST be removed at deploy time
+    // to prevent duplicate firings:
+    //   ssh root@vizora.cloud 'hermes cron list | grep -B1 vizora-* | head'
+    //   hermes cron remove <id-customer-lifecycle>
+    //   hermes cron remove <id-support-triage>
+    {
+      name: 'hermes-vizora-customer-lifecycle',
+      script: 'bash',
+      args: [
+        '/opt/vizora/app/scripts/agents/hermes/run-hermes-skill.sh',
+        'vizora-customer-lifecycle',
+        // The exact prompt that worked end-to-end via `hermes -z`. Keeping
+        // it here (vs in the SKILL) is intentional — the SKILL is the
+        // SYSTEM-prompt-equivalent, this is the USER-prompt-equivalent
+        // that actually triggers execution. Leaving it null produces
+        // "discuss the task" behavior in cron context.
+        'Run the vizora-customer-lifecycle skill end-to-end now. Follow every step in SKILL.md exactly. Step 1: invoke list_onboarding_candidates on the vizora-platform MCP server. Step 2: for each candidate, invoke log_shadow_row on the vizora-platform server with the per-org decision (or one heartbeat invocation if zero candidates). End silently — no chat output.',
+      ],
+      instances: 1,
+      exec_mode: 'fork',
+      cron_restart: '*/30 * * * *',
+      autorestart: false,
+      watch: false,
+      max_memory_restart: '256M',
+      log_date_format: 'YYYY-MM-DD HH:mm:ss Z',
+      max_size: '10M',
+      error_file: './logs/hermes-vizora-customer-lifecycle-error.log',
+      out_file: './logs/hermes-vizora-customer-lifecycle-out.log',
+      merge_logs: true,
+    },
+    {
+      name: 'hermes-vizora-support-triage',
+      script: 'bash',
+      args: [
+        '/opt/vizora/app/scripts/agents/hermes/run-hermes-skill.sh',
+        'vizora-support-triage',
+        'Run the vizora-support-triage skill end-to-end now. Follow every step in SKILL.md exactly. Step 1: invoke list_open_support_requests on the vizora MCP server. Step 4: for each ticket, invoke log_shadow_row on the vizora server with the per-ticket score (or one heartbeat invocation if zero tickets). End silently — no chat output.',
+      ],
+      instances: 1,
+      exec_mode: 'fork',
+      cron_restart: '*/5 * * * *',
+      autorestart: false,
+      watch: false,
+      max_memory_restart: '256M',
+      log_date_format: 'YYYY-MM-DD HH:mm:ss Z',
+      max_size: '10M',
+      error_file: './logs/hermes-vizora-support-triage-error.log',
+      out_file: './logs/hermes-vizora-support-triage-out.log',
+      merge_logs: true,
+    },
     // Scaffold agents below — gated OFF by default. Flip the corresponding
     // *_ENABLED env var to true to activate once implementation lands.
     {

--- a/scripts/agents/hermes/run-hermes-skill.sh
+++ b/scripts/agents/hermes/run-hermes-skill.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Drive a Hermes skill via one-shot prompt — replacement for `hermes cron`.
+#
+# We tried `hermes cron` and the model produced different (worse) behavior
+# in cron-firing context vs `hermes -z` invocation: probe loops on
+# get_prompt/read_resource and chat-text outputs instead of MCP tool
+# calls. Same model, same SKILL, same tools, but cron context appears
+# to inject something that confuses the agent. One-shot via -z works
+# end-to-end.
+#
+# This script is the bridge. PM2 fires it on a cron schedule (matching
+# the original hermes-cron cadence per agent), and it shells out to
+# `hermes -z` with the explicit action prompt that demonstrably works.
+#
+# Every run logs to /var/log/hermes/runner/<skill>.log (timestamped
+# start + Hermes stdout/stderr + end). On non-zero exit from hermes
+# we log it but ALWAYS exit 0 — PM2's cron_restart treats non-zero as
+# crash and triggers exponential backoff, which is the wrong behavior
+# for a fire-and-forget cron firing.
+#
+# Usage:
+#   run-hermes-skill.sh <skill-name> <prompt>
+#
+# Example:
+#   run-hermes-skill.sh vizora-customer-lifecycle "Run the skill end-to-end now..."
+
+set -uo pipefail
+
+SKILL="${1:-}"
+PROMPT="${2:-}"
+if [[ -z "$SKILL" || -z "$PROMPT" ]]; then
+  echo "usage: $0 <skill-name> <prompt>" >&2
+  exit 0
+fi
+
+LOGDIR="/var/log/hermes/runner"
+mkdir -p "$LOGDIR"
+LOG="$LOGDIR/${SKILL}.log"
+
+START=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+{
+  echo "─────────────────────────────────────────"
+  echo "[$START] start skill=$SKILL pid=$$"
+} >> "$LOG"
+
+# Bound the run. Hermes can occasionally hang; 5 min is generous for
+# our 5-min and 30-min cron cadences without overlapping.
+timeout 300 /usr/local/bin/hermes --skills "$SKILL" -z "$PROMPT" >> "$LOG" 2>&1
+RC=$?
+
+END=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+{
+  echo "[$END] end skill=$SKILL exit=$RC"
+} >> "$LOG"
+
+# ALWAYS exit 0 — PM2 cron_restart treats non-zero as crash.
+exit 0


### PR DESCRIPTION
Replaces `hermes cron` for the two shadow agents with PM2-cron-driven runner script. We proved the cron context produces erratic model behavior vs the one-shot `-z` path; this routes around it via a tiny bash wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)