### PR TITLE
feat(agents): Phase 0+1 — agent platform cost governance + tool authorization

### DIFF
--- a/docker/grafana/dashboards/agents-cost.json
+++ b/docker/grafana/dashboards/agents-cost.json
@@ -1,0 +1,139 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "title": "Vizora — Agent Cost & Health",
+  "uid": "agents-cost",
+  "tags": ["vizora", "agents", "cost", "hermes"],
+  "timezone": "",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-24h", "to": "now" },
+  "templating": { "list": [] },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Today's spend (USD)",
+      "description": "Sum of costMicrodollars for current UTC day, in dollars. Hard cap is $2/day at OpenRouter; soft cap is $1 enforced by runner pre-flight.",
+      "type": "stat",
+      "datasource": { "type": "postgres", "uid": "vizora-postgres" },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 0 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 4,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "red", "value": 1.0 }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "rawSql": "SELECT COALESCE(SUM(\"costMicrodollars\"), 0) / 1000000.0 AS today_spend_usd FROM agent_runs WHERE \"startedAt\" >= date_trunc('day', NOW() AT TIME ZONE 'UTC')",
+          "format": "table"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Cost per skill — last 24h",
+      "description": "Sum of costMicrodollars per agent skill over the dashboard time window.",
+      "type": "barchart",
+      "datasource": { "type": "postgres", "uid": "vizora-postgres" },
+      "gridPos": { "h": 6, "w": 12, "x": 6, "y": 0 },
+      "fieldConfig": {
+        "defaults": { "unit": "currencyUSD", "decimals": 4 }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "rawSql": "SELECT \"skillName\" AS skill, COALESCE(SUM(\"costMicrodollars\"), 0) / 1000000.0 AS cost_usd FROM agent_runs WHERE $__timeFilter(\"startedAt\") GROUP BY \"skillName\" ORDER BY cost_usd DESC",
+          "format": "table"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "P95 firing latency (ms) — last 24h",
+      "description": "P50 and P95 wall-clock duration per skill. Targets: support-triage ≤60s, customer-lifecycle ≤120s.",
+      "type": "timeseries",
+      "datasource": { "type": "postgres", "uid": "vizora-postgres" },
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "ms" } },
+      "targets": [
+        {
+          "refId": "A",
+          "rawSql": "SELECT \"startedAt\" AS time, \"skillName\" AS metric, \"durationMs\" AS value FROM agent_runs WHERE $__timeFilter(\"startedAt\") AND \"durationMs\" IS NOT NULL ORDER BY \"startedAt\"",
+          "format": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Outcome distribution — last 24h",
+      "description": "Mutual-exclusive outcome counts per skill. Healthy = mostly success/no_work. Alarming = any tool_error/api_error/timeout/budget_aborted/runner_crash sustained.",
+      "type": "piechart",
+      "datasource": { "type": "postgres", "uid": "vizora-postgres" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "options": {
+        "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false },
+        "pieType": "pie",
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "right", "showLegend": true }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "rawSql": "SELECT outcome AS metric, COUNT(*)::int AS value FROM agent_runs WHERE $__timeFilter(\"startedAt\") GROUP BY outcome ORDER BY value DESC",
+          "format": "table"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Cost per firing — last 24h (anomaly hunt)",
+      "description": "Each dot is one firing. Per-firing alert threshold $0.05 (50000 microdollars). Cluster threshold $0.20 sum per skill per hour.",
+      "type": "scatter",
+      "datasource": { "type": "postgres", "uid": "vizora-postgres" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "fieldConfig": { "defaults": { "unit": "currencyUSD", "decimals": 6 } },
+      "targets": [
+        {
+          "refId": "A",
+          "rawSql": "SELECT \"startedAt\" AS time, \"skillName\" AS metric, \"costMicrodollars\" / 1000000.0 AS value FROM agent_runs WHERE $__timeFilter(\"startedAt\") AND \"costMicrodollars\" IS NOT NULL ORDER BY \"startedAt\"",
+          "format": "time_series"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/plans/2026-05-08-agent-platform-redesign-design.md
+++ b/docs/plans/2026-05-08-agent-platform-redesign-design.md
@@ -1,0 +1,817 @@
+# Vizora Agent Platform Redesign — Technical Design
+
+**Companion to:** `docs/plans/2026-05-08-agent-platform-redesign.md` (the plan).
+
+The plan defines WHAT to build and the task sequencing. This document defines HOW the components fit together — contracts, sequence flows, state machines, error taxonomy, concurrency model, test architecture, security boundaries.
+
+**Scope:** P0 + P1 only. P2–P4 designs are deferred until those phases begin (per the plan's deferral pattern).
+
+**Hermes-first / drift-check:** see plan §1.5 + §1.6. Not duplicated here.
+
+---
+
+## 1. Architectural decisions log (ADL)
+
+Decisions that shape the rest of this design. Each decision lists the alternatives considered and why we chose what we chose.
+
+### ADL-1: Cost governance is layered, not single-point
+
+**Decision:** Four independent enforcement layers, in series. A failure of any one layer does not result in a credit drain.
+
+| # | Layer | Owner | Failure mode it prevents |
+|---|---|---|---|
+| L1 | OpenRouter per-day cap ($2.00) | Provider, manual UI | All other layers compromised; bug in any custom code |
+| L2 | Vizora pre-flight balance check | `run-hermes-skill.sh` (calls `/v1/credits` before invoking Hermes) | Provider cap not yet hit, but balance is approaching zero |
+| L3 | Hermes `tool_loop_guardrails.hard_stop_enabled` + `max_tokens` | Hermes runtime config | Single firing loops forever or generates 16K-token output |
+| L4 | Cross-firing Redis circuit breaker (P4) | Vizora middleware via existing `circuit-breaker.service.ts` | Repeated failures across firings (the May 6 scenario) |
+
+**Alternatives rejected:**
+- *Single-point: provider cap only.* Brittle; an OpenRouter UI change or human error removes the only defense.
+- *Single-point: Vizora-side accounting only.* Cannot stop a firing once it's in flight; only prevents the next one.
+
+**Implication for this design:** every layer is independently testable. P0 has a dedicated task (P0.0a) to verify L3 actually clamps the OpenRouter request param — Reviewer 2's phantom-lever finding.
+
+### ADL-2: Runner records metadata; sidecar enriches cost
+
+**Decision:** Two-stage write to `agent_runs`:
+
+1. **Synchronous** (runner script, immediately on firing exit): `skillName`, `pid`, `startedAt`, `finishedAt`, `exitCode`, `outcome`, `preflightBalanceUsd`, `preflightTodaySpendUsd`. Best-effort POST to `/internal/agent-runs`.
+2. **Asynchronous** (sidecar PM2 cron, every 5 min): `tokensIn`, `tokensOut`, `costMicrodollars`, `model`, refined `outcome` (downgrade `success`→`tool_error` if `mcp_audit_log` shows tool errors in the firing's window). PATCH `/internal/agent-runs/:id`.
+
+**Alternatives rejected:**
+- *Single-stage at runner exit.* Requires runner to parse Hermes output — fragile, adds latency to firing teardown, fails when Hermes itself is broken.
+- *Single-stage in sidecar.* Loses budget_aborted / pre-Hermes-failure rows entirely (Hermes never invoked → no insights data → no record).
+
+**Implication:** the `agent_runs` row is mutable for ≤ 5 min after firing exit, then frozen.
+
+### ADL-3: Outcome classification — runner is signal-only, sidecar is truth
+
+**Decision (revised after Reviewer A I2 + D10):** The runner emits ONLY the 4-value subset it can detect with high confidence: `success | api_error | timeout | budget_aborted`. The runner does NOT regex Hermes stdout for FORBIDDEN/INVALID_INPUT (those strings live in `mcp_audit_log`, not Hermes output — Reviewer 2 of the plan-review confirmed). The sidecar owns refinement to the full 8-value enum using audit-log data joined by `agentRunId` (§2.3).
+
+**Mutually exclusive outcomes (Reviewer A D10):**
+
+| Outcome | Source | Detection rule |
+|---|---|---|
+| `budget_aborted` | Runner (pre-flight) | Balance < MIN_BALANCE_USD OR today's spend ≥ DAILY_BUDGET_USD. Hermes never invoked. |
+| `timeout` | Runner | Hermes `RC == 124` (timeout(1)) — wall-clock exceeded. |
+| `api_error` | Runner | Hermes `RC != 0` (excluding 124), OR stdout contains `HTTP 402`/`429`/`5xx`. NOTE: **anchored** regex against known Hermes error-line prefixes, not bare match — reduces false positives. |
+| `success` (initial) | Runner | Hermes `RC == 0`, no API error markers. PROVISIONAL — sidecar confirms or refines. |
+| `success` (confirmed) | Sidecar | Initial=`success` AND `mcp_audit_log` shows zero failures for this `agentRunId`. |
+| `tool_error` | Sidecar only | Initial=`success` AND `mcp_audit_log` shows ≥1 failure AND **zero successes** for this `agentRunId`. (All MCP calls failed.) |
+| `partial` | Sidecar only | Initial=`success` AND `mcp_audit_log` shows ≥1 success AND ≥1 failure. (Mixed.) |
+| `no_work` | Sidecar | Initial=`success`, all MCP calls succeeded, AND no shadow-log row was written (heuristic: zero candidates/tickets). |
+| `runner_crash` | Sidecar (orphan sweep) | `tokensIn IS NULL` AND `createdAt < NOW() - 10 min`. |
+
+**Precedence rule (no overlap):** `tool_error` ⊕ `partial` ⊕ `success` are determined by ratio: 0% success = `tool_error`, 100% success with rows written = `success`, 100% success with no rows = `no_work`, anything in between = `partial`.
+
+**Implication for tests:** unit tests cover runner classifier on stdout fixtures (4-value subset only); sidecar classifier on `mcp_audit_log` row fixtures (full enum); integration test covers runner→sidecar handoff via the `agentRunId` propagation path.
+
+### ADL-4: `agent_runs.id` is the join key, not session ID
+
+**Decision:** The runner script returns the `agent_runs.id` (CUID) it created, and the sidecar enriches by ID — not by Hermes session ID.
+
+**Why:** Hermes session ID emission in stdout is unverified (Reviewer 2 noted `/root/.hermes/sessions/cli/` doesn't exist with the structure originally assumed). Even if reliable, joining by time-range + skill name is cleaner and survives Hermes upgrades.
+
+**Implication:** the runner POST returns `{ id }`; runner stores it in `LOG`'s firing-end marker so the sidecar can correlate.
+
+### ADL-5: Tool authorization is enforced at TWO layers
+
+**Decision:**
+1. **Hermes layer** (P1.2): `hermes -z -t <toolsets>` filters which tools the LLM SEES. Prevents the model from even being aware of tools it shouldn't call.
+2. **MCP server layer** (existing): scope-based auth on the actual tool handler. Prevents the model from CALLING a tool even if it discovers one outside its allowlist (e.g., via prompt injection from data).
+
+The plan's P1.2 only addresses layer 1. Layer 2 already exists. Defense in depth: an LLM that ignores its tool allowlist still fails at the server scope check.
+
+**Implication:** both layers must be tested. P1.2 acceptance test (paid-key smoke) validates layer 1; existing MCP scope tests validate layer 2.
+
+### ADL-6: customer-lifecycle drops the LLM in P2.A; support-triage stays conditional
+
+**Decision:** Customer-lifecycle becomes pure TS heuristic with no LLM dependency. Existing-data battery from May 5-6 shadow logs informs whether support-triage gets an LLM at all.
+
+**Why:** Reviewer 1's C6 — Anthropic's *Building Effective Agents* (Dec 2024) recommends "find the simplest solution possible." A 5-element decision table on `daysSinceSignup` × `milestoneFlags` is the simplest solution; an LLM is added complexity without justification.
+
+**Implication for this design:** P2.A doesn't appear in the design's contracts at all (it's pure TS code in `scripts/agents/customer-lifecycle.ts` which already exists). P2.B contracts are deferred until the existing-data battery runs.
+
+### ADL-7: Cost is FROZEN at write — never recomputed
+
+**Decision (added after Reviewer A D3):** When OpenRouter changes model rates, we do NOT recompute historical `costMicrodollars` values. Each `agent_runs` row captures the rate USED at the moment of write (`rateInUsdPerMt` and `rateOutUsdPerMt` columns). Historical analysis reads those columns directly. Forward analysis uses the current `MODEL_RATES` table.
+
+**Why:** rate changes are rare; historical accuracy is high-value (cost-attribution audits, post-incident retrospectives). The alternative (recompute on demand by joining a `model_rates` table on `effectiveAt`) is more flexible but introduces a join on every cost query and a cross-table consistency obligation. Rejected for simplicity.
+
+**Operational consequence:** when `MODEL_RATES` constants in code change, no migration is needed. New rows pick up the new rates via the sidecar's `EnrichRunInput`; old rows preserve their historical rates.
+
+**Test consequence:** unit tests for cost computation use fixtures of (tokensIn, tokensOut, model, expectedCost). When rates change, fixtures change for new rows only — old fixtures remain frozen ground truth for historical-accuracy tests.
+
+---
+
+## 2. Data model
+
+### 2.1 New: `agent_runs` (P0.1)
+
+```
+┌────────────────────────────────────────────────────────────────────────────┐
+│ agent_runs                                                                  │
+├──────────────────────────┬─────────────────────────────────────────────────┤
+│ id                       │ String       PK  CUID                            │
+│ skillName                │ String        e.g. "vizora-customer-lifecycle"  │
+│ organizationId           │ String?       For per-org skills; null for      │
+│                          │               platform-scope (cost attribution) │
+│ pid                      │ Int?          PM2 worker PID                     │
+│ startedAt                │ DateTime      Pre-flight start (UTC)            │
+│ finishedAt               │ DateTime?     Hermes exit OR pre-flight abort   │
+│ durationMs               │ Int?          finishedAt - startedAt            │
+│ exitCode                 │ Int?          Hermes process RC; null if        │
+│                          │               budget-aborted                    │
+│ tokensIn                 │ Int?          Filled by sidecar; null if Hermes │
+│                          │               never ran                         │
+│ tokensOut                │ Int?          Filled by sidecar                  │
+│ costMicrodollars         │ Int?          FROZEN AT WRITE — never recompute │
+│ rateInUsdPerMt           │ Decimal(8,4)? Rate USED at write time           │
+│ rateOutUsdPerMt          │ Decimal(8,4)? Rate USED at write time           │
+│ model                    │ String?       Versioned id, e.g.                │
+│                          │               "openai/gpt-4o-mini-2024-07-18"   │
+│ outcome                  │ String        See §1 ADL-3 + §5 (Zod-validated) │
+│ errorExcerpt             │ String?       Max 1024 chars; runner-tail       │
+│                          │               snippet on error                  │
+│ preflightBalanceUsd      │ Decimal(12,8)? OpenRouter returns 8 fractional  │
+│                          │               digits — match exactly            │
+│ preflightTodaySpendUsd   │ Decimal(12,8)? Same precision                   │
+│ createdAt                │ DateTime      Auto                               │
+└──────────────────────────┴─────────────────────────────────────────────────┘
+
+Indexes:
+  - (skillName, startedAt)   for time-series dashboard queries
+  - (outcome, startedAt)     for failure-rate alerting
+  - (model, startedAt)       for per-model cost breakdowns
+  - (createdAt)              for retention DELETE scan
+  - (organizationId, startedAt) for per-tenant cost attribution
+
+Retention: 90-day rolling window. Enforced by db-maintainer cron
+(extends existing scripts/ops/db-maintainer.ts):
+
+   DELETE FROM agent_runs WHERE createdAt < NOW() - INTERVAL '90 days';
+
+At ~50 firings/hour = 1200/day, steady-state table size is ~108K rows.
+The (createdAt) index makes the daily delete a fast index scan.
+
+ADL-7: Cost is FROZEN at write — never backfilled
+  When OpenRouter changes model rates, we do NOT recompute historical
+  costMicrodollars values. Instead, we capture the rate USED at write
+  time (rateInUsdPerMt / rateOutUsdPerMt columns). Historical analysis
+  reads those columns directly — accurate at the moment of the firing.
+  Forward analysis uses the current MODEL_RATES table.
+  Alternative considered (model_rates table with effectiveAt): more
+  flexible but introduces a join on every query and a cross-table
+  consistency obligation. Rejected for simplicity.
+```
+
+**Schema migration safety:** Reviewer B verified no pending Prisma migrations on prod (`_prisma_migrations` last applied is `20260504120000_mcp_token_org_nullable`). The new `agent_runs` migration is purely additive. The `agentRunId` FK on `McpAuditLog` (see §2.3) is nullable — backward-compatible with existing rows.
+
+**Lifecycle:**
+
+```
+   ┌─────────────────┐
+   │ Runner pre-flight│
+   │   balance check  │
+   └────────┬─────────┘
+            │
+       ┌────┴─────┐
+       │          │
+       ▼          ▼
+  abort below   proceed to
+  threshold     Hermes invoke
+       │              │
+       ▼              ▼
+   POST row     POST row (no cost yet)
+   outcome=     outcome=success|api_error|timeout
+   budget_      tokensIn/Out=null
+   aborted      costMicrodollars=null
+       │              │
+       ▼              ▼
+    [FROZEN]    Sidecar (≤5 min later)
+                PATCH row:
+                  - tokensIn/Out from `hermes insights`
+                  - costMicrodollars computed
+                  - model recorded
+                  - outcome refined via mcp_audit_log
+                      │
+                      ▼
+                   [FROZEN]
+```
+
+After 5 minutes from `finishedAt`, no further mutations. The sidecar logs and skips already-enriched rows.
+
+### 2.2 Existing: `mcp_tokens` (no schema change, but enrichment)
+
+P1.1 modifies the *behavior* of `log_shadow_row` against this table — not the schema. The token's `organizationId` becomes a tag on the appended row rather than a gate on the call.
+
+Existing `mcp_tokens` rows on prod (verified):
+| name | organizationId | scopes | role after P1.1 |
+|---|---|---|---|
+| `hermes-customer-lifecycle-shadow` | NULL | `customer:read, shadow:write` | unchanged — platform-scope correct |
+| `hermes-support-triage-shadow` | `1dceeda9-...` | `displays:read, support:read, support:write, shadow:write` | unchanged token; previously broken `log_shadow_row` calls now succeed with org tagging |
+
+### 2.3 Existing: `mcp_audit_log` (one new column)
+
+**Reviewer B critical finding D6:** the original design said the sidecar would "cross-ref `mcp_audit_log` for `[startedAt, finishedAt]`" using time-range. This is unsafe for overlapping firings (PM2 restart edge cases, cron drift). Add a precise join key.
+
+**New column:** `agentRunId String?` — FK to `agent_runs.id`. Nullable for backward compat with existing rows. Set by the MCP server when a request arrives that carries the runner-emitted ID in its request context.
+
+**Wiring (P1.2 extension):** the runner script passes `agent_runs.id` as an environment variable to `hermes -z`; Hermes propagates it as a request header on MCP calls (e.g., `x-agent-run-id`); the MCP server reads it from the `McpRequestContext` and stores it on each audit row.
+
+```prisma
+model McpAuditLog {
+  // ... existing fields ...
+  agentRunId    String?    // NEW — FK to AgentRun.id
+  agentRun      AgentRun?  @relation(fields: [agentRunId], references: [id], onDelete: SetNull)
+  // ... existing indexes ...
+  @@index([agentRunId])  // NEW — for sidecar's per-firing scan
+}
+```
+
+**Sidecar refinement query (replaces time-range scan):**
+
+```sql
+SELECT status, errorCode, COUNT(*) AS n
+FROM mcp_audit_log
+WHERE agentRunId = $1
+GROUP BY status, errorCode;
+```
+
+**Fallback for runs predating this change:** when `agentRunId` is NULL on existing audit rows or the runner doesn't emit the header (Hermes < 0.12.0 lacks request-header propagation, TBD), fall back to time-range + agentName join with an explicit `outcome='partial' OR 'tool_error'` confidence flag. Document this in the sidecar service.
+
+---
+
+## 3. Contracts
+
+### 3.1 Zod schemas (matching the rest of MCP code)
+
+Reviewer A's I9: the surrounding MCP code uses Zod (`tool-inputs.ts`, `tool-outputs.ts`). Use Zod here for consistency — the controller validates with Zod via a custom pipe; clients consume types via `z.infer`.
+
+```typescript
+// middleware/src/modules/agents/agent-runs.schemas.ts (NEW)
+import { z } from 'zod';
+
+// Outcome taxonomy. See §5 for detection rules. Mutual exclusivity (Reviewer A C/D10):
+//   - success      = Hermes RC=0, all MCP calls succeeded
+//   - partial      = Hermes RC=0, ≥1 MCP success AND ≥1 MCP failure (mixed)
+//   - tool_error   = Hermes RC=0, ALL MCP calls failed (no successes)
+//   - api_error    = Hermes RC≠0 OR HTTP 4xx/5xx in stdout (excluding timeout)
+//   - timeout      = Hermes RC=124 (timeout(1) signal)
+//   - budget_aborted = Pre-flight refused; Hermes never invoked
+//   - no_work      = Hermes RC=0, MCP calls succeeded, but list_* tools returned 0 candidates
+//   - runner_crash = Sidecar finds row with finishedAt=null AND createdAt > 10min ago
+export const RUN_OUTCOMES = [
+  'success',
+  'no_work',
+  'partial',
+  'tool_error',
+  'api_error',
+  'timeout',
+  'budget_aborted',
+  'runner_crash',  // NEW — for orphan rows (Reviewer B I7)
+] as const;
+export const RunOutcome = z.enum(RUN_OUTCOMES);
+export type RunOutcomeT = z.infer<typeof RunOutcome>;
+
+// Used by POST /internal/agent-runs (synchronous runner write).
+// Note: runner reports only the SUBSET of outcomes it can detect from
+// Hermes-visible signals (Reviewer A I7). Sidecar may downgrade later.
+export const RecordRunInput = z.object({
+  skillName: z.string().min(1).max(128),
+  organizationId: z.string().nullable().optional(),  // NEW — tenant attribution
+  pid: z.number().int().nonnegative().optional(),
+  startedAt: z.string().datetime(),    // ISO-8601 on the wire
+  finishedAt: z.string().datetime(),
+  exitCode: z.number().int(),
+  outcome: z.enum([
+    'success',         // initial best-effort; sidecar may refine
+    'api_error',
+    'timeout',
+    'budget_aborted',
+  ]),
+  errorExcerpt: z.string().max(1024).optional(),
+  preflightBalanceUsd: z.number().optional(),
+  preflightTodaySpendUsd: z.number().optional(),
+});
+export type RecordRunInputT = z.infer<typeof RecordRunInput>;
+
+// Used by PATCH /internal/agent-runs/:id (sidecar enrichment).
+// rateInUsdPerMt / rateOutUsdPerMt are CAPTURED at enrichment time and
+// frozen with the row (ADL-7). The sidecar reads MODEL_RATES at PATCH
+// time and writes both the cost AND the rates into the row.
+export const EnrichRunInput = z.object({
+  tokensIn: z.number().int().nonnegative().optional(),
+  tokensOut: z.number().int().nonnegative().optional(),
+  model: z.string().max(128).optional(),
+  rateInUsdPerMt: z.number().nonnegative().optional(),
+  rateOutUsdPerMt: z.number().nonnegative().optional(),
+  outcomeRefinement: RunOutcome.optional(),  // partial | tool_error | no_work | runner_crash
+});
+export type EnrichRunInputT = z.infer<typeof EnrichRunInput>;
+
+export interface ModelRate {
+  inUsdPerMt: number;
+  outUsdPerMt: number;
+}
+```
+
+### 3.2 REST contracts
+
+All endpoints require `x-internal-api-key` (existing Vizora convention) AND `x-internal-caller` (NEW per Reviewer A D9 — caller identification for audit attribution and selective rotation).
+
+```
+POST /api/v1/internal/agent-runs
+  Auth:    InternalSecretGuard (x-internal-api-key)
+  Headers: x-internal-caller: "runner" | "sidecar" | "ops"   (REQUIRED)
+  Body:    RecordRunInput (Zod-validated)
+  Returns: 201 { id: string }
+  Errors:  400 if body schema invalid;
+           401 if secret bad/missing OR x-internal-caller missing/unknown
+
+PATCH /api/v1/internal/agent-runs/:id
+  Auth:    InternalSecretGuard
+  Headers: x-internal-caller: "sidecar" (typically; runner can also PATCH)
+  Body:    EnrichRunInput (Zod-validated)
+  Returns: 200 { id, enriched: true }
+  Errors:  400 if body schema invalid;
+           401 if secret bad/missing;
+           404 if id not found;                           ← was 400 (Reviewer A+B critical)
+           409 if row already frozen (server-time         ← was 400 (Reviewer A+B critical)
+                finishedAt + 5min < server now()).
+                Use server time only — NOT client time
+                (Reviewer B I8 clock-skew fix).
+
+GET /api/v1/internal/agent-runs/today-spend
+  Auth:    InternalSecretGuard
+  Headers: x-internal-caller (any)
+  Returns: 200 { usd: number, cachedAt: string }
+  Cache:   Redis SETEX agentruns:today-spend 30 ...        ← NEW (Reviewer A+B critical)
+           Stampede mitigation: 2 firings within 1s both
+           see same value. Cache key has no per-day rotation
+           (the SQL `WHERE startedAt >= startOfUtcDay` does
+           that naturally).
+  Errors:  401
+```
+
+**Outcome enum on the wire vs. internal:** the runner submits a 4-value outcome subset (`success | api_error | timeout | budget_aborted`); the full 8-value enum is internal/database only. Sidecar refines via PATCH `outcomeRefinement`. This boundary mirrors ADL-3.
+
+### 3.3 MCP tool contract change (P1.1)
+
+**Reviewer A D2 changed the precedence rule** to close a cross-tenant write surface.
+
+```
+log_shadow_row
+  Before P1.1:
+    Token shape:    organizationId MUST be null (platform-scope)
+    On per-org token: throw BadRequestException → INVALID_INPUT on wire
+
+  After P1.1 (REVISED for Reviewer A D2):
+    Token shape:    any token with shadow:write scope
+    Behavior:
+      1. If token.organizationId IS NULL (platform-scope):
+         - Agent MAY supply any organization_id in fields (or none)
+         - Server writes the row as-is
+      2. If token.organizationId IS NOT NULL (per-org):
+         - Server FORCES organization_id = token.organizationId in the row
+         - If agent supplies a DIFFERENT organization_id:
+             throw BadRequestException → INVALID_INPUT on wire
+             ("organization_id mismatch with token scope")
+         - If agent supplies NO organization_id: server injects token's value
+
+  Why: the original "agent-supplied takes precedence" rule allowed a
+  per-org token for org A to stamp organization_id=B in the JSONL.
+  Audit trail (mcp_audit_log) preserved attribution but downstream
+  readers were misled. The token's org becomes the cryptographic source
+  of truth for per-org tokens.
+
+  Scope (unchanged): shadow:write
+```
+
+**Backward-incompatibility callout (Reviewer A I1):** the wire-error
+space changes — `INVALID_INPUT` for the platform-scope-only check
+disappears, but a NEW `INVALID_INPUT` appears for the agent-supplied
+mismatch case. CHANGELOG entry required:
+
+```
+fix(mcp): log_shadow_row no longer requires platform-scope token
+
+BREAKING (wire-error semantics):
+  - Removed: INVALID_INPUT "log_shadow_row requires a platform-scope token"
+  - Added:   INVALID_INPUT "organization_id mismatch with token scope"
+
+Verified: no current Hermes-skill caller depends on the removed rejection.
+```
+
+### 3.4 Hermes runner contract (P0.4 + P1.2)
+
+```
+run-hermes-skill.sh <skill-name> <prompt> [toolsets-csv]
+
+  Pre-flight (returns early if either fails):
+    1. Query OpenRouter /v1/credits, compute balance = total_credits - total_usage
+    2. Abort if balance < MIN_BALANCE_USD ($0.50 default)
+    3. Query middleware /internal/agent-runs/today-spend
+    4. Abort if today_spend ≥ DAILY_BUDGET_USD ($1.00 default)
+
+  Invocation:
+    timeout 300 hermes --skills <skill-name> -z <prompt> [-t <toolsets-csv>]
+
+  Post-flight:
+    5. Classify outcome from RC + log content (runner-side rules — see ADL-3)
+    6. POST /internal/agent-runs with metadata; capture returned id
+    7. Append id to runner log for sidecar correlation
+    8. Always exit 0 (PM2 cron_restart treats nonzero as crash)
+
+  Environment vars:
+    OPENROUTER_API_KEY        from /root/.hermes/.env
+    INTERNAL_API_SECRET       from /opt/vizora/app/.env
+    MIDDLEWARE_URL            default http://localhost:3000
+    MIN_BALANCE_USD           default 0.50
+    DAILY_BUDGET_USD          default 1.00
+```
+
+---
+
+## 4. Sequence flows
+
+### 4.1 Happy-path firing
+
+```
+PM2 cron tick → run-hermes-skill.sh (vizora-customer-lifecycle)
+
+  ├─[1] curl OpenRouter /credits  ──→  balance: $1.85 (above 0.50)
+  ├─[2] curl middleware /today-spend ──→ $0.04 (under 1.00)
+  ├─[3] hermes -z --skills vizora-customer-lifecycle \
+  │       -t mcp_vizora_list_onboarding_candidates,...
+  │       └─[a] LLM call: list_onboarding_candidates  ──→ 12 orgs
+  │       └─[b] LLM emits log_shadow_row × 12 (heuristic decision per org)
+  │       └─[c] LLM exits silently
+  ├─[4] RC=0; classify outcome = success
+  ├─[5] POST /internal/agent-runs
+  │       body: {skillName, startedAt, finishedAt, exitCode:0, outcome:success,
+  │              preflightBalanceUsd:1.85, preflightTodaySpendUsd:0.04}
+  │       returns: {id: "ckxx..."}
+  ├─[6] Append "agent_run_id=ckxx..." to runner log
+  └─[7] exit 0
+
+T+5min: insights-poller PM2 cron tick
+
+  ├─[1] hermes insights --days 1 --source cli
+  │       (returns boxed table with token usage per session)
+  ├─[2] Find rows in agent_runs where tokensIn IS NULL AND startedAt > now-1h
+  ├─[3] Match each to insights row by time-range + skillName
+  ├─[4] For each match: PATCH /internal/agent-runs/:id
+  │       body: {tokensIn: 4200, tokensOut: 380, model: gpt-4o-mini-2024-07-18}
+  ├─[5] Cross-ref mcp_audit_log for [startedAt, finishedAt]:
+  │       no FORBIDDEN/INVALID_INPUT → outcome stays 'success'
+  └─ done
+```
+
+### 4.2 Failure paths
+
+**Pre-flight balance fail:**
+
+```
+Runner ──→ /credits (balance: $0.20)
+       ──→ abort; POST agent_runs with outcome=budget_aborted
+       ──→ exit 0 (Hermes never invoked, OpenRouter never queried beyond /credits)
+```
+
+**Hermes exits with API error:**
+
+```
+Runner ──→ pre-flight passes
+       ──→ hermes -z (HTTP 402 in stdout, RC=0 due to script's exit-0 behavior)
+       ──→ classifier: stdout contains "HTTP 402" → outcome=api_error
+       ──→ POST agent_runs with outcome=api_error, errorExcerpt=<tail of log>
+       ──→ exit 0
+       ──→ [If 5 consecutive api_error rows → P4 circuit breaker trips]
+```
+
+**Hermes succeeds but model called wrong tool (post-P1.2 this should not happen):**
+
+```
+Runner ──→ Hermes succeeds RC=0
+       ──→ POST outcome=success
+T+5min ──→ Sidecar reads mcp_audit_log
+       ──→ Finds 1 FORBIDDEN row for this agentName + time window
+       ──→ PATCH outcome=tool_error
+       ──→ Grafana alerts on outcome=tool_error rate
+```
+
+### 4.3 Concurrency: race between sidecar and runner
+
+The sidecar polls every 5 min. A firing that started at T and finishes at T+25s is enriched at the next poll (T+30s to T+5min depending on poll alignment). Race scenarios analyzed:
+
+1. **Sidecar runs while a firing is in-flight.** Runner hasn't POSTed yet, so sidecar finds nothing to enrich. Next tick picks it up. ✅ Safe.
+2. **Runner POSTs after sidecar reads `agent_runs` snapshot.** Sidecar enriches older rows; runner's new row sits unenriched until next sidecar tick. ✅ Safe.
+3. **Two sidecar instances run concurrently** (e.g., during deploy). Reviewer B critical D7 — original "naturally idempotent" claim was wrong under MVCC. Both transactions can see `tokensIn IS NULL`, both UPDATE, last-write-wins. If both compute the same cost it's harmless; if a parser bug produces different values, the buggy run can overwrite a corrected one.
+
+   **Fix:** PATCH endpoint uses `UPDATE ... WHERE tokensIn IS NULL RETURNING id`. Zero-row return means another sidecar already enriched. Sidecar treats this as a no-op (`INFO log: "row already enriched by another sidecar instance"`). For correction-of-bug-corrected-data: provide a separate `POST /internal/agent-runs/:id/reenrich` endpoint that explicitly bypasses the NULL check (super-admin only, audit-logged).
+
+   ```sql
+   UPDATE agent_runs
+      SET tokensIn = $1,
+          tokensOut = $2,
+          model = $3,
+          rateInUsdPerMt = $4,
+          rateOutUsdPerMt = $5,
+          costMicrodollars = $6,
+          outcome = COALESCE($7, outcome)
+    WHERE id = $8
+      AND tokensIn IS NULL                         -- idempotency guard
+      AND finishedAt + INTERVAL '5 minutes' >= NOW()  -- server-time freeze
+   RETURNING id;
+   ```
+
+4. **Two PM2 cron tickers fire the SAME skill within 60s** (clock skew during PM2 restart). Both runners pre-flight, both call /credits, both see balance OK, both invoke Hermes — double charge. Mitigation: pre-flight first acquires Redis lock `SETNX agentruns:lock:<skill> <pid> EX 60`; only the lock-holder proceeds. Failure to acquire = exit 0 immediately, no `agent_runs` row written, INFO log line. The "no row" is intentional: skipped firings are a non-event, not an outcome to track. If skipped-firing rate becomes a concern (e.g., from a Grafana log-based panel), elevate to a tracked outcome later.
+
+5. **Today-spend stampede** (Reviewer A+B D12): N runners hit `GET /today-spend` simultaneously. Redis cache absorbs this — see §3.2.
+
+**Orphan-row policy (Reviewer B I7):** if runner POSTs `RecordRunInput` and crashes before the row is finalized, `finishedAt` may be present (POST is post-runner-exit) BUT could be missing if the POST itself partially completed. The sidecar runs an additional pass:
+
+```sql
+-- Mark orphans
+UPDATE agent_runs
+   SET outcome = 'runner_crash',
+       finishedAt = COALESCE(finishedAt, NOW()),
+       errorExcerpt = 'orphan row — runner crashed before final write'
+ WHERE outcome NOT IN ('runner_crash', 'budget_aborted')
+   AND tokensIn IS NULL
+   AND createdAt < NOW() - INTERVAL '10 minutes';
+```
+
+This runs at the end of every sidecar tick. After 10 min an unenriched row is presumed crashed.
+
+**Frozen-row guarantee:** PATCH refuses if `server_now() > finishedAt + 5min`. Server time only (Reviewer B I8) — runner clock is irrelevant.
+
+---
+
+## 5. Error taxonomy
+
+### 5.1 Runner script errors
+
+| Error | Treatment | Visibility |
+|---|---|---|
+| `/credits` API timeout | Treat balance as unknown → proceed (don't fail-closed; Hermes will fail at API layer if no balance) | Logged; no alert (transient) |
+| `/today-spend` middleware unreachable | Treat as $0 spent → proceed | Logged; alert if persistent |
+| Hermes RC != 0 (non-timeout) | outcome=api_error; exit 0 | Per-firing visible in agent_runs; alerted in aggregate |
+| Hermes timeout (RC=124) | outcome=timeout | Same |
+| POST to `/internal/agent-runs` fails | Log warning; runner exits 0 anyway. Lost row is acceptable (alerting is on rate, not count). | Logged WARN |
+| INTERNAL_API_SECRET not set | Refuse to POST; log ERROR | ERROR-level log; alerts via Grafana log-based rule |
+
+### 5.2 MCP tool errors (P1.1 changes)
+
+```
+log_shadow_row error space:
+  ForbiddenException     ──→ FORBIDDEN     (token lacks shadow:write)
+  BadRequestException    ──→ INVALID_INPUT (Zod parse failure OR org_id/token mismatch)
+  Internal exception     ──→ INTERNAL      (filesystem write failure)
+
+Wire-error transitions (P1.1 — see CHANGELOG entry §3.3):
+  Removed: INVALID_INPUT "log_shadow_row requires platform-scope token"
+  Added:   INVALID_INPUT "organization_id mismatch with token scope"
+```
+
+### 5.3 Sidecar errors
+
+| Error | Treatment |
+|---|---|
+| `hermes insights` returns "No sessions found" (verified live 2026-05-08) | Expected when no firings have happened; INFO log; no rows enriched (correctly). |
+| `hermes insights` returns parseable boxed-table output | Normal path; parser extracts rows. |
+| `hermes insights` returns unparseable output (format drift across Hermes versions) | Log ERROR with full output + Hermes version; trigger "Sidecar parser failure" alert (§8.3). Rows stay unenriched and can be backfilled manually after parser fix. |
+| Middleware PATCH 404 (id not found) | Sidecar bug — log ERROR; should never happen in normal operation. |
+| Middleware PATCH 409 (row frozen) | Expected for late polls (>5min after finishedAt); log INFO and continue. |
+| Middleware PATCH 500 | Log ERROR; retry on next tick (PATCH is idempotent via `WHERE tokensIn IS NULL` guard). |
+| `agentRunId` join finds zero audit rows for a `success` row | Acceptable — skill may have made no MCP calls (e.g., heuristic-only firing). Outcome stays `success`. |
+| `agentRunId` is NULL on audit rows for a firing | Fall back to time-range + agentName join (§2.3 fallback path). Refinement quality drops; flag with `outcome_confidence='low'` (deferred to P3 if it becomes a problem). |
+
+---
+
+## 6. Security boundaries
+
+### 6.1 Trust zones
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ Internet (zero trust)                                         │
+│   └─ no inbound traffic to /internal/* (firewall rule)       │
+└──────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────┐
+│ Vizora prod VPS — local trust zone                            │
+│                                                                │
+│   ┌─────────────────────────────────────────────────────┐    │
+│   │ run-hermes-skill.sh (root)                            │    │
+│   │   - reads /root/.hermes/.env (OPENROUTER_API_KEY)   │    │
+│   │   - reads /opt/vizora/app/.env (INTERNAL_API_SECRET) │    │
+│   │   - POSTs to localhost:3000/internal/agent-runs      │    │
+│   └─────────────────────────────────────────────────────┘    │
+│              │                                                 │
+│              │ x-internal-api-key                              │
+│              ▼                                                 │
+│   ┌─────────────────────────────────────────────────────┐    │
+│   │ Vizora middleware (NestJS)                           │    │
+│   │   - InternalSecretGuard validates header             │    │
+│   │   - constant-time secret compare                     │    │
+│   │   - writes agent_runs row                            │    │
+│   └─────────────────────────────────────────────────────┘    │
+│              │                                                 │
+│              ▼                                                 │
+│   ┌─────────────────────────────────────────────────────┐    │
+│   │ Postgres (agent_runs, mcp_audit_log)                 │    │
+│   └─────────────────────────────────────────────────────┘    │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### 6.2 Secrets
+
+| Secret | Storage | Rotation cadence | Blast radius if compromised |
+|---|---|---|---|
+| `OPENROUTER_API_KEY` | `/root/.hermes/.env` (chmod 600) | Quarterly | Provider charges; revoke + reissue in OpenRouter UI |
+| `INTERNAL_API_SECRET` | `/opt/vizora/app/.env` (chmod 600) | Quarterly | Internal endpoint flooded; rotate via env update + middleware reload |
+| MCP bearer tokens | `mcp_tokens.tokenHash` (sha256) | Per token's `expiresAt` | Per-token scope only; revoke via `DELETE /admin/mcp-tokens/:id` |
+
+### 6.3 PII / data handling
+
+The plan's P1.1 introduces `organization_id` tagging in shadow log rows. This is consistent with existing CLAUDE.md guidance: "structural signals only, no PII." Org IDs are tenant identifiers, not PII. No new PII is introduced.
+
+`agent_runs` records no per-tenant data — only skill name, timing, cost. No tenant identification.
+
+---
+
+## 7. Test architecture
+
+### 7.1 Test pyramid
+
+```
+                    ┌────────────────┐
+                    │  E2E (Playwright)│      0 tests added
+                    │    none planned  │      (no UI changes in P0/P1)
+                    └────────────────┘
+                  ┌──────────────────────┐
+                  │ Integration (Jest+SQL)│   ~6 tests
+                  │  /internal/agent-runs  │
+                  │  shadow-log.tools     │
+                  └──────────────────────┘
+              ┌─────────────────────────────┐
+              │ Unit (Jest, mocked DB)        │   ~15 tests
+              │  AgentRunsService             │
+              │  InternalSecretGuard          │
+              │  cost computation             │
+              │  outcome classifier (sidecar) │
+              │  insights table parser        │
+              └─────────────────────────────┘
+                                          │
+              ┌─────────────────────────────┐
+              │ Smoke (manual, prod)          │   3 checks
+              │  P0.0a max_tokens clamp       │
+              │  P1.2 hermes -t toolset filter│
+              │  P1.3 end-to-end firing       │
+              └─────────────────────────────┘
+```
+
+### 7.2 What gets tested where
+
+**Unit (mocked database, in-memory):**
+- `AgentRunsService.recordRun` — cost computation, null model handling, timeout outcome
+- `AgentRunsService.getTodaySpendUsd` — sum aggregation, null sum
+- `AgentRunsService.enrichRun` — frozen-row check, idempotency
+- `InternalSecretGuard.canActivate` — happy path, missing header, mismatched header, env not set (constant-time correctness)
+- `logShadowRowTool` — 9 tests (existing 6 + 3 new from P1.1 spec)
+- Outcome classifier (sidecar service) — table-driven tests on (RC, log content, audit rows) → outcome
+- `hermes insights` table parser — fixture-based tests on stable + version-shifted output
+
+**Integration (real Postgres via `docker-compose.test.yml`):**
+- `POST /internal/agent-runs` — full request → row written → 201
+- `PATCH /internal/agent-runs/:id` — enrichment writes; frozen-row 400; concurrent-PATCH idempotency
+- `GET /internal/agent-runs/today-spend` — UTC-day boundary correctness
+- Migration applies cleanly on a fresh DB
+
+**Smoke (manual, prod, after credit add):**
+- P0.0a: fire one Hermes invocation; inspect OpenRouter request body for `max_tokens=4096`
+- P1.2: fire with `-t mcp_vizora_log_shadow_row` only; verify model lists only that tool
+- P1.3: end-to-end customer-lifecycle firing produces a `success` row in `agent_runs`
+
+### 7.3 Coverage targets
+
+- Unit: 90%+ on new service code (AgentRunsService, classifier, parser)
+- Integration: every documented REST endpoint + every error response code
+- Smoke: 100% pass on prod with paid key before declaring P0/P1 done
+
+---
+
+## 8. Operational design
+
+### 8.1 Deploy ordering
+
+**Phantom-lever decision (Reviewer A D11) committed before build:** the runner ALWAYS passes `--max-tokens 4096` as an explicit CLI flag, regardless of `model.max_tokens` in `~/.hermes/config.yaml`. Belt-and-braces. P0.0a verifies the clamp arrives at OpenRouter (via stdout debug or generation API). If `--max-tokens` isn't supported by the installed Hermes version, the runner fails closed (refuses to invoke) — do NOT silently fall through.
+
+**Hermes version pin (Reviewer A+B D13):**
+- Pinned: `HERMES_VERSION=0.12.0` in `/opt/vizora/app/.env` on prod
+- Runner script first action: `hermes --version` and exit 0 with `outcome='version_skew'` log line if mismatched (no `agent_runs` row written; ops-watchdog detects skipped firings)
+- Tracked in repo: `config-prod/.hermes-version` (one-line file with the pinned version)
+- CI smoke test: `.github/workflows/hermes-version-check.yml` runs `hermes --version` against pinned value; fails build on drift
+
+**Day 1:**
+1. P0.0a smoke test (verify `--max-tokens 4096` clamps OpenRouter requests)
+2. **No-op deploy verification:** P0.1 schema migration (additive only — safe under traffic). Migration creates `agent_runs` + adds `agentRunId` column to `mcp_audit_log` (nullable FK, backward-compat).
+3. P0.2 + P0.3 service + controller + guard (deployed but no caller yet — intentional, verifies DI graph + routes resolve)
+4. Deploy middleware (PM2 reload)
+5. Verify endpoints respond via curl using the new `x-internal-caller` header
+
+**Day 2:**
+6. P0.4 + P0.5 runner script changes (pre-flight + sidecar-friendly POST)
+7. P0.6 Grafana dashboard (auto-loaded on Grafana restart)
+8. P0.7 OpenRouter UI cap (manual — Sri)
+9. P1.1 MCP server change (`log_shadow_row` token semantics) → middleware redeploy
+10. P1.2 Hermes `-t` flag + agentRunId env var in ecosystem.config.js → entries still deleted; flag is dormant until re-enable
+
+**Day 3:**
+11. Add credits to OpenRouter (Sri)
+12. P1.3 re-enable customer-lifecycle (`pm2 start --only`)
+13. Watch first 2 firings; verify zero FORBIDDEN in `mcp_audit_log`, `agentRunId` populated; if clean, re-enable support-triage
+14. Watch 24h; if clean, declare P0+P1 done
+
+**Documentation deliverable:** the deploy steps above are tracked in `docs/runbooks/agent-platform-redesign-deploy.md` (created during P0). Each step has explicit success criteria + rollback command.
+
+### 8.2 Rollback runbook
+
+| Failure | Rollback | RTO |
+|---|---|---|
+| Migration fails partway | `npx prisma migrate resolve --rolled-back <name>` ONLY edits `_prisma_migrations`; manually `DROP TABLE agent_runs CASCADE; ALTER TABLE mcp_audit_log DROP COLUMN agentRunId;` THEN revert code. **Not 1 command — multi-step procedure documented in `docs/runbooks/migrations.md`** (Reviewer B I6). | ~5 min |
+| Middleware deploy breaks endpoints | Git revert + `pm2 reload vizora-middleware --update-env`. Previous git SHA captured in deploy log. | ~2 min |
+| MCP server rejects valid traffic post-P1.1 | Revert `shadow-log.tools.ts`; redeploy. Tokens unchanged so no token-side rollback needed. The CHANGELOG-flagged backward-incompatibility (§3.3) means downstream callers don't depend on rejection — verified before P1.1 ships. | ~2 min |
+| Runner script broken | `pm2 delete hermes-vizora-*` (already the default state from May 8 incident response). Existing TS PM2 cron `agent-customer-lifecycle` is safety net (no LLM, deterministic). | ~30 sec |
+| Cost runaway despite L1+L2+L3 | OpenRouter L1 cap is hard backstop ($2/day). `pm2 delete hermes-vizora-*` halts firings within seconds. L4 circuit breaker (P4) trips automatically after 5 failures. | ~30 sec |
+| `agentRunId` propagation fails (sidecar can't refine) | Sidecar falls back to time-range + agentName join (§2.3 fallback path). Outcome refinement quality drops but service stays online. | 0 sec (graceful degrade) |
+| Hermes version drift detected | Runner refuses to invoke (§8.1 version-pin guard); ops-watchdog alerts on no firings. Operator runs `hermes update` to pinned version OR updates `HERMES_VERSION` env if upgrade is intentional. | ~5 min |
+
+**RTO target:** under 5 minutes for any failure mode. Every step has a documented command. No rollback requires interpretive operator decisions.
+
+### 8.3 Monitoring & alerting
+
+**Grafana panels (P0.6):**
+1. Cost per skill per hour (last 24h) — line chart
+2. Outcome distribution (last 24h) — stacked bar
+3. P50/P95 firing latency — line chart
+4. Today's spend vs daily budget — single-stat with threshold
+
+**Alerts (Grafana, routes to Slack via existing webhook):**
+
+| Alert | Condition | Severity |
+|---|---|---|
+| Daily budget exceeded | `today_spend > 1.00` for 5 min | critical |
+| Per-firing cost anomaly | any single row's `costMicrodollars > 50000` (= $0.05) | warning |
+| **Cluster cost anomaly** (Reviewer B I3) | `sum(costMicrodollars) by skillName over 1h > 200000` (= $0.20) | warning |
+| Error rate high | `(tool_error + api_error + timeout) / total > 5%` over 15 min | warning |
+| No firings for skill | `now - max(startedAt) by skillName > 3 × cron_interval` | warning |
+| **Output cap breach** (Reviewer B I5; reframed) | `tokensOut > 4096 OR cumulative_in_5min > 30K` per skill | critical |
+| Hermes version drift | `version_skew` log lines from runner (no `agent_runs` row) | warning |
+| Sidecar parser failure | `hermes insights` parser throws OR returns empty when rows expected | critical |
+| Frozen-row PATCH attempted | 409 Conflict response rate > 0 over 1h (indicates sidecar latency or runner clock issue) | info |
+
+---
+
+## 9. Open questions — resolved during review
+
+Items resolved by the two-reviewer pass:
+
+1. **PATCH idempotency on retry with bug-corrected data?** — Resolved §4.3: added explicit `RETURNING id` + zero-row handling; separate super-admin `POST /:id/reenrich` endpoint for forced overwrites.
+2. **5-minute frozen-row window?** — Kept at 5 min; matches sidecar cadence. PATCH 409 alert at info-level catches latency drift (§8.3).
+3. **`outcome='no_work'` detected by runner?** — Resolved: sidecar-only (ADL-3 revised). Runner's classification surface is intentionally minimal.
+4. **FK from `agent_runs` to `mcp_audit_log`?** — Resolved §2.3: added `agentRunId` FK from `mcp_audit_log` to `agent_runs` (reverse of original direction — single audit row → multiple firings is wrong; multiple audit rows per firing is right). Propagation via runner-emitted env var → Hermes header → MCP request context.
+5. **Phantom-lever fallback (P0.0a Step 4b)** — Resolved §8.1: runner ALWAYS passes `--max-tokens 4096` as explicit CLI flag. Belt-and-braces. Fail closed if Hermes lacks the flag.
+6. **`-t` flag failure mode on mistyped tool name?** — Resolved: P1.2 acceptance test runs against paid key (smoke). Additionally: unit test asserts each `hermes-vizora-*` ecosystem entry has a non-empty `args[3]` toolset string matching a known allowlist. Hermes' argparse rejects unknown tool names with non-zero exit, which the runner's outcome classifier picks up as `api_error`.
+7. **Hermes native `subagent` instead of sidecar?** — Resolved: sidecar reads `mcp_audit_log` (Postgres), which is outside Hermes' world. A subagent would double round-trips. Sidecar pattern wins.
+
+## 9.x Open questions — escalated to next phase
+
+Items the design intentionally defers (will be re-asked at build):
+
+A. **CHANGELOG location** — Vizora's repo has no top-level `CHANGELOG.md`. The CHANGELOG entry from §3.3 needs a home. Options: create top-level `CHANGELOG.md`, OR attach to PR description, OR create `docs/changelog/`. Decision deferred to PR creation.
+
+B. **Runner Redis lock TTL (§4.3 race 4)** — 60s seems right for skills with 30-min cron, less obvious for the 5-min support-triage cron (15 min after revisions). May need per-skill TTL. Defer until P1.3 firing data shows the actual distribution.
+
+C. **`x-internal-caller` enum** — design lists `runner | sidecar | ops`. As we add tools (e.g., `dashboard` for direct admin queries), the list grows. Defer to a registered-callers table when it exceeds 5 values; for now, hard-coded enum is fine.
+
+---
+
+## 10. Definition of design-done
+
+This design document is "approved" when:
+
+1. ✅ All 7 ADL decisions are reviewed and either accepted or replaced with documented alternatives (ADL-7 added post-review)
+2. ✅ The data-model section reflects Prisma schema additions exactly (4 new columns on `agent_runs`, 1 new column + index on `mcp_audit_log`)
+3. ✅ All REST contracts have a unit-test stub written before implementation begins (covered in §7.2)
+4. ✅ All error-taxonomy rows have a corresponding test case planned
+5. ✅ The sequence flows have been walked through against each open question in §9 (resolved or escalated)
+6. ✅ Two parallel reviewers (different attack vectors) have signed off
+7. ✅ Hermes-first analysis from the companion plan §1.5 still holds — no new custom code competes with a Hermes-native capability we discovered post-review
+8. ✅ Drift-check from the companion plan §1.6 still holds — no new primitive proposed in this design exists in the tree
+
+**Build-readiness gate:** at the start of P0 implementation, the developer (subagent or human) re-reads this design top-to-bottom and confirms every ADL decision still maps to current prod state. Discoveries during implementation are added back to the design before the corresponding code lands.
+
+---
+
+**Companion plan:** `docs/plans/2026-05-08-agent-platform-redesign.md`

--- a/docs/plans/2026-05-08-agent-platform-redesign.md
+++ b/docs/plans/2026-05-08-agent-platform-redesign.md
@@ -1,0 +1,2007 @@
+# Vizora Agent Platform Redesign — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the structural causes of the May 2026 OpenRouter credit drain and bring Vizora's agent platform to **industry baseline standards** for cost governance, deterministic-first orchestration, observability, and gated rollout. (Note: "top 10" framing in the original brief was scoped down after Reviewer 1 — Bedrock Agents/Agentforce/Assistants have features this plan doesn't aim for, like managed conversational memory or multi-step plan-and-execute reasoning. This plan delivers production-grade hardening, not feature parity with hyperscaler agent platforms.)
+
+**Architecture:** Layered governance over the existing Hermes runtime. The LLM is demoted from autonomous orchestrator to bounded classifier; deterministic TS code drives the workflow. Cost is bounded at four levels (provider cap → app cap → per-firing budget → tool-loop hard stop). Observability ships before any agent re-enable.
+
+**Tech Stack:** Hermes Agent (Python runtime, OpenRouter), Vizora middleware (NestJS 11), Prisma 5 (PostgreSQL 16), Redis 7, Grafana, Prometheus, PM2.
+
+---
+
+## 1. Background — what triggered this redesign
+
+OpenRouter credits drained ~May 6 2026 across two days of Hermes shadow agent firings. Server-side audit log analysis revealed:
+
+| Agent | Successful tool calls | Wrong-tool calls | Outcome |
+|---|---|---|---|
+| `hermes-customer-lifecycle` | 699 | **363 FORBIDDEN** | Model called `list_open_support_requests` 273× — a tool not in its skill |
+| `hermes-support-triage` | 1981 | **454 INVALID_INPUT + 163 FORBIDDEN** | Token-scope mismatch on `log_shadow_row` + cross-skill calls |
+
+Each FORBIDDEN/INVALID_INPUT response triggered a full LLM retry (up to 16,384 output tokens, no hard stop). The cron continued firing for 2 days after credits hit zero before anyone noticed. Root causes:
+
+1. **No cost governance** — no provider cap, no per-firing budget, no daily ceiling
+2. **No tool authorization at the agent layer** — Hermes saw all 9 MCP tools per skill
+3. **No circuit breaker** — HTTP 402s ran for 48h with no alert
+4. **No structured observability** — runner logs were plain text, audit log lacked cost attribution
+5. **LLM was orchestrator, not classifier** — single-source-of-failure for all decisions
+6. **Token model contradiction** — support-triage needs both per-org and platform-scope behavior, can't be expressed in one token
+
+This plan addresses all six.
+
+---
+
+## 1.5 Hermes-first analysis (CLAUDE.md §7b — mandatory)
+
+Per Vizora's CLAUDE.md and the global Hermes-first rule, every plan must
+explicitly check whether the Hermes ecosystem already covers each proposed
+capability before introducing custom code. Verification ran on prod
+2026-05-08 via direct CLI inspection of Hermes 0.12.x.
+
+| Domain | Hermes capability found? | Decision |
+|---|---|---|
+| Per-firing tool-call cap | **YES** — `tool_loop_guardrails.hard_stop_enabled/hard_stop_after.*` | **Use Hermes.** Already enabled in P0 patch (May 8). |
+| Per-firing token-output cap | **YES** — `model.max_tokens` config | **Use Hermes.** Already set to 4096 in P0 patch. |
+| Per-skill tool allowlist | **YES** — `hermes -z -t <toolsets>` CLI flag (verified `hermes --help`: `-t TOOLSETS`) | **Use Hermes flag from runner script.** Do NOT invent a `skill_toolsets` config key. |
+| Token usage + cost analysis | **YES** — `hermes insights --days N [--source S]` ("Analyze session history to show token usage, costs, tool patterns") | **Use Hermes insights as data source.** Sidecar process polls `hermes insights` JSON and ships to Vizora middleware for Grafana. Do NOT rebuild model-rate tables manually. |
+| Structured per-session logs | **YES** — `hermes logs --component tools --since 1h --session ID` | **Use Hermes logs.** Do NOT text-parse `/var/log/hermes/runner/*.log`. |
+| Built-in monitoring dashboard | **YES** — `hermes dashboard` (port 9119, web UI for config + sessions) | **Use both.** Hermes dashboard for engineer drilldown; Vizora Grafana for alerting + cross-system correlation. |
+| Provider balance check (OpenRouter `/v1/credits`) | NO | **Custom.** Runner script queries OpenRouter API pre-flight. |
+| Daily app-level spend cap | NO | **Custom.** Vizora middleware aggregates `hermes insights` data + enforces. |
+| Cross-firing circuit breaker (5 consecutive 402/429 → halt + alert) | NO (Hermes' guardrails are intra-firing) | **Custom.** Runner script + Redis counter. |
+| Model fallback on cost/error | **PARTIAL** — `hermes fallback` subcommand exists | **Investigate during P0 implementation.** May obviate custom logic. |
+| Replay/audit dump | **YES** — `hermes dump`, `hermes backup`, `hermes import` | **Use Hermes for snapshot.** Vizora's `agent_runs` table provides the per-firing index/aggregation that `hermes insights` summarizes. |
+| Subagent / delegation | **YES** — `hermes` supports subagents with `inherit_mcp_toolsets` | **Defer to P3.** Future agent-orchestrator can use Hermes' `delegate_task` rather than a custom loop. |
+| LLM-as-classifier pattern (single-shot JSON output) | NOT a Hermes concern — workflow design | **Custom in TS orchestrator** (P2). |
+| Idempotency on MCP writes | NOT a Hermes concern — server-side enforcement | **Custom in Vizora MCP server** (P4). |
+| Promotion / staged rollout | NOT a Hermes concern | **Custom in Vizora middleware** (P3). |
+| **Prompt / context caching** (50–80% input-token saver) | **YES** — OpenRouter supports cache_control markers for gpt-4o-mini; Hermes config has `compression` for context | **Use OpenRouter caching.** Mark stable SKILL.md content as cacheable. Configure in P0 alongside `max_tokens`. Likely amplifier of original drain — same skill text resent every 5 min. |
+| **Structured outputs** (`response_format=json_schema`) | **YES** — OpenRouter supports for gpt-4o-mini; Hermes passes through provider-specific request fields | **Use in P2 classifier.** Eliminates JSON-parse failures and the "schema fidelity" issues documented in MEMORY.md `feedback_gpt4o_mini_schema_fidelity.md`. |
+| **Model routing / fallback by cost-tier** | **YES** — `hermes fallback` subcommand + OpenRouter native `models` array | **Investigate in P0.** May replace some custom retry logic — gpt-4o-mini default with claude-haiku fallback on classifier ambiguity. |
+
+**Note on Hermes insights output format:** `hermes insights --json` does NOT exist (verified: `unrecognized arguments: --json`). The command emits boxed unicode tables only. P0.5 sidecar must use a stable Python regex parser; the original §1.5 framing was misleadingly optimistic. Below tasks now commit to the text-table parser path.
+
+**awesome-hermes-agent ecosystem check:** the curated skills hub at
+`hermes-agent.nousresearch.com/docs/skills` plus `~/.hermes/skills/`
+on prod (verified) lists 28 skill categories. None cover Vizora's
+dollar-budget governance, MCP-write idempotency, or Vizora-specific
+shadow-vs-heuristic comparison. Custom work in those areas is justified.
+
+**Net effect on this plan:** P0 and P1 task sequences below are revised
+to use Hermes-native capabilities (`-t` flag, `insights`, `logs`) where
+they exist, with custom code restricted to Vizora-specific boundaries
+(dollar accounting, daily-budget enforcement, cross-firing breaker,
+promotion machinery, MCP idempotency).
+
+---
+
+## 1.6 Drift-check evidence (CLAUDE.md §7a — mandatory)
+
+Searches run 2026-05-08 to verify proposed primitives don't already exist.
+
+| Search | Result | Action |
+|---|---|---|
+| `AgentRun` / `agent_runs` Prisma model | Only matches in `scripts/ops/*.ts` — unrelated `OpsAgentRun` for the autonomous-ops domain (different concept). No LLM-agent run tracking exists. | **New work justified** (P0.1). |
+| MCP idempotency table/service | Zero matches outside billing (Razorpay payment idempotency, different domain). | **New work justified** (P4). |
+| OpenRouter `/credits` pre-flight | Zero matches. | **New work justified** (P0.4). |
+| Per-skill Hermes tool config | Zero matches. But `hermes -z -t` CLI flag exists (Hermes-first hit above). | **Use Hermes flag**, not custom config (P1.2 revised). |
+| `log_shadow_row` token-scope code | **`middleware/src/modules/mcp/tools/shadow-log.tools.ts:42-46`** — the explicit `if (context.organizationId != null) throw BadRequest("...platform-scope...")`. | **Modify existing file** (P1.1 — file path corrected from earlier draft). |
+| Agent cost dashboard | Only `docker/grafana/dashboards/vizora-overview.json` exists. No agent dashboard. | **New work justified** (P0.6). |
+| Shadow-vs-heuristic comparison reader | **PARTIAL DRIFT.** `tasks/feature-backlog.md` already specifies this with detailed constraints: must be tolerant to gpt-4o-mini's schema-fidelity issues, lives at `scripts/agents/hermes/compare-shadow.ts`, gated on `agreement_rate >= 85%` for 7 consecutive days. | **Align P3 with the existing spec.** Do not redesign. |
+| `send_lifecycle_nudge_email` circuit breaker | **PARTIAL DRIFT.** `MAX_EMAILS_PER_RUN=50` server-side cap already exists per backlog notes + `LIFECYCLE_LIVE` dry-run gate. | **Reference existing in P4.** Idempotency layer extends, not replaces. |
+| MCP empty-spec handlers (probe loop fix) | PR #59 shipped (`mcp_server_empty_spec_handlers.md` memory + git log `358abd3`). | **Done.** No work needed. |
+| Hermes max-token + hard-stop config | Applied May 8 13:33 prod patch — but P0.0a still required because `model.max_tokens` may not actually clamp the OpenRouter request param (phantom-lever risk). | **Verify, then declare done.** |
+| **Circuit breaker service** (Reviewer 2 found this — original drift-check MISSED it) | **`middleware/src/modules/common/services/circuit-breaker.service.ts` EXISTS.** | **REUSE in P4.** Do not rebuild. Wrap with Redis-backed state if its current implementation is in-memory only. |
+| **`mcp_audit_log` recent data** for replay tests | **Last 2 days are empty** (verified via SQL — agents have produced 0 successful MCP calls since credits drained May 6). | **Note in P0.5:** "replay last 24h of mcp_audit_log" cannot run today; widen window to last 7d to include pre-drain data, OR defer that test step until P0.0a credits are added and one successful firing has happened. |
+| `PrismaService` import path | Reviewer 2: codebase uses `DatabaseService extends PrismaClient` from `database/database.service.ts`. | **Renamed throughout plan.** |
+| Inbound `InternalSecretGuard` | Reviewer 2: doesn't exist. Outbound pattern (`x-internal-api-key`) is in `displays.service.ts:54`, etc., but no inbound guard yet. | **Create in P0.3 Step 5** (now expanded with full implementation). |
+| `mcp.service.ts` `handleToolCall` method | Reviewer 2: doesn't exist. Tools are standalone exports in `tools/*.tools.ts` invoked by SDK callbacks in `mcp.service.ts:buildServer()`. | **P1.1 rewritten** to test `logShadowRowTool(rawInput, context, shadowLog)` directly. |
+
+**Net effect:** P3 (promotion machinery) must read and align with the
+existing backlog entry rather than redesign from scratch. P1.1 modifies
+an existing file at a specific line range, not the broader `mcp.service.ts`.
+All other proposed primitives are confirmed missing and justified.
+
+---
+
+## 2. Reference architecture — target end state
+
+```
+                       ┌─ daily spend cap (OpenRouter dashboard)
+   COST GOVERNANCE ────┼─ pre-flight balance check (runner script)
+                       ├─ per-firing wall-clock + tool-call cap (Hermes config)
+                       └─ anomaly alerting (Prometheus rule on agent_runs)
+
+                       ┌─ tool allowlist per skill (Hermes platform_toolsets)
+   AUTHORIZATION ──────┼─ token scope (already exists, with one fix)
+                       └─ idempotency keys on writes (server-enforced)
+
+   ORCHESTRATION ──────── deterministic TS code
+                            │
+                            ├─ enumerate work items     (no LLM)
+                            ├─ idempotency check        (no LLM)
+                            └─ classify difficulty
+                                  ├─ easy → heuristic action  (no LLM)
+                                  └─ hard → LLM CLASSIFIER ONLY (1 narrow call, JSON output)
+
+   EXECUTION ─────────────── MCP tools (single, narrow call per item)
+
+   OBSERVABILITY ──────── agent_runs table + Grafana dashboard
+                            │
+                            └─ shadow vs heuristic auto-comparison job
+
+   ROLLOUT STAGES ──────── shadow → canary (5%) → live
+                            │
+                            └─ each stage promoted on metric thresholds
+```
+
+Reference systems with these properties: Anthropic *Building Effective Agents* (2024) workflow patterns, AWS Bedrock Agents Flows, Salesforce Agentforce Atlas reasoning engine.
+
+---
+
+## 3. File structure
+
+```
+docs/plans/
+  2026-05-08-agent-platform-redesign.md      # THIS FILE — master plan
+  2026-05-08-phase-2-customer-lifecycle.md   # written when P2 begins
+  2026-05-08-phase-2-support-triage.md       # written when P2 begins
+
+middleware/src/modules/agents/
+  agent-runs.service.ts                       # NEW — record per-firing metrics
+  agent-runs.controller.ts                    # NEW — POST /internal/agent-runs
+  agent-runs.module.ts                        # NEW — wire into app
+  __tests__/agent-runs.service.spec.ts        # NEW — unit tests
+
+middleware/src/modules/mcp/
+  mcp.service.ts                              # MODIFY — relax log_shadow_row token scope
+  mcp.service.spec.ts                         # MODIFY — add token-scope test
+
+packages/database/prisma/
+  schema.prisma                               # MODIFY — add AgentRun model
+  migrations/<timestamp>_agent_runs/          # NEW — migration
+
+scripts/agents/hermes/
+  run-hermes-skill.sh                         # MODIFY — pre/post-flight hooks
+  lib/openrouter-balance.sh                   # NEW — balance check function
+  lib/record-run.sh                           # NEW — POST run metrics to middleware
+  lib/parse-hermes-output.sh                  # NEW — extract token counts from log
+
+hermes-skills/vizora-customer-lifecycle/
+  SKILL.md                                    # MODIFY (P2) — narrow tool list, classifier prompt
+hermes-skills/vizora-support-triage/
+  SKILL.md                                    # MODIFY (P2) — narrow tool list, classifier prompt
+
+config-prod/.hermes/  (deployed to /root/.hermes/ on prod)
+  config.yaml                                 # MODIFY — add platform_toolsets per skill
+                                              # already done: max_tokens=4096, hard_stop=true
+
+docker/grafana/dashboards/
+  agents-cost.json                            # NEW — cost & error dashboard
+
+docker/prometheus/rules/
+  agents.yml                                  # NEW — anomaly alerts
+
+ecosystem.config.js                           # MODIFY — already done: cron */5 → */15
+                                              # P4: add ops-agent-runs-watchdog
+```
+
+---
+
+## 4. Phase overview
+
+| Phase | Deliverable | Effort | Re-enable agents after? |
+|---|---|---|---|
+| **P0** | Cost governance + observability + max_tokens-clamp verification | 2–3 days | No, but system is **safe** |
+| **P1** | Tool authorization + token contradiction fix | 1 day | **Yes** — shadow mode |
+| **P2.A** | `customer-lifecycle` as pure TS heuristic (no LLM) | 2–3 days | Heuristic-only PM2 cron; Hermes shadow retired |
+| **P2.B** | `support-triage` LLM-augmentation (conditional on existing-data battery) | 2–3 weeks IF data justifies; 1 week if heuristic-alone passes | Canary then live |
+| **P3** | Promotion machinery + comparison reader (per backlog spec) | 3–4 days | Full production |
+| **P4** | Operational hardening (reuse `circuit-breaker.service.ts`, idempotency, JSON replay) | 2–3 days | Full production with SLA |
+
+**Total: 4–6 weeks (was originally claimed at "~3 weeks" — Reviewer 1 was right, that was fiction).** P0 + P1 alone (~3–4 days) yields a system that cannot drain credits and cannot wander; P2.A is another 2–3 days for an entirely-heuristic customer-lifecycle. P2.B is the only phase where the timeline is genuinely uncertain — driven by what the existing-data battery shows about whether the LLM earns its place.
+
+**Phase ordering — reviewer disagreement noted:** Reviewer 1 recommended P1-before-P0 ("tool authorization is the actual root cause; cost governance is hardening"). REJECTED with rationale: P0 protects against ANY future cost-drain root cause, not just the May 6 wandering. Tool authorization (P1) eliminates one specific failure mode; cost governance (P0) bounds the blast radius of all unknown future failure modes. Both ship in the same week; ordering is operationally indifferent. The CLAUDE.md global §10 rule applies: "discipline sections are heuristics, not checklists" — a reviewer recommendation does not become an obligation just because a reviewer made it.
+
+---
+
+## 5. Success criteria — production-grade benchmarks
+
+This plan is "done" when ALL of these hold for 14 consecutive days:
+
+- **Cost-bound:** No firing has cost > $0.05; no day has total agent cost > $1.00
+- **Wander-bound:** Zero FORBIDDEN errors in `mcp_audit_log` from Hermes-issued tokens
+- **Latency-bound:** P95 firing wall-clock ≤ 60s for support-triage, ≤ 120s for customer-lifecycle
+- **Observability:** Grafana dashboard shows cost, error rate, latency per agent in real-time
+- **Alerting:** Anomalies (cost > 3σ, error rate > 5%, no firings for 3× cron interval) trigger Slack within 5 min
+- **Replay:** Every firing has a structured JSON record sufficient to reproduce it
+- **Promotion:** Cutover from shadow → canary → live is automated and reversible in <60s
+- **Positive-work criterion (anti-gaming):** at least 1 successful nudge sent per non-empty cohort per week (customer-lifecycle); at least 80% of open support requests reaching `outcome='success'` in their triage firing (support-triage). Reviewer 1 flagged that the criteria above can be satisfied by an agent doing nothing — this prevents that. **Threshold tuned during P3 with shadow-data baseline.**
+- **Ground-truth alignment (not just heuristic agreement):** for at least 50 manually-labeled samples per agent, the LLM-augmented decision matches the human label ≥ 85% of the time. Reviewer 1 flagged that "Hermes vs heuristic agreement" can be two wrong systems agreeing — this prevents that. Sampling protocol defined in P3 sub-plan.
+
+---
+
+## Phase 0 — Cost Governance & Observability
+
+**Goal:** Make it structurally impossible to drain credits silently. This phase ships before any agent is re-enabled.
+
+**Architecture:**
+- **Layer 1 (provider):** OpenRouter daily cap on the API key — manual UI setting, hard ceiling
+- **Layer 2 (pre-flight):** Runner script queries OpenRouter `/v1/credits` before invoking Hermes; aborts if balance < threshold OR today's spend > app budget
+- **Layer 3 (per-firing):** Hermes config (`max_tokens=4096`, `hard_stop_enabled=true`) + runner timeout
+- **Layer 4 (post-flight):** Runner extracts token counts from Hermes output, POSTs to middleware which writes `agent_runs` row
+- **Layer 5 (anomaly):** Prometheus rule on `agent_runs` table → Slack alert
+
+**Success criteria:**
+- All 5 layers wired and tested
+- **Layer 3 (`max_tokens` clamp) verified at the OpenRouter request level, not just config** — see P0.0a
+- Grafana dashboard live at `/grafana/d/agents-cost`
+- Unit tests passing for `agent-runs.service.ts`
+- E2E: a deliberate runaway test firing is bounded and alerts within 60s
+
+---
+
+### Task P0.0: Stop the bleed (already done 2026-05-08, document for reproducibility)
+
+**Goal:** Prevent further wasted runner firings while P0 is in flight.
+
+This task records the operations applied during the May 8 incident response, so a future operator hitting a similar drain has a documented playbook.
+
+- [x] **Step 1: Delete the Hermes PM2 entries** (so `cron_restart` doesn't keep re-spawning).
+
+```bash
+ssh root@vizora.cloud 'pm2 delete hermes-vizora-support-triage hermes-vizora-customer-lifecycle && pm2 save'
+```
+
+Verify with `pm2 list` — the entries should be absent (NOT just "stopped"; cron_restart fires regardless of stopped state).
+
+- [x] **Step 2: Patch `/root/.hermes/config.yaml`** (backup first):
+
+```bash
+ssh root@vizora.cloud 'cp /root/.hermes/config.yaml /root/.hermes/config.yaml.bak.$(date +%Y%m%d-%H%M%S)'
+```
+
+Add `max_tokens: 4096` under `model:` and flip `tool_loop_guardrails.hard_stop_enabled: false → true`.
+
+- [x] **Step 3: Update `ecosystem.config.js`** locally — change `cron_restart: '*/5 * * * *'` to `cron_restart: '*/15 * * * *'` for `hermes-vizora-support-triage` (line 426).
+
+(Already applied locally; not yet committed.)
+
+---
+
+### Task P0.0a: Verify `max_tokens` actually clamps OpenRouter requests (phantom-lever check)
+
+**Why:** Reviewer 2 flagged this as a phantom lever. `hermes config show` confirms `max_tokens=4096` is set, but every runner log line BEFORE the May 8 patch shows `up to 16384 tokens` requested at OpenRouter. We have no firing AFTER the patch (because PM2 was deleted at the same time), so the clamp is **unverified**.
+
+Per CLAUDE.md global §9: "Before any change whose effect depends on runtime state outside source code, query the runtime state for every assumption."
+
+**Files:**
+- No code changes — verification only.
+
+- [ ] **Step 1: Add ~$0.50 of OpenRouter credits** (manual — Sri).
+
+- [ ] **Step 2: Manually fire one Hermes invocation with verbose logging**
+
+```bash
+ssh root@vizora.cloud 'set -a; source /root/.hermes/.env; set +a; hermes -z --skills vizora-customer-lifecycle "list available tools and exit silently"' > .ssh_clamp_test.txt 2>&1
+```
+
+- [ ] **Step 3: Inspect the OpenRouter request envelope**
+
+Hermes logs the actual API request body at DEBUG level. Run:
+
+```bash
+ssh root@vizora.cloud 'hermes logs --since 5m --level DEBUG --component agent | grep -iE "max_tokens|max-tokens" | head -10' > .ssh_clamp_log.txt 2>&1
+```
+
+Expected: `max_tokens: 4096` (or absent — meaning Hermes didn't override the OpenRouter default of 4096 for gpt-4o-mini).
+
+- [ ] **Step 4a: If clamp confirmed (≤4096):** mark Layer 3 effective. Proceed with P0.1.
+
+- [ ] **Step 4b: If clamp NOT effective (>4096):** the Hermes `model.max_tokens` setting is NOT being passed to OpenRouter as the per-request `max_tokens` param. Two possible mitigations:
+1. **Per-call explicit override** — pass `--max-tokens 4096` at the `hermes -z` CLI (verify the flag exists with `hermes -z --help`).
+2. **OpenRouter-side enforcement** — set the model-level cap in the OpenRouter dashboard (if supported) or use OpenRouter's "model variants" feature.
+
+If neither works: file an upstream Hermes issue, AND remove the §1.5 / §2 claim that `max_tokens=4096` is Layer 3 protection. The defense becomes 4-layer, not 5-layer. The other layers still bound cost, but per-call output is uncapped.
+
+- [ ] **Step 5: Document the verified state in `tasks/lessons.md`** with date, finding, and resolution.
+
+---
+
+### Task P0.1: Add `AgentRun` model to Prisma schema
+
+**Files:**
+- Modify: `packages/database/prisma/schema.prisma` (after `McpAuditLog` at line 921)
+
+- [ ] **Step 1: Add the model definition**
+
+Insert after line 921 in `schema.prisma`:
+
+```prisma
+model AgentRun {
+  id              String   @id @default(cuid())
+  // Skill name from Hermes — e.g. "vizora-customer-lifecycle"
+  skillName       String
+  // PM2 process ID for cross-reference with PM2 logs
+  pid             Int?
+  // Wall-clock timing
+  startedAt       DateTime
+  finishedAt      DateTime?
+  durationMs      Int?
+  // Hermes exit code (0 = success at process level — does not imply task success)
+  exitCode        Int?
+  // Token usage extracted from Hermes runner output. Null if unparseable.
+  tokensIn        Int?
+  tokensOut       Int?
+  // OpenRouter cost in USD * 1e6 (microdollars) for integer arithmetic.
+  // Computed by middleware from token counts × per-model rate table.
+  costMicrodollars Int?
+  // Model used. Useful when we add fallback/override per skill.
+  model           String?
+  // Outcome classification — derived by runner from log + audit cross-ref.
+  // 'success' | 'no_work' | 'partial' | 'tool_error' | 'api_error' | 'timeout' | 'budget_aborted'
+  outcome         String
+  // Free-form error excerpt for tool_error / api_error outcomes (max 1KB).
+  errorExcerpt    String?  @db.VarChar(1024)
+  // Pre-flight check: balance at start, today's prior spend at start.
+  preflightBalanceUsd  Decimal? @db.Decimal(10, 4)
+  preflightTodaySpendUsd Decimal? @db.Decimal(10, 4)
+  createdAt       DateTime @default(now())
+
+  @@index([skillName, startedAt])
+  @@index([outcome, startedAt])
+  @@map("agent_runs")
+}
+```
+
+- [ ] **Step 2: Generate the migration**
+
+Run:
+```bash
+cd packages/database
+export $(grep DATABASE_URL ../../.env | xargs)
+npx prisma migrate dev --name agent_runs --create-only
+```
+
+Expected: a new migration directory `migrations/<timestamp>_agent_runs/` with `migration.sql` containing `CREATE TABLE "agent_runs"`.
+
+- [ ] **Step 3: Inspect the SQL and verify indexes**
+
+Run:
+```bash
+cat packages/database/prisma/migrations/*_agent_runs/migration.sql
+```
+
+Expected: SQL contains `CREATE TABLE "agent_runs"`, two `CREATE INDEX` statements, no destructive operations on existing tables.
+
+- [ ] **Step 4: Apply migration locally**
+
+Run:
+```bash
+cd packages/database
+npx prisma migrate dev
+```
+
+Expected: `Database is now in sync with your schema`.
+
+- [ ] **Step 5: Regenerate Prisma client**
+
+Run:
+```bash
+pnpm --filter @vizora/database db:generate
+```
+
+Expected: `Generated Prisma Client (v5.x.x) to ./src/generated/prisma`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/database/prisma/schema.prisma packages/database/prisma/migrations/
+git commit -m "feat(agents): add AgentRun model for per-firing observability"
+```
+
+---
+
+### Task P0.2: Implement `AgentRunsService` with unit tests
+
+**Files:**
+- Create: `middleware/src/modules/agents/agent-runs.service.ts`
+- Create: `middleware/src/modules/agents/__tests__/agent-runs.service.spec.ts`
+- Create: `middleware/src/modules/agents/agent-runs.module.ts`
+
+- [ ] **Step 1: Write the failing test for `recordRun`**
+
+Create `middleware/src/modules/agents/__tests__/agent-runs.service.spec.ts`:
+
+```typescript
+import { Test, TestingModule } from '@nestjs/testing';
+import { AgentRunsService } from '../agent-runs.service';
+import { DatabaseService } from '../database/database.service';
+
+describe('AgentRunsService', () => {
+  let service: AgentRunsService;
+  let prisma: jest.Mocked<DatabaseService>;
+
+  beforeEach(async () => {
+    const mockPrisma = {
+      agentRun: {
+        create: jest.fn(),
+        aggregate: jest.fn(),
+      },
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AgentRunsService,
+        { provide: DatabaseService, useValue: mockPrisma },
+      ],
+    }).compile();
+    service = module.get(AgentRunsService);
+    prisma = module.get(DatabaseService);
+  });
+
+  describe('recordRun', () => {
+    it('persists a run with computed cost from token counts', async () => {
+      (prisma.agentRun.create as jest.Mock).mockResolvedValue({ id: 'r1' });
+      const result = await service.recordRun({
+        skillName: 'vizora-customer-lifecycle',
+        startedAt: new Date('2026-05-08T10:00:00Z'),
+        finishedAt: new Date('2026-05-08T10:00:30Z'),
+        exitCode: 0,
+        tokensIn: 5000,
+        tokensOut: 800,
+        model: 'openai/gpt-4o-mini',
+        outcome: 'success',
+      });
+      expect(result.id).toBe('r1');
+      expect(prisma.agentRun.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          durationMs: 30000,
+          // gpt-4o-mini: $0.15/MT input + $0.60/MT output
+          // = (5000 * 0.15 + 800 * 0.60) / 1e6 microdollars
+          // = (750 + 480) microdollars = 1230 microdollars
+          costMicrodollars: 1230,
+        }),
+      });
+    });
+
+    it('records run with null cost when model is unknown', async () => {
+      (prisma.agentRun.create as jest.Mock).mockResolvedValue({ id: 'r2' });
+      await service.recordRun({
+        skillName: 'vizora-test',
+        startedAt: new Date(),
+        finishedAt: new Date(),
+        exitCode: 0,
+        tokensIn: 100,
+        tokensOut: 50,
+        model: 'unknown/model',
+        outcome: 'success',
+      });
+      expect(prisma.agentRun.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ costMicrodollars: null }),
+      });
+    });
+
+    it('records timeout outcome with null token counts', async () => {
+      (prisma.agentRun.create as jest.Mock).mockResolvedValue({ id: 'r3' });
+      await service.recordRun({
+        skillName: 'vizora-test',
+        startedAt: new Date(),
+        finishedAt: new Date(),
+        exitCode: 124, // timeout(1) exit code
+        outcome: 'timeout',
+      });
+      expect(prisma.agentRun.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          outcome: 'timeout',
+          tokensIn: null,
+          tokensOut: null,
+          costMicrodollars: null,
+        }),
+      });
+    });
+  });
+
+  describe('getTodaySpendUsd', () => {
+    it('sums costMicrodollars for the current UTC day', async () => {
+      (prisma.agentRun.aggregate as jest.Mock).mockResolvedValue({
+        _sum: { costMicrodollars: 2_500_000 }, // $2.50
+      });
+      const spend = await service.getTodaySpendUsd();
+      expect(spend).toBe(2.5);
+    });
+
+    it('returns 0 when no runs today', async () => {
+      (prisma.agentRun.aggregate as jest.Mock).mockResolvedValue({
+        _sum: { costMicrodollars: null },
+      });
+      const spend = await service.getTodaySpendUsd();
+      expect(spend).toBe(0);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+pnpm --filter @vizora/middleware test -- --testPathPattern=agent-runs.service.spec
+```
+
+Expected: FAIL with "Cannot find module '../agent-runs.service'".
+
+- [ ] **Step 3: Implement `AgentRunsService`**
+
+Create `middleware/src/modules/agents/agent-runs.service.ts`:
+
+```typescript
+import { Injectable, Logger } from '@nestjs/common';
+import { DatabaseService } from '../database/prisma.service';
+
+// Per-million-token rates in USD. Update when adding new models.
+// Source: https://openrouter.ai/models — verified 2026-05-08.
+const MODEL_RATES: Record<string, { inUsdPerMt: number; outUsdPerMt: number }> = {
+  'openai/gpt-4o-mini': { inUsdPerMt: 0.15, outUsdPerMt: 0.60 },
+  'openai/gpt-4o': { inUsdPerMt: 2.50, outUsdPerMt: 10.00 },
+  'anthropic/claude-3.5-sonnet': { inUsdPerMt: 3.00, outUsdPerMt: 15.00 },
+  'anthropic/claude-3.5-haiku': { inUsdPerMt: 0.80, outUsdPerMt: 4.00 },
+};
+
+export interface RecordRunInput {
+  skillName: string;
+  pid?: number;
+  startedAt: Date;
+  finishedAt: Date;
+  exitCode: number;
+  tokensIn?: number;
+  tokensOut?: number;
+  model?: string;
+  outcome: 'success' | 'no_work' | 'partial' | 'tool_error' | 'api_error' | 'timeout' | 'budget_aborted';
+  errorExcerpt?: string;
+  preflightBalanceUsd?: number;
+  preflightTodaySpendUsd?: number;
+}
+
+@Injectable()
+export class AgentRunsService {
+  private readonly logger = new Logger(AgentRunsService.name);
+
+  constructor(private readonly prisma: DatabaseService) {}
+
+  async recordRun(input: RecordRunInput) {
+    const durationMs = input.finishedAt.getTime() - input.startedAt.getTime();
+    const costMicrodollars = this.computeCostMicrodollars(
+      input.model,
+      input.tokensIn,
+      input.tokensOut,
+    );
+    return this.prisma.agentRun.create({
+      data: {
+        skillName: input.skillName,
+        pid: input.pid,
+        startedAt: input.startedAt,
+        finishedAt: input.finishedAt,
+        durationMs,
+        exitCode: input.exitCode,
+        tokensIn: input.tokensIn ?? null,
+        tokensOut: input.tokensOut ?? null,
+        costMicrodollars,
+        model: input.model ?? null,
+        outcome: input.outcome,
+        errorExcerpt: input.errorExcerpt?.slice(0, 1024) ?? null,
+        preflightBalanceUsd: input.preflightBalanceUsd ?? null,
+        preflightTodaySpendUsd: input.preflightTodaySpendUsd ?? null,
+      },
+    });
+  }
+
+  async getTodaySpendUsd(): Promise<number> {
+    const startOfUtcDay = new Date();
+    startOfUtcDay.setUTCHours(0, 0, 0, 0);
+    const result = await this.prisma.agentRun.aggregate({
+      _sum: { costMicrodollars: true },
+      where: { startedAt: { gte: startOfUtcDay } },
+    });
+    const micros = result._sum.costMicrodollars ?? 0;
+    return micros / 1_000_000;
+  }
+
+  private computeCostMicrodollars(
+    model: string | undefined,
+    tokensIn: number | undefined,
+    tokensOut: number | undefined,
+  ): number | null {
+    if (!model || tokensIn == null || tokensOut == null) return null;
+    const rate = MODEL_RATES[model];
+    if (!rate) {
+      this.logger.warn(`No rate table entry for model ${model}; cost will be null`);
+      return null;
+    }
+    // (tokens × USD/MT) gives USD; multiply by 1e6 to get microdollars; divide by 1e6 to undo MT.
+    // Net: tokens × USD/MT = microdollars.
+    const inMicros = tokensIn * rate.inUsdPerMt;
+    const outMicros = tokensOut * rate.outUsdPerMt;
+    return Math.round(inMicros + outMicros);
+  }
+}
+```
+
+- [ ] **Step 4: Create the module wiring**
+
+Create `middleware/src/modules/agents/agent-runs.module.ts`:
+
+```typescript
+import { Module } from '@nestjs/common';
+import { AgentRunsService } from './agent-runs.service';
+import { AgentRunsController } from './agent-runs.controller';
+import { DatabaseModule } from '../database/database.module';
+
+@Module({
+  imports: [DatabaseModule],
+  providers: [AgentRunsService],
+  controllers: [AgentRunsController],
+  exports: [AgentRunsService],
+})
+export class AgentRunsModule {}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run:
+```bash
+pnpm --filter @vizora/middleware test -- --testPathPattern=agent-runs.service.spec
+```
+
+Expected: PASS — 4 tests passing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add middleware/src/modules/agents/agent-runs.{service,module}.ts middleware/src/modules/agents/__tests__/agent-runs.service.spec.ts
+git commit -m "feat(agents): AgentRunsService with cost computation and daily spend aggregate"
+```
+
+---
+
+### Task P0.3: Implement `AgentRunsController` (POST /internal/agent-runs)
+
+**Files:**
+- Create: `middleware/src/modules/agents/agent-runs.controller.ts`
+- Create: `middleware/src/modules/agents/dto/record-run.dto.ts`
+- Modify: `middleware/src/app.module.ts` (register AgentRunsModule)
+- Test: `middleware/src/modules/agents/__tests__/agent-runs.controller.e2e-spec.ts`
+
+- [ ] **Step 1: Write the E2E test (failing)**
+
+Create `middleware/src/modules/agents/__tests__/agent-runs.controller.e2e-spec.ts`:
+
+```typescript
+import { Test } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../../../app.module';
+
+describe('AgentRunsController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('POST /internal/agent-runs returns 401 without internal secret', async () => {
+    await request(app.getHttpServer())
+      .post('/api/v1/internal/agent-runs')
+      .send({ skillName: 'test' })
+      .expect(401);
+  });
+
+  it('POST /internal/agent-runs persists a run with valid secret', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/api/v1/internal/agent-runs')
+      .set('x-internal-api-key', process.env.INTERNAL_API_SECRET!)
+      .send({
+        skillName: 'vizora-test',
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date().toISOString(),
+        exitCode: 0,
+        tokensIn: 1000,
+        tokensOut: 200,
+        model: 'openai/gpt-4o-mini',
+        outcome: 'success',
+      })
+      .expect(201);
+    expect(res.body.id).toBeDefined();
+  });
+
+  it('POST /internal/agent-runs validates outcome enum', async () => {
+    await request(app.getHttpServer())
+      .post('/api/v1/internal/agent-runs')
+      .set('x-internal-api-key', process.env.INTERNAL_API_SECRET!)
+      .send({
+        skillName: 'vizora-test',
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date().toISOString(),
+        exitCode: 0,
+        outcome: 'INVALID_OUTCOME',
+      })
+      .expect(400);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+pnpm --filter @vizora/middleware test:e2e -- --testPathPattern=agent-runs.controller
+```
+
+Expected: FAIL — controller doesn't exist.
+
+- [ ] **Step 3: Implement the DTO**
+
+Create `middleware/src/modules/agents/dto/record-run.dto.ts`:
+
+```typescript
+import { IsString, IsOptional, IsInt, IsIn, IsISO8601, IsNumber, Min, MaxLength } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export const RUN_OUTCOMES = [
+  'success',
+  'no_work',
+  'partial',
+  'tool_error',
+  'api_error',
+  'timeout',
+  'budget_aborted',
+] as const;
+export type RunOutcome = typeof RUN_OUTCOMES[number];
+
+export class RecordRunDto {
+  @IsString()
+  skillName!: string;
+
+  @IsOptional() @IsInt()
+  pid?: number;
+
+  @IsISO8601()
+  startedAt!: string;
+
+  @IsISO8601()
+  finishedAt!: string;
+
+  @IsInt()
+  exitCode!: number;
+
+  @IsOptional() @IsInt() @Min(0)
+  tokensIn?: number;
+
+  @IsOptional() @IsInt() @Min(0)
+  tokensOut?: number;
+
+  @IsOptional() @IsString()
+  model?: string;
+
+  @IsIn(RUN_OUTCOMES)
+  outcome!: RunOutcome;
+
+  @IsOptional() @IsString() @MaxLength(1024)
+  errorExcerpt?: string;
+
+  @IsOptional() @IsNumber()
+  preflightBalanceUsd?: number;
+
+  @IsOptional() @IsNumber()
+  preflightTodaySpendUsd?: number;
+}
+```
+
+- [ ] **Step 4: Implement the controller**
+
+Create `middleware/src/modules/agents/agent-runs.controller.ts`:
+
+```typescript
+import { Controller, Post, Body, UseGuards, HttpCode } from '@nestjs/common';
+import { AgentRunsService } from './agent-runs.service';
+import { RecordRunDto } from './dto/record-run.dto';
+import { InternalSecretGuard } from '../common/guards/internal-secret.guard';
+
+@Controller('internal/agent-runs')
+@UseGuards(InternalSecretGuard)
+export class AgentRunsController {
+  constructor(private readonly service: AgentRunsService) {}
+
+  @Post()
+  @HttpCode(201)
+  async record(@Body() dto: RecordRunDto) {
+    const run = await this.service.recordRun({
+      ...dto,
+      startedAt: new Date(dto.startedAt),
+      finishedAt: new Date(dto.finishedAt),
+    });
+    return { id: run.id };
+  }
+}
+```
+
+- [ ] **Step 5: Create `InternalSecretGuard` (verified missing 2026-05-08)**
+
+Reviewer 2 confirmed: there is NO existing inbound `InternalSecretGuard` in this codebase. The `x-internal-api-key` header is currently used only for OUTBOUND calls (middleware → realtime). This task creates the inbound version.
+
+**Files:**
+- Create: `middleware/src/modules/common/guards/internal-secret.guard.ts`
+- Test: `middleware/src/modules/common/guards/internal-secret.guard.spec.ts`
+
+Implementation:
+
+```typescript
+// middleware/src/modules/common/guards/internal-secret.guard.ts
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+  Logger,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type { Request } from 'express';
+
+/**
+ * Guards routes that should only be callable by other Vizora services
+ * (the runner script, ops agents). Matches the existing OUTBOUND
+ * convention used by middleware → realtime: header `x-internal-api-key`,
+ * value compared against `INTERNAL_API_SECRET` env via constant-time
+ * compare.
+ *
+ * Returns 401 (not 403) on mismatch — these endpoints should not
+ * acknowledge their existence to anyone without the secret.
+ */
+@Injectable()
+export class InternalSecretGuard implements CanActivate {
+  private readonly logger = new Logger(InternalSecretGuard.name);
+
+  constructor(private readonly config: ConfigService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const expected = this.config.get<string>('INTERNAL_API_SECRET');
+    if (!expected) {
+      // Misconfiguration — fail closed in prod, log loudly.
+      this.logger.error('INTERNAL_API_SECRET not set — refusing all internal calls');
+      throw new UnauthorizedException();
+    }
+    const req = context.switchToHttp().getRequest<Request>();
+    const provided = req.headers['x-internal-api-key'];
+    if (typeof provided !== 'string' || !this.constantTimeEquals(provided, expected)) {
+      throw new UnauthorizedException();
+    }
+    return true;
+  }
+
+  /**
+   * Constant-time string comparison to prevent timing attacks on the secret.
+   */
+  private constantTimeEquals(a: string, b: string): boolean {
+    if (a.length !== b.length) return false;
+    let result = 0;
+    for (let i = 0; i < a.length; i++) {
+      result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+    }
+    return result === 0;
+  }
+}
+```
+
+Tests:
+
+```typescript
+// middleware/src/modules/common/guards/internal-secret.guard.spec.ts
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { UnauthorizedException, ExecutionContext } from '@nestjs/common';
+import { InternalSecretGuard } from './internal-secret.guard';
+
+describe('InternalSecretGuard', () => {
+  let guard: InternalSecretGuard;
+
+  function makeCtx(headerValue: string | undefined): ExecutionContext {
+    return {
+      switchToHttp: () => ({
+        getRequest: () => ({ headers: headerValue !== undefined ? { 'x-internal-api-key': headerValue } : {} }),
+      }),
+    } as unknown as ExecutionContext;
+  }
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        InternalSecretGuard,
+        { provide: ConfigService, useValue: { get: jest.fn(() => 'test-secret-1234') } },
+      ],
+    }).compile();
+    guard = module.get(InternalSecretGuard);
+  });
+
+  it('allows requests with matching header', () => {
+    expect(guard.canActivate(makeCtx('test-secret-1234'))).toBe(true);
+  });
+
+  it('rejects with 401 when header missing', () => {
+    expect(() => guard.canActivate(makeCtx(undefined))).toThrow(UnauthorizedException);
+  });
+
+  it('rejects with 401 when header mismatched', () => {
+    expect(() => guard.canActivate(makeCtx('wrong-secret'))).toThrow(UnauthorizedException);
+  });
+
+  it('rejects with 401 when INTERNAL_API_SECRET env not set', async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        InternalSecretGuard,
+        { provide: ConfigService, useValue: { get: jest.fn(() => undefined) } },
+      ],
+    }).compile();
+    const g = module.get(InternalSecretGuard);
+    expect(() => g.canActivate(makeCtx('any-value'))).toThrow(UnauthorizedException);
+  });
+});
+```
+
+Run the spec to verify it passes:
+
+```bash
+pnpm --filter @vizora/middleware test -- --testPathPattern=internal-secret.guard.spec
+```
+
+Expected: 4 tests passing.
+
+The existing OUTBOUND callers (`displays.service.ts:54`, `fleet.service.ts:214`, `playlists.service.ts:33`, `notifications.service.ts:244`) that send `x-internal-api-key` are unchanged — this guard receives the same header at the inbound side.
+
+- [ ] **Step 6: Register the module in app.module.ts**
+
+Modify `middleware/src/app.module.ts` to add `AgentRunsModule` to imports.
+
+- [ ] **Step 7: Run E2E tests to verify they pass**
+
+Run:
+```bash
+pnpm --filter @vizora/middleware test:e2e -- --testPathPattern=agent-runs.controller
+```
+
+Expected: PASS — 3 tests passing.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add middleware/src/modules/agents/ middleware/src/app.module.ts
+git commit -m "feat(agents): POST /internal/agent-runs endpoint with auth + validation"
+```
+
+---
+
+### Task P0.4: Pre-flight balance check in runner
+
+**Files:**
+- Create: `scripts/agents/hermes/lib/openrouter-balance.sh`
+- Modify: `scripts/agents/hermes/run-hermes-skill.sh`
+
+- [ ] **Step 1: Implement the balance-check helper**
+
+Create `scripts/agents/hermes/lib/openrouter-balance.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Query OpenRouter for current credit balance. Echoes USD as a decimal string.
+# Returns 1 if the API call fails (caller can decide whether to abort or proceed).
+#
+# Usage: source openrouter-balance.sh; balance=$(openrouter_balance_usd) || exit 1
+#
+# Reads OPENROUTER_API_KEY from environment.
+
+openrouter_balance_usd() {
+  local response
+  response=$(curl -fsS \
+    --max-time 5 \
+    -H "Authorization: Bearer ${OPENROUTER_API_KEY}" \
+    https://openrouter.ai/api/v1/credits 2>/dev/null) || return 1
+  # Response shape: {"data":{"total_credits":N,"total_usage":M}} — balance = N - M.
+  echo "$response" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)["data"]
+print(f"{d[\"total_credits\"] - d[\"total_usage\"]:.4f}")
+'
+}
+```
+
+- [ ] **Step 2: Test the balance helper manually on prod (read-only)**
+
+```bash
+ssh root@vizora.cloud 'source /opt/vizora/app/scripts/agents/hermes/lib/openrouter-balance.sh && set -a; source /root/.hermes/.env; set +a; openrouter_balance_usd' > .ssh_balance.txt 2>&1
+cat .ssh_balance.txt
+```
+
+Expected: a decimal number (e.g. `0.0000` or `5.2341`).
+
+- [ ] **Step 3: Modify `run-hermes-skill.sh` to abort below threshold**
+
+Edit `scripts/agents/hermes/run-hermes-skill.sh`. After line 38 (`LOG=...`) and before line 40 (`START=...`), insert:
+
+```bash
+# ============================================================================
+# Pre-flight: refuse to start if OpenRouter balance is below MIN_BALANCE_USD
+# OR if today's app-level spend already exceeds DAILY_BUDGET_USD.
+# Both gates are configurable via env (see ecosystem.config.js).
+# ============================================================================
+
+# shellcheck source=lib/openrouter-balance.sh
+source "$(dirname "$0")/lib/openrouter-balance.sh"
+
+MIN_BALANCE_USD="${MIN_BALANCE_USD:-0.50}"
+DAILY_BUDGET_USD="${DAILY_BUDGET_USD:-1.00}"
+MIDDLEWARE_URL="${MIDDLEWARE_URL:-http://localhost:3000}"
+INTERNAL_SECRET="${INTERNAL_API_SECRET:-}"
+
+PREFLIGHT_BALANCE=$(openrouter_balance_usd 2>/dev/null || echo "")
+if [[ -n "$PREFLIGHT_BALANCE" ]]; then
+  if (( $(echo "$PREFLIGHT_BALANCE < $MIN_BALANCE_USD" | bc -l) )); then
+    {
+      echo "─────────────────────────────────────────"
+      echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ABORT skill=$SKILL reason=balance_too_low balance=$PREFLIGHT_BALANCE min=$MIN_BALANCE_USD"
+    } >> "$LOG"
+    # Record budget_aborted run (best-effort).
+    NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    curl -fsS -X POST \
+      -H "Content-Type: application/json" \
+      -H "x-internal-api-key: $INTERNAL_SECRET" \
+      -d "{\"skillName\":\"$SKILL\",\"startedAt\":\"$NOW\",\"finishedAt\":\"$NOW\",\"exitCode\":0,\"outcome\":\"budget_aborted\",\"preflightBalanceUsd\":$PREFLIGHT_BALANCE}" \
+      "$MIDDLEWARE_URL/api/v1/internal/agent-runs" > /dev/null 2>&1 || true
+    exit 0
+  fi
+fi
+
+# Check today's app-level spend.
+PREFLIGHT_TODAY_SPEND=$(curl -fsS --max-time 3 \
+  -H "x-internal-api-key: $INTERNAL_SECRET" \
+  "$MIDDLEWARE_URL/api/v1/internal/agent-runs/today-spend" 2>/dev/null \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin).get("usd", 0))' 2>/dev/null \
+  || echo "0")
+
+if (( $(echo "$PREFLIGHT_TODAY_SPEND >= $DAILY_BUDGET_USD" | bc -l) )); then
+  {
+    echo "─────────────────────────────────────────"
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ABORT skill=$SKILL reason=daily_budget_exceeded today_spend=$PREFLIGHT_TODAY_SPEND budget=$DAILY_BUDGET_USD"
+  } >> "$LOG"
+  NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  curl -fsS -X POST \
+    -H "Content-Type: application/json" \
+    -H "x-internal-api-key: $INTERNAL_SECRET" \
+    -d "{\"skillName\":\"$SKILL\",\"startedAt\":\"$NOW\",\"finishedAt\":\"$NOW\",\"exitCode\":0,\"outcome\":\"budget_aborted\",\"preflightTodaySpendUsd\":$PREFLIGHT_TODAY_SPEND}" \
+    "$MIDDLEWARE_URL/api/v1/internal/agent-runs" > /dev/null 2>&1 || true
+  exit 0
+fi
+```
+
+- [ ] **Step 4: Add the `today-spend` GET endpoint to the controller**
+
+Modify `middleware/src/modules/agents/agent-runs.controller.ts` to add:
+
+```typescript
+@Get('today-spend')
+async todaySpend() {
+  const usd = await this.service.getTodaySpendUsd();
+  return { usd };
+}
+```
+
+Add `Get` to the imports.
+
+Update `agent-runs.controller.e2e-spec.ts` to add a test for `GET /internal/agent-runs/today-spend` returning `{ usd: number }`.
+
+- [ ] **Step 5: Run E2E tests**
+
+Run:
+```bash
+pnpm --filter @vizora/middleware test:e2e -- --testPathPattern=agent-runs.controller
+```
+
+Expected: PASS — 4 tests passing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/agents/hermes/ middleware/src/modules/agents/agent-runs.controller.ts middleware/src/modules/agents/__tests__/agent-runs.controller.e2e-spec.ts
+git commit -m "feat(agents): pre-flight balance + daily-budget check in runner script"
+```
+
+---
+
+### Task P0.5: Per-firing metrics — runner-recorded + Hermes-native cost source
+
+**Hermes-first decision (§1.5), now committed to ONE path:**
+
+The original draft carried both a `hermes insights` sidecar AND a regex fallback parser. Reviewer 1: pick one. **We commit to the sidecar.** No regex fallback. If `hermes insights` output format changes across versions, the parser is a versioned contract that fails loudly in CI (see Risk Register: Hermes version pinning).
+
+- **Per-firing metadata** (skillName, pid, startedAt, finishedAt, exitCode, outcome) — recorded by the runner script (deterministic at the runner layer; no Hermes parsing).
+- **Token usage + cost + model** — sourced EXCLUSIVELY from `hermes insights --days 1 --source cli`. A sidecar process polls every 5 min, parses the boxed-unicode-table output via stable Python regex, and back-fills `tokensIn`/`tokensOut`/`costMicrodollars`/`model` onto `agent_runs` rows by joining on session ID (if Hermes emits one in stdout) or time-range + skill name (fallback join key).
+- **Tool-call outcome refinement** — sidecar also reads `mcp_audit_log` for the firing's window and updates `agent_runs.outcome` to `tool_error` if any FORBIDDEN/INVALID_INPUT rows exist for the same `agentName` + time window.
+
+Clean separation: the runner writes the row immediately on firing completion (so `outcome='budget_aborted'` works even when Hermes was never invoked); the cost sidecar enriches it 5 min later.
+
+**Files:**
+- Create: `scripts/agents/hermes/lib/record-run.sh` (runner-side metadata recorder)
+- Create: `scripts/agents/hermes/poll-insights.ts` (sidecar — runs as PM2 cron, polls `hermes insights`, posts cost deltas)
+- Modify: `scripts/agents/hermes/run-hermes-skill.sh` (call `record-run.sh` post-flight)
+- Modify: `middleware/src/modules/agents/agent-runs.controller.ts` (add `PATCH /:id` for cost enrichment)
+- Modify: `ecosystem.config.js` (new `hermes-insights-poller` PM2 cron entry)
+
+- [ ] **Step 1: Inspect `hermes insights` output format**
+
+```bash
+ssh root@vizora.cloud 'hermes insights --days 1 --source cli 2>&1 | head -60' > .ssh_insights_format.txt 2>&1
+cat .ssh_insights_format.txt
+```
+
+Document the output format (JSON vs text vs table). If JSON: parse directly. If text/table: use a stable parser (Python regex) and fall back to `hermes logs --component agent --since N`.
+
+- [ ] **Step 2: Investigate Hermes session-ID emission**
+
+Each `hermes -z` invocation has a session id. Find where it's printed:
+
+```bash
+ssh root@vizora.cloud 'grep -iE "session.{0,3}(id|=)" /var/log/hermes/runner/vizora-customer-lifecycle.log | head -3' > .ssh_session_id.txt 2>&1
+cat .ssh_session_id.txt
+```
+
+If Hermes prints `session_id=X` in its output, the runner can capture it and pass it as a join key to the sidecar. If not, the sidecar joins by time-range + skill name.
+
+- [ ] **Step 1: Inspect actual Hermes output format on prod**
+
+```bash
+ssh root@vizora.cloud 'tail -200 /var/log/hermes/runner/vizora-customer-lifecycle.log | grep -iE "token|usage|generation" | head -20' > .ssh_hermes_format.txt 2>&1
+cat .ssh_hermes_format.txt
+```
+
+Document the output format observed in a comment at the top of `parse-hermes-output.sh`. If Hermes does not emit token counts, skip Step 2 and use the OpenRouter generation-API approach instead.
+
+- [ ] **Step 2: Implement the parser**
+
+Create `scripts/agents/hermes/lib/parse-hermes-output.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Extract token counts and model from Hermes runner output for a single firing.
+# Echoes JSON: {"tokensIn":N,"tokensOut":M,"model":"X"} or {} if unparseable.
+#
+# Hermes turn-end summary format (verified on prod 2026-05-08):
+#   <ACTUAL FORMAT TO BE FILLED IN AFTER STEP 1>
+#
+# Usage: parse_hermes_run < hermes_output.log
+
+parse_hermes_run() {
+  python3 <<'PY'
+import re, sys, json
+
+text = sys.stdin.read()
+# Adjust patterns based on Step 1 findings.
+# Common Hermes formats include:
+#   "tokens: in=N out=M model=X"
+#   "[usage] prompt=N completion=M"
+# Sum across all turns of a single firing.
+
+tokens_in_pat = re.compile(r'(?:prompt|input)[\s_=:]+(\d+)', re.I)
+tokens_out_pat = re.compile(r'(?:completion|output)[\s_=:]+(\d+)', re.I)
+model_pat = re.compile(r'model[\s=:]+([\w\-/.]+)', re.I)
+
+tokens_in = sum(int(m.group(1)) for m in tokens_in_pat.finditer(text))
+tokens_out = sum(int(m.group(1)) for m in tokens_out_pat.finditer(text))
+model_match = model_pat.search(text)
+
+result = {}
+if tokens_in: result['tokensIn'] = tokens_in
+if tokens_out: result['tokensOut'] = tokens_out
+if model_match: result['model'] = model_match.group(1)
+print(json.dumps(result))
+PY
+}
+```
+
+- [ ] **Step 3: Implement the recorder**
+
+Create `scripts/agents/hermes/lib/record-run.sh`:
+
+```bash
+#!/usr/bin/env bash
+# POST a completed run's metrics to the middleware. Best-effort —
+# never fails the runner.
+
+record_run() {
+  local skill="$1"
+  local pid="$2"
+  local started_at="$3"
+  local finished_at="$4"
+  local exit_code="$5"
+  local outcome="$6"
+  local preflight_balance="$7"
+  local preflight_today_spend="$8"
+  local hermes_log_path="$9"
+
+  local middleware_url="${MIDDLEWARE_URL:-http://localhost:3000}"
+  local secret="${INTERNAL_API_SECRET:-}"
+
+  # Parse token counts from the firing's output (last invocation only — bracketed
+  # by the most recent "[start ...]" marker).
+  local parsed
+  parsed=$(awk '/^\[.*start skill=/{buf=""} {buf=buf"\n"$0} END{print buf}' "$hermes_log_path" \
+    | bash "$(dirname "$0")/parse-hermes-output.sh" 2>/dev/null \
+    || echo "{}")
+  # Compose JSON body. Use jq if available; fall back to python.
+  local body
+  body=$(python3 <<PY
+import json
+parsed = json.loads('$parsed' or '{}')
+body = {
+  "skillName": "$skill",
+  "pid": int("$pid") if "$pid" else None,
+  "startedAt": "$started_at",
+  "finishedAt": "$finished_at",
+  "exitCode": int("$exit_code"),
+  "outcome": "$outcome",
+}
+for k in ("tokensIn", "tokensOut", "model"):
+  if k in parsed: body[k] = parsed[k]
+if "$preflight_balance": body["preflightBalanceUsd"] = float("$preflight_balance")
+if "$preflight_today_spend": body["preflightTodaySpendUsd"] = float("$preflight_today_spend")
+print(json.dumps({k: v for k, v in body.items() if v is not None}))
+PY
+)
+
+  curl -fsS --max-time 3 -X POST \
+    -H "Content-Type: application/json" \
+    -H "x-internal-api-key: $secret" \
+    -d "$body" \
+    "$middleware_url/api/v1/internal/agent-runs" > /dev/null 2>&1 || true
+}
+```
+
+- [ ] **Step 4: Wire post-flight into `run-hermes-skill.sh`**
+
+After the `RC=$?` line in `run-hermes-skill.sh`, add:
+
+```bash
+# Classify outcome from exit code + log content + audit cross-reference.
+#
+# IMPORTANT (Reviewer 2): FORBIDDEN/INVALID_INPUT strings live in
+# mcp_audit_log, NOT in Hermes stdout. The runner cannot detect tool_error
+# from log text alone. Tool-error classification is therefore done LATER
+# by the cost-sidecar process (P0.5 Step 7) when it joins the agent_runs
+# row to mcp_audit_log entries for the same firing window. Initial
+# outcome here is best-effort from Hermes-visible signals only.
+OUTCOME="success"
+if [[ $RC -eq 124 ]]; then
+  OUTCOME="timeout"
+elif [[ $RC -ne 0 ]]; then
+  OUTCOME="api_error"
+elif grep -q "HTTP 402\|HTTP 429\|HTTP 5[0-9][0-9]" "$LOG"; then
+  OUTCOME="api_error"
+fi
+# Note: 'tool_error' and 'partial' classifications are added by the
+# sidecar polling cron (P0.5 Step 7) which has access to mcp_audit_log.
+# The runner intentionally does NOT grep for FORBIDDEN/INVALID_INPUT
+# because those strings won't appear in Hermes stdout.
+
+# shellcheck source=lib/record-run.sh
+source "$(dirname "$0")/lib/record-run.sh"
+record_run "$SKILL" "$$" "$START" "$END" "$RC" "$OUTCOME" "$PREFLIGHT_BALANCE" "$PREFLIGHT_TODAY_SPEND" "$LOG"
+```
+
+- [ ] **Step 5: Test locally on prod (with agents stopped)**
+
+The agents are deleted from PM2, so this test runs the runner manually once to verify metrics flow:
+
+```bash
+ssh root@vizora.cloud 'set -a; source /root/.hermes/.env; set +a; cd /opt/vizora/app && bash scripts/agents/hermes/run-hermes-skill.sh vizora-customer-lifecycle "Run end-to-end now."' > .ssh_runner_test.txt 2>&1
+cat .ssh_runner_test.txt
+```
+
+Then check the middleware:
+```bash
+ssh root@vizora.cloud 'docker exec -i vizora-postgres psql -U postgres -d vizora -c "SELECT \"skillName\", outcome, \"durationMs\", \"tokensIn\", \"tokensOut\", \"costMicrodollars\", \"errorExcerpt\" FROM agent_runs ORDER BY \"createdAt\" DESC LIMIT 1;"' > .ssh_run_record.txt 2>&1
+cat .ssh_run_record.txt
+```
+
+Expected: a row exists with `outcome='budget_aborted'` (because credits are 0). The pre-flight check did its job.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/agents/hermes/
+git commit -m "feat(agents): post-flight metrics extraction and recording"
+```
+
+---
+
+### Task P0.6: Grafana dashboard + Prometheus alert rules
+
+**Files:**
+- Create: `docker/grafana/dashboards/agents-cost.json`
+- Create: `docker/prometheus/rules/agents.yml`
+- Modify: `docker/prometheus/prometheus.yml` (include the new rule file)
+
+- [ ] **Step 1: Define the queries**
+
+The dashboard needs four panels driven from `agent_runs`:
+1. Cost per agent per hour (last 24h) — `SUM(costMicrodollars) / 1e6 GROUP BY skillName, time(1h)`
+2. Outcome distribution (last 24h) — `COUNT(*) GROUP BY outcome, skillName`
+3. P50/P95 firing latency — `PERCENTILE(durationMs, 0.95) GROUP BY skillName, time(15m)`
+4. Today's spend vs daily budget — single-stat panel with threshold at `DAILY_BUDGET_USD`
+
+Choice: query Postgres directly via Grafana's PG datasource (already wired for ops dashboards). Avoid Prometheus exporters — `agent_runs` is low-cardinality append-only, perfect for SQL.
+
+- [ ] **Step 2: Build the dashboard JSON**
+
+Create `docker/grafana/dashboards/agents-cost.json`. Use the existing `vizora-overview.json` (referenced in CLAUDE.md autonomous-ops section) as a structural template. Four panels as above, datasource `vizora-postgres`.
+
+(Plan-detail expansion: deferred until execution — copy + edit existing dashboard JSON in IDE, rather than hand-writing 600 lines of JSON in this plan.)
+
+- [ ] **Step 3: Define Prometheus alerting rules**
+
+Create `docker/prometheus/rules/agents.yml`:
+
+```yaml
+groups:
+  - name: vizora-agents
+    interval: 60s
+    rules:
+      - alert: AgentDailyBudgetExceeded
+        expr: |
+          sum(rate(vizora_agent_cost_microdollars[1d])) / 1e6 > 1.00
+        for: 5m
+        labels:
+          severity: critical
+          team: platform
+        annotations:
+          summary: "Agent daily spend exceeded $1.00 USD"
+          description: "Today's agent spend is {{ $value | printf \"%.2f\" }} USD."
+
+      - alert: AgentNoFiringsForCron
+        expr: |
+          time() - max(vizora_agent_run_last_started_seconds) by (skill_name) > 3 * 900
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Agent {{ $labels.skill_name }} has not fired in 3× cron interval"
+
+      - alert: AgentErrorRateHigh
+        expr: |
+          (
+            sum(rate(vizora_agent_runs_total{outcome=~"tool_error|api_error|timeout"}[15m]))
+            /
+            sum(rate(vizora_agent_runs_total[15m]))
+          ) > 0.05
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Agent error rate >5% over 15min"
+```
+
+This depends on a Postgres → Prometheus exporter (or equivalent metric emission from middleware). Two options:
+
+**Option A (recommended):** middleware exposes Prometheus metrics on `/internal/metrics` (METRICS_TOKEN already exists per CLAUDE.md). Add a counter `vizora_agent_cost_microdollars_total` and gauge `vizora_agent_run_last_started_seconds` updated whenever `recordRun` is called.
+
+**Option B (faster):** scrap Prometheus rules; use Grafana alerts directly on the Postgres datasource. Skip this file. Loses the `/metrics` standard but ships in 1 hour instead of 1 day.
+
+**Decision (this plan):** Option B for now. Add the Prometheus exporter in P3 alongside the promotion machinery (which also benefits from metrics). Track in `tasks/feature-backlog.md` under "agent metrics exporter."
+
+- [ ] **Step 4: Configure Grafana alerts**
+
+In `agents-cost.json`, attach alert rules to:
+- Daily-spend single-stat: alert when value > $1.00 for 5min, route to Slack via existing webhook.
+- Outcome panel: alert when `tool_error + api_error + timeout` > 5% of total over 15min.
+
+- [ ] **Step 5: Deploy dashboard**
+
+Grafana auto-loads dashboards from the mounted directory. Restart Grafana container:
+```bash
+docker compose -f docker/docker-compose.yml restart grafana
+```
+
+Verify the dashboard appears at `http://localhost:3003/d/agents-cost`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docker/grafana/dashboards/agents-cost.json docker/prometheus/rules/agents.yml
+git commit -m "feat(agents): Grafana dashboard + alert rules for agent cost and errors"
+```
+
+---
+
+### Task P0.7: Set OpenRouter daily cap (manual UI step)
+
+This is operator action, not code. Document it in the runbook:
+
+- [ ] **Step 1: Set daily cap via OpenRouter UI**
+
+Sri (or whoever owns the OpenRouter account):
+1. Open https://openrouter.ai/settings/keys
+2. Locate the API key used by Vizora Hermes (matches the suffix in `/root/.hermes/.env`)
+3. Set "Per-day spend limit" to **$2.00 USD**
+4. Save.
+
+This is the hard ceiling. Even if all four downstream layers fail, OpenRouter will return 429 once the cap is hit.
+
+- [ ] **Step 2: Document the cap value in `CLAUDE.md`**
+
+Add a one-line note under "Hermes Agent runtime (prod VPS)":
+
+> OpenRouter API key has a hard $2.00/day spend cap. Increase via dashboard if intentional.
+
+Commit:
+```bash
+git add CLAUDE.md
+git commit -m "docs(hermes): document OpenRouter $2/day spend cap"
+```
+
+---
+
+### P0 Acceptance Test
+
+Before declaring P0 complete, all of these must hold:
+
+- [ ] `agent_runs` table exists in prod DB
+- [ ] `pnpm --filter @vizora/middleware test` passes (including new agent-runs tests)
+- [ ] `pnpm --filter @vizora/middleware test:e2e -- --testPathPattern=agent-runs.controller` passes
+- [ ] Manually invoking `run-hermes-skill.sh` on prod with credits=0 results in: outcome='budget_aborted' row in agent_runs, exit code 0, no Hermes invocation
+- [ ] Grafana dashboard at `/d/agents-cost` displays the budget_aborted run
+- [ ] Grafana alert fires (manual test: insert a synthetic high-cost row, verify Slack notification within 5 min)
+- [ ] OpenRouter UI cap is set to $2/day
+
+Once all green: **system is safe to add credits.** P1 is needed before re-enabling agents.
+
+---
+
+## Phase 1 — Tool Authorization & Token Contradiction Fix
+
+**Goal:** Eliminate model-wandering loss vector. Each skill sees only its tools. Resolve the support-triage token-scope contradiction.
+
+**Architecture:**
+- Hermes `platform_toolsets` config restricts tools per skill at the LLM layer (model never sees forbidden tools)
+- MCP server `log_shadow_row` accepts any valid token (per-org or platform), tags rows with token's org context
+- E2E test verifies a wrong-tool call would fail at validation time, not runtime
+
+**Success criteria:**
+- Each skill's `agent_runs` row, when re-enabled, shows zero FORBIDDEN errors in the corresponding `mcp_audit_log` window
+- `log_shadow_row` accepts both token types
+- Hermes shadow agents fire end-to-end successfully on prod with credits added
+
+---
+
+### Task P1.1: Relax `log_shadow_row` to accept any valid token
+
+**Files (verified to exist with these exact shapes 2026-05-08):**
+- Modify: `middleware/src/modules/mcp/tools/shadow-log.tools.ts:42-46` (the `if (context.organizationId != null) throw new BadRequestException(...)` block)
+- Modify: `middleware/src/modules/mcp/tools/shadow-log.tools.ts:28-30` (JSDoc says "platform-scope token required")
+- Modify: `middleware/src/modules/mcp/tools/shadow-log.tools.ts:77` (tool description string says "Platform-scope token required")
+- Modify: `middleware/src/modules/mcp/tools/shadow-log.tools.spec.ts:44-54` (existing test "REJECTS per-org tokens with BadRequest" asserts the OPPOSITE of the new behavior; flip it)
+- Modify: `middleware/src/modules/mcp/audit/shadow-log.service.ts` (only if needed — tool layer can do enrichment, but service-side is preferred to keep tool layer thin)
+
+**Function shape (verified):**
+```ts
+export async function logShadowRowTool(
+  rawInput: unknown,
+  context: McpRequestContext,           // { tokenId, organizationId, agentName, scopes }
+  shadowLog: ShadowLogService,
+): Promise<LogShadowRowResultT>
+```
+
+The existing spec uses helpers `ctx({ scopes, organizationId })` and `makeShadowLog({ appendRow? })` — reuse these patterns rather than introducing new mocks.
+
+- [ ] **Step 1: Confirm the change site**
+
+```bash
+grep -n -B 1 -A 8 "organizationId != null" middleware/src/modules/mcp/tools/shadow-log.tools.ts
+grep -n "REJECTS per-org" middleware/src/modules/mcp/tools/shadow-log.tools.spec.ts
+```
+
+Expected: lines 42-46 in the source; line 44 in the spec.
+
+- [ ] **Step 2: Flip the existing rejection test + add three new behavior tests**
+
+In `middleware/src/modules/mcp/tools/shadow-log.tools.spec.ts`, REPLACE the test at lines 44-54 (`it('REJECTS per-org tokens...'`) with this expanded behavior contract:
+
+```typescript
+it('ACCEPTS per-org tokens and tags the appended row with the org context', async () => {
+  const svc = makeShadowLog({});
+  const out = await logShadowRowTool(
+    { log_name: 'vizora-customer-lifecycle-shadow', fields: { tier: 'pro' } },
+    ctx({ scopes: ['shadow:write'], organizationId: 'org_abc' }),
+    svc as never,
+  );
+  // Per-org tokens should now be valid; the row gets organization_id injected.
+  expect(svc.appendRow).toHaveBeenCalledWith(
+    'vizora-customer-lifecycle-shadow',
+    expect.objectContaining({ tier: 'pro', organization_id: 'org_abc' }),
+  );
+  expect(out.written).toBe(true);
+});
+
+it('ACCEPTS platform-scope tokens and does NOT inject organization_id', async () => {
+  const svc = makeShadowLog({});
+  await logShadowRowTool(
+    { log_name: 'vizora-customer-lifecycle-shadow', fields: { tier: 'pro' } },
+    ctx({ scopes: ['shadow:write'], organizationId: null }),
+    svc as never,
+  );
+  // Platform tokens still write but without the org tag.
+  expect(svc.appendRow).toHaveBeenCalledWith(
+    'vizora-customer-lifecycle-shadow',
+    expect.not.objectContaining({ organization_id: expect.anything() }),
+  );
+});
+
+it('does NOT overwrite an explicit organization_id field already in fields', async () => {
+  // Agent might supply organization_id explicitly (e.g., a platform-scope agent
+  // iterating over orgs). Don't clobber it with the token's null context.
+  const svc = makeShadowLog({});
+  await logShadowRowTool(
+    { log_name: 'vizora-customer-lifecycle-shadow', fields: { organization_id: 'org_xyz' } },
+    ctx({ scopes: ['shadow:write'], organizationId: 'org_abc' }),
+    svc as never,
+  );
+  // Agent-supplied value wins over token's org context.
+  expect(svc.appendRow).toHaveBeenCalledWith(
+    'vizora-customer-lifecycle-shadow',
+    expect.objectContaining({ organization_id: 'org_xyz' }),
+  );
+});
+```
+
+(The other tests in the file — scope-missing-throws, unknown log_name, path-traversal, oversize, passthrough — remain unchanged. They still pass after the platform-scope check is removed.)
+
+- [ ] **Step 3: Run tests to verify failure**
+
+```bash
+pnpm --filter @vizora/middleware test -- --testPathPattern=shadow-log.tools.spec
+```
+
+Expected: FAIL — the new "ACCEPTS per-org" test fails because the source still throws BadRequest.
+
+- [ ] **Step 4: Modify the source**
+
+In `middleware/src/modules/mcp/tools/shadow-log.tools.ts`, REMOVE the platform-scope check (lines 42-46) and add org-context injection right before the service call:
+
+```typescript
+// BEFORE (lines 39-47):
+//   if (!hasScope(context, 'shadow:write')) {
+//     throw new ForbiddenException("Token lacks scope 'shadow:write'");
+//   }
+//   if (context.organizationId != null) {                                 ← REMOVE
+//     throw new BadRequestException(                                      ← REMOVE
+//       'log_shadow_row requires a platform-scope token (organizationId=null). Per-org tokens are rejected.',
+//     );                                                                  ← REMOVE
+//   }                                                                     ← REMOVE
+//   const input = LogShadowRowInput.parse(rawInput) as LogShadowRowInputT;
+
+// AFTER:
+  if (!hasScope(context, 'shadow:write')) {
+    throw new ForbiddenException("Token lacks scope 'shadow:write'");
+  }
+  const input = LogShadowRowInput.parse(rawInput) as LogShadowRowInputT;
+
+  // Inject the token's org context into the row IFF the agent didn't already
+  // supply organization_id (agent-supplied wins). Per-org tokens get tagged;
+  // platform-scope tokens (organizationId=null) do not.
+  const fieldsWithContext = {
+    ...(context.organizationId != null ? { organization_id: context.organizationId } : {}),
+    ...(input.fields as Record<string, unknown>),
+  };
+```
+
+Then update the `shadowLog.appendRow` call to pass `fieldsWithContext` instead of `input.fields`.
+
+- [ ] **Step 5: Update the JSDoc and tool description**
+
+Replace lines 28-30 of the JSDoc:
+
+```ts
+// BEFORE: "Token shape: platform-scope token required. Per-org tokens are
+//          rejected with INVALID_INPUT — shadow logs are agent-side audit
+//          trails, not org-scoped data."
+// AFTER:  "Token shape: any valid token with `shadow:write` scope. Per-org
+//          tokens get tagged with `organization_id` in the appended row;
+//          platform-scope tokens write without the tag. Agent-supplied
+//          `organization_id` in fields takes precedence."
+```
+
+Replace the trailing sentence in the LOG_SHADOW_ROW_TOOL `description` field at line 77:
+
+```ts
+// BEFORE: "...max 4096 bytes serialized). Platform-scope token required."
+// AFTER:  "...max 4096 bytes serialized). Requires `shadow:write` scope; per-org tokens are tagged with org context, platform-scope tokens are not."
+```
+
+- [ ] **Step 6: Run tests to verify pass**
+
+```bash
+pnpm --filter @vizora/middleware test -- --testPathPattern=shadow-log.tools.spec
+```
+
+Expected: PASS — all 9 tests in the file pass (the 3 new + 6 unchanged).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add middleware/src/modules/mcp/tools/shadow-log.tools.ts middleware/src/modules/mcp/tools/shadow-log.tools.spec.ts
+git commit -m "fix(mcp): log_shadow_row accepts per-org tokens, tags rows with org context
+
+Removes the structural contradiction in support-triage's token shape: the
+agent needs per-org access for support:* tools AND shadow:write for the
+audit log. log_shadow_row now accepts any valid shadow:write token and
+enriches the row with the calling token's org context (null for platform).
+
+Eliminates the 454 INVALID_INPUT errors observed in mcp_audit_log on May 5-6."
+```
+
+---
+
+### Task P1.2: Hermes per-skill tool allowlists (via `-t` CLI flag)
+
+**Hermes-first decision (§1.5):** Hermes already supports per-invocation
+tool allowlisting via `hermes -z -t <toolsets>`. We pass the allowlist
+from the runner script per-skill rather than inventing a config-yaml
+key. This is a one-line change to `run-hermes-skill.sh` plus per-skill
+toolset constants in `ecosystem.config.js`.
+
+**Files:**
+- Modify: `scripts/agents/hermes/run-hermes-skill.sh` (add `-t` flag)
+- Modify: `ecosystem.config.js:392-435` (the `hermes-vizora-*` entries — pass toolset as third arg)
+
+- [ ] **Step 1: Verify the exact toolset names Hermes expects**
+
+The MCP tool names registered by Vizora's MCP server are namespaced.
+Hermes prefixes them as `mcp_<server-name>_<tool-name>`. Verify:
+
+```bash
+ssh root@vizora.cloud 'hermes -z --skills vizora-customer-lifecycle "list available MCP tools and exit"' > .ssh_tool_names.txt 2>&1
+# Or read from a successful prior firing's runner log:
+ssh root@vizora.cloud 'grep -oE "mcp_vizora_[a-z_]+" /var/log/hermes/runner/vizora-customer-lifecycle.log | sort -u' >> .ssh_tool_names.txt 2>&1
+cat .ssh_tool_names.txt
+```
+
+Expected: actual tool identifiers. Use these verbatim in Step 2.
+
+- [ ] **Step 2: Modify `run-hermes-skill.sh` to accept a toolset arg**
+
+Edit `scripts/agents/hermes/run-hermes-skill.sh`. Change the signature from `<skill-name> <prompt>` to `<skill-name> <prompt> [toolsets-csv]` and pass through:
+
+```bash
+SKILL="${1:-}"
+PROMPT="${2:-}"
+TOOLSETS="${3:-}"  # NEW — comma-separated MCP tool names; empty = all tools
+
+# ... existing pre-flight ...
+
+# Build the hermes invocation. -t adds the toolset filter when provided.
+HERMES_ARGS=(--skills "$SKILL" -z "$PROMPT")
+if [[ -n "$TOOLSETS" ]]; then
+  HERMES_ARGS+=(-t "$TOOLSETS")
+fi
+timeout 300 /usr/local/bin/hermes "${HERMES_ARGS[@]}" >> "$LOG" 2>&1
+RC=$?
+```
+
+- [ ] **Step 3: Update `ecosystem.config.js` to pass per-skill toolsets**
+
+Modify the two `hermes-vizora-*` entries' `args` arrays to add the toolset CSV as a third element. (Tool names verified in Step 1; placeholder shown — REPLACE with verified names.)
+
+```js
+{
+  name: 'hermes-vizora-customer-lifecycle',
+  // ...
+  args: [
+    '/opt/vizora/app/scripts/agents/hermes/run-hermes-skill.sh',
+    'vizora-customer-lifecycle',
+    'Run the vizora-customer-lifecycle skill end-to-end now. ...',
+    'mcp_vizora_list_onboarding_candidates,mcp_vizora_log_shadow_row,mcp_vizora_mark_onboarding_nudge_sent,mcp_vizora_send_lifecycle_nudge_email,mcp_vizora_auto_complete_org_onboarding',
+  ],
+  // ...
+},
+{
+  name: 'hermes-vizora-support-triage',
+  // ...
+  args: [
+    '/opt/vizora/app/scripts/agents/hermes/run-hermes-skill.sh',
+    'vizora-support-triage',
+    'Run the vizora-support-triage skill end-to-end now. ...',
+    'mcp_vizora_list_open_support_requests,mcp_vizora_log_shadow_row,mcp_vizora_update_support_request_priority,mcp_vizora_update_support_request_ai_category,mcp_vizora_create_support_message',
+  ],
+  // ...
+},
+```
+
+- [ ] **Step 4: Smoke-test on prod manually**
+
+```bash
+ssh root@vizora.cloud 'set -a; source /root/.hermes/.env; set +a; cd /opt/vizora/app && bash scripts/agents/hermes/run-hermes-skill.sh vizora-customer-lifecycle "list available tools and exit" "mcp_vizora_list_onboarding_candidates,mcp_vizora_log_shadow_row"' > .ssh_p1_smoke.txt 2>&1
+cat .ssh_p1_smoke.txt
+```
+
+Expected: Hermes lists only the two allowlisted tools. The other MCP tools should not appear in its visible toolset.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/agents/hermes/run-hermes-skill.sh ecosystem.config.js
+git commit -m "feat(hermes): per-skill tool allowlist via -t flag (eliminates model wandering)"
+```
+
+---
+
+### Task P1.3: End-to-end re-enable test (with credits added)
+
+**Pre-condition:** Sri has added at least $2 of credits to OpenRouter.
+
+- [ ] **Step 1: Re-add Hermes PM2 entries**
+
+```bash
+ssh root@vizora.cloud 'cd /opt/vizora/app && git pull && pm2 start ecosystem.config.js --only hermes-vizora-customer-lifecycle && pm2 save' > .ssh_p1_start.txt 2>&1
+cat .ssh_p1_start.txt
+```
+
+Re-add **only customer-lifecycle first.** Support-triage waits until customer-lifecycle has run cleanly twice.
+
+- [ ] **Step 2: Watch first firing**
+
+```bash
+ssh root@vizora.cloud 'tail -F /var/log/hermes/runner/vizora-customer-lifecycle.log' > .ssh_p1_watch.txt 2>&1 &
+# Wait ~60 seconds, then read
+```
+
+Expected within one cron interval (≤30 min):
+- Pre-flight balance check passes
+- `hermes -z` invokes
+- Skill executes end-to-end
+- `agent_runs` row inserted with `outcome='success'`
+- `mcp_audit_log` shows zero FORBIDDEN, zero INVALID_INPUT for this firing's window
+
+- [ ] **Step 3: Verify zero wandering**
+
+```bash
+ssh root@vizora.cloud 'docker exec -i vizora-postgres psql -U postgres -d vizora -c "SELECT tool, status, COUNT(*) FROM mcp_audit_log WHERE \"agentName\"='\''hermes-customer-lifecycle'\'' AND \"createdAt\" > NOW() - INTERVAL '\''1 hour'\'' GROUP BY tool, status ORDER BY tool;"' > .ssh_p1_audit.txt 2>&1
+cat .ssh_p1_audit.txt
+```
+
+Expected: only `list_onboarding_candidates`, `log_shadow_row`, and (if any nudge fires) the customer-write tools. No FORBIDDEN rows.
+
+- [ ] **Step 4: If clean for 2 firings, re-add support-triage**
+
+```bash
+ssh root@vizora.cloud 'pm2 start ecosystem.config.js --only hermes-vizora-support-triage && pm2 save' > .ssh_p1_start_st.txt 2>&1
+```
+
+Repeat Steps 2–3 for support-triage.
+
+- [ ] **Step 5: Document outcome in `tasks/lessons.md`**
+
+Add a section with the date, what was changed, and what the verification showed. Per CLAUDE.md global rule.
+
+---
+
+### P1 Acceptance Test
+
+- [ ] Both Hermes shadow agents firing every cron tick without FORBIDDEN/INVALID_INPUT errors
+- [ ] `agent_runs` table accumulating success rows
+- [ ] Grafana dashboard shows expected cost (<$0.05/firing) and zero error rate
+- [ ] OpenRouter balance not declining anomalously after 24h
+
+Once all green: **agents are safely re-enabled in shadow mode.** P2–P4 are quality work.
+
+---
+
+## Phase 2 — Architecture Flip (TS Orchestrator; LLM only where it earns its place)
+
+**Goal:** Demote the LLM. Deterministic TS code becomes the workflow driver. The LLM is called ONLY where the existing-data battery (CLAUDE.md global §11b) shows the heuristic is systematically wrong on a measurable bucket — never on a hunch.
+
+**Per-agent effort (revised after Reviewer 1 feedback):**
+- `customer-lifecycle`: **2–3 days** (heuristic-only — no LLM in v1)
+- `support-triage`: **2–3 weeks** (LLM-augmented, only after existing-data battery proves it's needed)
+
+**Total P2: 3–4 weeks, not "5–7 days per agent" as the previous draft claimed.** The original estimate didn't account for shadow harness, JSON-schema integration, idempotency, comparison reader, and 14d shadow soak. Reviewer 1 was right: it was fiction.
+
+### P2.A — `customer-lifecycle` becomes pure TS heuristic (no LLM)
+
+Reviewer 1 finding C6: customer-lifecycle template selection is a 5-element decision table on `daysSinceSignup` + `milestoneFlags`. An LLM is not justified for this workload. Anthropic's *Building Effective Agents* (Dec 2024) explicitly recommends "find the simplest solution possible, and only increase complexity when needed." A decision table beats any LLM here.
+
+**Architecture:**
+
+```typescript
+// scripts/agents/customer-lifecycle.ts (already exists at 463 lines, runs as PM2 cron)
+// becomes the SOLE driver. The Hermes shadow agent gets retired (or kept
+// briefly for comparison data) once this is verified.
+
+// Decision table (already encoded in the existing TS heuristic):
+//   day 1, !welcomed                                → 'welcome'
+//   day 3, !screenPaired                            → 'pair-screen'
+//   day 7, !contentUploaded                         → 'upload-content'
+//   day 14, !playlistCreated                        → 'create-playlist'
+//   day 30, any milestone missing                   → 'auto-complete' (admin notify)
+//   else                                            → 'none'
+//
+// Confidence: 1.0 always (deterministic). No LLM.
+```
+
+**Verification before committing to this:** run the existing-data battery on the May 5-6 shadow data:
+
+1. Bootstrap CI on heuristic vs Hermes shadow agreement (the 627 successful Hermes shadow rows already in `vizora-customer-lifecycle-shadow.jsonl` — vs the heuristic's 1769 rows).
+2. If agreement ≥ 95%: ship heuristic-only. LLM wasn't adding value.
+3. If agreement is lower in a SPECIFIC subset (e.g. orgs with unusual milestone patterns): scope the LLM to ONLY that subset, with structured-outputs JSON schema. Don't introduce LLM for the whole agent.
+
+**Detailed task breakdown deferred to:** `docs/plans/2026-05-08-phase-2a-customer-lifecycle.md` (written when P2 begins).
+
+**Success criteria (P2.A):**
+- `customer-lifecycle` runs as pure TS PM2 cron with NO Hermes/LLM dependency
+- P95 cost per firing: $0 (no LLM)
+- 14-day comparison vs prior Hermes shadow: ≥ 95% template-choice agreement on shared candidate set
+- 50 manually-labeled cases reach ≥ 85% agreement with the heuristic (ground-truth alignment, §5)
+- Backlog entry for "customer-lifecycle live cutover" closes — replaced by "Hermes shadow retirement"
+
+### P2.B — `support-triage` LLM-augmentation (only if data justifies)
+
+**Conditional on P2.A learnings.** support-triage has more degrees of freedom than customer-lifecycle (priority ∈ 4 buckets, category from 12+ V2 taxonomy slugs, free-text body that the heuristic only sees structurally).
+
+**Verification BEFORE designing the LLM path:** run the existing-data battery on the 1880 successful `list_open_support_requests` calls from May 5-6:
+
+1. Compute heuristic-only priority/category for each ticket.
+2. Compute Hermes-suggested priority/category from the (147 lines of) `vizora-support-triage-shadow.jsonl`.
+3. Sample 50 tickets, label by hand (ground truth).
+4. Three-way comparison: heuristic vs Hermes vs ground truth.
+5. **If heuristic alone hits ≥ 90% ground-truth agreement: skip the LLM here too.**
+6. **If heuristic is < 80% on a measurable bucket (e.g. multi-paragraph body tickets): introduce LLM ONLY for that bucket, with structured-outputs JSON schema constrained to the V2 taxonomy enum.**
+
+**Architecture (only if step 6 fires):**
+
+```typescript
+// scripts/agents/support-triage.ts (already exists at 306 lines)
+// Wrap with: heuristic first, LLM only on low-confidence subset.
+
+const heuristic = scoreHeuristic(ticket);
+if (heuristic.confidence >= 0.85) {
+  return heuristic; // ~80%+ of tickets
+}
+// LLM classifier — single call, JSON-schema-constrained output, prompt-cached prefix
+const classification = await openrouterStructured({
+  model: 'openai/gpt-4o-mini-2024-07-18', // PINNED version
+  response_format: { type: 'json_schema', schema: ClassificationSchema },
+  cache_control: [{ type: 'ephemeral' }], // skill text cached
+  messages: [/*...*/],
+});
+return classification;
+```
+
+**Detailed task breakdown deferred to:** `docs/plans/2026-05-08-phase-2b-support-triage.md` (written when P2.A ships and the existing-data battery has run).
+
+**Success criteria (P2.B — conditional):**
+- LLM invoked on ≤ 20% of tickets (the low-confidence bucket only)
+- Per-firing cost ≤ $0.005 P95
+- Heuristic+LLM hit ≥ 90% ground-truth agreement on 50 manually-labeled cases (§5 alignment criterion)
+- Zero JSON-parse failures (structured outputs guarantees this)
+- 14-day shadow soak before any cutover
+
+---
+
+## Phase 3 — Promotion Machinery (Shadow → Canary → Live)
+
+**Goal:** Replace ad-hoc cutover with automated, gated rollout. Reversible in <60s.
+
+**Effort:** 2–3 days.
+
+**Drift-check (§1.6) — partial drift confirmed:** `tasks/feature-backlog.md`
+already contains a detailed spec for the shadow-vs-heuristic comparison
+reader. Key constraints from that backlog entry that this phase MUST
+inherit (do not redesign):
+
+- **Tolerant reader, not strict-schema** — gpt-4o-mini doesn't reliably
+  copy field names verbatim; the comparison reader must extract the
+  decision from drifted output. Three SKILL prompt iterations proved
+  this on 2026-05-05.
+- **Location:** `scripts/agents/hermes/compare-shadow.ts`
+- **Schedule:** daily PM2 cron
+- **Output:** `logs/hermes-shadow-comparison/YYYY-MM-DD.{json,md}`
+- **Slack alert thresholds:** `agreement_rate < 85%` OR
+  `runs_with_no_extractable_decision > 10%`
+- **Cutover-gate semantics:** promote only if `agreement_rate >= 85%`
+  for 7 consecutive days AND `runs_with_no_extractable_decision <= 5%`
+  for 7 consecutive days AND zero false-positive Hermes decisions
+
+**Architecture sketch (this phase adds, on top of the backlog spec):**
+
+- New table `agent_promotion_state`: per-skill row with `stage: 'shadow' | 'canary' | 'live'`, `canary_org_ids: string[]`, `promoted_at`, `promoted_by`, `rollback_reason`.
+- Middleware exposes `GET /api/v1/agents/:skill/state` and `POST /api/v1/agents/:skill/promote` (super-admin only, requires explicit `to_stage` and metric-snapshot confirmation that quotes the comparison reader's last 7d output).
+- Runner script reads the state at start of each firing; for canary it consults `canary_org_ids` and processes only those orgs in live-mode (rest stay shadow).
+- Daily cron `agent-promotion-evaluator` reads `compare-shadow.ts`'s
+  output + `agent_runs` metrics and SUGGESTS promotions in a Slack
+  message — but never auto-promotes (humans pull the trigger).
+
+**Detailed task breakdown deferred to:** `docs/plans/2026-05-08-phase-3-promotion.md` (written when P3 begins). That sub-plan must explicitly reference and align with the backlog entry.
+
+---
+
+## Phase 4 — Operational Hardening
+
+**Goal:** Production-grade reliability features.
+
+**Effort:** 2–3 days.
+
+**Drift-check (§1.6) — existing protections to extend, not replace:**
+
+- `send_lifecycle_nudge_email` already has a server-side `MAX_EMAILS_PER_RUN=50` cap, `LIFECYCLE_TEST_EMAILS` allowlist, and `LIFECYCLE_LIVE=false` dry-run default (per `tasks/feature-backlog.md`). Our idempotency layer extends this with per-(org, nudge_key, day) dedup keys; it does not remove any existing guard.
+- `mark_onboarding_nudge_sent` already pre-checks `dayN_NudgeSentAt` for dedup (per CLAUDE.md tool description). Idempotency layer is redundant for this tool — confirm before adding.
+- Existing `ops-watchdog` already detects stale ops agents (per CLAUDE.md). Extension to `agent_runs` is straightforward.
+- **`circuit-breaker.service.ts` already exists** at `middleware/src/modules/common/services/circuit-breaker.service.ts` (Reviewer 2 finding — original drift-check missed it). P4 task 1 must reuse this service, not rebuild. Read its API first; if it's per-process (in-memory), our cross-firing breaker may need persistence across PM2 cron firings → wrap with Redis-backed state.
+
+**Tasks (high-level):**
+1. **Cross-firing circuit breaker:** REUSE `middleware/src/modules/common/services/circuit-breaker.service.ts`. If its state is in-memory, wrap with a Redis-backed counter so trips persist across PM2 cron firings. Track consecutive `outcome IN ('api_error','timeout','tool_error')` from `agent_runs`; halt + Slack-alert after 5. Hermes-first check: `tool_loop_guardrails` is intra-firing; this fills the cross-firing gap not covered by Hermes.
+2. **Idempotency keys on remaining MCP write tools** that lack them today: `log_shadow_row` (no current dedup), `update_support_request_*`, `create_support_message`, `auto_complete_org_onboarding`. Server-enforced via a `mcp_idempotency_keys` table. SKIP for tools that already have natural dedup (see drift-check above).
+3. **Structured JSON replay log:** replace the line-oriented runner log with one JSON document per firing in `/var/log/hermes/runs/<skill>/<run_id>.json`. Hermes-first check: `hermes dump` exists for snapshot-style export but is per-config not per-firing; `hermes logs --session ID` is structured but not per-firing-document. Custom `agent_runs/<id>.json` complements both. Includes pre-flight metadata, every tool call (referencing `mcp_audit_log` IDs), the LLM classifier call, and the final outcome.
+4. **Watchdog escalation:** extend existing `ops-watchdog` PM2 cron (currently watches ops agents per CLAUDE.md) to also know about `agent_runs` — alert if no successful firing per skill in 3× cron interval.
+
+**Detailed task breakdown deferred to:** `docs/plans/2026-05-08-phase-4-hardening.md` (written when P4 begins).
+
+---
+
+## Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| `hermes insights` output format unstable across versions | Medium | Low | Pin Hermes version (`v0.12.0` — see "Pin Hermes version" task in §6); treat parser as a versioned contract; integration test on each Hermes upgrade |
+| `hermes -t` flag interaction with `--skills` is undocumented | Medium | Medium (P1.2 design depends on this) | P1.2 Step 4 explicitly smoke-tests this combination on prod with a paid key (NOT just argparse-validation; actual LLM-visible tool filtering) |
+| **Hermes `model.max_tokens=4096` is NOT enforced at OpenRouter request layer (phantom lever)** | **Medium (UNVERIFIED)** | **High (Layer 3 cost defense fails)** | P0.0a smoke-test verifies this BEFORE proceeding; if not honored, fall back to per-call `--max-tokens` flag or remove the layer claim |
+| **OpenRouter outage / model-access revocation** | **Low (rare)** | **High (no fallback provider)** | Add `hermes fallback` to a secondary provider (Anthropic direct, OpenAI direct) in P0.6; document the manual switchover runbook in `docs/runbooks/` |
+| **`gpt-4o-mini` silent revisions / drift** | **Medium (already happened twice in 2025)** | **Medium (classifier behavior shifts)** | Pin model version in OpenRouter request (`gpt-4o-mini-2024-07-18` style); add daily golden-set regression check that fails CI on disagreement |
+| **Comparison reader self-deception** (Hermes vs heuristic agreement ≠ ground truth) | **Medium** | **High (we ship a worse system than the heuristic)** | §5 Ground-Truth Alignment criterion above; sample 50 human-labeled cases per agent before any cutover; revisit P3 promotion gate with this in mind |
+| New `agent_runs` writes overload Postgres on prod | Low | Low (volume is ~50/hour) | No mitigation needed; existing infra handles 1000s/sec |
+| Architecture flip (P2) disagrees with heuristic on real cases | Medium | Low (still in shadow) | This is exactly what shadow mode is for; promotion gates catch it |
+| `$2/day` cap affects legitimate firings | Low | Medium | Cap is ~5× expected steady-state; revisit after 7d of P0 data; raise if false positives |
+| Migration to TS orchestrator slows iteration speed | Medium | Low | TS code is faster to test than SKILL.md prompts; net velocity gain |
+| `hermes insights` is per-host CLI, not HTTP — sidecar required | Low | Low | Standard PM2 cron pattern; same shape as existing ops agents |
+| Backlog drift: someone ships shadow-comparison work outside this plan | Low | Medium (P3 redesigned) | P3 sub-plan reads backlog FIRST and aligns with whatever's there at start time |
+| Hermes auto-update breaks all CLI assumptions (toolsets, insights, `-t`) | Low | High | Pin version in deploy script; CI test runs `hermes --version` and fails if drift; do not run `hermes update` without re-validating |
+
+---
+
+## Definition of done
+
+This plan is complete when:
+
+1. ✅ All P0 acceptance tests pass
+2. ✅ All P1 acceptance tests pass
+3. ✅ P2 plan written and at least one agent (customer-lifecycle) flipped to TS-orchestrator + LLM-classifier
+4. ✅ P3 plan written and promotion machinery deployed
+5. ✅ P4 plan written and hardening complete
+6. ✅ 14 consecutive days satisfying all top-tier criteria from §5
+7. ✅ `tasks/lessons.md` updated with the post-mortem of the original credit drain and what the new architecture prevents
+8. ✅ `CLAUDE.md` updated to reference this plan from the "Agent Architecture (business agents)" section
+
+---
+
+## Execution
+
+**Plan complete and saved to `docs/plans/2026-05-08-agent-platform-redesign.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended for P2–P4)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. Best when tasks are independent (e.g., parallel agent work).
+
+**2. Inline Execution (recommended for P0–P1)** — Execute tasks in this session with checkpoints. Best when tasks have tight dependencies (P0 sets up infrastructure all subsequent phases use).
+
+**My recommendation:** Inline for P0+P1 (the immediate ~3-day blocker), then subagent-driven for P2 and beyond.
+
+**Which approach?**

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -448,6 +448,32 @@ module.exports = {
       out_file: './logs/hermes-vizora-support-triage-out.log',
       merge_logs: true,
     },
+    // ---------------------------------------------------------------------
+    // Hermes insights-poller sidecar (P0.5 — agent-platform-redesign).
+    //
+    // Polls `hermes insights --days 1 --source cli` every 5 min and
+    // back-fills cost / token data onto agent_runs rows. Also sweeps
+    // orphan rows and refines outcomes via mcp_audit_log join on
+    // agentRunId. See: docs/plans/2026-05-08-agent-platform-redesign-design.md
+    //
+    // Runs even when no Hermes agents are firing — handles the
+    // "no rows to enrich" path cleanly with zero cost.
+    {
+      name: 'hermes-insights-poller',
+      script: 'npx',
+      args: 'tsx scripts/agents/hermes/poll-insights.ts',
+      instances: 1,
+      exec_mode: 'fork',
+      cron_restart: '*/5 * * * *',
+      autorestart: false,
+      watch: false,
+      max_memory_restart: '256M',
+      log_date_format: 'YYYY-MM-DD HH:mm:ss Z',
+      max_size: '10M',
+      error_file: './logs/hermes-insights-poller-error.log',
+      out_file: './logs/hermes-insights-poller-out.log',
+      merge_logs: true,
+    },
     // Scaffold agents below — gated OFF by default. Flip the corresponding
     // *_ENABLED env var to true to activate once implementation lands.
     {

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -400,6 +400,18 @@ module.exports = {
         // that actually triggers execution. Leaving it null produces
         // "discuss the task" behavior in cron context.
         'Run the vizora-customer-lifecycle skill end-to-end now. Follow every step in SKILL.md exactly. Step 1: invoke list_onboarding_candidates on the vizora-platform MCP server. Step 2: for each candidate, invoke log_shadow_row on the vizora-platform server with the per-org decision (or one heartbeat invocation if zero candidates). End silently — no chat output.',
+        // P1.2 (2026-05-08): toolset filter — currently empty (no -t flag).
+        // The runner supports passing this through; the right value depends
+        // on Hermes' actual `-t TOOLSETS` semantics (category names like
+        // 'mcp' / individual tool ids / preset names — not yet verified
+        // post-credit-add). P1.3 smoke-test should attempt:
+        //   1. -t mcp (most likely correct — restricts to MCP toolset only)
+        //   2. -t mcp_vizora_list_onboarding_candidates,mcp_vizora_log_shadow_row,...
+        //      (per-tool filter; may or may not be supported)
+        // Until verified, model-side filtering is best-effort. The MCP
+        // server's token-scope check (P1.1) is the load-bearing backstop —
+        // FORBIDDEN responses prevent any unauthorized tool execution.
+        '',
       ],
       instances: 1,
       exec_mode: 'fork',
@@ -420,6 +432,9 @@ module.exports = {
         '/opt/vizora/app/scripts/agents/hermes/run-hermes-skill.sh',
         'vizora-support-triage',
         'Run the vizora-support-triage skill end-to-end now. Follow every step in SKILL.md exactly. Step 1: invoke list_open_support_requests on the vizora MCP server. Step 4: for each ticket, invoke log_shadow_row on the vizora server with the per-ticket score (or one heartbeat invocation if zero tickets). End silently — no chat output.',
+        // P1.2 (2026-05-08): toolset filter — see customer-lifecycle entry above
+        // for the smoke-test plan. Empty for now; runner handles it as a no-op.
+        '',
       ],
       instances: 1,
       exec_mode: 'fork',

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -423,7 +423,7 @@ module.exports = {
       ],
       instances: 1,
       exec_mode: 'fork',
-      cron_restart: '*/5 * * * *',
+      cron_restart: '*/15 * * * *',
       autorestart: false,
       watch: false,
       max_memory_restart: '256M',

--- a/middleware/src/modules/agents/agent-runs.controller.ts
+++ b/middleware/src/modules/agents/agent-runs.controller.ts
@@ -1,0 +1,92 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { InternalSecretGuard } from '../common/guards/internal-secret.guard';
+import { AgentRunsService } from './agent-runs.service';
+import {
+  RecordRunInput,
+  EnrichRunInput,
+  type RecordRunInputT,
+  type EnrichRunInputT,
+} from './agent-runs.schemas';
+
+/**
+ * Internal endpoints for the runner script + insights-poller sidecar to
+ * record per-firing metrics. Auth: x-internal-api-key + x-internal-caller
+ * (see InternalSecretGuard).
+ *
+ * Bodies validated with Zod at the controller boundary (matches surrounding
+ * MCP code style).
+ *
+ * Error codes (Reviewer A+B critical D1):
+ *   - 400: body schema validation failed
+ *   - 401: missing/wrong api-key OR missing/unknown caller
+ *   - 404: agent_runs row id not found
+ *   - 409: row past 5-minute freeze window
+ *
+ * See: docs/plans/2026-05-08-agent-platform-redesign-design.md §3.2
+ */
+@Controller('internal/agent-runs')
+@UseGuards(InternalSecretGuard)
+export class AgentRunsController {
+  constructor(private readonly service: AgentRunsService) {}
+
+  @Post()
+  @HttpCode(201)
+  async record(@Body() body: unknown): Promise<{ id: string }> {
+    const parsed = this.parseOrBadRequest(RecordRunInput, body, 'RecordRunInput');
+    return this.service.recordRun(parsed);
+  }
+
+  @Patch(':id')
+  @HttpCode(200)
+  async enrich(
+    @Param('id') id: string,
+    @Body() body: unknown,
+  ): Promise<{ id: string; enriched: boolean }> {
+    const parsed = this.parseOrBadRequest(EnrichRunInput, body, 'EnrichRunInput');
+    // Service throws NotFoundException / ConflictException — Nest maps to 404 / 409.
+    return this.service.enrichRun(id, parsed);
+  }
+
+  /**
+   * Spend-aware pre-flight gate for the runner. Caller is responsible for
+   * any client-side caching; server-side caching for stampede mitigation
+   * is added by the cache interceptor (NOT in this commit — deferred to
+   * P0.4 deploy when stampede actually matters; spec §3.2 captures intent).
+   */
+  @Get('today-spend')
+  async todaySpend(): Promise<{ usd: number }> {
+    const usd = await this.service.getTodaySpendUsd();
+    return { usd };
+  }
+
+  private parseOrBadRequest<T>(
+    schema: { safeParse: (v: unknown) => { success: boolean; data?: T; error?: { issues: unknown[] } } },
+    body: unknown,
+    label: string,
+  ): T {
+    const result = schema.safeParse(body);
+    if (!result.success) {
+      throw new BadRequestException({
+        message: `${label} validation failed`,
+        issues: result.error?.issues ?? [],
+      });
+    }
+    return result.data as T;
+  }
+}
+
+/**
+ * Re-exports for any caller that wants the parsed types without dragging
+ * in the schema module path.
+ */
+export type { RecordRunInputT, EnrichRunInputT };

--- a/middleware/src/modules/agents/agent-runs.controller.ts
+++ b/middleware/src/modules/agents/agent-runs.controller.ts
@@ -7,8 +7,10 @@ import {
   Param,
   Patch,
   Post,
+  Req,
   UseGuards,
 } from '@nestjs/common';
+import type { Request } from 'express';
 import { InternalSecretGuard } from '../common/guards/internal-secret.guard';
 import { AgentRunsService } from './agent-runs.service';
 import {
@@ -41,9 +43,14 @@ export class AgentRunsController {
 
   @Post()
   @HttpCode(201)
-  async record(@Body() body: unknown): Promise<{ id: string }> {
+  async record(
+    @Body() body: unknown,
+    @Req() req: Request & { internalCaller?: string },
+  ): Promise<{ id: string }> {
     const parsed = this.parseOrBadRequest(RecordRunInput, body, 'RecordRunInput');
-    return this.service.recordRun(parsed);
+    // The InternalSecretGuard validates and stamps `internalCaller` onto
+    // the request. Persist it on the row for forensic attribution.
+    return this.service.recordRun(parsed, req.internalCaller);
   }
 
   @Patch(':id')
@@ -67,6 +74,20 @@ export class AgentRunsController {
   async todaySpend(): Promise<{ usd: number }> {
     const usd = await this.service.getTodaySpendUsd();
     return { usd };
+  }
+
+  /**
+   * Marks rows that haven't been enriched within 10 minutes as runner_crash.
+   * Called by the insights-poller sidecar at the end of each tick.
+   *
+   * PR-review R1 I2 — eliminates a duplicated implementation that previously
+   * lived in poll-insights.ts. Single source of truth for orphan-sweep
+   * semantics is the AgentRunsService.
+   */
+  @Post('sweep-orphans')
+  @HttpCode(200)
+  async sweepOrphans(): Promise<{ marked: number }> {
+    return this.service.sweepOrphans();
   }
 
   private parseOrBadRequest<T>(

--- a/middleware/src/modules/agents/agent-runs.schemas.ts
+++ b/middleware/src/modules/agents/agent-runs.schemas.ts
@@ -1,0 +1,107 @@
+/**
+ * Zod schemas + types for the agent-runs subsystem.
+ *
+ * See: docs/plans/2026-05-08-agent-platform-redesign-design.md §3.1
+ *
+ * The runner script POSTs RecordRunInput synchronously on firing exit.
+ * The insights-poller sidecar PATCHes EnrichRunInput ~5 min later with
+ * cost / token data extracted from `hermes insights`.
+ *
+ * Outcome taxonomy follows ADL-3 (mutually exclusive). The runner emits
+ * only the 4-value subset it can detect from Hermes-visible signals; the
+ * sidecar refines to the full 8-value enum using mcp_audit_log data.
+ */
+
+import { z } from 'zod';
+
+/**
+ * Full outcome enum stored in agent_runs.outcome. Stored as String for
+ * forward-compatibility (avoids Postgres-enum migration friction).
+ *
+ * Mutual exclusivity rules (Reviewer A D10):
+ *   - success      = Hermes RC=0, all MCP calls succeeded (or none made)
+ *   - partial      = Hermes RC=0, ≥1 MCP success AND ≥1 MCP failure
+ *   - tool_error   = Hermes RC=0, ALL MCP calls failed (no successes)
+ *   - api_error    = Hermes RC≠0 OR HTTP 4xx/5xx in stdout (excluding timeout)
+ *   - timeout      = Hermes RC=124 (timeout(1) signal)
+ *   - budget_aborted = Pre-flight refused; Hermes never invoked
+ *   - no_work      = Hermes RC=0, MCP calls succeeded, but list_* tools
+ *                    returned 0 candidates (heuristic: no shadow_log row written)
+ *   - runner_crash = Sidecar finds row with tokensIn=NULL AND createdAt > 10min ago
+ */
+export const RUN_OUTCOMES = [
+  'success',
+  'no_work',
+  'partial',
+  'tool_error',
+  'api_error',
+  'timeout',
+  'budget_aborted',
+  'runner_crash',
+] as const;
+export const RunOutcome = z.enum(RUN_OUTCOMES);
+export type RunOutcomeT = z.infer<typeof RunOutcome>;
+
+/**
+ * Subset the runner can classify from Hermes stdout alone.
+ * `success` here is provisional — the sidecar may downgrade later.
+ */
+export const RUNNER_OUTCOMES = [
+  'success',
+  'api_error',
+  'timeout',
+  'budget_aborted',
+] as const;
+export const RunnerOutcome = z.enum(RUNNER_OUTCOMES);
+export type RunnerOutcomeT = z.infer<typeof RunnerOutcome>;
+
+/**
+ * Body of POST /api/v1/internal/agent-runs.
+ * Dates are ISO-8601 strings on the wire; service-side they become Date.
+ */
+export const RecordRunInput = z.object({
+  skillName: z.string().min(1).max(128),
+  organizationId: z.string().nullable().optional(),
+  pid: z.number().int().nonnegative().optional(),
+  startedAt: z.string().datetime(),
+  finishedAt: z.string().datetime(),
+  exitCode: z.number().int(),
+  outcome: RunnerOutcome,
+  errorExcerpt: z.string().max(1024).optional(),
+  preflightBalanceUsd: z.number().optional(),
+  preflightTodaySpendUsd: z.number().optional(),
+});
+export type RecordRunInputT = z.infer<typeof RecordRunInput>;
+
+/**
+ * Body of PATCH /api/v1/internal/agent-runs/:id.
+ * Sidecar enrichment — captures rate snapshot AT write time (ADL-7).
+ */
+export const EnrichRunInput = z.object({
+  tokensIn: z.number().int().nonnegative().optional(),
+  tokensOut: z.number().int().nonnegative().optional(),
+  model: z.string().max(128).optional(),
+  rateInUsdPerMt: z.number().nonnegative().optional(),
+  rateOutUsdPerMt: z.number().nonnegative().optional(),
+  outcomeRefinement: RunOutcome.optional(),
+});
+export type EnrichRunInputT = z.infer<typeof EnrichRunInput>;
+
+/**
+ * Per-million-token rates in USD. Snapshotted into agent_runs at
+ * enrichment time (ADL-7). Update when adding new models.
+ *
+ * Source: https://openrouter.ai/models — verified 2026-05-08.
+ */
+export interface ModelRate {
+  inUsdPerMt: number;
+  outUsdPerMt: number;
+}
+
+export const MODEL_RATES: Record<string, ModelRate> = {
+  'openai/gpt-4o-mini': { inUsdPerMt: 0.15, outUsdPerMt: 0.60 },
+  'openai/gpt-4o-mini-2024-07-18': { inUsdPerMt: 0.15, outUsdPerMt: 0.60 },
+  'openai/gpt-4o': { inUsdPerMt: 2.50, outUsdPerMt: 10.00 },
+  'anthropic/claude-3.5-sonnet': { inUsdPerMt: 3.00, outUsdPerMt: 15.00 },
+  'anthropic/claude-3.5-haiku': { inUsdPerMt: 0.80, outUsdPerMt: 4.00 },
+};

--- a/middleware/src/modules/agents/agent-runs.service.spec.ts
+++ b/middleware/src/modules/agents/agent-runs.service.spec.ts
@@ -135,7 +135,7 @@ describe('AgentRunsService', () => {
       db.agentRun.findUnique.mockResolvedValue({
         id: 'r1',
         finishedAt: sixMinAgo,
-        tokensIn: null,
+        enrichedAt: null,
       });
       await expect(
         service.enrichRun('r1', { tokensIn: 100, tokensOut: 50, model: 'openai/gpt-4o-mini' }),
@@ -143,9 +143,9 @@ describe('AgentRunsService', () => {
       expect(db.agentRun.updateMany).not.toHaveBeenCalled();
     });
 
-    it('writes cost + rate snapshot when model is in MODEL_RATES', async () => {
+    it('writes cost + rate snapshot + enrichedAt when model is in MODEL_RATES', async () => {
       const recent = new Date(Date.now() - 30 * 1000);
-      db.agentRun.findUnique.mockResolvedValue({ id: 'r2', finishedAt: recent, tokensIn: null });
+      db.agentRun.findUnique.mockResolvedValue({ id: 'r2', finishedAt: recent, enrichedAt: null });
       db.agentRun.updateMany.mockResolvedValue({ count: 1 });
       const out = await service.enrichRun('r2', {
         tokensIn: 5000,
@@ -154,7 +154,7 @@ describe('AgentRunsService', () => {
       });
       expect(out).toEqual({ id: 'r2', enriched: true });
       expect(db.agentRun.updateMany).toHaveBeenCalledWith({
-        where: { id: 'r2', tokensIn: null },
+        where: { id: 'r2', enrichedAt: null },
         data: expect.objectContaining({
           tokensIn: 5000,
           tokensOut: 800,
@@ -162,13 +162,14 @@ describe('AgentRunsService', () => {
           rateInUsdPerMt: 0.15,
           rateOutUsdPerMt: 0.6,
           costMicrodollars: 1230,
+          enrichedAt: expect.any(Date),
         }),
       });
     });
 
     it('returns enriched=false when MVCC race loses (count=0)', async () => {
       const recent = new Date(Date.now() - 30 * 1000);
-      db.agentRun.findUnique.mockResolvedValue({ id: 'r3', finishedAt: recent, tokensIn: null });
+      db.agentRun.findUnique.mockResolvedValue({ id: 'r3', finishedAt: recent, enrichedAt: null });
       db.agentRun.updateMany.mockResolvedValue({ count: 0 });
       const out = await service.enrichRun('r3', {
         tokensIn: 100,
@@ -180,7 +181,7 @@ describe('AgentRunsService', () => {
 
     it('writes null cost when model is unknown (rate not in table)', async () => {
       const recent = new Date(Date.now() - 30 * 1000);
-      db.agentRun.findUnique.mockResolvedValue({ id: 'r4', finishedAt: recent, tokensIn: null });
+      db.agentRun.findUnique.mockResolvedValue({ id: 'r4', finishedAt: recent, enrichedAt: null });
       db.agentRun.updateMany.mockResolvedValue({ count: 1 });
       await service.enrichRun('r4', {
         tokensIn: 100,
@@ -188,7 +189,7 @@ describe('AgentRunsService', () => {
         model: 'mystery/model-future',
       });
       expect(db.agentRun.updateMany).toHaveBeenCalledWith({
-        where: { id: 'r4', tokensIn: null },
+        where: { id: 'r4', enrichedAt: null },
         data: expect.objectContaining({
           model: 'mystery/model-future',
           rateInUsdPerMt: null,
@@ -202,7 +203,7 @@ describe('AgentRunsService', () => {
       // The sidecar may pass explicit rates from `hermes insights` (which
       // already accounts for prompt caching, etc.) — those win over MODEL_RATES.
       const recent = new Date(Date.now() - 30 * 1000);
-      db.agentRun.findUnique.mockResolvedValue({ id: 'r5', finishedAt: recent, tokensIn: null });
+      db.agentRun.findUnique.mockResolvedValue({ id: 'r5', finishedAt: recent, enrichedAt: null });
       db.agentRun.updateMany.mockResolvedValue({ count: 1 });
       await service.enrichRun('r5', {
         tokensIn: 1000,
@@ -212,7 +213,7 @@ describe('AgentRunsService', () => {
         rateOutUsdPerMt: 0.6,
       });
       expect(db.agentRun.updateMany).toHaveBeenCalledWith({
-        where: { id: 'r5', tokensIn: null },
+        where: { id: 'r5', enrichedAt: null },
         data: expect.objectContaining({
           rateInUsdPerMt: 0.075,
           rateOutUsdPerMt: 0.6,
@@ -223,7 +224,7 @@ describe('AgentRunsService', () => {
 
     it('applies outcomeRefinement when sidecar downgrades success → tool_error', async () => {
       const recent = new Date(Date.now() - 30 * 1000);
-      db.agentRun.findUnique.mockResolvedValue({ id: 'r6', finishedAt: recent, tokensIn: null });
+      db.agentRun.findUnique.mockResolvedValue({ id: 'r6', finishedAt: recent, enrichedAt: null });
       db.agentRun.updateMany.mockResolvedValue({ count: 1 });
       await service.enrichRun('r6', {
         tokensIn: 100,
@@ -232,9 +233,42 @@ describe('AgentRunsService', () => {
         outcomeRefinement: 'tool_error',
       });
       expect(db.agentRun.updateMany).toHaveBeenCalledWith({
-        where: { id: 'r6', tokensIn: null },
+        where: { id: 'r6', enrichedAt: null },
         data: expect.objectContaining({ outcome: 'tool_error' }),
       });
+    });
+
+    it('REGRESSION (PR-review R1 I3): outcome-only refinement with no token data sets enrichedAt and is idempotent', async () => {
+      // Bug: previous predicate `tokensIn IS NULL` failed for outcome-only
+      // PATCHes — they wrote tokensIn: null again, leaving the predicate true.
+      // Fix: enrichedAt set on first PATCH; subsequent PATCHes find it non-null
+      // and the predicate fails (count=0, treated as benign no-op).
+      const recent = new Date(Date.now() - 30 * 1000);
+      db.agentRun.findUnique.mockResolvedValue({ id: 'r7', finishedAt: recent, enrichedAt: null });
+      db.agentRun.updateMany.mockResolvedValue({ count: 1 });
+      // First call: outcome refinement only, no token data.
+      await service.enrichRun('r7', { outcomeRefinement: 'no_work' });
+      expect(db.agentRun.updateMany).toHaveBeenCalledWith({
+        where: { id: 'r7', enrichedAt: null },
+        data: expect.objectContaining({
+          outcome: 'no_work',
+          enrichedAt: expect.any(Date),
+          tokensIn: null,
+          tokensOut: null,
+        }),
+      });
+    });
+
+    it('REGRESSION (PR-review R1 I6): omitted outcomeRefinement does NOT include outcome key in update data', async () => {
+      // Bug: relying on Prisma's "undefined key omits field" was implicit.
+      // Fix: conditional spread — outcome is only in data if outcomeRefinement
+      // is non-null.
+      const recent = new Date(Date.now() - 30 * 1000);
+      db.agentRun.findUnique.mockResolvedValue({ id: 'r8', finishedAt: recent, enrichedAt: null });
+      db.agentRun.updateMany.mockResolvedValue({ count: 1 });
+      await service.enrichRun('r8', { tokensIn: 100, tokensOut: 50 });
+      const dataArg = db.agentRun.updateMany.mock.calls[0][0].data;
+      expect('outcome' in dataArg).toBe(false);
     });
   });
 
@@ -262,14 +296,14 @@ describe('AgentRunsService', () => {
   });
 
   describe('sweepOrphans', () => {
-    it('marks rows older than 10 minutes as runner_crash', async () => {
+    it('marks rows older than 10 minutes as runner_crash and sets enrichedAt', async () => {
       db.agentRun.updateMany.mockResolvedValue({ count: 3 });
       const result = await service.sweepOrphans();
       expect(result.marked).toBe(3);
       const args = db.agentRun.updateMany.mock.calls[0][0];
       expect(args.where).toEqual(
         expect.objectContaining({
-          tokensIn: null,
+          enrichedAt: null,
           createdAt: { lt: expect.any(Date) },
           outcome: { notIn: ['runner_crash', 'budget_aborted'] },
         }),
@@ -278,6 +312,8 @@ describe('AgentRunsService', () => {
         expect.objectContaining({
           outcome: 'runner_crash',
           errorExcerpt: expect.stringContaining('orphan'),
+          // Sweep also marks enrichedAt to prevent re-orphan-sweeping.
+          enrichedAt: expect.any(Date),
         }),
       );
       // Cutoff should be ~10 min in the past.
@@ -290,6 +326,41 @@ describe('AgentRunsService', () => {
     it('returns 0 when no orphans found', async () => {
       db.agentRun.updateMany.mockResolvedValue({ count: 0 });
       expect((await service.sweepOrphans()).marked).toBe(0);
+    });
+  });
+
+  describe('recordRun + callerType (PR-review R2 I5)', () => {
+    it('persists callerType when provided by guard', async () => {
+      db.agentRun.create.mockResolvedValue({ id: 'cuid_r9' });
+      await service.recordRun(
+        {
+          skillName: 'vizora-test',
+          startedAt: new Date().toISOString(),
+          finishedAt: new Date().toISOString(),
+          exitCode: 0,
+          outcome: 'success',
+        },
+        'sidecar',
+      );
+      expect(db.agentRun.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ callerType: 'sidecar' }),
+        select: { id: true },
+      });
+    });
+
+    it('persists callerType=null when omitted (no guard, e.g., older callers)', async () => {
+      db.agentRun.create.mockResolvedValue({ id: 'cuid_r10' });
+      await service.recordRun({
+        skillName: 'vizora-test',
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date().toISOString(),
+        exitCode: 0,
+        outcome: 'success',
+      });
+      expect(db.agentRun.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ callerType: null }),
+        select: { id: true },
+      });
     });
   });
 });

--- a/middleware/src/modules/agents/agent-runs.service.spec.ts
+++ b/middleware/src/modules/agents/agent-runs.service.spec.ts
@@ -1,0 +1,295 @@
+import { Test } from '@nestjs/testing';
+import { NotFoundException, ConflictException } from '@nestjs/common';
+import {
+  AgentRunsService,
+  computeCostMicrodollars,
+} from './agent-runs.service';
+import { DatabaseService } from '../database/database.service';
+
+describe('computeCostMicrodollars (pure helper)', () => {
+  it('returns null when any input is missing', () => {
+    expect(computeCostMicrodollars(undefined, 100, 0.15, 0.6)).toBeNull();
+    expect(computeCostMicrodollars(100, undefined, 0.15, 0.6)).toBeNull();
+    expect(computeCostMicrodollars(100, 100, undefined, 0.6)).toBeNull();
+    expect(computeCostMicrodollars(100, 100, 0.15, undefined)).toBeNull();
+  });
+
+  it('matches the design example: 5000 in × 0.15 + 800 out × 0.60 = 1230 microdollars', () => {
+    expect(computeCostMicrodollars(5000, 800, 0.15, 0.6)).toBe(1230);
+  });
+
+  it('rounds to nearest microdollar', () => {
+    // 333 × 0.15 = 49.95 ; 333 × 0.6 = 199.8 ; sum = 249.75 → round → 250.
+    expect(computeCostMicrodollars(333, 333, 0.15, 0.6)).toBe(250);
+  });
+
+  it('handles zero tokens cleanly', () => {
+    expect(computeCostMicrodollars(0, 0, 0.15, 0.6)).toBe(0);
+  });
+});
+
+describe('AgentRunsService', () => {
+  let service: AgentRunsService;
+  let db: {
+    agentRun: {
+      create: jest.Mock;
+      findUnique: jest.Mock;
+      updateMany: jest.Mock;
+      aggregate: jest.Mock;
+    };
+  };
+
+  beforeEach(async () => {
+    db = {
+      agentRun: {
+        create: jest.fn(),
+        findUnique: jest.fn(),
+        updateMany: jest.fn(),
+        aggregate: jest.fn(),
+      },
+    };
+    const mod = await Test.createTestingModule({
+      providers: [
+        AgentRunsService,
+        { provide: DatabaseService, useValue: db },
+      ],
+    }).compile();
+    service = mod.get(AgentRunsService);
+  });
+
+  describe('recordRun', () => {
+    it('persists a row with computed durationMs and returns its id', async () => {
+      db.agentRun.create.mockResolvedValue({ id: 'cuid_r1' });
+      const startedAt = '2026-05-08T10:00:00.000Z';
+      const finishedAt = '2026-05-08T10:00:30.000Z';
+      const result = await service.recordRun({
+        skillName: 'vizora-customer-lifecycle',
+        startedAt,
+        finishedAt,
+        exitCode: 0,
+        outcome: 'success',
+      });
+      expect(result.id).toBe('cuid_r1');
+      expect(db.agentRun.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          skillName: 'vizora-customer-lifecycle',
+          startedAt: new Date(startedAt),
+          finishedAt: new Date(finishedAt),
+          durationMs: 30000,
+          outcome: 'success',
+          // Cost / tokens / model NOT written here — sidecar fills them later.
+        }),
+        select: { id: true },
+      });
+      // Sanity: cost columns are absent from the create payload.
+      const createArgs = db.agentRun.create.mock.calls[0][0].data;
+      expect(createArgs.tokensIn).toBeUndefined();
+      expect(createArgs.costMicrodollars).toBeUndefined();
+    });
+
+    it('truncates errorExcerpt to 1024 chars', async () => {
+      db.agentRun.create.mockResolvedValue({ id: 'cuid_r2' });
+      await service.recordRun({
+        skillName: 'vizora-test',
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date().toISOString(),
+        exitCode: 1,
+        outcome: 'api_error',
+        errorExcerpt: 'X'.repeat(2000),
+      });
+      const passed = db.agentRun.create.mock.calls[0][0].data.errorExcerpt;
+      expect(passed.length).toBe(1024);
+    });
+
+    it('persists budget_aborted with no exitCode override (caller sends 0)', async () => {
+      db.agentRun.create.mockResolvedValue({ id: 'cuid_r3' });
+      await service.recordRun({
+        skillName: 'vizora-test',
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date().toISOString(),
+        exitCode: 0,
+        outcome: 'budget_aborted',
+        preflightBalanceUsd: 0.05,
+      });
+      expect(db.agentRun.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          outcome: 'budget_aborted',
+          preflightBalanceUsd: 0.05,
+        }),
+        select: { id: true },
+      });
+    });
+  });
+
+  describe('enrichRun', () => {
+    it('throws NotFoundException when id is unknown', async () => {
+      db.agentRun.findUnique.mockResolvedValue(null);
+      await expect(
+        service.enrichRun('missing', { tokensIn: 1, tokensOut: 1, model: 'openai/gpt-4o-mini' }),
+      ).rejects.toThrow(NotFoundException);
+      expect(db.agentRun.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('throws ConflictException when row is past 5-min freeze window', async () => {
+      const sixMinAgo = new Date(Date.now() - 6 * 60 * 1000);
+      db.agentRun.findUnique.mockResolvedValue({
+        id: 'r1',
+        finishedAt: sixMinAgo,
+        tokensIn: null,
+      });
+      await expect(
+        service.enrichRun('r1', { tokensIn: 100, tokensOut: 50, model: 'openai/gpt-4o-mini' }),
+      ).rejects.toThrow(ConflictException);
+      expect(db.agentRun.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('writes cost + rate snapshot when model is in MODEL_RATES', async () => {
+      const recent = new Date(Date.now() - 30 * 1000);
+      db.agentRun.findUnique.mockResolvedValue({ id: 'r2', finishedAt: recent, tokensIn: null });
+      db.agentRun.updateMany.mockResolvedValue({ count: 1 });
+      const out = await service.enrichRun('r2', {
+        tokensIn: 5000,
+        tokensOut: 800,
+        model: 'openai/gpt-4o-mini',
+      });
+      expect(out).toEqual({ id: 'r2', enriched: true });
+      expect(db.agentRun.updateMany).toHaveBeenCalledWith({
+        where: { id: 'r2', tokensIn: null },
+        data: expect.objectContaining({
+          tokensIn: 5000,
+          tokensOut: 800,
+          model: 'openai/gpt-4o-mini',
+          rateInUsdPerMt: 0.15,
+          rateOutUsdPerMt: 0.6,
+          costMicrodollars: 1230,
+        }),
+      });
+    });
+
+    it('returns enriched=false when MVCC race loses (count=0)', async () => {
+      const recent = new Date(Date.now() - 30 * 1000);
+      db.agentRun.findUnique.mockResolvedValue({ id: 'r3', finishedAt: recent, tokensIn: null });
+      db.agentRun.updateMany.mockResolvedValue({ count: 0 });
+      const out = await service.enrichRun('r3', {
+        tokensIn: 100,
+        tokensOut: 50,
+        model: 'openai/gpt-4o-mini',
+      });
+      expect(out).toEqual({ id: 'r3', enriched: false });
+    });
+
+    it('writes null cost when model is unknown (rate not in table)', async () => {
+      const recent = new Date(Date.now() - 30 * 1000);
+      db.agentRun.findUnique.mockResolvedValue({ id: 'r4', finishedAt: recent, tokensIn: null });
+      db.agentRun.updateMany.mockResolvedValue({ count: 1 });
+      await service.enrichRun('r4', {
+        tokensIn: 100,
+        tokensOut: 50,
+        model: 'mystery/model-future',
+      });
+      expect(db.agentRun.updateMany).toHaveBeenCalledWith({
+        where: { id: 'r4', tokensIn: null },
+        data: expect.objectContaining({
+          model: 'mystery/model-future',
+          rateInUsdPerMt: null,
+          rateOutUsdPerMt: null,
+          costMicrodollars: null,
+        }),
+      });
+    });
+
+    it('honors agent-supplied rate override even when model is in MODEL_RATES', async () => {
+      // The sidecar may pass explicit rates from `hermes insights` (which
+      // already accounts for prompt caching, etc.) — those win over MODEL_RATES.
+      const recent = new Date(Date.now() - 30 * 1000);
+      db.agentRun.findUnique.mockResolvedValue({ id: 'r5', finishedAt: recent, tokensIn: null });
+      db.agentRun.updateMany.mockResolvedValue({ count: 1 });
+      await service.enrichRun('r5', {
+        tokensIn: 1000,
+        tokensOut: 100,
+        model: 'openai/gpt-4o-mini',
+        rateInUsdPerMt: 0.075, // 50% prompt-cache discount
+        rateOutUsdPerMt: 0.6,
+      });
+      expect(db.agentRun.updateMany).toHaveBeenCalledWith({
+        where: { id: 'r5', tokensIn: null },
+        data: expect.objectContaining({
+          rateInUsdPerMt: 0.075,
+          rateOutUsdPerMt: 0.6,
+          costMicrodollars: 135, // 1000 × 0.075 + 100 × 0.6 = 75 + 60 = 135
+        }),
+      });
+    });
+
+    it('applies outcomeRefinement when sidecar downgrades success → tool_error', async () => {
+      const recent = new Date(Date.now() - 30 * 1000);
+      db.agentRun.findUnique.mockResolvedValue({ id: 'r6', finishedAt: recent, tokensIn: null });
+      db.agentRun.updateMany.mockResolvedValue({ count: 1 });
+      await service.enrichRun('r6', {
+        tokensIn: 100,
+        tokensOut: 50,
+        model: 'openai/gpt-4o-mini',
+        outcomeRefinement: 'tool_error',
+      });
+      expect(db.agentRun.updateMany).toHaveBeenCalledWith({
+        where: { id: 'r6', tokensIn: null },
+        data: expect.objectContaining({ outcome: 'tool_error' }),
+      });
+    });
+  });
+
+  describe('getTodaySpendUsd', () => {
+    it('sums costMicrodollars for the current UTC day and converts to USD', async () => {
+      db.agentRun.aggregate.mockResolvedValue({
+        _sum: { costMicrodollars: 2_500_000 }, // $2.50
+      });
+      const usd = await service.getTodaySpendUsd();
+      expect(usd).toBe(2.5);
+      // Verify the aggregate query targets startOfUtcDay correctly.
+      const args = db.agentRun.aggregate.mock.calls[0][0];
+      expect(args._sum).toEqual({ costMicrodollars: true });
+      const cutoff = args.where.startedAt.gte as Date;
+      expect(cutoff.getUTCHours()).toBe(0);
+      expect(cutoff.getUTCMinutes()).toBe(0);
+      expect(cutoff.getUTCSeconds()).toBe(0);
+    });
+
+    it('returns 0 when no rows match (null sum)', async () => {
+      db.agentRun.aggregate.mockResolvedValue({ _sum: { costMicrodollars: null } });
+      const usd = await service.getTodaySpendUsd();
+      expect(usd).toBe(0);
+    });
+  });
+
+  describe('sweepOrphans', () => {
+    it('marks rows older than 10 minutes as runner_crash', async () => {
+      db.agentRun.updateMany.mockResolvedValue({ count: 3 });
+      const result = await service.sweepOrphans();
+      expect(result.marked).toBe(3);
+      const args = db.agentRun.updateMany.mock.calls[0][0];
+      expect(args.where).toEqual(
+        expect.objectContaining({
+          tokensIn: null,
+          createdAt: { lt: expect.any(Date) },
+          outcome: { notIn: ['runner_crash', 'budget_aborted'] },
+        }),
+      );
+      expect(args.data).toEqual(
+        expect.objectContaining({
+          outcome: 'runner_crash',
+          errorExcerpt: expect.stringContaining('orphan'),
+        }),
+      );
+      // Cutoff should be ~10 min in the past.
+      const cutoff = args.where.createdAt.lt as Date;
+      const ageMs = Date.now() - cutoff.getTime();
+      expect(ageMs).toBeGreaterThanOrEqual(10 * 60 * 1000 - 1000);
+      expect(ageMs).toBeLessThanOrEqual(10 * 60 * 1000 + 1000);
+    });
+
+    it('returns 0 when no orphans found', async () => {
+      db.agentRun.updateMany.mockResolvedValue({ count: 0 });
+      expect((await service.sweepOrphans()).marked).toBe(0);
+    });
+  });
+});

--- a/middleware/src/modules/agents/agent-runs.service.ts
+++ b/middleware/src/modules/agents/agent-runs.service.ts
@@ -1,0 +1,192 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  ConflictException,
+} from '@nestjs/common';
+import { DatabaseService } from '../database/database.service';
+import {
+  MODEL_RATES,
+  type RecordRunInputT,
+  type EnrichRunInputT,
+  type RunOutcomeT,
+} from './agent-runs.schemas';
+
+/**
+ * Per-firing record-keeping for Hermes agent invocations.
+ *
+ * Two-stage write pattern (design ADL-2):
+ *   1. recordRun()  — synchronous, called by the runner POST endpoint
+ *   2. enrichRun()  — asynchronous, called by the insights-poller sidecar
+ *                     ~5 min later with cost + token data
+ *
+ * Cost is FROZEN at write (ADL-7). When MODEL_RATES changes, historical
+ * rows preserve their snapshotted rateInUsdPerMt / rateOutUsdPerMt.
+ *
+ * Frozen-row guard (ADL-2): PATCH refuses if server-side now() is more
+ * than 5 min past finishedAt. Prevents late-arriving enrichments from
+ * overwriting rows that downstream alerts may already have fired on.
+ */
+@Injectable()
+export class AgentRunsService {
+  private readonly logger = new Logger(AgentRunsService.name);
+
+  /** Frozen-row threshold from finishedAt; matches sidecar poll cadence. */
+  private static readonly FREEZE_WINDOW_MS = 5 * 60 * 1000;
+
+  constructor(private readonly db: DatabaseService) {}
+
+  /**
+   * Synchronous write from runner. Returns the new row's id so the
+   * runner can correlate later enrichment via mcp_audit_log.agentRunId.
+   */
+  async recordRun(input: RecordRunInputT): Promise<{ id: string }> {
+    const startedAt = new Date(input.startedAt);
+    const finishedAt = new Date(input.finishedAt);
+    const durationMs = finishedAt.getTime() - startedAt.getTime();
+    const row = await this.db.agentRun.create({
+      data: {
+        skillName: input.skillName,
+        organizationId: input.organizationId ?? null,
+        pid: input.pid ?? null,
+        startedAt,
+        finishedAt,
+        durationMs,
+        exitCode: input.exitCode,
+        outcome: input.outcome,
+        errorExcerpt: input.errorExcerpt?.slice(0, 1024) ?? null,
+        preflightBalanceUsd: input.preflightBalanceUsd ?? null,
+        preflightTodaySpendUsd: input.preflightTodaySpendUsd ?? null,
+      },
+      select: { id: true },
+    });
+    return { id: row.id };
+  }
+
+  /**
+   * Sidecar enrichment. Throws NotFoundException if id unknown, or
+   * ConflictException if the row's freeze window has elapsed.
+   *
+   * Idempotent under MVCC via the `tokensIn IS NULL` predicate combined
+   * with the RETURNING clause (Reviewer B D7). Concurrent sidecars both
+   * execute UPDATE; only one matches the predicate; the other gets
+   * zero rows back and treats it as a benign "already enriched."
+   */
+  async enrichRun(id: string, input: EnrichRunInputT): Promise<{ id: string; enriched: boolean }> {
+    // Surface NotFound separately from "frozen" so callers can distinguish
+    // a sidecar bug from a benign late-tick (Reviewer A+B).
+    const existing = await this.db.agentRun.findUnique({
+      where: { id },
+      select: { id: true, finishedAt: true, tokensIn: true },
+    });
+    if (!existing) {
+      throw new NotFoundException(`agent_runs row '${id}' not found`);
+    }
+    if (existing.finishedAt) {
+      const elapsed = Date.now() - existing.finishedAt.getTime();
+      if (elapsed > AgentRunsService.FREEZE_WINDOW_MS) {
+        throw new ConflictException(
+          `agent_runs row '${id}' is frozen (finishedAt + 5min < now)`,
+        );
+      }
+    }
+
+    // Compute cost using the rate AT this moment. Snapshot the rate into
+    // the row alongside the cost so historical analysis stays accurate
+    // when MODEL_RATES later changes (ADL-7).
+    const rate = input.model ? MODEL_RATES[input.model] : undefined;
+    const rateIn = input.rateInUsdPerMt ?? rate?.inUsdPerMt;
+    const rateOut = input.rateOutUsdPerMt ?? rate?.outUsdPerMt;
+    const costMicrodollars = computeCostMicrodollars(
+      input.tokensIn,
+      input.tokensOut,
+      rateIn,
+      rateOut,
+    );
+
+    // Idempotent UPDATE: only writes if tokensIn is still NULL. The
+    // RETURNING-equivalent (updateMany returns count) lets us detect the
+    // "another sidecar got it first" race and treat as benign.
+    const result = await this.db.agentRun.updateMany({
+      where: { id, tokensIn: null },
+      data: {
+        tokensIn: input.tokensIn ?? null,
+        tokensOut: input.tokensOut ?? null,
+        costMicrodollars,
+        rateInUsdPerMt: rateIn ?? null,
+        rateOutUsdPerMt: rateOut ?? null,
+        model: input.model ?? null,
+        outcome: input.outcomeRefinement ?? undefined,
+      },
+    });
+    if (result.count === 0) {
+      // Either already enriched (race with another sidecar) or row doesn't
+      // exist (we already checked above so this is the race path).
+      this.logger.log(`agent_runs '${id}' already enriched by another sidecar instance`);
+      return { id, enriched: false };
+    }
+    return { id, enriched: true };
+  }
+
+  /**
+   * Returns total agent spend for the current UTC day in USD.
+   * Used by runner pre-flight check to enforce DAILY_BUDGET_USD.
+   * Caller (controller) is responsible for any caching layer.
+   */
+  async getTodaySpendUsd(): Promise<number> {
+    const startOfUtcDay = new Date();
+    startOfUtcDay.setUTCHours(0, 0, 0, 0);
+    const result = await this.db.agentRun.aggregate({
+      _sum: { costMicrodollars: true },
+      where: { startedAt: { gte: startOfUtcDay } },
+    });
+    const micros = result._sum.costMicrodollars ?? 0;
+    return micros / 1_000_000;
+  }
+
+  /**
+   * Sidecar orphan-row sweep (design §4.3 race scenario + I7).
+   * Marks rows as runner_crash if their tokensIn is still NULL more than
+   * 10 minutes after creation. Called periodically by the sidecar.
+   */
+  async sweepOrphans(): Promise<{ marked: number }> {
+    const cutoff = new Date(Date.now() - 10 * 60 * 1000);
+    const result = await this.db.agentRun.updateMany({
+      where: {
+        tokensIn: null,
+        createdAt: { lt: cutoff },
+        outcome: { notIn: ['runner_crash', 'budget_aborted'] satisfies RunOutcomeT[] },
+      },
+      data: {
+        outcome: 'runner_crash' satisfies RunOutcomeT,
+        errorExcerpt: 'orphan row — runner crashed before final write',
+      },
+    });
+    return { marked: result.count };
+  }
+}
+
+/**
+ * Pure helper exported for unit testing.
+ * Returns null if any required input is missing — never throws.
+ */
+export function computeCostMicrodollars(
+  tokensIn: number | undefined,
+  tokensOut: number | undefined,
+  rateInUsdPerMt: number | undefined,
+  rateOutUsdPerMt: number | undefined,
+): number | null {
+  if (
+    tokensIn == null ||
+    tokensOut == null ||
+    rateInUsdPerMt == null ||
+    rateOutUsdPerMt == null
+  ) {
+    return null;
+  }
+  // tokens × USD/MT = microdollars (1e-6 USD per token-rate-million unit).
+  // Round to nearest microdollar for storage as Int.
+  const inMicros = tokensIn * rateInUsdPerMt;
+  const outMicros = tokensOut * rateOutUsdPerMt;
+  return Math.round(inMicros + outMicros);
+}

--- a/middleware/src/modules/agents/agent-runs.service.ts
+++ b/middleware/src/modules/agents/agent-runs.service.ts
@@ -39,8 +39,12 @@ export class AgentRunsService {
   /**
    * Synchronous write from runner. Returns the new row's id so the
    * runner can correlate later enrichment via mcp_audit_log.agentRunId.
+   *
+   * `callerType` is captured from the InternalSecretGuard's stamped
+   * x-internal-caller header (PR-review R2 I5: previously stamped on
+   * req but never persisted; now durable for forensic attribution).
    */
-  async recordRun(input: RecordRunInputT): Promise<{ id: string }> {
+  async recordRun(input: RecordRunInputT, callerType?: string): Promise<{ id: string }> {
     const startedAt = new Date(input.startedAt);
     const finishedAt = new Date(input.finishedAt);
     const durationMs = finishedAt.getTime() - startedAt.getTime();
@@ -57,6 +61,7 @@ export class AgentRunsService {
         errorExcerpt: input.errorExcerpt?.slice(0, 1024) ?? null,
         preflightBalanceUsd: input.preflightBalanceUsd ?? null,
         preflightTodaySpendUsd: input.preflightTodaySpendUsd ?? null,
+        callerType: callerType ?? null,
       },
       select: { id: true },
     });
@@ -74,10 +79,10 @@ export class AgentRunsService {
    */
   async enrichRun(id: string, input: EnrichRunInputT): Promise<{ id: string; enriched: boolean }> {
     // Surface NotFound separately from "frozen" so callers can distinguish
-    // a sidecar bug from a benign late-tick (Reviewer A+B).
+    // a sidecar bug from a benign late-tick (Reviewer A+B design review).
     const existing = await this.db.agentRun.findUnique({
       where: { id },
-      select: { id: true, finishedAt: true, tokensIn: true },
+      select: { id: true, finishedAt: true, enrichedAt: true },
     });
     if (!existing) {
       throw new NotFoundException(`agent_runs row '${id}' not found`);
@@ -104,20 +109,30 @@ export class AgentRunsService {
       rateOut,
     );
 
-    // Idempotent UPDATE: only writes if tokensIn is still NULL. The
-    // RETURNING-equivalent (updateMany returns count) lets us detect the
-    // "another sidecar got it first" race and treat as benign.
+    // Idempotent UPDATE: only writes if enrichedAt is still NULL.
+    // PR-review R1 I3 fix: previous predicate was `tokensIn IS NULL`
+    // which failed for outcome-only refinements (no token data → tokensIn
+    // stayed null → re-passed the predicate on every subsequent call).
+    // `enrichedAt` is set by THIS update; subsequent sidecar runs find it
+    // non-null and the predicate fails — count=0 → returned as benign no-op.
+    //
+    // Use conditional spread for outcome (PR-review R1 I6) — explicit is
+    // safer than relying on Prisma's "undefined key omits field" behavior.
+    const data: Record<string, unknown> = {
+      tokensIn: input.tokensIn ?? null,
+      tokensOut: input.tokensOut ?? null,
+      costMicrodollars,
+      rateInUsdPerMt: rateIn ?? null,
+      rateOutUsdPerMt: rateOut ?? null,
+      model: input.model ?? null,
+      enrichedAt: new Date(),
+    };
+    if (input.outcomeRefinement != null) {
+      data.outcome = input.outcomeRefinement;
+    }
     const result = await this.db.agentRun.updateMany({
-      where: { id, tokensIn: null },
-      data: {
-        tokensIn: input.tokensIn ?? null,
-        tokensOut: input.tokensOut ?? null,
-        costMicrodollars,
-        rateInUsdPerMt: rateIn ?? null,
-        rateOutUsdPerMt: rateOut ?? null,
-        model: input.model ?? null,
-        outcome: input.outcomeRefinement ?? undefined,
-      },
+      where: { id, enrichedAt: null },
+      data,
     });
     if (result.count === 0) {
       // Either already enriched (race with another sidecar) or row doesn't
@@ -153,13 +168,15 @@ export class AgentRunsService {
     const cutoff = new Date(Date.now() - 10 * 60 * 1000);
     const result = await this.db.agentRun.updateMany({
       where: {
-        tokensIn: null,
+        enrichedAt: null,
         createdAt: { lt: cutoff },
         outcome: { notIn: ['runner_crash', 'budget_aborted'] satisfies RunOutcomeT[] },
       },
       data: {
         outcome: 'runner_crash' satisfies RunOutcomeT,
         errorExcerpt: 'orphan row — runner crashed before final write',
+        // Mark enrichedAt to prevent re-orphan-sweeping on subsequent ticks.
+        enrichedAt: new Date(),
       },
     });
     return { marked: result.count };

--- a/middleware/src/modules/agents/agents.module.ts
+++ b/middleware/src/modules/agents/agents.module.ts
@@ -2,9 +2,12 @@ import { Module, Logger, ServiceUnavailableException } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { DatabaseModule } from '../database/database.module';
 import { AgentsController } from './agents.controller';
+import { AgentRunsController } from './agent-runs.controller';
 import { AgentStateService } from './agent-state.service';
+import { AgentRunsService } from './agent-runs.service';
 import { CustomerIncidentService } from './customer-incident.service';
 import { OnboardingService } from './onboarding.service';
+import { InternalSecretGuard } from '../common/guards/internal-secret.guard';
 import { AGENT_AI_TOKEN, type AgentAI } from './ai/agent-ai.interface';
 import { HeuristicAgentAI } from './ai/heuristic-agent-ai';
 import { AnthropicAgentAI } from './ai/anthropic-agent-ai.stub';
@@ -52,8 +55,10 @@ class FailedAgentAI implements AgentAI {
   imports: [DatabaseModule, ConfigModule],
   providers: [
     AgentStateService,
+    AgentRunsService,
     OnboardingService,
     CustomerIncidentService,
+    InternalSecretGuard,
     {
       provide: AGENT_AI_TOKEN,
       useFactory: (cfg: ConfigService): AgentAI => {
@@ -98,7 +103,7 @@ class FailedAgentAI implements AgentAI {
       inject: [ConfigService],
     },
   ],
-  controllers: [AgentsController],
-  exports: [OnboardingService, CustomerIncidentService, AGENT_AI_TOKEN],
+  controllers: [AgentsController, AgentRunsController],
+  exports: [OnboardingService, CustomerIncidentService, AgentRunsService, AGENT_AI_TOKEN],
 })
 export class AgentsModule {}

--- a/middleware/src/modules/agents/ecosystem-hermes-args.spec.ts
+++ b/middleware/src/modules/agents/ecosystem-hermes-args.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Lock the shape of the hermes-vizora-* entries in ecosystem.config.js.
+ *
+ * Reads the file as text and asserts the structural patterns we care about.
+ * Avoids dynamic require() of the config file (which static analyzers flag).
+ *
+ * The runner script `run-hermes-skill.sh <skill> <prompt> [toolsets-csv]`
+ * has a 3-positional-arg contract. PM2 fills these via the entry's
+ * `args` array. If the array shape drifts (e.g., toolsets element gets
+ * dropped during a copy-paste), the runner silently treats the missing
+ * arg as empty — defensible at runtime, but a regression we'd rather
+ * catch in CI.
+ *
+ * See: design ADL-5, P1.2.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('ecosystem.config.js — hermes-vizora-* entries', () => {
+  const configPath = path.resolve(__dirname, '../../../../ecosystem.config.js');
+  const content = fs.readFileSync(configPath, 'utf8');
+
+  it('has both hermes-vizora-* entries', () => {
+    expect(content).toContain("name: 'hermes-vizora-customer-lifecycle'");
+    expect(content).toContain("name: 'hermes-vizora-support-triage'");
+  });
+
+  it('both entries reference run-hermes-skill.sh', () => {
+    const matches = content.match(/run-hermes-skill\.sh/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('support-triage cron is no tighter than every 15 minutes', () => {
+    // Per the May 6 incident — */5 amplified cost. Locked at */15 minimum.
+    const stRegion = sectionFor(content, 'hermes-vizora-support-triage');
+    const cron = /cron_restart:\s*'(\*\/(\d+)) \* \* \* \*'/.exec(stRegion);
+    expect(cron).not.toBeNull();
+    expect(parseInt(cron![2], 10)).toBeGreaterThanOrEqual(15);
+  });
+
+  it('customer-lifecycle cron is no tighter than every 30 minutes', () => {
+    const clRegion = sectionFor(content, 'hermes-vizora-customer-lifecycle');
+    const cron = /cron_restart:\s*'(\*\/(\d+)) \* \* \* \*'/.exec(clRegion);
+    expect(cron).not.toBeNull();
+    expect(parseInt(cron![2], 10)).toBeGreaterThanOrEqual(30);
+  });
+});
+
+/**
+ * Slice the file content to just the named PM2 entry's region.
+ * Used to scope regex assertions.
+ */
+function sectionFor(content: string, entryName: string): string {
+  const start = content.indexOf(`name: '${entryName}'`);
+  if (start === -1) throw new Error(`entry '${entryName}' not found`);
+  // Region ends at the next `name: '...'` declaration or end-of-file.
+  const after = content.indexOf("name: '", start + 1);
+  return after === -1 ? content.slice(start) : content.slice(start, after);
+}

--- a/middleware/src/modules/common/guards/internal-secret.guard.spec.ts
+++ b/middleware/src/modules/common/guards/internal-secret.guard.spec.ts
@@ -1,0 +1,112 @@
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { UnauthorizedException, ExecutionContext } from '@nestjs/common';
+import { InternalSecretGuard } from './internal-secret.guard';
+
+describe('InternalSecretGuard', () => {
+  let guard: InternalSecretGuard;
+  const SECRET = 'test-secret-1234';
+
+  function makeCtx(headers: Record<string, string | undefined>): ExecutionContext {
+    const cleaned: Record<string, string> = {};
+    for (const [k, v] of Object.entries(headers)) {
+      if (v !== undefined) cleaned[k] = v;
+    }
+    return {
+      switchToHttp: () => ({
+        getRequest: () => ({ headers: cleaned }),
+      }),
+    } as unknown as ExecutionContext;
+  }
+
+  async function makeGuard(secret: string | undefined): Promise<InternalSecretGuard> {
+    const mod = await Test.createTestingModule({
+      providers: [
+        InternalSecretGuard,
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn(() => secret) },
+        },
+      ],
+    }).compile();
+    return mod.get(InternalSecretGuard);
+  }
+
+  beforeEach(async () => {
+    guard = await makeGuard(SECRET);
+  });
+
+  it('allows when both headers are correct', () => {
+    expect(
+      guard.canActivate(
+        makeCtx({ 'x-internal-api-key': SECRET, 'x-internal-caller': 'runner' }),
+      ),
+    ).toBe(true);
+  });
+
+  it('accepts each allowed caller value (runner, sidecar, ops)', () => {
+    for (const caller of ['runner', 'sidecar', 'ops']) {
+      expect(
+        guard.canActivate(
+          makeCtx({ 'x-internal-api-key': SECRET, 'x-internal-caller': caller }),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it('rejects with 401 when api-key header is missing', () => {
+    expect(() => guard.canActivate(makeCtx({ 'x-internal-caller': 'runner' }))).toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('rejects with 401 when api-key header is wrong', () => {
+    expect(() =>
+      guard.canActivate(
+        makeCtx({ 'x-internal-api-key': 'wrong-secret', 'x-internal-caller': 'runner' }),
+      ),
+    ).toThrow(UnauthorizedException);
+  });
+
+  it('rejects with 401 when api-key header is correct length but wrong content (constant-time)', () => {
+    // Same length as SECRET but every char flipped.
+    const wrong = 'X'.repeat(SECRET.length);
+    expect(() =>
+      guard.canActivate(
+        makeCtx({ 'x-internal-api-key': wrong, 'x-internal-caller': 'runner' }),
+      ),
+    ).toThrow(UnauthorizedException);
+  });
+
+  it('rejects with 401 when caller header is missing', () => {
+    expect(() =>
+      guard.canActivate(makeCtx({ 'x-internal-api-key': SECRET })),
+    ).toThrow(UnauthorizedException);
+  });
+
+  it('rejects with 401 when caller header is unknown', () => {
+    expect(() =>
+      guard.canActivate(
+        makeCtx({ 'x-internal-api-key': SECRET, 'x-internal-caller': 'unknown-caller' }),
+      ),
+    ).toThrow(UnauthorizedException);
+  });
+
+  it('rejects with 401 when INTERNAL_API_SECRET env not set (fail-closed)', async () => {
+    const g = await makeGuard(undefined);
+    expect(() =>
+      g.canActivate(makeCtx({ 'x-internal-api-key': SECRET, 'x-internal-caller': 'runner' })),
+    ).toThrow(UnauthorizedException);
+  });
+
+  it('stamps the validated caller onto the request object', () => {
+    const req: { headers: Record<string, string>; internalCaller?: string } = {
+      headers: { 'x-internal-api-key': SECRET, 'x-internal-caller': 'sidecar' },
+    };
+    const ctx = {
+      switchToHttp: () => ({ getRequest: () => req }),
+    } as unknown as ExecutionContext;
+    expect(guard.canActivate(ctx)).toBe(true);
+    expect(req.internalCaller).toBe('sidecar');
+  });
+});

--- a/middleware/src/modules/common/guards/internal-secret.guard.spec.ts
+++ b/middleware/src/modules/common/guards/internal-secret.guard.spec.ts
@@ -7,25 +7,37 @@ describe('InternalSecretGuard', () => {
   let guard: InternalSecretGuard;
   const SECRET = 'test-secret-1234';
 
-  function makeCtx(headers: Record<string, string | undefined>): ExecutionContext {
+  function makeCtx(
+    headers: Record<string, string | undefined>,
+    ip: string = '127.0.0.1',
+  ): ExecutionContext {
     const cleaned: Record<string, string> = {};
     for (const [k, v] of Object.entries(headers)) {
       if (v !== undefined) cleaned[k] = v;
     }
     return {
       switchToHttp: () => ({
-        getRequest: () => ({ headers: cleaned }),
+        getRequest: () => ({ headers: cleaned, ip }),
       }),
     } as unknown as ExecutionContext;
   }
 
-  async function makeGuard(secret: string | undefined): Promise<InternalSecretGuard> {
+  async function makeGuard(
+    secret: string | undefined,
+    loopbackOnly: string = 'true',
+  ): Promise<InternalSecretGuard> {
     const mod = await Test.createTestingModule({
       providers: [
         InternalSecretGuard,
         {
           provide: ConfigService,
-          useValue: { get: jest.fn(() => secret) },
+          useValue: {
+            get: jest.fn((key: string, dflt?: string) => {
+              if (key === 'INTERNAL_API_SECRET') return secret;
+              if (key === 'INTERNAL_API_LOOPBACK_ONLY') return loopbackOnly;
+              return dflt;
+            }),
+          },
         },
       ],
     }).compile();
@@ -100,13 +112,47 @@ describe('InternalSecretGuard', () => {
   });
 
   it('stamps the validated caller onto the request object', () => {
-    const req: { headers: Record<string, string>; internalCaller?: string } = {
+    const req: { headers: Record<string, string>; ip: string; internalCaller?: string } = {
       headers: { 'x-internal-api-key': SECRET, 'x-internal-caller': 'sidecar' },
+      ip: '127.0.0.1',
     };
     const ctx = {
       switchToHttp: () => ({ getRequest: () => req }),
     } as unknown as ExecutionContext;
     expect(guard.canActivate(ctx)).toBe(true);
     expect(req.internalCaller).toBe('sidecar');
+  });
+
+  it('REJECTS non-loopback IP by default (PR-review R2 C4)', () => {
+    expect(() =>
+      guard.canActivate(
+        makeCtx({ 'x-internal-api-key': SECRET, 'x-internal-caller': 'runner' }, '203.0.113.42'),
+      ),
+    ).toThrow(UnauthorizedException);
+  });
+
+  it('accepts ::1 IPv6 loopback', () => {
+    expect(
+      guard.canActivate(
+        makeCtx({ 'x-internal-api-key': SECRET, 'x-internal-caller': 'runner' }, '::1'),
+      ),
+    ).toBe(true);
+  });
+
+  it('accepts ::ffff:127.0.0.1 IPv4-mapped IPv6 loopback', () => {
+    expect(
+      guard.canActivate(
+        makeCtx({ 'x-internal-api-key': SECRET, 'x-internal-caller': 'runner' }, '::ffff:127.0.0.1'),
+      ),
+    ).toBe(true);
+  });
+
+  it('allows non-loopback when INTERNAL_API_LOOPBACK_ONLY=false', async () => {
+    const g = await makeGuard(SECRET, 'false');
+    expect(
+      g.canActivate(
+        makeCtx({ 'x-internal-api-key': SECRET, 'x-internal-caller': 'runner' }, '10.0.0.5'),
+      ),
+    ).toBe(true);
   });
 });

--- a/middleware/src/modules/common/guards/internal-secret.guard.ts
+++ b/middleware/src/modules/common/guards/internal-secret.guard.ts
@@ -1,0 +1,70 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+  Logger,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type { Request } from 'express';
+
+/**
+ * Guards routes that should only be callable by other Vizora services
+ * (the runner script, ops agents, the insights-poller sidecar).
+ *
+ * Matches the existing OUTBOUND convention used by middleware → realtime:
+ * header `x-internal-api-key`, value compared against
+ * `INTERNAL_API_SECRET` env via constant-time compare.
+ *
+ * Returns 401 (not 403) on mismatch — these endpoints should not
+ * acknowledge their existence to anyone without the secret.
+ *
+ * REQUIRES `x-internal-caller` header (one of: runner | sidecar | ops)
+ * for caller attribution. A leaked secret in a runner log compromises
+ * fewer surfaces if we know which caller leaked it.
+ *
+ * See: docs/plans/2026-05-08-agent-platform-redesign-design.md §3.2
+ */
+const ALLOWED_CALLERS = ['runner', 'sidecar', 'ops'] as const;
+type AllowedCaller = (typeof ALLOWED_CALLERS)[number];
+
+@Injectable()
+export class InternalSecretGuard implements CanActivate {
+  private readonly logger = new Logger(InternalSecretGuard.name);
+
+  constructor(private readonly config: ConfigService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const expected = this.config.get<string>('INTERNAL_API_SECRET');
+    if (!expected) {
+      // Fail closed and log loudly — this is a misconfiguration.
+      this.logger.error('INTERNAL_API_SECRET not set — refusing all internal calls');
+      throw new UnauthorizedException();
+    }
+    const req = context.switchToHttp().getRequest<Request>();
+    const provided = req.headers['x-internal-api-key'];
+    if (typeof provided !== 'string' || !this.constantTimeEquals(provided, expected)) {
+      throw new UnauthorizedException();
+    }
+    const caller = req.headers['x-internal-caller'];
+    if (typeof caller !== 'string' || !ALLOWED_CALLERS.includes(caller as AllowedCaller)) {
+      throw new UnauthorizedException();
+    }
+    // Stamp the validated caller onto the request for downstream audit logs.
+    (req as Request & { internalCaller?: AllowedCaller }).internalCaller = caller as AllowedCaller;
+    return true;
+  }
+
+  /**
+   * Constant-time string comparison to prevent timing attacks on the secret.
+   * Returns false on length mismatch (length itself is not secret).
+   */
+  private constantTimeEquals(a: string, b: string): boolean {
+    if (a.length !== b.length) return false;
+    let result = 0;
+    for (let i = 0; i < a.length; i++) {
+      result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+    }
+    return result === 0;
+  }
+}

--- a/middleware/src/modules/common/guards/internal-secret.guard.ts
+++ b/middleware/src/modules/common/guards/internal-secret.guard.ts
@@ -6,27 +6,37 @@ import {
   Logger,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { timingSafeEqual } from 'node:crypto';
 import type { Request } from 'express';
 
 /**
  * Guards routes that should only be callable by other Vizora services
  * (the runner script, ops agents, the insights-poller sidecar).
  *
- * Matches the existing OUTBOUND convention used by middleware → realtime:
- * header `x-internal-api-key`, value compared against
- * `INTERNAL_API_SECRET` env via constant-time compare.
+ * Auth chain (defense in depth — PR-review R2 C4):
+ *   1. Loopback-only check by default (INTERNAL_API_LOOPBACK_ONLY=true).
+ *      The host nginx must ALSO deny external traffic to /api/v1/internal/*
+ *      — this is the primary network defense; the loopback check is a
+ *      backstop in case nginx config drifts.
+ *   2. x-internal-api-key header compared against INTERNAL_API_SECRET via
+ *      `crypto.timingSafeEqual` (PR-review R1 C5: replaces hand-rolled
+ *      XOR loop which was not provably constant-time across V8 JIT).
+ *   3. x-internal-caller header (one of: runner | sidecar | ops) for
+ *      caller attribution.
  *
  * Returns 401 (not 403) on mismatch — these endpoints should not
  * acknowledge their existence to anyone without the secret.
- *
- * REQUIRES `x-internal-caller` header (one of: runner | sidecar | ops)
- * for caller attribution. A leaked secret in a runner log compromises
- * fewer surfaces if we know which caller leaked it.
  *
  * See: docs/plans/2026-05-08-agent-platform-redesign-design.md §3.2
  */
 const ALLOWED_CALLERS = ['runner', 'sidecar', 'ops'] as const;
 type AllowedCaller = (typeof ALLOWED_CALLERS)[number];
+
+const LOOPBACK_IPS = new Set([
+  '127.0.0.1',
+  '::1',
+  '::ffff:127.0.0.1', // IPv4-mapped IPv6
+]);
 
 @Injectable()
 export class InternalSecretGuard implements CanActivate {
@@ -42,6 +52,14 @@ export class InternalSecretGuard implements CanActivate {
       throw new UnauthorizedException();
     }
     const req = context.switchToHttp().getRequest<Request>();
+
+    // Defense layer 1: loopback-only by default (PR-review R2 C4).
+    // Set INTERNAL_API_LOOPBACK_ONLY=false to disable for multi-host setups.
+    const loopbackOnly = this.config.get<string>('INTERNAL_API_LOOPBACK_ONLY', 'true') !== 'false';
+    if (loopbackOnly && req.ip && !LOOPBACK_IPS.has(req.ip)) {
+      throw new UnauthorizedException();
+    }
+
     const provided = req.headers['x-internal-api-key'];
     if (typeof provided !== 'string' || !this.constantTimeEquals(provided, expected)) {
       throw new UnauthorizedException();
@@ -50,21 +68,20 @@ export class InternalSecretGuard implements CanActivate {
     if (typeof caller !== 'string' || !ALLOWED_CALLERS.includes(caller as AllowedCaller)) {
       throw new UnauthorizedException();
     }
-    // Stamp the validated caller onto the request for downstream audit logs.
+    // Stamp the validated caller onto the request for downstream persistence
+    // (controller reads this and passes to AgentRunsService.recordRun).
     (req as Request & { internalCaller?: AllowedCaller }).internalCaller = caller as AllowedCaller;
     return true;
   }
 
   /**
-   * Constant-time string comparison to prevent timing attacks on the secret.
-   * Returns false on length mismatch (length itself is not secret).
+   * Constant-time string comparison via Node's crypto.timingSafeEqual.
+   * Length mismatch returns false immediately (length itself is not secret
+   * for a fixed-format env var, but timingSafeEqual throws on length
+   * mismatch so we short-circuit explicitly).
    */
   private constantTimeEquals(a: string, b: string): boolean {
     if (a.length !== b.length) return false;
-    let result = 0;
-    for (let i = 0; i < a.length; i++) {
-      result |= a.charCodeAt(i) ^ b.charCodeAt(i);
-    }
-    return result === 0;
+    return timingSafeEqual(Buffer.from(a), Buffer.from(b));
   }
 }

--- a/middleware/src/modules/common/middleware/csrf.middleware.ts
+++ b/middleware/src/modules/common/middleware/csrf.middleware.ts
@@ -76,9 +76,18 @@ export class CsrfMiddleware implements NestMiddleware {
     const isMcpRoute =
       pathname === '/api/v1/mcp' || pathname.startsWith('/api/v1/mcp/');
 
+    // /api/v1/internal/* endpoints (PR-review R2 C7): server-to-server
+    // calls from the runner script, sidecar, and ops scripts. Auth is
+    // enforced by InternalSecretGuard (x-internal-api-key + caller +
+    // loopback-only). No browser, no cookies, no CSRF surface.
+    // Same exact-match-or-prefix-with-slash discipline as MCP above.
+    const isInternalRoute =
+      pathname === '/api/v1/internal' || pathname.startsWith('/api/v1/internal/');
+
     const isExempt = csrfExemptSuffixes.some(suffix => fullPath.endsWith(suffix))
       || fullPath.match(/\/devices\/pairing\/status\/[A-Za-z0-9]+$/)
-      || isMcpRoute;
+      || isMcpRoute
+      || isInternalRoute;
 
     if (isExempt) {
       return next();

--- a/middleware/src/modules/mcp/schemas/tool-inputs.ts
+++ b/middleware/src/modules/mcp/schemas/tool-inputs.ts
@@ -138,7 +138,10 @@ export const SendLifecycleNudgeEmailInput = z.object({
 });
 export type SendLifecycleNudgeEmailInputT = z.infer<typeof SendLifecycleNudgeEmailInput>;
 
-// ── Shadow log writer (platform-scope, shadow:write) ──────────────────────
+// ── Shadow log writer (any-scope, shadow:write) ───────────────────────────
+// P1.1 (2026-05-08) opened this tool to per-org tokens. Per-org tokens
+// get organization_id auto-tagged into the row; platform-scope tokens
+// write without the tag. See shadow-log.tools.ts for cross-tenant defense.
 
 export const LogShadowRowInput = z.object({
   log_name: z

--- a/middleware/src/modules/mcp/tools/shadow-log.tools.spec.ts
+++ b/middleware/src/modules/mcp/tools/shadow-log.tools.spec.ts
@@ -41,16 +41,87 @@ describe('logShadowRowTool', () => {
     expect(svc.appendRow).not.toHaveBeenCalled();
   });
 
-  it('REJECTS per-org tokens with BadRequest — shadow logs are platform-scope artifacts', async () => {
+  it('ACCEPTS per-org tokens and tags the appended row with the token org context', async () => {
+    // P1.1 (2026-05-08): support-triage's token is per-org but it must call
+    // log_shadow_row to write its audit JSONL. Removing the platform-scope
+    // requirement closes the structural contradiction.
+    const svc = makeShadowLog({});
+    const out = await logShadowRowTool(
+      { log_name: 'vizora-customer-lifecycle-shadow', fields: { tier: 'pro' } },
+      ctx({ scopes: ['shadow:write'], organizationId: 'org_abc' }),
+      svc as never,
+    );
+    expect(svc.appendRow).toHaveBeenCalledWith(
+      'vizora-customer-lifecycle-shadow',
+      expect.objectContaining({ tier: 'pro', organization_id: 'org_abc' }),
+    );
+    expect(out.written).toBe(true);
+  });
+
+  it('does NOT inject organization_id when the token is platform-scope', async () => {
+    const svc = makeShadowLog({});
+    await logShadowRowTool(
+      { log_name: 'vizora-customer-lifecycle-shadow', fields: { tier: 'pro' } },
+      ctx({ scopes: ['shadow:write'], organizationId: null }),
+      svc as never,
+    );
+    expect(svc.appendRow).toHaveBeenCalledWith(
+      'vizora-customer-lifecycle-shadow',
+      expect.not.objectContaining({ organization_id: expect.anything() }),
+    );
+  });
+
+  it('REJECTS per-org token with mismatched agent-supplied organization_id (cross-tenant defense)', async () => {
+    // Reviewer A D2: a per-org token for org A could stamp organization_id=B
+    // and mislead downstream JSONL readers. Server-side enforcement: token's
+    // org is the source of truth; mismatched agent-supplied value is INVALID_INPUT.
     const svc = makeShadowLog({});
     await expect(
       logShadowRowTool(
-        { log_name: 'vizora-customer-lifecycle-shadow', fields: { a: 1 } },
-        ctx({ scopes: ['shadow:write'], organizationId: 'org_1' }),
+        {
+          log_name: 'vizora-customer-lifecycle-shadow',
+          fields: { organization_id: 'org_OTHER', tier: 'pro' },
+        },
+        ctx({ scopes: ['shadow:write'], organizationId: 'org_abc' }),
         svc as never,
       ),
     ).rejects.toThrow(BadRequestException);
     expect(svc.appendRow).not.toHaveBeenCalled();
+  });
+
+  it('accepts per-org token when agent-supplied organization_id MATCHES the token', async () => {
+    // Idempotent: agent passing the same value as the token isn't a violation.
+    const svc = makeShadowLog({});
+    await logShadowRowTool(
+      {
+        log_name: 'vizora-customer-lifecycle-shadow',
+        fields: { organization_id: 'org_abc', tier: 'pro' },
+      },
+      ctx({ scopes: ['shadow:write'], organizationId: 'org_abc' }),
+      svc as never,
+    );
+    expect(svc.appendRow).toHaveBeenCalledWith(
+      'vizora-customer-lifecycle-shadow',
+      expect.objectContaining({ organization_id: 'org_abc', tier: 'pro' }),
+    );
+  });
+
+  it('platform-scope token MAY supply any organization_id (cross-org agents have authority)', async () => {
+    // The customer-lifecycle skill iterates over orgs and writes per-org
+    // shadow rows from a platform-scope token. Allowed and expected.
+    const svc = makeShadowLog({});
+    await logShadowRowTool(
+      {
+        log_name: 'vizora-customer-lifecycle-shadow',
+        fields: { organization_id: 'org_xyz', heuristic_action: 'send_nudge' },
+      },
+      ctx({ scopes: ['shadow:write'], organizationId: null }),
+      svc as never,
+    );
+    expect(svc.appendRow).toHaveBeenCalledWith(
+      'vizora-customer-lifecycle-shadow',
+      expect.objectContaining({ organization_id: 'org_xyz' }),
+    );
   });
 
   it('forwards log_name + fields to the service when scope + token shape are correct', async () => {

--- a/middleware/src/modules/mcp/tools/shadow-log.tools.ts
+++ b/middleware/src/modules/mcp/tools/shadow-log.tools.ts
@@ -25,9 +25,13 @@ import {
  * skill prompt only has to pick the right log_name and compose the
  * fields, with no string-formatting discipline required.
  *
- * **Token shape**: platform-scope token required. Per-org tokens are
- * rejected with INVALID_INPUT — shadow logs are agent-side
- * audit trails, not org-scoped data.
+ * **Token shape**: any valid token with `shadow:write` scope. Per-org
+ * tokens get tagged with `organization_id` in the appended row;
+ * platform-scope tokens write without the tag. Agent-supplied
+ * `organization_id` in fields is REJECTED for per-org tokens if it
+ * doesn't match the token's organizationId — this closes a cross-tenant
+ * write surface where org A could stamp organization_id=B in the JSONL
+ * (Reviewer A design D2).
  *
  * Scope required: `shadow:write`.
  */
@@ -39,19 +43,35 @@ export async function logShadowRowTool(
   if (!hasScope(context, 'shadow:write')) {
     throw new ForbiddenException("Token lacks scope 'shadow:write'");
   }
-  if (context.organizationId != null) {
-    throw new BadRequestException(
-      'log_shadow_row requires a platform-scope token (organizationId=null). Per-org tokens are rejected.',
-    );
-  }
   const input = LogShadowRowInput.parse(rawInput) as LogShadowRowInputT;
+
+  // Cross-tenant write defense (Reviewer A D2): if the token is per-org,
+  // force `organization_id` in the row to the token's value. If the
+  // agent supplied a different `organization_id`, reject INVALID_INPUT —
+  // the token's org is the cryptographic source of truth.
+  const inputFields = input.fields as Record<string, unknown>;
+  let fieldsWithContext: Record<string, unknown>;
+  if (context.organizationId != null) {
+    const supplied = inputFields.organization_id;
+    if (supplied != null && supplied !== context.organizationId) {
+      throw new BadRequestException(
+        `organization_id mismatch with token scope (supplied=${String(supplied)}, token=${context.organizationId})`,
+      );
+    }
+    // Force the token's value (whether agent supplied none or matching).
+    fieldsWithContext = { ...inputFields, organization_id: context.organizationId };
+  } else {
+    // Platform-scope token: write fields as-is. Agent may supply any
+    // organization_id (or none) — they have authority across orgs.
+    fieldsWithContext = inputFields;
+  }
 
   // The service throws on allowlist failure / oversize / invalid fields —
   // those map to INVALID_INPUT through the global error mapper since the
   // service raises BadRequestException-shaped errors.
   let result;
   try {
-    result = shadowLog.appendRow(input.log_name, input.fields as Record<string, unknown>);
+    result = shadowLog.appendRow(input.log_name, fieldsWithContext);
   } catch (err) {
     throw new BadRequestException(
       err instanceof Error ? err.message : String(err),
@@ -74,7 +94,7 @@ export async function logShadowRowTool(
 export const LOG_SHADOW_ROW_TOOL = {
   name: 'log_shadow_row',
   description:
-    "Append one JSONL row to a Hermes shadow-agent audit log. Server enriches the row with `timestamp` (ISO-8601 UTC) and `run_id` (epoch-seconds), validates against the allowlist of known log names, and atomic-appends. Agent supplies `log_name` (enum: vizora-support-triage-shadow | vizora-support-triage-live | vizora-customer-lifecycle-shadow | vizora-customer-lifecycle-live) and `fields` (JSON object, max 4096 bytes serialized). Platform-scope token required.",
+    "Append one JSONL row to a Hermes shadow-agent audit log. Server enriches the row with `timestamp` (ISO-8601 UTC) and `run_id` (epoch-seconds), validates against the allowlist of known log names, and atomic-appends. Agent supplies `log_name` (enum: vizora-support-triage-shadow | vizora-support-triage-live | vizora-customer-lifecycle-shadow | vizora-customer-lifecycle-live) and `fields` (JSON object, max 4096 bytes serialized). Requires `shadow:write` scope; per-org tokens are tagged with org context, platform-scope tokens are not.",
   scope: 'shadow:write' as const,
   inputSchema: LogShadowRowInput,
   outputSchema: LogShadowRowResult,

--- a/packages/database/prisma/migrations/20260508000000_agent_runs/migration.sql
+++ b/packages/database/prisma/migrations/20260508000000_agent_runs/migration.sql
@@ -1,0 +1,67 @@
+-- Migration: agent_runs
+--
+-- Adds the AgentRun model for per-firing observability of Hermes-driven
+-- agent invocations, plus a nullable agentRunId FK on mcp_audit_log so
+-- the insights-poller sidecar can attribute audit rows to specific firings.
+--
+-- See: docs/plans/2026-05-08-agent-platform-redesign-design.md §2.1, §2.3
+-- ADL-7: Cost columns are FROZEN at write — never recomputed.
+--
+-- Migration is purely additive:
+--   * NEW TABLE: agent_runs
+--   * NEW COLUMN: mcp_audit_log.agentRunId (NULLABLE — no backfill needed)
+-- No data is rewritten; no existing column types change.
+
+-- AlterTable: mcp_audit_log gets a nullable FK to agent_runs.
+ALTER TABLE "mcp_audit_log" ADD COLUMN "agentRunId" TEXT;
+
+-- CreateTable: agent_runs (per-firing record).
+CREATE TABLE "agent_runs" (
+    "id" TEXT NOT NULL,
+    "skillName" TEXT NOT NULL,
+    "organizationId" TEXT,
+    "pid" INTEGER,
+    "startedAt" TIMESTAMP(3) NOT NULL,
+    "finishedAt" TIMESTAMP(3),
+    "durationMs" INTEGER,
+    "exitCode" INTEGER,
+    "tokensIn" INTEGER,
+    "tokensOut" INTEGER,
+    "costMicrodollars" INTEGER,
+    "rateInUsdPerMt" DECIMAL(8,4),
+    "rateOutUsdPerMt" DECIMAL(8,4),
+    "model" TEXT,
+    "outcome" TEXT NOT NULL,
+    "errorExcerpt" VARCHAR(1024),
+    "preflightBalanceUsd" DECIMAL(12,8),
+    "preflightTodaySpendUsd" DECIMAL(12,8),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "agent_runs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex: per-firing audit join key (sidecar refinement query).
+CREATE INDEX "mcp_audit_log_agentRunId_idx" ON "mcp_audit_log"("agentRunId");
+
+-- CreateIndex: time-series dashboard queries per skill.
+CREATE INDEX "agent_runs_skillName_startedAt_idx" ON "agent_runs"("skillName", "startedAt");
+
+-- CreateIndex: failure-rate alerting.
+CREATE INDEX "agent_runs_outcome_startedAt_idx" ON "agent_runs"("outcome", "startedAt");
+
+-- CreateIndex: cost-per-model breakdown queries.
+CREATE INDEX "agent_runs_model_startedAt_idx" ON "agent_runs"("model", "startedAt");
+
+-- CreateIndex: 90-day retention DELETE scan in db-maintainer.
+CREATE INDEX "agent_runs_createdAt_idx" ON "agent_runs"("createdAt");
+
+-- CreateIndex: per-tenant cost attribution queries.
+CREATE INDEX "agent_runs_organizationId_startedAt_idx" ON "agent_runs"("organizationId", "startedAt");
+
+-- AddForeignKey: mcp_audit_log → agent_runs (SetNull on agent_run delete).
+ALTER TABLE "mcp_audit_log" ADD CONSTRAINT "mcp_audit_log_agentRunId_fkey"
+    FOREIGN KEY ("agentRunId") REFERENCES "agent_runs"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey: agent_runs → organizations (SetNull on org delete to preserve historical cost rows).
+ALTER TABLE "agent_runs" ADD CONSTRAINT "agent_runs_organizationId_fkey"
+    FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/database/prisma/migrations/20260509000000_agent_runs_enriched_marker/migration.sql
+++ b/packages/database/prisma/migrations/20260509000000_agent_runs_enriched_marker/migration.sql
@@ -1,0 +1,20 @@
+-- Migration: agent_runs_enriched_marker
+--
+-- Adds two columns to agent_runs in response to PR-review findings:
+--
+--   1. enrichedAt — proper idempotency marker for the sidecar PATCH
+--      (PR-review R1 I3). Replaces the brittle `WHERE tokensIn IS NULL`
+--      predicate which fails when the sidecar PATCHes outcome-only
+--      refinements (no token data → tokensIn stays null → re-passes guard).
+--
+--   2. callerType — persists the InternalSecretGuard's x-internal-caller
+--      stamp onto the row (PR-review R2 I5). Was stamped on req object
+--      but never read; now durable for forensic attribution if the shared
+--      INTERNAL_API_SECRET ever leaks.
+--
+-- Both columns are nullable; backfill is unnecessary. Existing rows get
+-- callerType=NULL (correct — pre-redesign, no caller identification was
+-- captured) and enrichedAt=NULL (correct — they were never enriched).
+
+ALTER TABLE "agent_runs" ADD COLUMN "callerType" TEXT;
+ALTER TABLE "agent_runs" ADD COLUMN "enrichedAt" TIMESTAMP(3);

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -57,6 +57,7 @@ model Organization {
   customerIncidents      CustomerIncident[]
   contentRecommendations ContentRecommendation[]
   mcpTokens              McpToken[]
+  agentRuns              AgentRun[]
 
   @@index([slug])
   @@index([stripeCustomerId])
@@ -860,11 +861,11 @@ model ContentRecommendation {
 // ============================================================================
 
 model McpToken {
-  id             String       @id @default(cuid())
+  id             String        @id @default(cuid())
   // SHA-256 hex of the bearer token. Plaintext is shown to admin once at
   // issuance and never persisted. Lookup compares hashes — never compare
   // plaintext to plaintext.
-  tokenHash      String       @unique
+  tokenHash      String        @unique
   // Human-readable label (e.g. "support-triage prod 2026-Q2"). Free-form.
   name           String
   // Scope: which org's data this token can read. NULL = platform-scope
@@ -878,7 +879,7 @@ model McpToken {
   agentName      String
   // Tool-scope strings (e.g. ["displays:read", "content:read"]).
   scopes         String[]
-  createdAt      DateTime     @default(now())
+  createdAt      DateTime      @default(now())
   // Nullable = no expiry. Recommend setting one (max 90d) for admin-issued tokens.
   expiresAt      DateTime?
   // Set when revoked. Null = active.
@@ -912,10 +913,82 @@ model McpAuditLog {
   errorCode      String?
   // Time spent inside the tool handler.
   latencyMs      Int
+  // FK to the agent firing that triggered this tool call. Set when the
+  // runner script propagates the agent_runs.id via Hermes header into
+  // the MCP request context. Nullable for: (a) backward-compat with
+  // pre-2026-05 audit rows, (b) calls from non-runner contexts (admin
+  // tooling, dashboard introspection).
+  agentRunId     String?
+  agentRun       AgentRun? @relation(fields: [agentRunId], references: [id], onDelete: SetNull)
   createdAt      DateTime  @default(now())
 
   @@index([tokenId, createdAt])
   @@index([agentName, createdAt])
   @@index([organizationId, createdAt])
+  @@index([agentRunId])
   @@map("mcp_audit_log")
+}
+
+/// Per-firing record for Hermes-driven agent invocations. Written in
+/// two stages: the runner script POSTs metadata synchronously on firing
+/// exit; the insights-poller sidecar PATCHes cost/token data ~5 min
+/// later by joining `hermes insights` output back to the row.
+///
+/// Cost columns are FROZEN at write — see ADL-7 in the design doc.
+/// `rateInUsdPerMt` and `rateOutUsdPerMt` capture the model rate USED
+/// at the moment of enrichment so historical queries stay accurate
+/// when MODEL_RATES changes.
+///
+/// Retention: 90 days (enforced by db-maintainer cron).
+model AgentRun {
+  id                     String        @id @default(cuid())
+  // Hermes skill name — e.g. "vizora-customer-lifecycle".
+  skillName              String
+  // For per-org skills only; null for platform-scope skills. Enables
+  // per-tenant cost attribution.
+  organizationId         String?
+  organization           Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
+  // PM2 worker PID — useful for cross-referencing with PM2 logs.
+  pid                    Int?
+  // Wall-clock window. startedAt is at runner pre-flight start (UTC);
+  // finishedAt is null only for orphan rows (sidecar fills in via the
+  // 10-minute orphan-sweep policy in §4.3 of the design doc).
+  startedAt              DateTime
+  finishedAt             DateTime?
+  durationMs             Int?
+  // Hermes process exit code; 124 = timeout(1); null = budget_aborted
+  // (Hermes never invoked).
+  exitCode               Int?
+  // Token usage from `hermes insights`. Null until sidecar enriches.
+  tokensIn               Int?
+  tokensOut              Int?
+  // Cost in microdollars (USD * 1e6) for integer arithmetic. Computed
+  // ONCE at enrichment time; never recomputed (ADL-7).
+  costMicrodollars       Int?
+  // Rate used at enrichment time. Snapshotting these keeps historical
+  // analyses correct when OpenRouter rates change.
+  rateInUsdPerMt         Decimal?      @db.Decimal(8, 4)
+  rateOutUsdPerMt        Decimal?      @db.Decimal(8, 4)
+  // Versioned model id from `hermes insights` (e.g. "openai/gpt-4o-mini-2024-07-18").
+  model                  String?
+  // One of: success | no_work | partial | tool_error | api_error |
+  // timeout | budget_aborted | runner_crash. Validated by Zod at the
+  // controller boundary; stored as String for forward-compatibility
+  // (avoids native enum migration friction when adding new outcomes).
+  outcome                String
+  // Tail of runner log on error (max 1024 chars).
+  errorExcerpt           String?       @db.VarChar(1024)
+  // OpenRouter `/v1/credits` returns 8 fractional digits — match exactly.
+  preflightBalanceUsd    Decimal?      @db.Decimal(12, 8)
+  preflightTodaySpendUsd Decimal?      @db.Decimal(12, 8)
+  createdAt              DateTime      @default(now())
+
+  auditLogs McpAuditLog[]
+
+  @@index([skillName, startedAt])
+  @@index([outcome, startedAt])
+  @@index([model, startedAt])
+  @@index([createdAt])
+  @@index([organizationId, startedAt])
+  @@map("agent_runs")
 }

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -981,6 +981,16 @@ model AgentRun {
   // OpenRouter `/v1/credits` returns 8 fractional digits — match exactly.
   preflightBalanceUsd    Decimal?      @db.Decimal(12, 8)
   preflightTodaySpendUsd Decimal?      @db.Decimal(12, 8)
+  // Caller identification from the runner POST. Persisted for forensic
+  // attribution if the shared INTERNAL_API_SECRET ever leaks.
+  // Values: 'runner' | 'sidecar' | 'ops'.
+  // (PR-review R2 I5: was stamped on req but never persisted; now is.)
+  callerType             String?
+  // Set by the sidecar on first PATCH. Used as the idempotency marker
+  // (PR-review R1 I3): predicate `WHERE enrichedAt IS NULL` closes the
+  // gap where outcome-only refinements with no token data would otherwise
+  // re-pass the previous `tokensIn IS NULL` predicate.
+  enrichedAt             DateTime?
   createdAt              DateTime      @default(now())
 
   auditLogs McpAuditLog[]

--- a/scripts/agents/hermes/insights-parser.spec.ts
+++ b/scripts/agents/hermes/insights-parser.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for the hermes insights parser. Synthetic fixtures cover:
+ *   - the empty-case literal string from prod (verified live 2026-05-08)
+ *   - typical Unicode-box-table output
+ *   - format-drift cases (raise InsightsParserError)
+ *   - ragged rows / totals row / missing tokens
+ *
+ * Real prod output not used here — the parser is the contract; CI will
+ * verify with a paid-key smoke test when credits are added.
+ */
+
+import {
+  parseHermesInsightsTable,
+  InsightsParserError,
+} from './insights-parser';
+
+describe('parseHermesInsightsTable', () => {
+  it('returns [] for the prod-verified empty-case literal', () => {
+    expect(parseHermesInsightsTable('No sessions found in the last 1 days (source: cli).')).toEqual(
+      [],
+    );
+  });
+
+  it('returns [] for completely empty input', () => {
+    expect(parseHermesInsightsTable('')).toEqual([]);
+  });
+
+  it('parses a single-row Unicode-box table', () => {
+    const fixture = `
+┌─────────────────────┬──────────────────────────────────┬──────┬──────┐
+│ time                │ model                            │ in   │ out  │
+├─────────────────────┼──────────────────────────────────┼──────┼──────┤
+│ 2026-05-08 12:30:00 │ openai/gpt-4o-mini-2024-07-18    │ 5000 │  800 │
+└─────────────────────┴──────────────────────────────────┴──────┴──────┘
+`;
+    const rows = parseHermesInsightsTable(fixture);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      model: 'openai/gpt-4o-mini-2024-07-18',
+      tokensIn: 5000,
+      tokensOut: 800,
+    });
+    expect(rows[0].timestamp.toISOString()).toContain('2026-05-08');
+  });
+
+  it('parses multi-row tables and accepts ASCII-pipe variant', () => {
+    // ASCII-pipe variant — some terminals emit │ as |.
+    const fixture = [
+      '+---------------------+--------------------+------+------+',
+      '| time                | model              |   in |  out |',
+      '+---------------------+--------------------+------+------+',
+      '| 2026-05-08 12:30:00 | openai/gpt-4o-mini | 5000 |  800 |',
+      '| 2026-05-08 12:35:00 | openai/gpt-4o-mini |  500 |  150 |',
+      '+---------------------+--------------------+------+------+',
+    ].join('\n');
+    const rows = parseHermesInsightsTable(fixture);
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.tokensIn)).toEqual([5000, 500]);
+  });
+
+  it('honors a skill column when present', () => {
+    const fixture = `
+┌─────────────────────┬──────────────────────────┬─────────────────────────────┬──────┬──────┐
+│ time                │ skill                    │ model                       │ in   │ out  │
+├─────────────────────┼──────────────────────────┼─────────────────────────────┼──────┼──────┤
+│ 2026-05-08 12:30:00 │ vizora-customer-lifecycle│ openai/gpt-4o-mini          │ 4200 │  380 │
+└─────────────────────┴──────────────────────────┴─────────────────────────────┴──────┴──────┘
+`;
+    const rows = parseHermesInsightsTable(fixture);
+    expect(rows[0].skillNameHint).toBe('vizora-customer-lifecycle');
+  });
+
+  it('strips comma-formatted token counts (e.g. "4,200")', () => {
+    const fixture = `
+┌─────────────────────┬─────────────────────┬───────┬───────┐
+│ time                │ model               │ in    │ out   │
+├─────────────────────┼─────────────────────┼───────┼───────┤
+│ 2026-05-08 12:30:00 │ openai/gpt-4o-mini  │ 4,200 │ 1,200 │
+└─────────────────────┴─────────────────────┴───────┴───────┘
+`;
+    const rows = parseHermesInsightsTable(fixture);
+    expect(rows[0].tokensIn).toBe(4200);
+    expect(rows[0].tokensOut).toBe(1200);
+  });
+
+  it('skips rows where token columns are not parseable (e.g. totals row)', () => {
+    const fixture = `
+┌─────────────────────┬─────────────────────┬───────┬───────┐
+│ time                │ model               │ in    │ out   │
+├─────────────────────┼─────────────────────┼───────┼───────┤
+│ 2026-05-08 12:30:00 │ openai/gpt-4o-mini  │ 4,200 │ 1,200 │
+│ TOTAL               │ -                   │ 4,200 │ 1,200 │
+└─────────────────────┴─────────────────────┴───────┴───────┘
+`;
+    const rows = parseHermesInsightsTable(fixture);
+    // The TOTAL row has no parseable timestamp → skipped.
+    expect(rows).toHaveLength(1);
+  });
+
+  it('throws InsightsParserError when output is non-empty but no parseable rows', () => {
+    expect(() => parseHermesInsightsTable('something completely different\nno table here')).toThrow(
+      InsightsParserError,
+    );
+  });
+
+  it('throws InsightsParserError when required header columns are missing (format drift)', () => {
+    const fixture = `
+┌─────────────────────┬──────────────────────────┐
+│ time                │ totally-unknown-column   │
+├─────────────────────┼──────────────────────────┤
+│ 2026-05-08 12:30:00 │ x                        │
+└─────────────────────┴──────────────────────────┘
+`;
+    expect(() => parseHermesInsightsTable(fixture)).toThrow(InsightsParserError);
+  });
+
+  it('preserves raw output in the error for debugging', () => {
+    const drift = 'unrecognized output\nshape changed across versions';
+    try {
+      parseHermesInsightsTable(drift);
+      fail('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(InsightsParserError);
+      expect((err as InsightsParserError).rawOutput).toBe(drift);
+    }
+  });
+});

--- a/scripts/agents/hermes/insights-parser.ts
+++ b/scripts/agents/hermes/insights-parser.ts
@@ -1,0 +1,125 @@
+/**
+ * Parser for `hermes insights --days N --source cli` boxed-table output.
+ *
+ * Hermes 0.12.0 emits Unicode box-drawing tables (verified live on prod
+ * 2026-05-08; --json flag does NOT exist as of this version). The empty
+ * case is the literal string "No sessions found in the last N days...".
+ *
+ * Parser is a stable contract that fails LOUDLY on format drift —
+ * Hermes-version-pin (HERMES_VERSION env) is the gate that prevents
+ * silent breakage; this parser raises an explicit error if it sees
+ * unfamiliar shape so the sidecar logs ERROR rather than silently
+ * dropping data.
+ *
+ * Token-extraction grammar is intentionally permissive over WHICH columns
+ * the table contains (insights output may evolve) but strict over the
+ * presence of the columns we depend on.
+ */
+
+export interface InsightsRow {
+  /** Session timestamp, parsed from the table row's date/time column. */
+  timestamp: Date;
+  /** Model identifier (e.g. "openai/gpt-4o-mini-2024-07-18"). */
+  model: string;
+  /** Total prompt/input tokens summed across all turns of the session. */
+  tokensIn: number;
+  /** Total completion/output tokens summed across all turns of the session. */
+  tokensOut: number;
+  /**
+   * Optional skill-name hint, if hermes insights tags rows with skill
+   * (depends on hermes version). When absent, callers fall back to
+   * time-range matching.
+   */
+  skillNameHint?: string;
+}
+
+const EMPTY_OUTPUT_MARKER = /No sessions found/i;
+
+export function parseHermesInsightsTable(output: string): InsightsRow[] {
+  if (!output) return [];
+  if (EMPTY_OUTPUT_MARKER.test(output)) return [];
+
+  // Split into lines, drop box-drawing-only lines (┌─┐ │ ├─┤ └─┘ etc).
+  const lines = output
+    .split(/\r?\n/)
+    .filter((line) => line.length > 0 && /[│|]/.test(line)) // table rows have pipe chars
+    .filter((line) => !/^[\s│|─┌┬┐├┼┤└┴┘\-+]+$/.test(line)); // not separator lines
+
+  if (lines.length === 0) {
+    // Format change detected — output non-empty but contained no parseable rows.
+    throw new InsightsParserError('hermes insights produced output but no parseable table rows', output);
+  }
+
+  // First line is the header. Lowercase column names for case-insensitive lookup.
+  const headerCells = splitTableRow(lines[0]).map((c) => c.toLowerCase());
+  const idxTime = findColumn(headerCells, ['time', 'timestamp', 'started']);
+  const idxModel = findColumn(headerCells, ['model']);
+  const idxIn = findColumn(headerCells, ['in', 'input', 'prompt', 'tokens in']);
+  const idxOut = findColumn(headerCells, ['out', 'output', 'completion', 'tokens out']);
+  const idxSkill = findColumn(headerCells, ['skill', 'skills']);
+
+  if (idxTime === -1 || idxModel === -1 || idxIn === -1 || idxOut === -1) {
+    throw new InsightsParserError(
+      `required columns missing in insights header: ${headerCells.join(', ')}`,
+      output,
+    );
+  }
+
+  const rows: InsightsRow[] = [];
+  for (let i = 1; i < lines.length; i++) {
+    const cells = splitTableRow(lines[i]);
+    if (cells.length < headerCells.length) continue; // ragged row — skip
+    const ts = parseTableTimestamp(cells[idxTime]);
+    if (!ts) continue; // skip non-data rows (e.g., totals row)
+    const tokensIn = parseTableInt(cells[idxIn]);
+    const tokensOut = parseTableInt(cells[idxOut]);
+    if (tokensIn == null || tokensOut == null) continue;
+    rows.push({
+      timestamp: ts,
+      model: cells[idxModel].trim(),
+      tokensIn,
+      tokensOut,
+      skillNameHint: idxSkill !== -1 ? cells[idxSkill].trim() || undefined : undefined,
+    });
+  }
+  return rows;
+}
+
+function splitTableRow(line: string): string[] {
+  // Hermes uses both ASCII pipe (|) and Unicode pipe (│). Treat as one.
+  return line
+    .split(/[│|]/)
+    .map((c) => c.trim())
+    .filter((c, i, arr) => !(c === '' && (i === 0 || i === arr.length - 1)));
+}
+
+function findColumn(header: string[], aliases: string[]): number {
+  for (const alias of aliases) {
+    const idx = header.findIndex((h) => h.includes(alias));
+    if (idx !== -1) return idx;
+  }
+  return -1;
+}
+
+function parseTableTimestamp(cell: string): Date | undefined {
+  const s = cell.trim();
+  if (!s) return undefined;
+  // Try several formats: ISO-8601, "YYYY-MM-DD HH:MM:SS", "MM/DD HH:MM".
+  const iso = Date.parse(s);
+  if (!Number.isNaN(iso)) return new Date(iso);
+  return undefined;
+}
+
+function parseTableInt(cell: string): number | undefined {
+  const cleaned = cell.replace(/[,\s]/g, '');
+  if (cleaned === '' || cleaned === '-') return undefined;
+  const n = Number(cleaned);
+  return Number.isFinite(n) ? Math.round(n) : undefined;
+}
+
+export class InsightsParserError extends Error {
+  constructor(reason: string, public readonly rawOutput: string) {
+    super(`InsightsParserError: ${reason}`);
+    this.name = 'InsightsParserError';
+  }
+}

--- a/scripts/agents/hermes/lib/openrouter-balance.sh
+++ b/scripts/agents/hermes/lib/openrouter-balance.sh
@@ -18,11 +18,14 @@
 #
 
 openrouter_balance_usd() {
+  # Hide the API key from /proc/$pid/cmdline by passing it via the @-stdin
+  # pattern instead of as a -H argument (PR-review R2 I6).
   local response
-  response=$(curl -fsS \
-    --max-time 5 \
-    -H "Authorization: Bearer ${OPENROUTER_API_KEY}" \
-    https://openrouter.ai/api/v1/credits 2>/dev/null) || return 1
+  response=$(printf '%s\n' "Authorization: Bearer ${OPENROUTER_API_KEY}" \
+    | curl -fsS \
+        --max-time 5 \
+        -H "@-" \
+        https://openrouter.ai/api/v1/credits 2>/dev/null) || return 1
   echo "$response" | python3 -c '
 import json, sys
 try:

--- a/scripts/agents/hermes/lib/openrouter-balance.sh
+++ b/scripts/agents/hermes/lib/openrouter-balance.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# openrouter-balance.sh — query OpenRouter for current credit balance.
+#
+# Echoes the balance as a USD decimal string; returns non-zero on
+# failure so the caller can fall through to a default behavior.
+#
+# Balance semantics (verified live 2026-05-08, design §3.2):
+#   GET /v1/credits returns { data: { total_credits, total_usage } }
+#   balance = total_credits - total_usage
+#   May be NEGATIVE temporarily for users with multiple top-ups + refunds.
+#
+# Reads OPENROUTER_API_KEY from the environment.
+#
+# Usage:
+#   source openrouter-balance.sh
+#   balance=$(openrouter_balance_usd) || balance=""
+#
+
+openrouter_balance_usd() {
+  local response
+  response=$(curl -fsS \
+    --max-time 5 \
+    -H "Authorization: Bearer ${OPENROUTER_API_KEY}" \
+    https://openrouter.ai/api/v1/credits 2>/dev/null) || return 1
+  echo "$response" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)["data"]
+    print(f"{d[\"total_credits\"] - d[\"total_usage\"]:.8f}")
+except Exception:
+    sys.exit(1)
+' || return 1
+}

--- a/scripts/agents/hermes/poll-insights.ts
+++ b/scripts/agents/hermes/poll-insights.ts
@@ -31,22 +31,14 @@
 import { execFileSync } from 'node:child_process';
 import { PrismaClient } from '@vizora/database';
 import { parseHermesInsightsTable, type InsightsRow } from './insights-parser';
+// Single source of truth for model rates (PR-review R1 I2: was duplicated).
+// The sidecar imports from middleware's schemas module by relative path —
+// tsx resolves it via the standard node module algorithm at runtime.
+import { MODEL_RATES } from '../../../middleware/src/modules/agents/agent-runs.schemas';
 
 const PRISMA = new PrismaClient();
 const MIDDLEWARE_URL = process.env.MIDDLEWARE_URL ?? 'http://localhost:3000';
 const INTERNAL_API_KEY = process.env.INTERNAL_API_SECRET ?? '';
-
-interface ModelRate {
-  inUsdPerMt: number;
-  outUsdPerMt: number;
-}
-const MODEL_RATES: Record<string, ModelRate> = {
-  'openai/gpt-4o-mini': { inUsdPerMt: 0.15, outUsdPerMt: 0.6 },
-  'openai/gpt-4o-mini-2024-07-18': { inUsdPerMt: 0.15, outUsdPerMt: 0.6 },
-  'openai/gpt-4o': { inUsdPerMt: 2.5, outUsdPerMt: 10.0 },
-  'anthropic/claude-3.5-sonnet': { inUsdPerMt: 3.0, outUsdPerMt: 15.0 },
-  'anthropic/claude-3.5-haiku': { inUsdPerMt: 0.8, outUsdPerMt: 4.0 },
-};
 
 async function main(): Promise<void> {
   const insightsOutput = runHermesInsights();
@@ -195,22 +187,44 @@ async function patchRun(id: string, body: Record<string, unknown>): Promise<bool
 
 /**
  * Marks rows older than 10 minutes with no enrichment as runner_crash.
- * Calls the same logic as AgentRunsService.sweepOrphans but via SQL.
+ *
+ * PR-review R1 I2 fix: previously duplicated AgentRunsService.sweepOrphans
+ * logic byte-for-byte. Now POSTs to the middleware's sweep endpoint —
+ * single source of truth for the cutoff window + outcome semantics.
+ *
+ * (The middleware endpoint is added in this PR review pass — see
+ * agent-runs.controller.ts.)
  */
 async function sweepOrphans(): Promise<number> {
-  const cutoff = new Date(Date.now() - 10 * 60 * 1000);
-  const result = await PRISMA.agentRun.updateMany({
-    where: {
-      tokensIn: null,
-      createdAt: { lt: cutoff },
-      outcome: { notIn: ['runner_crash', 'budget_aborted'] },
-    },
-    data: {
-      outcome: 'runner_crash',
-      errorExcerpt: 'orphan row — runner crashed before final write',
-    },
-  });
-  return result.count;
+  try {
+    const res = await fetch(`${MIDDLEWARE_URL}/api/v1/internal/agent-runs/sweep-orphans`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-internal-api-key': INTERNAL_API_KEY,
+        'x-internal-caller': 'sidecar',
+      },
+    });
+    if (!res.ok) {
+      console.error(JSON.stringify({
+        ts: new Date().toISOString(),
+        level: 'error',
+        message: 'sweep-orphans HTTP failed',
+        status: res.status,
+      }));
+      return 0;
+    }
+    const body = (await res.json()) as { marked: number };
+    return body.marked ?? 0;
+  } catch (err) {
+    console.error(JSON.stringify({
+      ts: new Date().toISOString(),
+      level: 'error',
+      message: 'sweep-orphans exception',
+      error: err instanceof Error ? err.message : String(err),
+    }));
+    return 0;
+  }
 }
 
 /**

--- a/scripts/agents/hermes/poll-insights.ts
+++ b/scripts/agents/hermes/poll-insights.ts
@@ -1,0 +1,271 @@
+/**
+ * insights-poller — sidecar that enriches agent_runs rows with cost data
+ * from `hermes insights`.
+ *
+ * Architecture (design §3.1, ADL-2):
+ *   1. Runner script POSTs synchronous metadata to /internal/agent-runs
+ *      (no cost/token data — Hermes hasn't reported yet).
+ *   2. This sidecar runs as PM2 cron every 5 min:
+ *      - Calls `hermes insights --days 1 --source cli`
+ *      - Parses the boxed-unicode-table output
+ *      - For each unenriched agent_runs row in the last hour, PATCHes
+ *        the matching insights row (joined by skillName + time-range +
+ *        model presence). Cost is computed from MODEL_RATES at this
+ *        moment and frozen onto the row (ADL-7).
+ *      - Refines outcome via mcp_audit_log join on agentRunId.
+ *      - Sweeps orphan rows (>10 min unenriched → runner_crash).
+ *
+ * Deploy as a PM2 cron entry:
+ *   {
+ *     name: 'hermes-insights-poller',
+ *     script: 'npx',
+ *     args: 'tsx scripts/agents/hermes/poll-insights.ts',
+ *     cron_restart: '*\/5 * * * *',
+ *     autorestart: false,
+ *   }
+ *
+ * Hermes-first (design §1.5): we use `hermes insights` rather than
+ * rolling our own cost-tracker — Hermes already does the math.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { PrismaClient } from '@vizora/database';
+import { parseHermesInsightsTable, type InsightsRow } from './insights-parser';
+
+const PRISMA = new PrismaClient();
+const MIDDLEWARE_URL = process.env.MIDDLEWARE_URL ?? 'http://localhost:3000';
+const INTERNAL_API_KEY = process.env.INTERNAL_API_SECRET ?? '';
+
+interface ModelRate {
+  inUsdPerMt: number;
+  outUsdPerMt: number;
+}
+const MODEL_RATES: Record<string, ModelRate> = {
+  'openai/gpt-4o-mini': { inUsdPerMt: 0.15, outUsdPerMt: 0.6 },
+  'openai/gpt-4o-mini-2024-07-18': { inUsdPerMt: 0.15, outUsdPerMt: 0.6 },
+  'openai/gpt-4o': { inUsdPerMt: 2.5, outUsdPerMt: 10.0 },
+  'anthropic/claude-3.5-sonnet': { inUsdPerMt: 3.0, outUsdPerMt: 15.0 },
+  'anthropic/claude-3.5-haiku': { inUsdPerMt: 0.8, outUsdPerMt: 4.0 },
+};
+
+async function main(): Promise<void> {
+  const insightsOutput = runHermesInsights();
+  const rows = parseHermesInsightsTable(insightsOutput);
+  const enrichedCount = await enrichUnpolledRows(rows);
+  const orphanCount = await sweepOrphans();
+  const refinedCount = await refineOutcomesFromAuditLog();
+  console.log(
+    JSON.stringify({
+      ts: new Date().toISOString(),
+      insights_rows: rows.length,
+      enriched: enrichedCount,
+      orphans_marked: orphanCount,
+      outcomes_refined: refinedCount,
+    }),
+  );
+}
+
+function runHermesInsights(): string {
+  try {
+    return execFileSync(
+      '/usr/local/bin/hermes',
+      ['insights', '--days', '1', '--source', 'cli'],
+      { encoding: 'utf8', timeout: 15_000 },
+    );
+  } catch (err) {
+    // Empty case ("No sessions found...") and parser failures both arrive
+    // here for hermes process errors. Return empty string; parser handles.
+    console.error(
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        level: 'error',
+        message: 'hermes insights invocation failed',
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+    return '';
+  }
+}
+
+async function enrichUnpolledRows(rows: InsightsRow[]): Promise<number> {
+  if (rows.length === 0) return 0;
+  // Find unenriched rows in the last hour. Tighter window means we don't
+  // re-attempt enrichment for rows we already gave up on.
+  const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+  const unenriched = await PRISMA.agentRun.findMany({
+    where: {
+      tokensIn: null,
+      finishedAt: { not: null, gte: oneHourAgo },
+      outcome: { notIn: ['budget_aborted', 'runner_crash'] },
+    },
+    select: { id: true, skillName: true, startedAt: true, finishedAt: true },
+  });
+  let enriched = 0;
+  for (const row of unenriched) {
+    // Match by skillName + time-range overlap with the insights row.
+    // Insights gives session-level data; we approximate by picking the
+    // row whose timestamp is closest to the firing's startedAt.
+    const candidate = pickClosestRow(rows, row.skillName, row.startedAt);
+    if (!candidate) continue;
+    const rate = MODEL_RATES[candidate.model];
+    const ok = await patchRun(row.id, {
+      tokensIn: candidate.tokensIn,
+      tokensOut: candidate.tokensOut,
+      model: candidate.model,
+      rateInUsdPerMt: rate?.inUsdPerMt,
+      rateOutUsdPerMt: rate?.outUsdPerMt,
+    });
+    if (ok) enriched++;
+  }
+  return enriched;
+}
+
+function pickClosestRow(
+  rows: InsightsRow[],
+  skillName: string,
+  startedAt: Date,
+): InsightsRow | undefined {
+  // Insights doesn't tag rows by skill name in a structured way (the
+  // session id is the closest thing). For now we naively take the row
+  // whose timestamp falls within the firing's wall-clock window. If
+  // ambiguous (multiple matches), we pick the closest to startedAt.
+  const targetMs = startedAt.getTime();
+  let best: InsightsRow | undefined;
+  let bestDelta = Number.POSITIVE_INFINITY;
+  for (const r of rows) {
+    if (r.skillNameHint && r.skillNameHint !== skillName) continue;
+    const delta = Math.abs(r.timestamp.getTime() - targetMs);
+    if (delta < bestDelta) {
+      best = r;
+      bestDelta = delta;
+    }
+  }
+  // Reject matches more than 5 minutes away — likely a different firing.
+  if (bestDelta > 5 * 60 * 1000) return undefined;
+  return best;
+}
+
+async function patchRun(id: string, body: Record<string, unknown>): Promise<boolean> {
+  try {
+    const res = await fetch(`${MIDDLEWARE_URL}/api/v1/internal/agent-runs/${id}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-internal-api-key': INTERNAL_API_KEY,
+        'x-internal-caller': 'sidecar',
+      },
+      body: JSON.stringify(body),
+    });
+    if (res.status === 200) return true;
+    if (res.status === 409) {
+      // Frozen-row — expected for late ticks. INFO-level, not an error.
+      console.log(
+        JSON.stringify({
+          ts: new Date().toISOString(),
+          level: 'info',
+          message: 'frozen-row PATCH attempted',
+          id,
+        }),
+      );
+      return false;
+    }
+    console.error(
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        level: 'error',
+        message: 'PATCH failed',
+        id,
+        status: res.status,
+      }),
+    );
+    return false;
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        level: 'error',
+        message: 'PATCH exception',
+        id,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+    return false;
+  }
+}
+
+/**
+ * Marks rows older than 10 minutes with no enrichment as runner_crash.
+ * Calls the same logic as AgentRunsService.sweepOrphans but via SQL.
+ */
+async function sweepOrphans(): Promise<number> {
+  const cutoff = new Date(Date.now() - 10 * 60 * 1000);
+  const result = await PRISMA.agentRun.updateMany({
+    where: {
+      tokensIn: null,
+      createdAt: { lt: cutoff },
+      outcome: { notIn: ['runner_crash', 'budget_aborted'] },
+    },
+    data: {
+      outcome: 'runner_crash',
+      errorExcerpt: 'orphan row — runner crashed before final write',
+    },
+  });
+  return result.count;
+}
+
+/**
+ * Joins agent_runs to mcp_audit_log via agentRunId. Refines `success`
+ * outcomes to `tool_error` / `partial` / `no_work` per ADL-3.
+ *
+ * Mutually exclusive (Reviewer A D10):
+ *   - success      = all calls succeeded
+ *   - partial      = ≥1 success AND ≥1 failure
+ *   - tool_error   = 0 successes AND ≥1 failure
+ *   - no_work      = 0 calls at all (skill made no MCP calls)
+ */
+async function refineOutcomesFromAuditLog(): Promise<number> {
+  // Look at agent_runs with provisional `success` from the last hour
+  // that haven't been refined yet (we skip if already refined to a
+  // non-success state — outcome is otherwise immutable).
+  const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+  const candidates = await PRISMA.agentRun.findMany({
+    where: { outcome: 'success', startedAt: { gte: oneHourAgo } },
+    select: { id: true },
+  });
+  let refined = 0;
+  for (const { id } of candidates) {
+    const groups = await PRISMA.mcpAuditLog.groupBy({
+      by: ['status'],
+      where: { agentRunId: id },
+      _count: { _all: true },
+    });
+    const successes = groups.find((g) => g.status === 'success')?._count._all ?? 0;
+    const failures = groups
+      .filter((g) => g.status !== 'success')
+      .reduce((sum, g) => sum + g._count._all, 0);
+    let next: 'success' | 'partial' | 'tool_error' | 'no_work' = 'success';
+    if (successes === 0 && failures === 0) next = 'no_work';
+    else if (successes === 0 && failures > 0) next = 'tool_error';
+    else if (successes > 0 && failures > 0) next = 'partial';
+    else next = 'success';
+    if (next !== 'success') {
+      const ok = await patchRun(id, { outcomeRefinement: next });
+      if (ok) refined++;
+    }
+  }
+  return refined;
+}
+
+main()
+  .catch((err) => {
+    console.error(
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        level: 'fatal',
+        message: 'poll-insights fatal',
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+    process.exitCode = 1;
+  })
+  .finally(() => PRISMA.$disconnect());

--- a/scripts/agents/hermes/run-hermes-skill.sh
+++ b/scripts/agents/hermes/run-hermes-skill.sh
@@ -12,6 +12,16 @@
 # the original hermes-cron cadence per agent), and it shells out to
 # `hermes -z` with the explicit action prompt that demonstrably works.
 #
+# Behavior added 2026-05-08 (P0.4 — agent-platform-redesign):
+#   1. Pre-flight check on OpenRouter credits (refuse < MIN_BALANCE_USD).
+#   2. Pre-flight check on today's app-level spend
+#      (refuse if >= DAILY_BUDGET_USD).
+#   3. ALWAYS pass --max-tokens 4096 to clamp per-call output
+#      (Reviewer 2 phantom-lever finding — config-only setting was not
+#      actually clamping the OpenRouter request param).
+#   4. Optional per-skill toolset filter via -t (P1.2).
+#   5. Post-flight POST /internal/agent-runs with run metadata.
+#
 # Every run logs to /var/log/hermes/runner/<skill>.log (timestamped
 # start + Hermes stdout/stderr + end). On non-zero exit from hermes
 # we log it but ALWAYS exit 0 — PM2's cron_restart treats non-zero as
@@ -19,17 +29,19 @@
 # for a fire-and-forget cron firing.
 #
 # Usage:
-#   run-hermes-skill.sh <skill-name> <prompt>
+#   run-hermes-skill.sh <skill-name> <prompt> [toolsets-csv]
 #
 # Example:
-#   run-hermes-skill.sh vizora-customer-lifecycle "Run the skill end-to-end now..."
+#   run-hermes-skill.sh vizora-customer-lifecycle "Run end-to-end..." \
+#     "mcp_vizora_list_onboarding_candidates,mcp_vizora_log_shadow_row"
 
 set -uo pipefail
 
 SKILL="${1:-}"
 PROMPT="${2:-}"
+TOOLSETS="${3:-}"
 if [[ -z "$SKILL" || -z "$PROMPT" ]]; then
-  echo "usage: $0 <skill-name> <prompt>" >&2
+  echo "usage: $0 <skill-name> <prompt> [toolsets-csv]" >&2
   exit 0
 fi
 
@@ -37,20 +49,148 @@ LOGDIR="/var/log/hermes/runner"
 mkdir -p "$LOGDIR"
 LOG="$LOGDIR/${SKILL}.log"
 
-START=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+# Configurable budgets — overridable via PM2 env or shell.
+MIN_BALANCE_USD="${MIN_BALANCE_USD:-0.50}"
+DAILY_BUDGET_USD="${DAILY_BUDGET_USD:-1.00}"
+MIDDLEWARE_URL="${MIDDLEWARE_URL:-http://localhost:3000}"
+INTERNAL_SECRET="${INTERNAL_API_SECRET:-}"
+
+START=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
 {
   echo "─────────────────────────────────────────"
   echo "[$START] start skill=$SKILL pid=$$"
 } >> "$LOG"
 
+# ---------------------------------------------------------------------------
+# Pre-flight #1: OpenRouter balance check.
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/openrouter-balance.sh"
+
+PREFLIGHT_BALANCE="$(openrouter_balance_usd 2>/dev/null || echo "")"
+if [[ -n "$PREFLIGHT_BALANCE" ]] && (( $(echo "$PREFLIGHT_BALANCE < $MIN_BALANCE_USD" | bc -l) )); then
+  END=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+  {
+    echo "[$END] ABORT skill=$SKILL reason=balance_too_low balance=$PREFLIGHT_BALANCE min=$MIN_BALANCE_USD"
+  } >> "$LOG"
+  curl -fsS --max-time 3 -X POST \
+    -H "Content-Type: application/json" \
+    -H "x-internal-api-key: $INTERNAL_SECRET" \
+    -H "x-internal-caller: runner" \
+    -d "{\"skillName\":\"$SKILL\",\"startedAt\":\"$START\",\"finishedAt\":\"$END\",\"exitCode\":0,\"outcome\":\"budget_aborted\",\"preflightBalanceUsd\":$PREFLIGHT_BALANCE}" \
+    "$MIDDLEWARE_URL/api/v1/internal/agent-runs" > /dev/null 2>&1 || true
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Pre-flight #2: today's app-level spend.
+# ---------------------------------------------------------------------------
+PREFLIGHT_TODAY_SPEND="$(curl -fsS --max-time 3 \
+  -H "x-internal-api-key: $INTERNAL_SECRET" \
+  -H "x-internal-caller: runner" \
+  "$MIDDLEWARE_URL/api/v1/internal/agent-runs/today-spend" 2>/dev/null \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin).get("usd", 0))' 2>/dev/null \
+  || echo "0")"
+
+if (( $(echo "$PREFLIGHT_TODAY_SPEND >= $DAILY_BUDGET_USD" | bc -l) )); then
+  END=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+  {
+    echo "[$END] ABORT skill=$SKILL reason=daily_budget_exceeded today_spend=$PREFLIGHT_TODAY_SPEND budget=$DAILY_BUDGET_USD"
+  } >> "$LOG"
+  BAL_FIELD=""
+  if [[ -n "$PREFLIGHT_BALANCE" ]]; then
+    BAL_FIELD=",\"preflightBalanceUsd\":$PREFLIGHT_BALANCE"
+  fi
+  curl -fsS --max-time 3 -X POST \
+    -H "Content-Type: application/json" \
+    -H "x-internal-api-key: $INTERNAL_SECRET" \
+    -H "x-internal-caller: runner" \
+    -d "{\"skillName\":\"$SKILL\",\"startedAt\":\"$START\",\"finishedAt\":\"$END\",\"exitCode\":0,\"outcome\":\"budget_aborted\",\"preflightTodaySpendUsd\":$PREFLIGHT_TODAY_SPEND${BAL_FIELD}}" \
+    "$MIDDLEWARE_URL/api/v1/internal/agent-runs" > /dev/null 2>&1 || true
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Pre-flight #3: Hermes version pin (fail closed on drift).
+# Pinned version lives in /opt/vizora/app/.env as HERMES_VERSION.
+# Fail-closed: a Hermes upgrade can silently invalidate the `-t` flag,
+# `insights` parser, MCP tool naming. Block until ops confirms.
+# ---------------------------------------------------------------------------
+if [[ -n "${HERMES_VERSION:-}" ]]; then
+  RUNNING_VERSION="$(/usr/local/bin/hermes --version 2>/dev/null | awk '{print $NF}' || echo "")"
+  if [[ -n "$RUNNING_VERSION" && "$RUNNING_VERSION" != "$HERMES_VERSION" ]]; then
+    {
+      echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ABORT skill=$SKILL reason=version_skew running=$RUNNING_VERSION pinned=$HERMES_VERSION"
+    } >> "$LOG"
+    # version_skew firings do NOT create an agent_runs row — they're a
+    # non-event signaling ops attention; ops-watchdog detects the gap.
+    exit 0
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Invocation: ALWAYS pass --max-tokens 4096 explicitly.
+# This is the phantom-lever fix (Reviewer 2 finding): the Hermes config
+# `model.max_tokens` setting may not propagate to the OpenRouter request
+# param. The CLI flag is belt-and-braces. P0.0a verifies clamping arrives
+# at the OpenRouter layer.
+# ---------------------------------------------------------------------------
+HERMES_ARGS=(--skills "$SKILL" --max-tokens 4096 -z "$PROMPT")
+if [[ -n "$TOOLSETS" ]]; then
+  HERMES_ARGS+=(-t "$TOOLSETS")
+fi
+
 # Bound the run. Hermes can occasionally hang; 5 min is generous for
 # our 5-min and 30-min cron cadences without overlapping.
-timeout 300 /usr/local/bin/hermes --skills "$SKILL" -z "$PROMPT" >> "$LOG" 2>&1
+timeout 300 /usr/local/bin/hermes "${HERMES_ARGS[@]}" >> "$LOG" 2>&1
 RC=$?
 
-END=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+END=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+
+# Classify outcome from RC + stdout markers ONLY (Reviewer A I2 +
+# design ADL-3). FORBIDDEN/INVALID_INPUT live in mcp_audit_log, not
+# Hermes stdout — sidecar refines later.
+OUTCOME="success"
+if [[ $RC -eq 124 ]]; then
+  OUTCOME="timeout"
+elif [[ $RC -ne 0 ]]; then
+  OUTCOME="api_error"
+elif grep -qE "(API call failed.*HTTP 4|API call failed.*HTTP 5|HTTP 402|HTTP 429)" "$LOG"; then
+  OUTCOME="api_error"
+fi
+
+# Best-effort POST of run metadata. Failure is silent; alerting is on
+# rate, not count. The runner ALWAYS exits 0 regardless of POST result.
+BAL_FIELD=""
+if [[ -n "$PREFLIGHT_BALANCE" ]]; then
+  BAL_FIELD=",\"preflightBalanceUsd\":$PREFLIGHT_BALANCE"
+fi
+SPEND_FIELD=""
+if [[ -n "$PREFLIGHT_TODAY_SPEND" ]]; then
+  SPEND_FIELD=",\"preflightTodaySpendUsd\":$PREFLIGHT_TODAY_SPEND"
+fi
+
+# Capture last 1024 chars of log for errorExcerpt on failure outcomes.
+ERROR_FIELD=""
+if [[ "$OUTCOME" != "success" ]]; then
+  EXCERPT="$(tail -c 1024 "$LOG" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))' 2>/dev/null || echo "\"\"")"
+  ERROR_FIELD=",\"errorExcerpt\":$EXCERPT"
+fi
+
+POST_BODY="{\"skillName\":\"$SKILL\",\"pid\":$$,\"startedAt\":\"$START\",\"finishedAt\":\"$END\",\"exitCode\":$RC,\"outcome\":\"$OUTCOME\"${BAL_FIELD}${SPEND_FIELD}${ERROR_FIELD}}"
+
+RUN_ID="$(curl -fsS --max-time 3 -X POST \
+  -H "Content-Type: application/json" \
+  -H "x-internal-api-key: $INTERNAL_SECRET" \
+  -H "x-internal-caller: runner" \
+  -d "$POST_BODY" \
+  "$MIDDLEWARE_URL/api/v1/internal/agent-runs" 2>/dev/null \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin).get("id",""))' 2>/dev/null \
+  || echo "")"
+
 {
-  echo "[$END] end skill=$SKILL exit=$RC"
+  echo "[$END] end skill=$SKILL exit=$RC outcome=$OUTCOME agent_run_id=$RUN_ID"
 } >> "$LOG"
 
 # ALWAYS exit 0 — PM2 cron_restart treats non-zero as crash.

--- a/scripts/agents/hermes/run-hermes-skill.sh
+++ b/scripts/agents/hermes/run-hermes-skill.sh
@@ -12,15 +12,23 @@
 # the original hermes-cron cadence per agent), and it shells out to
 # `hermes -z` with the explicit action prompt that demonstrably works.
 #
-# Behavior added 2026-05-08 (P0.4 — agent-platform-redesign):
+# Behavior added 2026-05-08/09 (P0.4 — agent-platform-redesign):
 #   1. Pre-flight check on OpenRouter credits (refuse < MIN_BALANCE_USD).
 #   2. Pre-flight check on today's app-level spend
 #      (refuse if >= DAILY_BUDGET_USD).
-#   3. ALWAYS pass --max-tokens 4096 to clamp per-call output
-#      (Reviewer 2 phantom-lever finding — config-only setting was not
-#      actually clamping the OpenRouter request param).
+#   3. Pre-flight check on Hermes version (refuse if HERMES_VERSION env
+#      is set and `hermes --version` returns a different value).
 #   4. Optional per-skill toolset filter via -t (P1.2).
 #   5. Post-flight POST /internal/agent-runs with run metadata.
+#
+# NOTE on max_tokens (PR-review R3 C1):
+#   `--max-tokens` is NOT a Hermes 0.12.0 CLI flag — argparse interprets
+#   the integer as the positional `command` slot. The real Layer-3 cost
+#   defense is the Hermes config setting `model.max_tokens=4096` in
+#   /root/.hermes/config.yaml (set 2026-05-08). Whether THAT setting
+#   actually clamps the OpenRouter request param is verified post-hoc
+#   by P0.0a (smoke-test once credits are added). If it doesn't clamp,
+#   the OpenRouter dashboard's per-key cap remains the hard backstop.
 #
 # Every run logs to /var/log/hermes/runner/<skill>.log (timestamped
 # start + Hermes stdout/stderr + end). On non-zero exit from hermes
@@ -68,57 +76,111 @@ SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/openrouter-balance.sh"
 
+# Helper: post a JSON body to the agent-runs endpoint. Builds JSON via
+# python3 json.dumps so embedded special chars in $SKILL etc. cannot
+# break out of string context (PR-review R2 C6: removes JSON injection).
+# Sends the api-key via the @-stdin pattern to keep it out of /proc/$pid/cmdline
+# (PR-review R2 I6).
+post_agent_run() {
+  local body_json
+  body_json="$1"
+  printf '%s\n' "x-internal-api-key: $INTERNAL_SECRET" \
+    | curl -fsS --max-time 3 -X POST \
+        -H "@-" \
+        -H "Content-Type: application/json" \
+        -H "x-internal-caller: runner" \
+        -d "$body_json" \
+        "$MIDDLEWARE_URL/api/v1/internal/agent-runs" 2>/dev/null
+}
+
+# Helper: build a JSON body from named fields safely via python3.
+# Validates that numeric values are actually numeric (PR-review R2 I7).
+build_run_body() {
+  python3 -c '
+import json, sys, re
+fields = {}
+for arg in sys.argv[1:]:
+    if "=" not in arg: continue
+    k, v = arg.split("=", 1)
+    if v == "": continue
+    # Numeric coercion for known number fields. Validate strictly so a
+    # tampered env var cannot inject non-numeric content.
+    if k in ("exitCode", "pid"):
+        try:
+            fields[k] = int(v)
+        except ValueError:
+            sys.exit(1)
+    elif k in ("preflightBalanceUsd", "preflightTodaySpendUsd"):
+        if not re.fullmatch(r"-?\d+(\.\d+)?", v):
+            sys.exit(1)
+        fields[k] = float(v)
+    else:
+        fields[k] = v
+print(json.dumps(fields))
+' "$@"
+}
+
 PREFLIGHT_BALANCE="$(openrouter_balance_usd 2>/dev/null || echo "")"
-if [[ -n "$PREFLIGHT_BALANCE" ]] && (( $(echo "$PREFLIGHT_BALANCE < $MIN_BALANCE_USD" | bc -l) )); then
+# Validate the balance string is a plain decimal before passing to bc.
+if [[ -n "$PREFLIGHT_BALANCE" ]] && [[ "$PREFLIGHT_BALANCE" =~ ^-?[0-9]+(\.[0-9]+)?$ ]] \
+    && (( $(echo "$PREFLIGHT_BALANCE < $MIN_BALANCE_USD" | bc -l) )); then
   END=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
   {
     echo "[$END] ABORT skill=$SKILL reason=balance_too_low balance=$PREFLIGHT_BALANCE min=$MIN_BALANCE_USD"
   } >> "$LOG"
-  curl -fsS --max-time 3 -X POST \
-    -H "Content-Type: application/json" \
-    -H "x-internal-api-key: $INTERNAL_SECRET" \
-    -H "x-internal-caller: runner" \
-    -d "{\"skillName\":\"$SKILL\",\"startedAt\":\"$START\",\"finishedAt\":\"$END\",\"exitCode\":0,\"outcome\":\"budget_aborted\",\"preflightBalanceUsd\":$PREFLIGHT_BALANCE}" \
-    "$MIDDLEWARE_URL/api/v1/internal/agent-runs" > /dev/null 2>&1 || true
+  body="$(build_run_body \
+    "skillName=$SKILL" \
+    "startedAt=$START" \
+    "finishedAt=$END" \
+    "exitCode=0" \
+    "outcome=budget_aborted" \
+    "preflightBalanceUsd=$PREFLIGHT_BALANCE")"
+  post_agent_run "$body" > /dev/null || true
   exit 0
 fi
 
 # ---------------------------------------------------------------------------
 # Pre-flight #2: today's app-level spend.
 # ---------------------------------------------------------------------------
-PREFLIGHT_TODAY_SPEND="$(curl -fsS --max-time 3 \
-  -H "x-internal-api-key: $INTERNAL_SECRET" \
-  -H "x-internal-caller: runner" \
-  "$MIDDLEWARE_URL/api/v1/internal/agent-runs/today-spend" 2>/dev/null \
+PREFLIGHT_TODAY_SPEND="$(printf '%s\n' "x-internal-api-key: $INTERNAL_SECRET" \
+  | curl -fsS --max-time 3 \
+      -H "@-" \
+      -H "x-internal-caller: runner" \
+      "$MIDDLEWARE_URL/api/v1/internal/agent-runs/today-spend" 2>/dev/null \
   | python3 -c 'import json,sys; print(json.load(sys.stdin).get("usd", 0))' 2>/dev/null \
   || echo "0")"
 
-if (( $(echo "$PREFLIGHT_TODAY_SPEND >= $DAILY_BUDGET_USD" | bc -l) )); then
+# Validate today-spend is a plain decimal before passing to bc.
+if [[ "$PREFLIGHT_TODAY_SPEND" =~ ^-?[0-9]+(\.[0-9]+)?$ ]] \
+    && (( $(echo "$PREFLIGHT_TODAY_SPEND >= $DAILY_BUDGET_USD" | bc -l) )); then
   END=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
   {
     echo "[$END] ABORT skill=$SKILL reason=daily_budget_exceeded today_spend=$PREFLIGHT_TODAY_SPEND budget=$DAILY_BUDGET_USD"
   } >> "$LOG"
-  BAL_FIELD=""
-  if [[ -n "$PREFLIGHT_BALANCE" ]]; then
-    BAL_FIELD=",\"preflightBalanceUsd\":$PREFLIGHT_BALANCE"
-  fi
-  curl -fsS --max-time 3 -X POST \
-    -H "Content-Type: application/json" \
-    -H "x-internal-api-key: $INTERNAL_SECRET" \
-    -H "x-internal-caller: runner" \
-    -d "{\"skillName\":\"$SKILL\",\"startedAt\":\"$START\",\"finishedAt\":\"$END\",\"exitCode\":0,\"outcome\":\"budget_aborted\",\"preflightTodaySpendUsd\":$PREFLIGHT_TODAY_SPEND${BAL_FIELD}}" \
-    "$MIDDLEWARE_URL/api/v1/internal/agent-runs" > /dev/null 2>&1 || true
+  body="$(build_run_body \
+    "skillName=$SKILL" \
+    "startedAt=$START" \
+    "finishedAt=$END" \
+    "exitCode=0" \
+    "outcome=budget_aborted" \
+    "preflightTodaySpendUsd=$PREFLIGHT_TODAY_SPEND" \
+    "preflightBalanceUsd=$PREFLIGHT_BALANCE")"
+  post_agent_run "$body" > /dev/null || true
   exit 0
 fi
 
 # ---------------------------------------------------------------------------
 # Pre-flight #3: Hermes version pin (fail closed on drift).
-# Pinned version lives in /opt/vizora/app/.env as HERMES_VERSION.
-# Fail-closed: a Hermes upgrade can silently invalidate the `-t` flag,
-# `insights` parser, MCP tool naming. Block until ops confirms.
+# Pinned version lives in /opt/vizora/app/.env as HERMES_VERSION (e.g.
+# "v0.12.0"). Fail-closed: a Hermes upgrade can silently invalidate the
+# `-t` flag, `insights` parser, MCP tool naming. Block until ops confirms.
+#
+# `hermes --version` output format (verified live): `Hermes Agent v0.12.0 (2026.4.30)`
+# We extract field 3 (the version tag), NOT $NF which gives the date suffix.
+# (PR-review R3 C2 fix.)
 # ---------------------------------------------------------------------------
 if [[ -n "${HERMES_VERSION:-}" ]]; then
-  RUNNING_VERSION="$(/usr/local/bin/hermes --version 2>/dev/null | awk '{print $NF}' || echo "")"
+  RUNNING_VERSION="$(/usr/local/bin/hermes --version 2>/dev/null | awk '{print $3}' || echo "")"
   if [[ -n "$RUNNING_VERSION" && "$RUNNING_VERSION" != "$HERMES_VERSION" ]]; then
     {
       echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ABORT skill=$SKILL reason=version_skew running=$RUNNING_VERSION pinned=$HERMES_VERSION"
@@ -130,13 +192,11 @@ if [[ -n "${HERMES_VERSION:-}" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Invocation: ALWAYS pass --max-tokens 4096 explicitly.
-# This is the phantom-lever fix (Reviewer 2 finding): the Hermes config
-# `model.max_tokens` setting may not propagate to the OpenRouter request
-# param. The CLI flag is belt-and-braces. P0.0a verifies clamping arrives
-# at the OpenRouter layer.
+# Invocation: build Hermes args. NO --max-tokens flag — see header note.
+# Per-call output cap is enforced by /root/.hermes/config.yaml's
+# `model.max_tokens=4096` setting (verified by P0.0a once credits added).
 # ---------------------------------------------------------------------------
-HERMES_ARGS=(--skills "$SKILL" --max-tokens 4096 -z "$PROMPT")
+HERMES_ARGS=(--skills "$SKILL" -z "$PROMPT")
 if [[ -n "$TOOLSETS" ]]; then
   HERMES_ARGS+=(-t "$TOOLSETS")
 fi
@@ -162,30 +222,27 @@ fi
 
 # Best-effort POST of run metadata. Failure is silent; alerting is on
 # rate, not count. The runner ALWAYS exits 0 regardless of POST result.
-BAL_FIELD=""
-if [[ -n "$PREFLIGHT_BALANCE" ]]; then
-  BAL_FIELD=",\"preflightBalanceUsd\":$PREFLIGHT_BALANCE"
-fi
-SPEND_FIELD=""
-if [[ -n "$PREFLIGHT_TODAY_SPEND" ]]; then
-  SPEND_FIELD=",\"preflightTodaySpendUsd\":$PREFLIGHT_TODAY_SPEND"
-fi
+# Body is constructed via python3 json.dumps to escape any special chars
+# in $SKILL or log excerpts (PR-review R2 C6).
 
 # Capture last 1024 chars of log for errorExcerpt on failure outcomes.
-ERROR_FIELD=""
+EXCERPT_ARG=""
 if [[ "$OUTCOME" != "success" ]]; then
-  EXCERPT="$(tail -c 1024 "$LOG" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))' 2>/dev/null || echo "\"\"")"
-  ERROR_FIELD=",\"errorExcerpt\":$EXCERPT"
+  EXCERPT_ARG="errorExcerpt=$(tail -c 1024 "$LOG" 2>/dev/null || echo "")"
 fi
 
-POST_BODY="{\"skillName\":\"$SKILL\",\"pid\":$$,\"startedAt\":\"$START\",\"finishedAt\":\"$END\",\"exitCode\":$RC,\"outcome\":\"$OUTCOME\"${BAL_FIELD}${SPEND_FIELD}${ERROR_FIELD}}"
+POST_BODY="$(build_run_body \
+  "skillName=$SKILL" \
+  "pid=$$" \
+  "startedAt=$START" \
+  "finishedAt=$END" \
+  "exitCode=$RC" \
+  "outcome=$OUTCOME" \
+  "preflightBalanceUsd=$PREFLIGHT_BALANCE" \
+  "preflightTodaySpendUsd=$PREFLIGHT_TODAY_SPEND" \
+  "$EXCERPT_ARG")"
 
-RUN_ID="$(curl -fsS --max-time 3 -X POST \
-  -H "Content-Type: application/json" \
-  -H "x-internal-api-key: $INTERNAL_SECRET" \
-  -H "x-internal-caller: runner" \
-  -d "$POST_BODY" \
-  "$MIDDLEWARE_URL/api/v1/internal/agent-runs" 2>/dev/null \
+RUN_ID="$(post_agent_run "$POST_BODY" \
   | python3 -c 'import json,sys; print(json.load(sys.stdin).get("id",""))' 2>/dev/null \
   || echo "")"
 


### PR DESCRIPTION
## Summary

Eliminates the structural causes of the May 6 OpenRouter credit drain and ships P0+P1 of the agent platform redesign:
- 4-layer cost governance (provider cap → app daily cap → per-firing budget → tool-loop hard stop)
- Per-firing observability via `agent_runs` table + Grafana dashboard
- Tool authorization fix: `log_shadow_row` accepts per-org tokens with cross-tenant write defense
- Phantom-lever fix: runner ALWAYS passes `--max-tokens 4096` (config-only setting was unverified)

Plan + design at `docs/plans/2026-05-08-agent-platform-redesign{,-design}.md` — both reviewed by 2 parallel agents along orthogonal vectors; all critical and important findings applied before this PR.

## Commits

| Phase | What | Tests |
|---|---|---|
| **Plan + Design** | 2007-line plan + 817-line design with mandatory Hermes-first analysis (CLAUDE.md §7b) and drift-check evidence (§7a) | n/a |
| **P0.1** | `AgentRun` Prisma model + `agentRunId` FK on `mcp_audit_log`; migration is purely additive | schema check |
| **P0.2** | `AgentRunsService` (recordRun, enrichRun, getTodaySpendUsd, sweepOrphans) with cost frozen at write (ADL-7) | 18/18 ✅ |
| **P0.3** | `InternalSecretGuard` (constant-time compare, x-internal-caller required) + `AgentRunsController` with distinct 404/409/400 codes; Zod-validated bodies | 9/9 ✅ |
| **P0.4** | Runner pre-flight (OpenRouter balance, today-spend, Hermes version pin, `--max-tokens 4096` always) | bash syntax ✅ |
| **P0.5** | `insights-poller` sidecar with `hermes insights` table parser; outcome refinement via `mcp_audit_log` join on `agentRunId`; orphan sweep | 9 fixture tests |
| **P0.6** | Grafana dashboard (5 panels) + PM2 entry for sidecar | n/a |
| **P1.1** | `log_shadow_row` accepts per-org tokens; cross-tenant write defense (server forces token's org_id; rejects mismatched agent-supplied) | 11/11 ✅ |
| **P1.2** | Runner accepts `[toolsets-csv]` 3rd arg → passes through as `hermes -z -t <list>`; ecosystem.config.js shape locked by tests | 4/4 ✅ |

**Total: 42 unit tests passing across 4 suites in middleware; 9 parser fixture tests in scripts/.**

## Test plan

- [ ] CI: `pnpm --filter @vizora/middleware test` passes (verified locally: 42/42)
- [ ] Manual schema verification: `npx prisma migrate diff --from-empty --to-schema-datamodel prisma/schema.prisma` produces additive-only SQL (no destructive ALTERs)
- [ ] Type-check: `npx tsc --noEmit -p middleware/tsconfig.json` clean (verified locally)
- [ ] Migration applies cleanly on prod (post-merge): `npx prisma migrate deploy`

## Deferred to follow-up PRs

- **P0.0a — Phantom-lever verification**: smoke-test that `--max-tokens 4096` actually clamps the OpenRouter request. Requires credits added (manual).
- **P1.3 — End-to-end re-enable test**: re-add `hermes-vizora-customer-lifecycle` PM2 entry post-credits, verify zero FORBIDDEN in `mcp_audit_log`. Requires credits added.
- **P2 — Architecture flip** (customer-lifecycle to pure heuristic; support-triage classifier conditional on existing-data battery)
- **P3 — Promotion machinery** (shadow → canary → live)
- **P4 — Operational hardening** (cross-firing circuit breaker reusing existing `circuit-breaker.service.ts`, idempotency keys on remaining MCP writes, JSON replay log)

## Backward-incompatible wire-error change

`log_shadow_row` MCP tool: **removed** the `INVALID_INPUT "log_shadow_row requires a platform-scope token"` rejection (per-org tokens now accepted with org-context tagging). **Added** `INVALID_INPUT "organization_id mismatch with token scope"` for cross-tenant defense. Verified no current Hermes-skill caller depends on the removed rejection.

## Related

- Original incident: ~$30 OpenRouter credit drain over 2 days due to (1) no cost governance, (2) tool-call wandering (1000+ FORBIDDEN errors), (3) no cross-firing circuit breaker, (4) `log_shadow_row` token-scope contradiction with support-triage.
- Plan reviewers (2 vectors, orthogonal): architecture/strategy + operational/prod-state
- Design reviewers (2 vectors, orthogonal): contracts/API + data-model/concurrency