### PR TITLE
feat(notifications): O7 — Configurable downtime alert rules

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -134,7 +134,7 @@ These are documented + non-blocking for customer-1. Investigations done; impleme
 | L2 | Set up UptimeRobot monitoring for health endpoints | XS (1h) | TODO | Manual: create account, add monitors |
 | L3 | Custom error pages (branded 404, 500) | S (4h) | TODO | Currently default/unstyled |
 | L4 | Basic knowledge base / help docs page | M (1d) | TODO | FAQ + getting started guide |
-| L5 | Proof-of-play tracking (log content displayed per device) | M (1d) | TODO | Advertisers need this |
+| L5 | Proof-of-play tracking (log content displayed per device) | M (1d) | TODO | Advertisers need this. **Expanded scope in O2 below** (saved views, scheduled email, tag filters, exports). |
 | L6 | Emergency content override (push urgent to all devices) | S (4h) | TODO | Critical for corporate/healthcare |
 | L7 | Device remote reload command via WebSocket | S (2h) | TODO | Remote restart already missing too |
 | L8 | Wire real-time notification emission on creation | S (2h) | TODO | Currently polling, not real-time |
@@ -151,10 +151,10 @@ These are documented + non-blocking for customer-1. Investigations done; impleme
 | M1 | CloudFlare CDN + DDoS protection | S (4h) | TODO | Static assets served directly now |
 | M2 | Weather widget (OpenWeatherMap free API) | M (1d) | TODO | Top customer request for signage |
 | M3 | Google Sheets data source integration | L (3d) | TODO | Key for dynamic menu boards |
-| M4 | Content moderation workflow (flag -> review -> approve) | M (2d) | TODO | |
+| M4 | Content moderation workflow (flag -> review -> approve) | M (2d) | TODO | Today's `content.service.ts:712-843` is a moderation flag, not an approval pipeline. **Expanded to proposer→approver→publish in O10 below.** |
 | M5 | Expand template library to 150 templates | M (2d) | TODO | Currently 78 |
 | M6 | Device remote restart command | S (4h) | TODO | |
-| M7 | Push-to-group endpoint (single API call) | S (4h) | TODO | Currently iterate client-side |
+| M7 | Push-to-group endpoint (single API call) | S (4h) | TODO | Currently iterate client-side. **Generalized in O1 below** (also adds tag-based targeting + push from templates/layouts/widgets/playlists). |
 | M8 | Data retention policy (auto-purge audit logs > 90 days) | S (4h) | TODO | |
 | M9 | Profile editing: avatar upload | S (4h) | TODO | Name editing done, avatar missing |
 | M10 | Fix Loki volume mount (logs lost on restart) | XS (1h) | TODO | Docker-compose change |
@@ -162,6 +162,29 @@ These are documented + non-blocking for customer-1. Investigations done; impleme
 | M12 | Security alert emails (new login, password changed) | S (4h) | TODO | |
 
 **Total effort: ~15 dev-days**
+
+---
+
+## OptiSigns Parity Roadmap (from 2026-05-17 audit)
+
+Items where Vizora has real foundation in the codebase + high customer value vs OptiSigns gaps. Full analysis: `docs/plans/2026-05-17-optsigns-vizora-feature-gap.md`. Cross-quarter — each item carries its own effort; no quarterly bucket.
+
+Items the audit listed but we are NOT pursuing live (Engage/kiosk, live remote view, WebRTC, Office docs, white-label, nested playlists, etc.) are parked in `tasks/feature-backlog.md` under "OptiSigns parity — deferred items" with trigger conditions.
+
+| # | Item | Effort | Foundation | Audit ref |
+|---|------|--------|------------|-----------|
+| O1 | **Unified Push to Screens** — first-class push endpoints from content/templates/layouts/widgets/playlists; **tag-based targeting** (push to `tag=lobby`); append-to-playlist mode; scheduled push with auto-revert; temporary takeover with expiration | M (3d) | `displays.controller.ts:198-211` exists; `Tag/DisplayTag` exist; fleet `resolveTargetDevices` (`fleet.service.ts:159-206`) needs tag resolver | P0 #2 |
+| O2 | **Proof-of-play reports** — saved report views, scheduled email delivery, asset/display tag filters, CSV/Excel/PDF/raw export over existing impression model | M (3d) | `ContentImpression` has duration + completionPercentage + indexes (`schema.prisma:284-305`). **Supersedes L5.** | P0 #4 |
+| O3 | **Designer depth extension** — shapes, layers, lockable template fields, animation, drawing, asset-library insertion, export-as-image. Extension of existing canvas, not a rewrite | L (5d) | `TemplateEditorCanvas` + `useEditorHistory` + `useCanvasZoom` + `DisplayPickerModal` already wired (`web/src/app/dashboard/templates/[id]/edit/page-client.tsx`) | P0 #1 |
+| O4 | **Tag-rule auto-assignment engine** — "if display has tag X then auto-assign playlist Y"; rule evaluator on tag-change / new-display events | M (2d) | New `TagRule` Prisma model + evaluator; pairs with O1's tag-based push | P0 #2 |
+| O5 | **Public customer API + SDK + webhooks** — production Swagger (not dev-only), OpenAPI export, npm SDK package, outbound webhook delivery for org events (display.offline, content.published, schedule.activated, etc.) | L (5d) | `ApiKey` + scopes already exist; Swagger gated to non-prod in `main.ts:129-166`; no SDK, no outbound webhooks today | P1 #10 |
+| O6 | **Mass provisioning** — bulk CSV pairing, provisioning templates (stored Wi-Fi + default playlist + orientation + scaling), pre-generated device-token CSVs, kiosk/player config bundles | M (3d) | Single-device pairing in `pairing.service.ts`; bulk-ops DTO is operations-only today (`displays/dto/bulk-operations.dto.ts`) | P1 #7 |
+| O7 | **Configurable downtime alert rules** — per tag/group with custom recipients, not just the hard-coded `device.offline` listener | S (1d) | `notifications.service.ts:277` is a fixed `@OnEvent` handler — replace with rule table + evaluator | P1 #6 |
+| O8 | **Generic API-to-screen data source** — JSON/XML/CSV polling source with mapping config, surfaced as a widget; the building block for POS-style integrations without bespoke per-vendor connectors | M (3d) | `widgets` module + `SheetsWidget` shipped; extends pattern to arbitrary HTTP source | P0 #3 |
+| O9 | **Teams + folder-level access control + custom roles** — new `Team`, `FolderPermission` (read/write/admin per folder), and `Role`/`Permission` models replacing the fixed `auth.constants.ts:46-50` enum | L (5d) | Flat org today: every user in an org sees everything. Foundation for enterprise plans | P0 #5 |
+| O10 | **Content proposal/approval pipeline** — separate proposer and approver roles; proposer creates draft, approver publishes; distinct from today's moderation flag | M (3d) | `content.service.ts:712-843` is moderation only. **Supersedes M4 + Q7.** | P0 #5 |
+
+**Total effort: ~36 dev-days.** Sequence recommendation from the audit (revised per O3 foundation note): O1 → O2 → O7 → O4 → O8 → O3 → O9 → O10 → O6 → O5. Reasoning: O1/O2/O7 connect existing primitives for fast visible wins; O3 (Designer) is bigger but already has scaffolding; O5 (Public API) goes last because it locks the contract.
 
 ---
 
@@ -175,7 +198,7 @@ These are documented + non-blocking for customer-1. Investigations done; impleme
 | Q4 | Social media feed widget (Instagram) | M (2d) | TODO | |
 | Q5 | Clock/countdown widget | S (4h) | TODO | |
 | Q6 | AI Template Designer (integrate Claude/OpenAI) | L (5d) | TODO | API costs — need revenue first |
-| Q7 | Content approval workflow | M (2d) | TODO | |
+| Q7 | Content approval workflow | M (2d) | TODO | **Superseded by O10 below.** |
 | Q8 | Custom branding per organization | M (2d) | TODO | |
 | Q9 | Return policy page + SLA page | S (4h) | TODO | Legal |
 | Q10 | Expand template library to 300+ | L (5d) | TODO | |

--- a/docs/runbooks/first-customer-onboarding.md
+++ b/docs/runbooks/first-customer-onboarding.md
@@ -123,6 +123,15 @@ ssh root@vizora.cloud 'cd /opt/vizora/app/packages/database && npx prisma migrat
 cat .ssh_pmstat.txt
 # Expect: "Database schema is up to date!"
 
+# Check 2b (O7 — alert rules seed) — REQUIRED after migration 20260519050346_add_alert_rules
+# is applied for the FIRST time on prod. Without this step, existing orgs lose their
+# device-offline alerts (the rule-driven evaluator has nothing to evaluate).
+# Idempotent — safe to re-run; rows with the auto-migrated name are skipped.
+ssh root@vizora.cloud 'cd /opt/vizora/app && export $(grep DATABASE_URL .env | xargs) && npx tsx packages/database/scripts/seed-default-alert-rules.ts' > .ssh_seed.txt 2>&1
+cat .ssh_seed.txt
+# Expect: "[seed] Done. created=N skipped_existing=0 orgs_with_no_admins=M"
+# If `created=0 skipped_existing=N` on second run, the seed already landed — that's correct.
+
 # Check 3: OpenRouter balance + daily cap
 # Open https://openrouter.ai/settings/keys in browser
 # Verify per-day spend cap = $2.00 (or higher if customer #1 traffic profile demands)

--- a/docs/runbooks/first-customer-onboarding.md
+++ b/docs/runbooks/first-customer-onboarding.md
@@ -118,19 +118,45 @@ ssh root@vizora.cloud 'pm2 list'
 #         hermes-vizora-customer-lifecycle (cron: stopped between firings is normal)
 #         hermes-vizora-support-triage NOT enabled (per design — see follow-up #3 in production-readiness-report.md)
 
-# Check 2: Migrations applied
+# Check 2: Migrations applied (pre-flight visibility — no writes)
 ssh root@vizora.cloud 'cd /opt/vizora/app/packages/database && npx prisma migrate status' > .ssh_pmstat.txt 2>&1
 cat .ssh_pmstat.txt
-# Expect: "Database schema is up to date!"
+# Expect: "Database schema is up to date!" — OR a list of pending migrations
+# you're about to apply via Check 2a below.
 
-# Check 2b (O7 — alert rules seed) — REQUIRED after migration 20260519050346_add_alert_rules
+# ---------------------------------------------------------------------------
+# Checks 2a → 2b → 2c MUST run in this order. Skipping 2b (`prisma generate`)
+# between migrate-deploy and the seed leaves the local Prisma client stale,
+# and the seed will fail with a confusing `TypeError: Cannot read properties
+# of undefined (reading 'findUnique')` on whatever model was added by the
+# new migration. Verified locally 2026-05-19.
+# ---------------------------------------------------------------------------
+
+# Check 2a: Apply migrations
+ssh root@vizora.cloud 'cd /opt/vizora/app && pnpm --filter @vizora/database exec prisma migrate deploy' > .ssh_migrate.txt 2>&1
+cat .ssh_migrate.txt
+# Expect: "All migrations have been successfully applied." (or "No pending migrations.")
+
+# Check 2b: Regenerate the Prisma client BEFORE any script that imports
+# packages/database/src/generated/prisma (e.g. the O7 seed below). Schema
+# additions are invisible to runtime callers until generate runs.
+ssh root@vizora.cloud 'cd /opt/vizora/app && pnpm --filter @vizora/database exec prisma generate --schema packages/database/prisma/schema.prisma' > .ssh_prisma_generate.txt 2>&1
+cat .ssh_prisma_generate.txt
+# Expect: "Generated Prisma Client (v...) to ./src/generated/prisma in Xms"
+
+# Check 2c (O7 — alert rules seed) — REQUIRED after migration 20260519050346_add_alert_rules
 # is applied for the FIRST time on prod. Without this step, existing orgs lose their
-# device-offline alerts (the rule-driven evaluator has nothing to evaluate).
+# device-offline alerts (the rule-driven evaluator has nothing to evaluate). New orgs
+# created post-deploy are auto-seeded via AuthService.register (PR #63 follow-up); this
+# backfill is needed only for orgs that pre-date the migration.
 # Idempotent — safe to re-run; rows with the auto-migrated name are skipped.
 ssh root@vizora.cloud 'cd /opt/vizora/app && export $(grep DATABASE_URL .env | xargs) && npx tsx packages/database/scripts/seed-default-alert-rules.ts' > .ssh_seed.txt 2>&1
 cat .ssh_seed.txt
 # Expect: "[seed] Done. created=N skipped_existing=0 orgs_with_no_admins=M"
 # If `created=0 skipped_existing=N` on second run, the seed already landed — that's correct.
+# If you see "Cannot read properties of undefined (reading 'findUnique')" or similar
+# on prisma.alertRule / prisma.alertRuleFire — Check 2b was skipped or failed. Re-run
+# 2b and then 2c.
 
 # Check 3: OpenRouter balance + daily cap
 # Open https://openrouter.ai/settings/keys in browser

--- a/middleware/src/modules/auth/auth.module.ts
+++ b/middleware/src/modules/auth/auth.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { AuthController } from './auth.controller';
@@ -6,6 +6,7 @@ import { AuthService } from './auth.service';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { DatabaseModule } from '../database/database.module';
 import { BillingModule } from '../billing/billing.module';
+import { NotificationsModule } from '../notifications/notifications.module';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { RolesGuard } from './guards/roles.guard';
 import { APP_GUARD } from '@nestjs/core';
@@ -14,6 +15,10 @@ import { APP_GUARD } from '@nestjs/core';
   imports: [
     DatabaseModule,
     BillingModule,
+    // forwardRef because NotificationsModule's AlertRulesController uses
+    // RolesGuard from this module (AuthModule). The forwardRef breaks the
+    // would-be circular import at module-graph resolution time.
+    forwardRef(() => NotificationsModule),
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.registerAsync({
       useFactory: () => {

--- a/middleware/src/modules/auth/auth.service.spec.ts
+++ b/middleware/src/modules/auth/auth.service.spec.ts
@@ -72,6 +72,7 @@ describe('AuthService', () => {
   let mockRedisService: any;
   let mockMailService: any;
   let mockGeoService: any;
+  let mockAlertRulesService: any;
 
   const mockUser = {
     id: 'user-123',
@@ -156,6 +157,10 @@ describe('AuthService', () => {
 
     const mockEventEmitter = { emit: jest.fn() };
 
+    mockAlertRulesService = {
+      seedDefaultRuleForOrg: jest.fn().mockResolvedValue(undefined),
+    };
+
     // Directly instantiate the service with mocked dependencies
     service = new AuthService(
       mockDatabaseService as DatabaseService,
@@ -166,6 +171,7 @@ describe('AuthService', () => {
       mockBillingService as any,
       mockStorageService as any,
       mockEventEmitter as any,
+      mockAlertRulesService as any,
     );
     
     // Reset bcrypt mocks
@@ -206,6 +212,39 @@ describe('AuthService', () => {
       });
       // Default bcrypt rounds is 12 (matches env validation default)
       expect(bcrypt.hash).toHaveBeenCalledWith(registerDto.password, 12);
+    });
+
+    it('seeds the default downtime alert rule for the new org (PR-review fix)', async () => {
+      // The original O7 PR removed the hard-coded device.offline notification
+      // path. The seed script handles existing orgs at deploy time, but new
+      // orgs created post-deploy would silently lose offline alerts. This
+      // test pins the registration-time seed call.
+      mockDatabaseService.user.findUnique.mockResolvedValue(null);
+      mockDatabaseService.organization.findUnique.mockResolvedValue(null);
+      mockDatabaseService.organization.create.mockResolvedValue(mockOrganization);
+      mockDatabaseService.user.create.mockResolvedValue(mockUser);
+      mockDatabaseService.auditLog.create.mockResolvedValue({});
+      (bcrypt.hash as jest.Mock).mockResolvedValue('hashed-password');
+
+      await service.register(registerDto);
+
+      expect(mockAlertRulesService.seedDefaultRuleForOrg).toHaveBeenCalledWith(
+        mockOrganization.id,
+        [mockUser.id],
+      );
+    });
+
+    it('does not block registration if the seed fails (fire-and-forget with warn)', async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue(null);
+      mockDatabaseService.organization.findUnique.mockResolvedValue(null);
+      mockDatabaseService.organization.create.mockResolvedValue(mockOrganization);
+      mockDatabaseService.user.create.mockResolvedValue(mockUser);
+      mockDatabaseService.auditLog.create.mockResolvedValue({});
+      (bcrypt.hash as jest.Mock).mockResolvedValue('hashed-password');
+      mockAlertRulesService.seedDefaultRuleForOrg.mockRejectedValue(new Error('DB temporarily down'));
+
+      // Registration must still succeed — the seed is a best-effort follow-up.
+      await expect(service.register(registerDto)).resolves.toHaveProperty('token');
     });
 
     it('should throw ConflictException if email already exists', async () => {

--- a/middleware/src/modules/auth/auth.service.ts
+++ b/middleware/src/modules/auth/auth.service.ts
@@ -8,6 +8,8 @@ import {
   HttpException,
   HttpStatus,
   ServiceUnavailableException,
+  Inject,
+  forwardRef,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -22,6 +24,7 @@ import { AUTH_CONSTANTS } from './constants/auth.constants';
 import { GeoService } from '../common/services/geo.service';
 import { BillingService } from '../billing/billing.service';
 import { StorageService } from '../storage/storage.service';
+import { AlertRulesService } from '../notifications/alert-rules/alert-rules.service';
 
 // Account lockout constants
 const MAX_LOGIN_ATTEMPTS = 10;
@@ -42,6 +45,8 @@ export class AuthService {
     private billingService: BillingService,
     private storageService: StorageService,
     private events: EventEmitter2,
+    @Inject(forwardRef(() => AlertRulesService))
+    private alertRulesService: AlertRulesService,
   ) {}
 
   async register(dto: RegisterDto, clientIp?: string) {
@@ -126,6 +131,18 @@ export class AuthService {
     });
 
     const { organization, user } = result;
+
+    // Seed the default device-offline alert rule for this new org. Without
+    // this, new orgs created post-O7 have NO default rule and silently lose
+    // device-offline alerts (the old hard-coded handler was removed).
+    // Idempotent + retry-safe: re-runs are no-ops via the (organizationId,
+    // name) unique index. Errors are logged but never propagated — a failed
+    // seed must not block registration.
+    this.alertRulesService.seedDefaultRuleForOrg(organization.id, [user.id]).catch((err) => {
+      this.logger.warn(
+        `Failed to seed default alert rule for new org ${organization.id}: ${err instanceof Error ? err.message : 'unknown'}`,
+      );
+    });
 
     // Generate JWT token
     const token = this.generateToken(user, organization);

--- a/middleware/src/modules/mail/mail.service.spec.ts
+++ b/middleware/src/modules/mail/mail.service.spec.ts
@@ -1,0 +1,66 @@
+import { MailService } from './mail.service';
+
+describe('MailService.escapeHtml', () => {
+  it('escapes &, <, >, ", and \'', () => {
+    expect(MailService.escapeHtml('a & b')).toBe('a &amp; b');
+    expect(MailService.escapeHtml('<script>')).toBe('&lt;script&gt;');
+    expect(MailService.escapeHtml('"quoted"')).toBe('&quot;quoted&quot;');
+    expect(MailService.escapeHtml("o'reilly")).toBe('o&#39;reilly');
+  });
+
+  it('escapes & first to avoid double-escaping', () => {
+    expect(MailService.escapeHtml('&lt;')).toBe('&amp;lt;');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(MailService.escapeHtml('')).toBe('');
+  });
+
+  it('returns plain text unchanged', () => {
+    expect(MailService.escapeHtml('Lobby Display 01')).toBe('Lobby Display 01');
+  });
+});
+
+describe('MailService.sendDeviceOfflineAlertEmail', () => {
+  let service: MailService;
+  let sendMailSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    service = new MailService();
+    // sendMail is private but accessible via type assertion for testing
+    sendMailSpy = jest.spyOn(service as unknown as { sendMail: jest.Func }, 'sendMail').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('sends with deviceName escaped in subject and body', async () => {
+    await service.sendDeviceOfflineAlertEmail('ops@example.com', '<bad>name</bad>');
+
+    expect(sendMailSpy).toHaveBeenCalledTimes(1);
+    const [to, subject, html, label, sender] = sendMailSpy.mock.calls[0];
+
+    expect(to).toBe('ops@example.com');
+    expect(subject).toBe('Device offline: <bad>name</bad>');                  // subject is plain text — Nodemailer handles encoding
+    expect(html).toContain('&lt;bad&gt;name&lt;/bad&gt;');                    // body MUST be HTML-escaped
+    expect(html).not.toContain('<bad>name</bad>');                            // unescaped form MUST NOT appear in HTML
+    expect(label).toBe('Device offline alert');
+    expect(sender).toBe('noreply');
+  });
+
+  it('renders a CTA pointing at /dashboard/devices', async () => {
+    await service.sendDeviceOfflineAlertEmail('ops@example.com', 'Lobby 1');
+
+    const [, , html] = sendMailSpy.mock.calls[0];
+    expect(html).toContain('/dashboard/devices');
+    expect(html).toContain('View Devices');
+  });
+
+  it('passes deviceName with quote characters through escapeHtml', async () => {
+    await service.sendDeviceOfflineAlertEmail('ops@example.com', 'a"b\'c');
+
+    const [, , html] = sendMailSpy.mock.calls[0];
+    expect(html).toContain('a&quot;b&#39;c');
+  });
+});

--- a/middleware/src/modules/mail/mail.service.spec.ts
+++ b/middleware/src/modules/mail/mail.service.spec.ts
@@ -42,9 +42,11 @@ describe('MailService.sendDeviceOfflineAlertEmail', () => {
     const [to, subject, html, label, sender] = sendMailSpy.mock.calls[0];
 
     expect(to).toBe('ops@example.com');
-    expect(subject).toBe('Device offline: <bad>name</bad>');                  // subject is plain text — Nodemailer handles encoding
-    expect(html).toContain('&lt;bad&gt;name&lt;/bad&gt;');                    // body MUST be HTML-escaped
-    expect(html).not.toContain('<bad>name</bad>');                            // unescaped form MUST NOT appear in HTML
+    // PR-review fix: subject MUST also be escaped — some clients render HTML
+    // entities in subjects, and logging tools can choke on < or " in subjects.
+    expect(subject).toBe('Device offline: &lt;bad&gt;name&lt;/bad&gt;');
+    expect(html).toContain('&lt;bad&gt;name&lt;/bad&gt;');                    // body must be HTML-escaped too
+    expect(html).not.toContain('<bad>name</bad>');                            // unescaped form MUST NOT appear
     expect(label).toBe('Device offline alert');
     expect(sender).toBe('noreply');
   });

--- a/middleware/src/modules/mail/mail.service.ts
+++ b/middleware/src/modules/mail/mail.service.ts
@@ -341,6 +341,54 @@ export class MailService {
   // Auth emails
   // ---------------------------------------------------------------------------
 
+  // ---------------------------------------------------------------------------
+  // Alert emails (O7 — configurable downtime alert rules)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Sends a "device offline" alert to a single recipient. Called per-recipient
+   * by AlertRuleEvaluator when a rule matches a device.offline event. The
+   * deviceName is user-controlled and is escaped before interpolation.
+   */
+  async sendDeviceOfflineAlertEmail(to: string, deviceName: string): Promise<void> {
+    const subject = `Device offline: ${deviceName}`;
+    const safeName = MailService.escapeHtml(deviceName);
+    const html = this.wrapInTemplate(`
+          <h1 style="color:#F0ECE8;font-size:22px;font-weight:700;margin:0 0 8px 0;">Device offline</h1>
+          <p style="color:#8A9BA3;font-size:14px;line-height:1.6;margin:0 0 24px 0;">
+            The display <strong style="color:#F0ECE8;">${safeName}</strong> is currently offline.
+            You're receiving this because an alert rule on your Vizora account matches this device.
+          </p>
+          ${this.ctaButton('View Devices', `${this.appUrl}/dashboard/devices`)}
+          <p style="color:#5A6B73;font-size:12px;line-height:1.5;margin:16px 0 0 0;">
+            Manage your alert rules in Settings &rarr; Alerts.
+          </p>
+    `);
+    await this.sendMail(to, subject, html, 'Device offline alert', 'noreply');
+  }
+
+  /**
+   * Escape HTML-special characters so user-controlled input (e.g. device
+   * nickname) cannot break out of the surrounding markup or inject script.
+   * Defensive — the email is sent to internal operators, but a hostile org
+   * admin could otherwise plant XSS targeting their own users.
+   *
+   * Static so it can be called from contexts that haven't instantiated
+   * MailService (tests, callers that just want to sanitize).
+   */
+  static escapeHtml(input: string): string {
+    return input
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Auth emails (continued)
+  // ---------------------------------------------------------------------------
+
   async sendPasswordResetEmail(
     to: string,
     firstName: string,

--- a/middleware/src/modules/mail/mail.service.ts
+++ b/middleware/src/modules/mail/mail.service.ts
@@ -351,8 +351,11 @@ export class MailService {
    * deviceName is user-controlled and is escaped before interpolation.
    */
   async sendDeviceOfflineAlertEmail(to: string, deviceName: string): Promise<void> {
-    const subject = `Device offline: ${deviceName}`;
     const safeName = MailService.escapeHtml(deviceName);
+    // Subject MUST also be escaped — some email clients render HTML entities
+    // in subjects, and a deviceName containing < or " can break logging /
+    // monitoring tools that consume the subject line. PR review found this.
+    const subject = `Device offline: ${safeName}`;
     const html = this.wrapInTemplate(`
           <h1 style="color:#F0ECE8;font-size:22px;font-weight:700;margin:0 0 8px 0;">Device offline</h1>
           <p style="color:#8A9BA3;font-size:14px;line-height:1.6;margin:0 0 24px 0;">

--- a/middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.spec.ts
+++ b/middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.spec.ts
@@ -1,0 +1,377 @@
+import { of, throwError } from 'rxjs';
+import { AlertRuleEvaluator } from './alert-rule.evaluator';
+import { AlertRulesService } from './alert-rules.service';
+import { DatabaseService } from '../../database/database.service';
+import { MailService } from '../../mail/mail.service';
+import { HttpService } from '@nestjs/axios';
+
+describe('AlertRuleEvaluator', () => {
+  let evaluator: AlertRuleEvaluator;
+  let db: any;
+  let alertRulesService: jest.Mocked<Pick<AlertRulesService, 'findActiveForEvent' | 'tryClaimDedupWindow'>>;
+  let mail: jest.Mocked<Pick<MailService, 'sendDeviceOfflineAlertEmail'>>;
+  let http: jest.Mocked<Pick<HttpService, 'post'>>;
+
+  const orgId = 'org-123';
+  const deviceId = 'device-1';
+  const deviceName = 'Lobby Display';
+
+  const payload = { deviceId, deviceName, organizationId: orgId };
+
+  beforeEach(() => {
+    db = {
+      display: { findUnique: jest.fn() },
+      notification: { create: jest.fn() },
+    };
+    alertRulesService = {
+      findActiveForEvent: jest.fn(),
+      tryClaimDedupWindow: jest.fn(),
+    } as any;
+    mail = { sendDeviceOfflineAlertEmail: jest.fn() } as any;
+    http = { post: jest.fn() } as any;
+
+    evaluator = new AlertRuleEvaluator(
+      db as unknown as DatabaseService,
+      alertRulesService as unknown as AlertRulesService,
+      mail as unknown as MailService,
+      http as unknown as HttpService,
+    );
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // Helper — produce a rule of given scope
+  const makeRule = (overrides: Partial<any> = {}) => ({
+    id: 'rule-1',
+    organizationId: orgId,
+    name: 'r',
+    triggerEvent: 'device.offline',
+    isActive: true,
+    scope: 'all',
+    scopeTagId: null,
+    scopeGroupId: null,
+    scopeDisplayId: null,
+    minOfflineSec: 120,
+    recipients: [{ id: 'rec-1', channel: 'in_app', target: 'user-1' }],
+    ...overrides,
+  });
+
+  // 10 minutes ago, relative to real now. Guarantees offlineSec > minOfflineSec (120)
+  // regardless of when the test suite runs.
+  const makeDevice = (overrides: Partial<any> = {}) => ({
+    id: deviceId,
+    lastHeartbeat: new Date(Date.now() - 10 * 60 * 1000),
+    tags: [],
+    groups: [],
+    ...overrides,
+  });
+
+  // ---------------------------------------------------------------------------
+  // Top-level
+  // ---------------------------------------------------------------------------
+  it('logs warn and returns when device does not exist (no rules evaluated)', async () => {
+    db.display.findUnique.mockResolvedValue(null);
+
+    await evaluator.handleDeviceOffline(payload);
+
+    expect(alertRulesService.findActiveForEvent).not.toHaveBeenCalled();
+  });
+
+  it('no-op when org has zero active rules', async () => {
+    db.display.findUnique.mockResolvedValue(makeDevice());
+    alertRulesService.findActiveForEvent.mockResolvedValue([]);
+
+    await evaluator.handleDeviceOffline(payload);
+
+    expect(alertRulesService.tryClaimDedupWindow).not.toHaveBeenCalled();
+    expect(db.notification.create).not.toHaveBeenCalled();
+  });
+
+  it('top-level try/catch swallows DB failures so EventEmitter does not crash', async () => {
+    db.display.findUnique.mockRejectedValue(new Error('DB down'));
+
+    await expect(evaluator.handleDeviceOffline(payload)).resolves.toBeUndefined();
+  });
+
+  // ---------------------------------------------------------------------------
+  // lastHeartbeat=null edge case
+  // ---------------------------------------------------------------------------
+  it('fires rule when lastHeartbeat is null (treats as infinitely offline)', async () => {
+    db.display.findUnique.mockResolvedValue(makeDevice({ lastHeartbeat: null }));
+    alertRulesService.findActiveForEvent.mockResolvedValue([makeRule({ minOfflineSec: 99999 })]);
+    alertRulesService.tryClaimDedupWindow.mockResolvedValue(true);
+    db.notification.create.mockResolvedValue({});
+
+    await evaluator.handleDeviceOffline(payload);
+
+    expect(db.notification.create).toHaveBeenCalledTimes(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Scope matching
+  // ---------------------------------------------------------------------------
+  describe('scope', () => {
+    beforeEach(() => {
+      alertRulesService.tryClaimDedupWindow.mockResolvedValue(true);
+      db.notification.create.mockResolvedValue({});
+    });
+
+    it('scope=all matches every device', async () => {
+      db.display.findUnique.mockResolvedValue(makeDevice());
+      alertRulesService.findActiveForEvent.mockResolvedValue([makeRule({ scope: 'all' })]);
+
+      await evaluator.handleDeviceOffline(payload);
+
+      expect(db.notification.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('scope=tag matches when device has the tag', async () => {
+      db.display.findUnique.mockResolvedValue(
+        makeDevice({ tags: [{ tagId: 'tag-1' }, { tagId: 'tag-2' }] }),
+      );
+      alertRulesService.findActiveForEvent.mockResolvedValue([
+        makeRule({ scope: 'tag', scopeTagId: 'tag-2' }),
+      ]);
+
+      await evaluator.handleDeviceOffline(payload);
+
+      expect(db.notification.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('scope=tag skips when device lacks the tag', async () => {
+      db.display.findUnique.mockResolvedValue(makeDevice({ tags: [{ tagId: 'tag-9' }] }));
+      alertRulesService.findActiveForEvent.mockResolvedValue([
+        makeRule({ scope: 'tag', scopeTagId: 'tag-2' }),
+      ]);
+
+      await evaluator.handleDeviceOffline(payload);
+
+      expect(db.notification.create).not.toHaveBeenCalled();
+    });
+
+    it('scope=tag with scopeTagId=null (Tag was deleted) skips with WARN log', async () => {
+      const warnSpy = jest.spyOn((evaluator as any).logger, 'warn');
+      db.display.findUnique.mockResolvedValue(makeDevice({ tags: [{ tagId: 'tag-1' }] }));
+      alertRulesService.findActiveForEvent.mockResolvedValue([
+        makeRule({ scope: 'tag', scopeTagId: null }),
+      ]);
+
+      await evaluator.handleDeviceOffline(payload);
+
+      expect(db.notification.create).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('scope=tag but scopeTagId=null'));
+    });
+
+    it('scope=group matches when device is in the group', async () => {
+      db.display.findUnique.mockResolvedValue(
+        makeDevice({ groups: [{ displayGroupId: 'group-3' }] }),
+      );
+      alertRulesService.findActiveForEvent.mockResolvedValue([
+        makeRule({ scope: 'group', scopeGroupId: 'group-3' }),
+      ]);
+
+      await evaluator.handleDeviceOffline(payload);
+
+      expect(db.notification.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('scope=group with scopeGroupId=null skips with WARN log', async () => {
+      const warnSpy = jest.spyOn((evaluator as any).logger, 'warn');
+      db.display.findUnique.mockResolvedValue(makeDevice());
+      alertRulesService.findActiveForEvent.mockResolvedValue([
+        makeRule({ scope: 'group', scopeGroupId: null }),
+      ]);
+
+      await evaluator.handleDeviceOffline(payload);
+
+      expect(db.notification.create).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalled();
+    });
+
+    it('scope=display matches when display id is exact', async () => {
+      db.display.findUnique.mockResolvedValue(makeDevice());
+      alertRulesService.findActiveForEvent.mockResolvedValue([
+        makeRule({ scope: 'display', scopeDisplayId: deviceId }),
+      ]);
+
+      await evaluator.handleDeviceOffline(payload);
+
+      expect(db.notification.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('scope=display skips when scopeDisplayId is different', async () => {
+      db.display.findUnique.mockResolvedValue(makeDevice());
+      alertRulesService.findActiveForEvent.mockResolvedValue([
+        makeRule({ scope: 'display', scopeDisplayId: 'other-display' }),
+      ]);
+
+      await evaluator.handleDeviceOffline(payload);
+
+      expect(db.notification.create).not.toHaveBeenCalled();
+    });
+
+    it('unknown scope value skips with WARN log', async () => {
+      const warnSpy = jest.spyOn((evaluator as any).logger, 'warn');
+      db.display.findUnique.mockResolvedValue(makeDevice());
+      alertRulesService.findActiveForEvent.mockResolvedValue([makeRule({ scope: 'mystery' })]);
+
+      await evaluator.handleDeviceOffline(payload);
+
+      expect(db.notification.create).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown scope'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // minOfflineSec debounce
+  // ---------------------------------------------------------------------------
+  it('skips dispatch when offlineSec < minOfflineSec', async () => {
+    // lastHeartbeat 60s ago, minOfflineSec=300 → offlineSec=60 → skip
+    const now = new Date('2026-05-19T10:00:00Z');
+    jest.useFakeTimers().setSystemTime(now);
+
+    db.display.findUnique.mockResolvedValue(
+      makeDevice({ lastHeartbeat: new Date('2026-05-19T09:59:00Z') }),
+    );
+    alertRulesService.findActiveForEvent.mockResolvedValue([
+      makeRule({ minOfflineSec: 300 }),
+    ]);
+
+    await evaluator.handleDeviceOffline(payload);
+
+    expect(alertRulesService.tryClaimDedupWindow).not.toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Atomic dedup
+  // ---------------------------------------------------------------------------
+  it('dispatches only when tryClaimDedupWindow returns true', async () => {
+    db.display.findUnique.mockResolvedValue(makeDevice());
+    alertRulesService.findActiveForEvent.mockResolvedValue([makeRule()]);
+    alertRulesService.tryClaimDedupWindow.mockResolvedValue(false);
+
+    await evaluator.handleDeviceOffline(payload);
+
+    expect(db.notification.create).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Per-recipient try/catch
+  // ---------------------------------------------------------------------------
+  it('one failing recipient does not block the others', async () => {
+    db.display.findUnique.mockResolvedValue(makeDevice());
+    alertRulesService.findActiveForEvent.mockResolvedValue([
+      makeRule({
+        recipients: [
+          { id: 'rec-1', channel: 'in_app', target: 'user-1' },
+          { id: 'rec-2', channel: 'email', target: 'a@b.com' },
+        ],
+      }),
+    ]);
+    alertRulesService.tryClaimDedupWindow.mockResolvedValue(true);
+    // Make the in_app dispatch throw — emulating an FK violation on userId
+    db.notification.create.mockRejectedValueOnce(new Error('FK violation on userId'));
+    mail.sendDeviceOfflineAlertEmail.mockResolvedValue(undefined);
+
+    await evaluator.handleDeviceOffline(payload);
+
+    // Email recipient still received its alert
+    expect(mail.sendDeviceOfflineAlertEmail).toHaveBeenCalledWith('a@b.com', deviceName);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Channels
+  // ---------------------------------------------------------------------------
+  it('dispatches in_app via db.notification.create with scoped userId', async () => {
+    db.display.findUnique.mockResolvedValue(makeDevice());
+    alertRulesService.findActiveForEvent.mockResolvedValue([makeRule()]);
+    alertRulesService.tryClaimDedupWindow.mockResolvedValue(true);
+    db.notification.create.mockResolvedValue({});
+
+    await evaluator.handleDeviceOffline(payload);
+
+    expect(db.notification.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        organizationId: orgId,
+        userId: 'user-1',
+        type: 'device_offline',
+        severity: 'warning',
+      }),
+    });
+  });
+
+  it('dispatches slack_webhook with maxRedirects:0 and 5s timeout', async () => {
+    db.display.findUnique.mockResolvedValue(makeDevice());
+    alertRulesService.findActiveForEvent.mockResolvedValue([
+      makeRule({
+        recipients: [
+          { id: 'rec-1', channel: 'slack_webhook', target: 'https://hooks.slack.com/services/T/B/x' },
+        ],
+      }),
+    ]);
+    alertRulesService.tryClaimDedupWindow.mockResolvedValue(true);
+    http.post.mockReturnValue(of({ data: 'ok' }) as any);
+
+    await evaluator.handleDeviceOffline(payload);
+
+    expect(http.post).toHaveBeenCalledWith(
+      'https://hooks.slack.com/services/T/B/x',
+      expect.objectContaining({ text: expect.any(String) }),
+      expect.objectContaining({ maxRedirects: 0, timeout: 5000 }),
+    );
+  });
+
+  it('SSRF guard at dispatch: rejects non-Slack URL even if it slipped past the DTO', async () => {
+    db.display.findUnique.mockResolvedValue(makeDevice());
+    alertRulesService.findActiveForEvent.mockResolvedValue([
+      makeRule({
+        recipients: [
+          { id: 'rec-1', channel: 'slack_webhook', target: 'http://internal/foo' },
+        ],
+      }),
+    ]);
+    alertRulesService.tryClaimDedupWindow.mockResolvedValue(true);
+    const errSpy = jest.spyOn((evaluator as any).logger, 'error');
+
+    await evaluator.handleDeviceOffline(payload);
+
+    expect(http.post).not.toHaveBeenCalled();
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('fails allowlist'));
+  });
+
+  it('escapes Slack markdown special characters in deviceName', async () => {
+    db.display.findUnique.mockResolvedValue(makeDevice());
+    alertRulesService.findActiveForEvent.mockResolvedValue([
+      makeRule({
+        recipients: [
+          { id: 'rec-1', channel: 'slack_webhook', target: 'https://hooks.slack.com/services/T/B/x' },
+        ],
+      }),
+    ]);
+    alertRulesService.tryClaimDedupWindow.mockResolvedValue(true);
+    http.post.mockReturnValue(of({ data: 'ok' }) as any);
+
+    await evaluator.handleDeviceOffline({ ...payload, deviceName: '*pwn*' });
+
+    const body = (http.post as jest.Mock).mock.calls[0][1];
+    // The "*pwn*" should be escaped to "\\*pwn\\*" so Slack doesn't render as bold
+    expect(body.text).toContain('\\*pwn\\*');
+    expect(body.text).not.toMatch(/\*pwn\*/);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Zero recipients edge case
+  // ---------------------------------------------------------------------------
+  it('rule with zero recipients is a silent no-op (no error, no dispatch)', async () => {
+    db.display.findUnique.mockResolvedValue(makeDevice());
+    alertRulesService.findActiveForEvent.mockResolvedValue([makeRule({ recipients: [] })]);
+    alertRulesService.tryClaimDedupWindow.mockResolvedValue(true);
+
+    await evaluator.handleDeviceOffline(payload);
+
+    expect(db.notification.create).not.toHaveBeenCalled();
+    expect(mail.sendDeviceOfflineAlertEmail).not.toHaveBeenCalled();
+    expect(http.post).not.toHaveBeenCalled();
+  });
+});

--- a/middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.spec.ts
+++ b/middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.spec.ts
@@ -244,7 +244,7 @@ describe('AlertRuleEvaluator', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Atomic dedup
+  // Atomic dedup — per (rule, device)
   // ---------------------------------------------------------------------------
   it('dispatches only when tryClaimDedupWindow returns true', async () => {
     db.display.findUnique.mockResolvedValue(makeDevice());
@@ -254,6 +254,41 @@ describe('AlertRuleEvaluator', () => {
     await evaluator.handleDeviceOffline(payload);
 
     expect(db.notification.create).not.toHaveBeenCalled();
+  });
+
+  it('passes both ruleId AND deviceId to tryClaimDedupWindow (per-device dedup)', async () => {
+    db.display.findUnique.mockResolvedValue(makeDevice());
+    alertRulesService.findActiveForEvent.mockResolvedValue([makeRule({ id: 'rule-X' })]);
+    alertRulesService.tryClaimDedupWindow.mockResolvedValue(true);
+    db.notification.create.mockResolvedValue({});
+
+    await evaluator.handleDeviceOffline(payload);
+
+    expect(alertRulesService.tryClaimDedupWindow).toHaveBeenCalledWith(
+      'rule-X',
+      deviceId,
+      expect.any(Date),
+    );
+  });
+
+  it('same rule fires for device A and then device B independently (the PR-review fix)', async () => {
+    db.display.findUnique.mockResolvedValue(makeDevice({ id: 'device-A' }));
+    alertRulesService.findActiveForEvent.mockResolvedValue([makeRule()]);
+    // First call: claim succeeds for device-A
+    alertRulesService.tryClaimDedupWindow.mockResolvedValueOnce(true);
+    db.notification.create.mockResolvedValue({});
+
+    await evaluator.handleDeviceOffline({ deviceId: 'device-A', deviceName: 'A', organizationId: orgId });
+
+    // Now device B goes offline — even though the rule fired 5 min ago for device-A,
+    // it must fire independently for device-B (different per-device dedup state).
+    db.display.findUnique.mockResolvedValue(makeDevice({ id: 'device-B' }));
+    alertRulesService.tryClaimDedupWindow.mockResolvedValueOnce(true);
+
+    await evaluator.handleDeviceOffline({ deviceId: 'device-B', deviceName: 'B', organizationId: orgId });
+
+    // Both devices got their in_app notification
+    expect(db.notification.create).toHaveBeenCalledTimes(2);
   });
 
   // ---------------------------------------------------------------------------

--- a/middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.ts
+++ b/middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.ts
@@ -101,8 +101,14 @@ export class AlertRuleEvaluator {
       if (!this.scopeMatches(rule, device)) continue;
       if (offlineSec < rule.minOfflineSec) continue;
 
-      // Atomic CAS — only the instance whose UPDATE affects 1 row dispatches
-      const claimed = await this.alertRulesService.tryClaimDedupWindow(rule.id, now);
+      // Atomic CAS — only the instance whose upsert affects 1 row dispatches.
+      // Per-(rule, device) dedup: a rule matching N devices alerts for EACH
+      // device, not just the first to go offline in the window.
+      const claimed = await this.alertRulesService.tryClaimDedupWindow(
+        rule.id,
+        device.id,
+        now,
+      );
       if (!claimed) continue;
 
       await this.dispatchAll(rule, payload);

--- a/middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.ts
+++ b/middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.ts
@@ -1,0 +1,246 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import { OnEvent } from '@nestjs/event-emitter';
+import { firstValueFrom } from 'rxjs';
+import { Prisma } from '@vizora/database';
+import { DatabaseService } from '../../database/database.service';
+import { MailService } from '../../mail/mail.service';
+import { AlertRulesService } from './alert-rules.service';
+import {
+  Channel,
+  SLACK_WEBHOOK_REGEX,
+  TriggerEvent,
+  escapeSlackText,
+} from './alert-rule.types';
+
+interface DeviceOfflinePayload {
+  deviceId: string;
+  deviceName: string;
+  organizationId: string;
+}
+
+/**
+ * O7 — Rule-driven evaluator for `device.offline` events.
+ *
+ * Replaces the hard-coded `handleDeviceOffline` handler that previously
+ * lived in NotificationsService. Now, when a device transitions offline:
+ *   1. Look up the device with its tags + groups.
+ *   2. Load all active rules for the org with `triggerEvent='device.offline'`.
+ *   3. For each rule:
+ *      - Match scope against the device (all/tag/group/display).
+ *      - Check minOfflineSec debounce against device.lastHeartbeat.
+ *      - Atomically claim the 15-min dedup window (tryClaimDedupWindow).
+ *      - Dispatch to each recipient, one channel at a time, with
+ *        per-recipient try/catch so one failure doesn't kill others.
+ *
+ * Behavior change vs the old handler:
+ *   - Old: every org user got an in-app notification on every offline event.
+ *   - New: only orgs with explicit rules + recipients get alerts.
+ *
+ * The migration's seed script preserves 1:1 behavior for existing orgs by
+ * seeding a default rule (scope=all, recipients=admins, channel=in_app).
+ */
+@Injectable()
+export class AlertRuleEvaluator {
+  private readonly logger = new Logger(AlertRuleEvaluator.name);
+
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly alertRulesService: AlertRulesService,
+    private readonly mail: MailService,
+    private readonly http: HttpService,
+  ) {}
+
+  /**
+   * Top-level handler. The outer try/catch matches the INVARIANT in
+   * `app.module.ts:42-54` — async @OnEvent handlers MUST swallow errors
+   * because EventEmitter2's `ignoreErrors:false` config turns uncaught
+   * rejections into process-level errors (= PM2 restart storm).
+   */
+  @OnEvent('device.offline', { async: true })
+  async handleDeviceOffline(payload: DeviceOfflinePayload): Promise<void> {
+    try {
+      await this.evaluate(payload);
+    } catch (err) {
+      this.logger.error(
+        `Alert rule evaluation failed for device ${payload.deviceId}`,
+        err instanceof Error ? err.stack : String(err),
+      );
+    }
+  }
+
+  private async evaluate(payload: DeviceOfflinePayload): Promise<void> {
+    const device = await this.db.display.findUnique({
+      where: { id: payload.deviceId },
+      include: {
+        tags: { select: { tagId: true } },
+        groups: { select: { displayGroupId: true } },
+      },
+    });
+    if (!device) {
+      this.logger.warn(
+        `device.offline event for unknown device ${payload.deviceId} — skipping all rules`,
+      );
+      return;
+    }
+
+    const rules = await this.alertRulesService.findActiveForEvent(
+      payload.organizationId,
+      'device.offline',
+    );
+    if (rules.length === 0) return;
+
+    const now = new Date();
+    // If lastHeartbeat is null (device that never sent a heartbeat), treat as
+    // infinitely offline — any minOfflineSec threshold trivially passes.
+    const offlineSec = device.lastHeartbeat
+      ? Math.floor((now.getTime() - device.lastHeartbeat.getTime()) / 1000)
+      : Number.POSITIVE_INFINITY;
+
+    for (const rule of rules) {
+      if (!this.scopeMatches(rule, device)) continue;
+      if (offlineSec < rule.minOfflineSec) continue;
+
+      // Atomic CAS — only the instance whose UPDATE affects 1 row dispatches
+      const claimed = await this.alertRulesService.tryClaimDedupWindow(rule.id, now);
+      if (!claimed) continue;
+
+      await this.dispatchAll(rule, payload);
+    }
+  }
+
+  /**
+   * Scope predicate. Logs a WARN when a scope FK is null (the referenced
+   * Tag / DisplayGroup / Display was deleted, leaving the rule in a zombie
+   * state). The rule still survives in the DB so the org can fix it; the
+   * evaluator just won't fire it.
+   */
+  private scopeMatches(
+    rule: { id: string; scope: string; scopeTagId: string | null; scopeGroupId: string | null; scopeDisplayId: string | null },
+    device: { id: string; tags: { tagId: string }[]; groups: { displayGroupId: string }[] },
+  ): boolean {
+    switch (rule.scope) {
+      case 'all':
+        return true;
+      case 'tag':
+        if (rule.scopeTagId == null) {
+          this.logger.warn(
+            `Rule ${rule.id} has scope=tag but scopeTagId=null (referenced Tag was deleted). Rule will never fire — consider disabling or re-scoping.`,
+          );
+          return false;
+        }
+        return device.tags.some((t) => t.tagId === rule.scopeTagId);
+      case 'group':
+        if (rule.scopeGroupId == null) {
+          this.logger.warn(
+            `Rule ${rule.id} has scope=group but scopeGroupId=null (referenced DisplayGroup was deleted).`,
+          );
+          return false;
+        }
+        return device.groups.some((g) => g.displayGroupId === rule.scopeGroupId);
+      case 'display':
+        if (rule.scopeDisplayId == null) {
+          this.logger.warn(
+            `Rule ${rule.id} has scope=display but scopeDisplayId=null (referenced Display was deleted).`,
+          );
+          return false;
+        }
+        return rule.scopeDisplayId === device.id;
+      default:
+        this.logger.warn(`Unknown scope "${rule.scope}" on rule ${rule.id} — skipping`);
+        return false;
+    }
+  }
+
+  /**
+   * Per-recipient dispatch. Each recipient is wrapped in its own try/catch
+   * so a single failure (FK violation, SMTP timeout, Slack 503) doesn't
+   * prevent other recipients from receiving the alert.
+   */
+  private async dispatchAll(
+    rule: { id: string; recipients: { id: string; channel: string; target: string }[] },
+    payload: DeviceOfflinePayload,
+  ): Promise<void> {
+    for (const recipient of rule.recipients) {
+      try {
+        switch (recipient.channel as Channel) {
+          case 'in_app':
+            await this.dispatchInApp(recipient, payload);
+            break;
+          case 'email':
+            await this.dispatchEmail(recipient, payload);
+            break;
+          case 'slack_webhook':
+            await this.dispatchSlack(recipient, payload);
+            break;
+          default:
+            this.logger.warn(
+              `Unknown channel "${recipient.channel}" on recipient ${recipient.id} — skipping`,
+            );
+        }
+      } catch (err) {
+        this.logger.error(
+          `Recipient dispatch failed (rule=${rule.id}, recipient=${recipient.id}, channel=${recipient.channel})`,
+          err instanceof Error ? err.stack : String(err),
+        );
+      }
+    }
+  }
+
+  private async dispatchInApp(
+    recipient: { target: string },
+    payload: DeviceOfflinePayload,
+  ): Promise<void> {
+    await this.db.notification.create({
+      data: {
+        organizationId: payload.organizationId,
+        userId: recipient.target,
+        type: 'device_offline',
+        severity: 'warning',
+        title: 'Device offline',
+        message: `${payload.deviceName} is offline`,
+        metadata: { deviceId: payload.deviceId } as Prisma.InputJsonValue,
+      },
+    });
+  }
+
+  private async dispatchEmail(
+    recipient: { target: string },
+    payload: DeviceOfflinePayload,
+  ): Promise<void> {
+    await this.mail.sendDeviceOfflineAlertEmail(recipient.target, payload.deviceName);
+  }
+
+  private async dispatchSlack(
+    recipient: { id: string; target: string },
+    payload: DeviceOfflinePayload,
+  ): Promise<void> {
+    // SSRF guard — DTO validates at create time, but a tampered record (direct
+    // DB write) is rejected here too. Defense in depth.
+    if (!SLACK_WEBHOOK_REGEX.test(recipient.target)) {
+      this.logger.error(
+        `Slack webhook recipient ${recipient.id} rejected at dispatch — URL fails allowlist`,
+      );
+      return;
+    }
+
+    // SSRF defense: maxRedirects=0 prevents Slack 302 -> attacker chain.
+    // timeout=5000 prevents slow-loris hold-open from blocking other dispatches.
+    await firstValueFrom(
+      this.http.post(
+        recipient.target,
+        { text: `:rotating_light: *${escapeSlackText(payload.deviceName)}* is offline` },
+        { maxRedirects: 0, timeout: 5000 },
+      ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test-only exposed methods (no underscore convention — these are also useful
+  // for the evaluator spec to exercise scope matching in isolation)
+  // ---------------------------------------------------------------------------
+  /** @internal — exposed for unit tests */
+  _scopeMatchesForTest(rule: any, device: any): boolean {
+    return this.scopeMatches(rule, device);
+  }
+}

--- a/middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.ts
+++ b/middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.ts
@@ -235,12 +235,4 @@ export class AlertRuleEvaluator {
     );
   }
 
-  // ---------------------------------------------------------------------------
-  // Test-only exposed methods (no underscore convention — these are also useful
-  // for the evaluator spec to exercise scope matching in isolation)
-  // ---------------------------------------------------------------------------
-  /** @internal — exposed for unit tests */
-  _scopeMatchesForTest(rule: any, device: any): boolean {
-    return this.scopeMatches(rule, device);
-  }
 }

--- a/middleware/src/modules/notifications/alert-rules/alert-rule.types.ts
+++ b/middleware/src/modules/notifications/alert-rules/alert-rule.types.ts
@@ -1,0 +1,52 @@
+/**
+ * O7 — Configurable downtime alert rules.
+ *
+ * Source of truth for the enum-like string values + tuning constants used
+ * across DTO validation, service logic, and the evaluator. Centralized so a
+ * change in the allowed-channel list (or the dedup window) requires editing
+ * exactly one file.
+ */
+
+export const TRIGGER_EVENTS = ['device.offline'] as const;
+export type TriggerEvent = (typeof TRIGGER_EVENTS)[number];
+
+export const SCOPES = ['all', 'tag', 'group', 'display'] as const;
+export type Scope = (typeof SCOPES)[number];
+
+export const CHANNELS = ['in_app', 'email', 'slack_webhook'] as const;
+export type Channel = (typeof CHANNELS)[number];
+
+/** 15-minute dedup window per rule (atomic CAS via `tryClaimDedupWindow`). */
+export const DEDUP_WINDOW_MS = 15 * 60 * 1000;
+
+/**
+ * Floor for `minOfflineSec`. The stale-heartbeat cron in
+ * `displays.service.ts` only emits `device.offline` once a device's
+ * `lastHeartbeat` is >2 min stale, so any `minOfflineSec` below 120s would
+ * be silently equivalent to 120. DTO rejects values below this.
+ */
+export const MIN_OFFLINE_SEC_FLOOR = 120;
+
+/** Hard upper bound on recipients per rule. Defends against fan-out abuse. */
+export const MAX_RECIPIENTS_PER_RULE = 20;
+
+/**
+ * Allowlist regex for `slack_webhook` channel targets. Slack incoming webhook
+ * URLs are of the form https://hooks.slack.com/services/T.../B.../xxx.
+ * Validated at DTO time AND re-validated at dispatch time (defense in depth
+ * in case a record was tampered with via direct DB write).
+ *
+ * Adding more webhook channels (PagerDuty, Discord, Teams) is deferred to a
+ * follow-up PR — each needs its own allowlist + payload shape + integration
+ * tests.
+ */
+export const SLACK_WEBHOOK_REGEX = /^https:\/\/hooks\.slack\.com\/services\//;
+
+/**
+ * Slack's `text` field renders Markdown. A device named e.g. `*pwn*` would
+ * render as bold, mangling the alert. Escape backtick + the four format
+ * delimiters before interpolation.
+ */
+export function escapeSlackText(s: string): string {
+  return s.replace(/[`*_~|]/g, (c) => `\\${c}`);
+}

--- a/middleware/src/modules/notifications/alert-rules/alert-rules.controller.spec.ts
+++ b/middleware/src/modules/notifications/alert-rules/alert-rules.controller.spec.ts
@@ -114,9 +114,12 @@ describe('AlertRulesController', () => {
       expect(roles).toContain('admin');
     });
 
-    it('POST create does NOT require admin (any org user can create)', () => {
+    it('POST create requires @Roles("admin") — PR-review fix', () => {
+      // Was previously open to any org user. Tightened because POST allows
+      // inline recipients (same privilege as the admin-gated
+      // /:id/recipients endpoint — inconsistent to gate one but not the other).
       const roles = reflector.get<string[]>('roles', controller.create);
-      expect(roles).toBeUndefined();
+      expect(roles).toContain('admin');
     });
 
     it('GET findAll does NOT require admin', () => {

--- a/middleware/src/modules/notifications/alert-rules/alert-rules.controller.spec.ts
+++ b/middleware/src/modules/notifications/alert-rules/alert-rules.controller.spec.ts
@@ -1,0 +1,132 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AlertRulesController } from './alert-rules.controller';
+import { AlertRulesService } from './alert-rules.service';
+import { RolesGuard } from '../../auth/guards/roles.guard';
+import { Reflector } from '@nestjs/core';
+
+describe('AlertRulesController', () => {
+  let controller: AlertRulesController;
+  let service: jest.Mocked<AlertRulesService>;
+
+  const orgId = 'org-123';
+
+  beforeEach(async () => {
+    service = {
+      create: jest.fn(),
+      findAll: jest.fn(),
+      findOne: jest.fn(),
+      update: jest.fn(),
+      remove: jest.fn(),
+      addRecipient: jest.fn(),
+      removeRecipient: jest.fn(),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AlertRulesController],
+      providers: [
+        { provide: AlertRulesService, useValue: service },
+        Reflector,
+      ],
+    })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get(AlertRulesController);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ---------------------------------------------------------------------------
+  // Delegation correctness — each endpoint forwards to the service with orgId
+  // ---------------------------------------------------------------------------
+  it('POST forwards to service.create with orgId', async () => {
+    service.create.mockResolvedValue({ id: 'rule-1' } as any);
+    const dto: any = { name: 'r', triggerEvent: 'device.offline', scope: 'all', recipients: [] };
+    await controller.create(orgId, dto);
+    expect(service.create).toHaveBeenCalledWith(orgId, dto);
+  });
+
+  it('GET / forwards filters to service.findAll', async () => {
+    service.findAll.mockResolvedValue([]);
+    const query: any = { isActive: true, triggerEvent: 'device.offline' };
+    await controller.findAll(orgId, query);
+    expect(service.findAll).toHaveBeenCalledWith(orgId, query);
+  });
+
+  it('GET /:id forwards to service.findOne with orgId', async () => {
+    service.findOne.mockResolvedValue({ id: 'rule-1' } as any);
+    await controller.findOne(orgId, 'rule-1');
+    expect(service.findOne).toHaveBeenCalledWith(orgId, 'rule-1');
+  });
+
+  it('PATCH /:id forwards to service.update with orgId', async () => {
+    service.update.mockResolvedValue({ id: 'rule-1' } as any);
+    const dto: any = { isActive: false };
+    await controller.update(orgId, 'rule-1', dto);
+    expect(service.update).toHaveBeenCalledWith(orgId, 'rule-1', dto);
+  });
+
+  it('DELETE /:id forwards to service.remove with orgId (admin-gated)', async () => {
+    service.remove.mockResolvedValue(undefined);
+    await controller.remove(orgId, 'rule-1');
+    expect(service.remove).toHaveBeenCalledWith(orgId, 'rule-1');
+  });
+
+  it('POST /:id/recipients forwards to service.addRecipient (admin-gated)', async () => {
+    service.addRecipient.mockResolvedValue({ id: 'rec-1' } as any);
+    const dto: any = { channel: 'in_app', target: 'user-1' };
+    await controller.addRecipient(orgId, 'rule-1', dto);
+    expect(service.addRecipient).toHaveBeenCalledWith(orgId, 'rule-1', dto);
+  });
+
+  it('DELETE /:id/recipients/:recipientId forwards to service.removeRecipient (admin-gated)', async () => {
+    service.removeRecipient.mockResolvedValue(undefined);
+    await controller.removeRecipient(orgId, 'rule-1', 'rec-1');
+    expect(service.removeRecipient).toHaveBeenCalledWith(orgId, 'rule-1', 'rec-1');
+  });
+
+  // ---------------------------------------------------------------------------
+  // RBAC metadata check — admin-gated endpoints carry the @Roles('admin') decorator
+  // (cannot exercise the guard itself without a full DI ring + JWT context;
+  // the structural check below proves the gate is wired)
+  // ---------------------------------------------------------------------------
+  describe('RBAC decorators', () => {
+    const reflector = new Reflector();
+
+    it('PATCH carries @Roles("admin")', () => {
+      const roles = reflector.get<string[]>('roles', controller.update);
+      expect(roles).toContain('admin');
+    });
+
+    it('DELETE rule carries @Roles("admin")', () => {
+      const roles = reflector.get<string[]>('roles', controller.remove);
+      expect(roles).toContain('admin');
+    });
+
+    it('POST recipient carries @Roles("admin")', () => {
+      const roles = reflector.get<string[]>('roles', controller.addRecipient);
+      expect(roles).toContain('admin');
+    });
+
+    it('DELETE recipient carries @Roles("admin")', () => {
+      const roles = reflector.get<string[]>('roles', controller.removeRecipient);
+      expect(roles).toContain('admin');
+    });
+
+    it('POST create does NOT require admin (any org user can create)', () => {
+      const roles = reflector.get<string[]>('roles', controller.create);
+      expect(roles).toBeUndefined();
+    });
+
+    it('GET findAll does NOT require admin', () => {
+      const roles = reflector.get<string[]>('roles', controller.findAll);
+      expect(roles).toBeUndefined();
+    });
+
+    it('GET findOne does NOT require admin', () => {
+      const roles = reflector.get<string[]>('roles', controller.findOne);
+      expect(roles).toBeUndefined();
+    });
+  });
+});

--- a/middleware/src/modules/notifications/alert-rules/alert-rules.controller.ts
+++ b/middleware/src/modules/notifications/alert-rules/alert-rules.controller.ts
@@ -1,0 +1,104 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ParseIdPipe } from '../../common/pipes/parse-id.pipe';
+import { RolesGuard } from '../../auth/guards/roles.guard';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import { AlertRulesService } from './alert-rules.service';
+import { CreateAlertRuleDto } from './dto/create-alert-rule.dto';
+import { UpdateAlertRuleDto } from './dto/update-alert-rule.dto';
+import { CreateRecipientDto } from './dto/create-recipient.dto';
+import { ListAlertRulesQueryDto } from './dto/list-alert-rules-query.dto';
+
+/**
+ * O7 — CRUD API for configurable downtime alert rules.
+ *
+ * RBAC:
+ *   - POST (create), GET (list/detail) — any logged-in org user
+ *   - PATCH, DELETE, recipient mutations — admin only
+ *
+ * The admin gate on mutations prevents a non-admin from disabling a
+ * critical rule (PATCH isActive=false) or routing alerts to themselves
+ * via addRecipient — both effective rule subversion.
+ */
+@UseGuards(RolesGuard)
+@Controller('notifications/alert-rules')
+export class AlertRulesController {
+  constructor(private readonly service: AlertRulesService) {}
+
+  @Post()
+  create(
+    @CurrentUser('organizationId') organizationId: string,
+    @Body() dto: CreateAlertRuleDto,
+  ) {
+    return this.service.create(organizationId, dto);
+  }
+
+  @Get()
+  findAll(
+    @CurrentUser('organizationId') organizationId: string,
+    @Query() query: ListAlertRulesQueryDto,
+  ) {
+    return this.service.findAll(organizationId, query);
+  }
+
+  @Get(':id')
+  findOne(
+    @CurrentUser('organizationId') organizationId: string,
+    @Param('id', ParseIdPipe) id: string,
+  ) {
+    return this.service.findOne(organizationId, id);
+  }
+
+  @Patch(':id')
+  @Roles('admin')
+  update(
+    @CurrentUser('organizationId') organizationId: string,
+    @Param('id', ParseIdPipe) id: string,
+    @Body() dto: UpdateAlertRuleDto,
+  ) {
+    return this.service.update(organizationId, id, dto);
+  }
+
+  @Delete(':id')
+  @Roles('admin')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  remove(
+    @CurrentUser('organizationId') organizationId: string,
+    @Param('id', ParseIdPipe) id: string,
+  ) {
+    return this.service.remove(organizationId, id);
+  }
+
+  @Post(':id/recipients')
+  @Roles('admin')
+  addRecipient(
+    @CurrentUser('organizationId') organizationId: string,
+    @Param('id', ParseIdPipe) id: string,
+    @Body() dto: CreateRecipientDto,
+  ) {
+    return this.service.addRecipient(organizationId, id, dto);
+  }
+
+  @Delete(':id/recipients/:recipientId')
+  @Roles('admin')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  removeRecipient(
+    @CurrentUser('organizationId') organizationId: string,
+    @Param('id', ParseIdPipe) id: string,
+    @Param('recipientId', ParseIdPipe) recipientId: string,
+  ) {
+    return this.service.removeRecipient(organizationId, id, recipientId);
+  }
+}

--- a/middleware/src/modules/notifications/alert-rules/alert-rules.controller.ts
+++ b/middleware/src/modules/notifications/alert-rules/alert-rules.controller.ts
@@ -38,6 +38,7 @@ export class AlertRulesController {
   constructor(private readonly service: AlertRulesService) {}
 
   @Post()
+  @Roles('admin')
   create(
     @CurrentUser('organizationId') organizationId: string,
     @Body() dto: CreateAlertRuleDto,

--- a/middleware/src/modules/notifications/alert-rules/alert-rules.service.spec.ts
+++ b/middleware/src/modules/notifications/alert-rules/alert-rules.service.spec.ts
@@ -1,0 +1,261 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { AlertRulesService } from './alert-rules.service';
+import { DatabaseService } from '../../database/database.service';
+import { DEDUP_WINDOW_MS, MIN_OFFLINE_SEC_FLOOR } from './alert-rule.types';
+
+describe('AlertRulesService', () => {
+  let service: AlertRulesService;
+  let db: any;
+
+  const orgId = 'org-123';
+  const otherOrgId = 'org-other';
+
+  beforeEach(() => {
+    db = {
+      alertRule: {
+        create: jest.fn(),
+        findFirst: jest.fn(),
+        findMany: jest.fn(),
+        update: jest.fn(),
+        updateMany: jest.fn(),
+        delete: jest.fn(),
+      },
+      alertRuleRecipient: {
+        create: jest.fn(),
+        findFirst: jest.fn(),
+        delete: jest.fn(),
+      },
+      user: {
+        findFirst: jest.fn(),
+      },
+      tag: {
+        findFirst: jest.fn(),
+      },
+      displayGroup: {
+        findFirst: jest.fn(),
+      },
+      display: {
+        findFirst: jest.fn(),
+      },
+    };
+    service = new AlertRulesService(db as unknown as DatabaseService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ---------------------------------------------------------------------------
+  // create
+  // ---------------------------------------------------------------------------
+  describe('create', () => {
+    const baseDto = {
+      name: 'Lobby offline alert',
+      triggerEvent: 'device.offline' as const,
+      scope: 'all' as const,
+      recipients: [{ channel: 'in_app' as const, target: 'user-1' }],
+    };
+
+    it('creates a rule with one in_app recipient when target user is in the same org', async () => {
+      db.user.findFirst.mockResolvedValue({ id: 'user-1', organizationId: orgId });
+      db.alertRule.create.mockResolvedValue({ id: 'rule-1', ...baseDto, organizationId: orgId });
+
+      await service.create(orgId, baseDto);
+
+      expect(db.user.findFirst).toHaveBeenCalledWith({
+        where: { id: 'user-1', organizationId: orgId },
+      });
+      expect(db.alertRule.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects in_app recipient whose target user is in another org (cross-tenant guard)', async () => {
+      db.user.findFirst.mockResolvedValue(null); // user-from-other-org NOT found in our org
+
+      await expect(service.create(orgId, baseDto)).rejects.toThrow(ForbiddenException);
+      expect(db.alertRule.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects scope=tag when scopeTagId does not exist in the org', async () => {
+      db.tag.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.create(orgId, {
+          ...baseDto,
+          scope: 'tag',
+          scopeTagId: 'tag-doesnt-exist',
+          recipients: [{ channel: 'email', target: 'a@b.com' }],
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('accepts scope=tag when Tag exists in the org', async () => {
+      db.tag.findFirst.mockResolvedValue({ id: 'tag-1', organizationId: orgId });
+      db.alertRule.create.mockResolvedValue({ id: 'rule-1' });
+
+      await service.create(orgId, {
+        ...baseDto,
+        scope: 'tag',
+        scopeTagId: 'tag-1',
+        recipients: [{ channel: 'email', target: 'a@b.com' }],
+      });
+
+      expect(db.alertRule.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects slack_webhook with non-Slack URL at the service layer (belt-and-braces)', async () => {
+      await expect(
+        service.create(orgId, {
+          ...baseDto,
+          recipients: [{ channel: 'slack_webhook', target: 'http://internal/foo' }],
+        }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('clears scope FKs that do not match the chosen scope (only the matching FK is persisted)', async () => {
+      db.tag.findFirst.mockResolvedValue({ id: 'tag-1', organizationId: orgId });
+      db.alertRule.create.mockResolvedValue({ id: 'rule-1' });
+
+      await service.create(orgId, {
+        ...baseDto,
+        scope: 'tag',
+        scopeTagId: 'tag-1',
+        scopeGroupId: 'group-stale',     // should be ignored
+        scopeDisplayId: 'display-stale', // should be ignored
+        recipients: [{ channel: 'email', target: 'a@b.com' }],
+      });
+
+      const dataArg = db.alertRule.create.mock.calls[0][0].data;
+      expect(dataArg.scopeTagId).toBe('tag-1');
+      expect(dataArg.scopeGroupId).toBeNull();
+      expect(dataArg.scopeDisplayId).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // findOne / cross-org
+  // ---------------------------------------------------------------------------
+  describe('findOne', () => {
+    it('returns the rule when it exists and belongs to the org', async () => {
+      db.alertRule.findFirst.mockResolvedValue({ id: 'rule-1', organizationId: orgId });
+      await expect(service.findOne(orgId, 'rule-1')).resolves.toEqual(
+        expect.objectContaining({ id: 'rule-1' }),
+      );
+    });
+
+    it('throws NotFoundException when rule belongs to another org (no leakage of existence)', async () => {
+      db.alertRule.findFirst.mockResolvedValue(null); // findFirst filters by orgId
+      await expect(service.findOne(orgId, 'rule-other-org')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    it('throws NotFoundException on cross-org PATCH', async () => {
+      db.alertRule.findFirst.mockResolvedValue(null);
+      await expect(service.update(orgId, 'rule-x', { name: 'new' })).rejects.toThrow(NotFoundException);
+      expect(db.alertRule.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('remove', () => {
+    it('throws NotFoundException on cross-org DELETE', async () => {
+      db.alertRule.findFirst.mockResolvedValue(null);
+      await expect(service.remove(orgId, 'rule-x')).rejects.toThrow(NotFoundException);
+      expect(db.alertRule.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // addRecipient — cross-tenant in_app guard
+  // ---------------------------------------------------------------------------
+  describe('addRecipient', () => {
+    beforeEach(() => {
+      db.alertRule.findFirst.mockResolvedValue({ id: 'rule-1', organizationId: orgId });
+    });
+
+    it('adds an in_app recipient whose target user is in the same org', async () => {
+      db.user.findFirst.mockResolvedValue({ id: 'user-1', organizationId: orgId });
+      db.alertRuleRecipient.create.mockResolvedValue({ id: 'rec-1' });
+
+      await service.addRecipient(orgId, 'rule-1', { channel: 'in_app', target: 'user-1' });
+
+      expect(db.alertRuleRecipient.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('REJECTS in_app recipient whose target userId belongs to another org', async () => {
+      db.user.findFirst.mockResolvedValue(null); // userId not found in THIS org
+
+      await expect(
+        service.addRecipient(orgId, 'rule-1', { channel: 'in_app', target: 'user-from-other-org' }),
+      ).rejects.toThrow(ForbiddenException);
+      expect(db.alertRuleRecipient.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('removeRecipient', () => {
+    it('throws NotFoundException when the rule does not belong to the caller org', async () => {
+      db.alertRule.findFirst.mockResolvedValue(null);
+      await expect(service.removeRecipient(orgId, 'rule-x', 'rec-1')).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException when the recipient is not on the named rule', async () => {
+      db.alertRule.findFirst.mockResolvedValue({ id: 'rule-1', organizationId: orgId });
+      db.alertRuleRecipient.findFirst.mockResolvedValue(null);
+      await expect(service.removeRecipient(orgId, 'rule-1', 'rec-not-here')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // findActiveForEvent — evaluator query
+  // ---------------------------------------------------------------------------
+  describe('findActiveForEvent', () => {
+    it('queries with isActive=true AND triggerEvent filter, including recipients', async () => {
+      db.alertRule.findMany.mockResolvedValue([]);
+      await service.findActiveForEvent(orgId, 'device.offline');
+      expect(db.alertRule.findMany).toHaveBeenCalledWith({
+        where: { organizationId: orgId, triggerEvent: 'device.offline', isActive: true },
+        include: { recipients: true },
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // tryClaimDedupWindow — atomic CAS
+  // ---------------------------------------------------------------------------
+  describe('tryClaimDedupWindow', () => {
+    it('returns true when updateMany reports count=1 (we claimed the window)', async () => {
+      db.alertRule.updateMany.mockResolvedValue({ count: 1 });
+      const claimed = await service.tryClaimDedupWindow('rule-1', new Date('2026-05-19T10:00:00Z'));
+      expect(claimed).toBe(true);
+    });
+
+    it('returns false when updateMany reports count=0 (another instance won)', async () => {
+      db.alertRule.updateMany.mockResolvedValue({ count: 0 });
+      const claimed = await service.tryClaimDedupWindow('rule-1', new Date('2026-05-19T10:00:00Z'));
+      expect(claimed).toBe(false);
+    });
+
+    it('predicate excludes rows that fired within the 15-min window', async () => {
+      db.alertRule.updateMany.mockResolvedValue({ count: 1 });
+      const now = new Date('2026-05-19T10:00:00Z');
+      await service.tryClaimDedupWindow('rule-1', now);
+
+      const whereArg = db.alertRule.updateMany.mock.calls[0][0].where;
+      expect(whereArg.id).toBe('rule-1');
+      // OR clause should let us claim if lastFiredAt is null OR older than the window
+      expect(whereArg.OR).toHaveLength(2);
+      const ltCondition = whereArg.OR.find((c: any) => c.lastFiredAt?.lt);
+      expect(ltCondition.lastFiredAt.lt).toEqual(new Date(now.getTime() - DEDUP_WINDOW_MS));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Constants regression
+  // ---------------------------------------------------------------------------
+  describe('constants', () => {
+    it('MIN_OFFLINE_SEC_FLOOR matches the stale-heartbeat cron threshold (2 min = 120s)', () => {
+      expect(MIN_OFFLINE_SEC_FLOOR).toBe(120);
+    });
+
+    it('DEDUP_WINDOW_MS is 15 minutes', () => {
+      expect(DEDUP_WINDOW_MS).toBe(15 * 60 * 1000);
+    });
+  });
+});

--- a/middleware/src/modules/notifications/alert-rules/alert-rules.service.spec.ts
+++ b/middleware/src/modules/notifications/alert-rules/alert-rules.service.spec.ts
@@ -25,6 +25,10 @@ describe('AlertRulesService', () => {
         findFirst: jest.fn(),
         delete: jest.fn(),
       },
+      alertRuleFire: {
+        create: jest.fn(),
+        updateMany: jest.fn(),
+      },
       user: {
         findFirst: jest.fn(),
       },
@@ -217,32 +221,128 @@ describe('AlertRulesService', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // tryClaimDedupWindow — atomic CAS
+  // tryClaimDedupWindow — atomic CAS, per-(rule, device)
   // ---------------------------------------------------------------------------
   describe('tryClaimDedupWindow', () => {
-    it('returns true when updateMany reports count=1 (we claimed the window)', async () => {
-      db.alertRule.updateMany.mockResolvedValue({ count: 1 });
-      const claimed = await service.tryClaimDedupWindow('rule-1', new Date('2026-05-19T10:00:00Z'));
+    const ruleId = 'rule-1';
+    const deviceA = 'device-A';
+    const deviceB = 'device-B';
+    const now = new Date('2026-05-19T10:00:00Z');
+
+    it('updateMany count=1 (existing stale row claimed) → returns true', async () => {
+      db.alertRuleFire.updateMany.mockResolvedValue({ count: 1 });
+
+      const claimed = await service.tryClaimDedupWindow(ruleId, deviceA, now);
+
       expect(claimed).toBe(true);
+      expect(db.alertRuleFire.create).not.toHaveBeenCalled();
     });
 
-    it('returns false when updateMany reports count=0 (another instance won)', async () => {
-      db.alertRule.updateMany.mockResolvedValue({ count: 0 });
-      const claimed = await service.tryClaimDedupWindow('rule-1', new Date('2026-05-19T10:00:00Z'));
+    it('updateMany count=0 AND create succeeds (no prior row) → returns true', async () => {
+      db.alertRuleFire.updateMany.mockResolvedValue({ count: 0 });
+      db.alertRuleFire.create.mockResolvedValue({ id: 'fire-1' });
+
+      const claimed = await service.tryClaimDedupWindow(ruleId, deviceA, now);
+
+      expect(claimed).toBe(true);
+      expect(db.alertRuleFire.create).toHaveBeenCalledWith({
+        data: { alertRuleId: ruleId, deviceId: deviceA, lastFiredAt: now },
+      });
+    });
+
+    it('updateMany count=0 AND create throws P2002 (lost race / fresh row) → returns false', async () => {
+      db.alertRuleFire.updateMany.mockResolvedValue({ count: 0 });
+      const p2002 = Object.assign(new Error('Unique constraint'), { code: 'P2002' });
+      db.alertRuleFire.create.mockRejectedValue(p2002);
+
+      const claimed = await service.tryClaimDedupWindow(ruleId, deviceA, now);
+
       expect(claimed).toBe(false);
     });
 
-    it('predicate excludes rows that fired within the 15-min window', async () => {
-      db.alertRule.updateMany.mockResolvedValue({ count: 1 });
-      const now = new Date('2026-05-19T10:00:00Z');
-      await service.tryClaimDedupWindow('rule-1', now);
+    it('updateMany count=0 AND create throws non-P2002 → re-throws (real error)', async () => {
+      db.alertRuleFire.updateMany.mockResolvedValue({ count: 0 });
+      db.alertRuleFire.create.mockRejectedValue(new Error('connection refused'));
 
-      const whereArg = db.alertRule.updateMany.mock.calls[0][0].where;
-      expect(whereArg.id).toBe('rule-1');
-      // OR clause should let us claim if lastFiredAt is null OR older than the window
-      expect(whereArg.OR).toHaveLength(2);
-      const ltCondition = whereArg.OR.find((c: any) => c.lastFiredAt?.lt);
-      expect(ltCondition.lastFiredAt.lt).toEqual(new Date(now.getTime() - DEDUP_WINDOW_MS));
+      await expect(service.tryClaimDedupWindow(ruleId, deviceA, now)).rejects.toThrow(
+        'connection refused',
+      );
+    });
+
+    it('claims are independent per (rule, device) — same rule, two devices both claim', async () => {
+      db.alertRuleFire.updateMany.mockResolvedValueOnce({ count: 1 });
+      const claimedA = await service.tryClaimDedupWindow(ruleId, deviceA, now);
+
+      db.alertRuleFire.updateMany.mockResolvedValueOnce({ count: 0 });
+      db.alertRuleFire.create.mockResolvedValueOnce({ id: 'fire-B' });
+      const claimedB = await service.tryClaimDedupWindow(ruleId, deviceB, now);
+
+      expect(claimedA).toBe(true);
+      expect(claimedB).toBe(true);
+    });
+
+    it('updateMany predicate uses lastFiredAt < (now - DEDUP_WINDOW_MS)', async () => {
+      db.alertRuleFire.updateMany.mockResolvedValue({ count: 1 });
+
+      await service.tryClaimDedupWindow(ruleId, deviceA, now);
+
+      const where = db.alertRuleFire.updateMany.mock.calls[0][0].where;
+      expect(where.alertRuleId).toBe(ruleId);
+      expect(where.deviceId).toBe(deviceA);
+      expect(where.lastFiredAt.lt).toEqual(new Date(now.getTime() - DEDUP_WINDOW_MS));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // seedDefaultRuleForOrg — used by post-migration script AND by AuthService
+  // for new-org auto-seeding. Idempotent.
+  // ---------------------------------------------------------------------------
+  describe('seedDefaultRuleForOrg', () => {
+    it('creates a default rule with one in_app recipient per admin', async () => {
+      db.alertRule.create.mockResolvedValue({ id: 'rule-1' });
+
+      await service.seedDefaultRuleForOrg(orgId, ['admin-1', 'admin-2']);
+
+      expect(db.alertRule.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          organizationId: orgId,
+          name: 'Default offline alert (auto-migrated)',
+          triggerEvent: 'device.offline',
+          isActive: true,
+          scope: 'all',
+          minOfflineSec: 120,
+          recipients: {
+            create: [
+              { channel: 'in_app', target: 'admin-1' },
+              { channel: 'in_app', target: 'admin-2' },
+            ],
+          },
+        }),
+      });
+    });
+
+    it('creates the rule with zero recipients when adminUserIds is empty', async () => {
+      db.alertRule.create.mockResolvedValue({ id: 'rule-1' });
+
+      await service.seedDefaultRuleForOrg(orgId, []);
+
+      const dataArg = db.alertRule.create.mock.calls[0][0].data;
+      expect(dataArg.recipients.create).toEqual([]);
+    });
+
+    it('is idempotent — re-seed catches P2002 and returns without error', async () => {
+      const p2002 = Object.assign(new Error('Unique constraint'), { code: 'P2002' });
+      db.alertRule.create.mockRejectedValue(p2002);
+
+      await expect(service.seedDefaultRuleForOrg(orgId, ['admin-1'])).resolves.toBeUndefined();
+    });
+
+    it('rethrows non-P2002 errors', async () => {
+      db.alertRule.create.mockRejectedValue(new Error('connection refused'));
+
+      await expect(service.seedDefaultRuleForOrg(orgId, ['admin-1'])).rejects.toThrow(
+        'connection refused',
+      );
     });
   });
 

--- a/middleware/src/modules/notifications/alert-rules/alert-rules.service.ts
+++ b/middleware/src/modules/notifications/alert-rules/alert-rules.service.ts
@@ -1,0 +1,278 @@
+import {
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { DatabaseService } from '../../database/database.service';
+import { CreateAlertRuleDto } from './dto/create-alert-rule.dto';
+import { UpdateAlertRuleDto } from './dto/update-alert-rule.dto';
+import { CreateRecipientDto } from './dto/create-recipient.dto';
+import { ListAlertRulesQueryDto } from './dto/list-alert-rules-query.dto';
+import {
+  Channel,
+  DEDUP_WINDOW_MS,
+  SLACK_WEBHOOK_REGEX,
+  TriggerEvent,
+} from './alert-rule.types';
+
+/**
+ * O7 — CRUD + evaluator helpers for configurable downtime alert rules.
+ *
+ * All operations are scoped to an organizationId. Cross-org access produces
+ * `NotFoundException` (the rule is considered not to exist from the caller's
+ * perspective — no leakage of existence).
+ *
+ * Cross-tenant validation for `in_app` recipients (the target userId MUST
+ * belong to the same org as the rule) is enforced here, NOT at the DTO
+ * layer, because the DTO doesn't know the caller's organizationId. This is
+ * a deliberate trust boundary — a hostile org admin must not be able to
+ * route `in_app` notifications to another org's user.
+ */
+@Injectable()
+export class AlertRulesService {
+  private readonly logger = new Logger(AlertRulesService.name);
+
+  constructor(private readonly db: DatabaseService) {}
+
+  // ---------------------------------------------------------------------------
+  // CRUD
+  // ---------------------------------------------------------------------------
+
+  async create(organizationId: string, dto: CreateAlertRuleDto) {
+    // Cross-tenant validation BEFORE any DB write so we don't half-create
+    for (const recipient of dto.recipients) {
+      await this.validateRecipient(organizationId, recipient);
+    }
+
+    // Existence checks for scope FKs — fail-fast on bad scopeTagId / scopeGroupId / scopeDisplayId
+    await this.validateScope(organizationId, dto.scope, {
+      scopeTagId: dto.scopeTagId,
+      scopeGroupId: dto.scopeGroupId,
+      scopeDisplayId: dto.scopeDisplayId,
+    });
+
+    return this.db.alertRule.create({
+      data: {
+        organizationId,
+        name: dto.name,
+        triggerEvent: dto.triggerEvent,
+        isActive: dto.isActive ?? true,
+        scope: dto.scope,
+        scopeTagId: dto.scope === 'tag' ? dto.scopeTagId : null,
+        scopeGroupId: dto.scope === 'group' ? dto.scopeGroupId : null,
+        scopeDisplayId: dto.scope === 'display' ? dto.scopeDisplayId : null,
+        minOfflineSec: dto.minOfflineSec ?? undefined,
+        recipients: {
+          create: dto.recipients.map((r) => ({
+            channel: r.channel,
+            target: r.target,
+          })),
+        },
+      },
+      include: { recipients: true },
+    });
+  }
+
+  async findAll(organizationId: string, query?: ListAlertRulesQueryDto) {
+    return this.db.alertRule.findMany({
+      where: {
+        organizationId,
+        ...(query?.isActive !== undefined ? { isActive: query.isActive } : {}),
+        ...(query?.triggerEvent ? { triggerEvent: query.triggerEvent } : {}),
+      },
+      include: { recipients: true },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async findOne(organizationId: string, id: string) {
+    const rule = await this.db.alertRule.findFirst({
+      where: { id, organizationId },
+      include: { recipients: true },
+    });
+    if (!rule) {
+      throw new NotFoundException(`Alert rule ${id} not found`);
+    }
+    return rule;
+  }
+
+  async update(organizationId: string, id: string, dto: UpdateAlertRuleDto) {
+    // Existence + cross-org guard
+    await this.findOne(organizationId, id);
+
+    if (dto.scope) {
+      await this.validateScope(organizationId, dto.scope, {
+        scopeTagId: dto.scopeTagId,
+        scopeGroupId: dto.scopeGroupId,
+        scopeDisplayId: dto.scopeDisplayId,
+      });
+    }
+
+    return this.db.alertRule.update({
+      where: { id },
+      data: {
+        ...(dto.name !== undefined ? { name: dto.name } : {}),
+        ...(dto.triggerEvent !== undefined ? { triggerEvent: dto.triggerEvent } : {}),
+        ...(dto.isActive !== undefined ? { isActive: dto.isActive } : {}),
+        ...(dto.scope !== undefined ? { scope: dto.scope } : {}),
+        ...(dto.scope === 'tag' ? { scopeTagId: dto.scopeTagId, scopeGroupId: null, scopeDisplayId: null } : {}),
+        ...(dto.scope === 'group' ? { scopeGroupId: dto.scopeGroupId, scopeTagId: null, scopeDisplayId: null } : {}),
+        ...(dto.scope === 'display' ? { scopeDisplayId: dto.scopeDisplayId, scopeTagId: null, scopeGroupId: null } : {}),
+        ...(dto.scope === 'all' ? { scopeTagId: null, scopeGroupId: null, scopeDisplayId: null } : {}),
+        ...(dto.minOfflineSec !== undefined ? { minOfflineSec: dto.minOfflineSec } : {}),
+      },
+      include: { recipients: true },
+    });
+  }
+
+  async remove(organizationId: string, id: string): Promise<void> {
+    // Existence + cross-org guard
+    await this.findOne(organizationId, id);
+    // Recipients cascade-delete via Prisma FK.
+    await this.db.alertRule.delete({ where: { id } });
+  }
+
+  async addRecipient(organizationId: string, ruleId: string, dto: CreateRecipientDto) {
+    // Existence + cross-org guard
+    await this.findOne(organizationId, ruleId);
+    await this.validateRecipient(organizationId, dto);
+
+    return this.db.alertRuleRecipient.create({
+      data: {
+        alertRuleId: ruleId,
+        channel: dto.channel,
+        target: dto.target,
+      },
+    });
+  }
+
+  async removeRecipient(
+    organizationId: string,
+    ruleId: string,
+    recipientId: string,
+  ): Promise<void> {
+    // Existence + cross-org guard for the rule
+    await this.findOne(organizationId, ruleId);
+
+    // Verify the recipient is actually on this rule (defense against ID-mismatch)
+    const recipient = await this.db.alertRuleRecipient.findFirst({
+      where: { id: recipientId, alertRuleId: ruleId },
+    });
+    if (!recipient) {
+      throw new NotFoundException(`Recipient ${recipientId} not found on rule ${ruleId}`);
+    }
+
+    await this.db.alertRuleRecipient.delete({ where: { id: recipientId } });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Evaluator helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Evaluator query: load active rules for an org + triggerEvent including
+   * their recipients (we need recipients to dispatch).
+   */
+  async findActiveForEvent(organizationId: string, triggerEvent: TriggerEvent) {
+    return this.db.alertRule.findMany({
+      where: { organizationId, triggerEvent, isActive: true },
+      include: { recipients: true },
+    });
+  }
+
+  /**
+   * Atomic CAS-style claim of the 15-min dedup window.
+   *
+   * Returns true if THIS caller successfully claimed the window (and should
+   * dispatch), false if another instance (PM2 cluster) already claimed it
+   * within the window.
+   *
+   * Implementation: `updateMany` with a predicate `lastFiredAt < threshold OR
+   * lastFiredAt IS NULL`. The `count` field tells us if the row was actually
+   * updated. Count === 1 means we won the race; count === 0 means we lost.
+   */
+  async tryClaimDedupWindow(ruleId: string, now: Date): Promise<boolean> {
+    const threshold = new Date(now.getTime() - DEDUP_WINDOW_MS);
+    const result = await this.db.alertRule.updateMany({
+      where: {
+        id: ruleId,
+        OR: [{ lastFiredAt: null }, { lastFiredAt: { lt: threshold } }],
+      },
+      data: { lastFiredAt: now },
+    });
+    return result.count === 1;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Per-channel validation called from `create` and `addRecipient`.
+   *
+   * - in_app:         target userId MUST belong to the same org. Cross-tenant
+   *                   leak prevention — a hostile org-A admin must not route
+   *                   `in_app` notifications to an org-B userId.
+   * - email:          shape validated at DTO; no additional check.
+   * - slack_webhook:  regex re-validated at the DTO too, but belt-and-braces.
+   */
+  private async validateRecipient(
+    organizationId: string,
+    dto: { channel: Channel; target: string },
+  ): Promise<void> {
+    if (dto.channel === 'in_app') {
+      const user = await this.db.user.findFirst({
+        where: { id: dto.target, organizationId },
+      });
+      if (!user) {
+        throw new ForbiddenException(
+          `in_app target userId ${dto.target} does not belong to this organization`,
+        );
+      }
+      return;
+    }
+
+    if (dto.channel === 'slack_webhook') {
+      if (!SLACK_WEBHOOK_REGEX.test(dto.target)) {
+        throw new ForbiddenException('slack_webhook target failed allowlist');
+      }
+      return;
+    }
+
+    // email — DTO has already validated shape via class-validator.
+  }
+
+  /**
+   * Per-scope existence + cross-org check. Catches typos / stale IDs at
+   * write time rather than at evaluate time (where we'd silently skip).
+   */
+  private async validateScope(
+    organizationId: string,
+    scope: string,
+    ids: { scopeTagId?: string; scopeGroupId?: string; scopeDisplayId?: string },
+  ): Promise<void> {
+    if (scope === 'tag' && ids.scopeTagId) {
+      const tag = await this.db.tag.findFirst({
+        where: { id: ids.scopeTagId, organizationId },
+      });
+      if (!tag) throw new NotFoundException(`Tag ${ids.scopeTagId} not found in this organization`);
+    }
+    if (scope === 'group' && ids.scopeGroupId) {
+      const group = await this.db.displayGroup.findFirst({
+        where: { id: ids.scopeGroupId, organizationId },
+      });
+      if (!group) {
+        throw new NotFoundException(`DisplayGroup ${ids.scopeGroupId} not found in this organization`);
+      }
+    }
+    if (scope === 'display' && ids.scopeDisplayId) {
+      const display = await this.db.display.findFirst({
+        where: { id: ids.scopeDisplayId, organizationId },
+      });
+      if (!display) {
+        throw new NotFoundException(`Display ${ids.scopeDisplayId} not found in this organization`);
+      }
+    }
+  }
+}

--- a/middleware/src/modules/notifications/alert-rules/alert-rules.service.ts
+++ b/middleware/src/modules/notifications/alert-rules/alert-rules.service.ts
@@ -182,26 +182,111 @@ export class AlertRulesService {
   }
 
   /**
-   * Atomic CAS-style claim of the 15-min dedup window.
+   * Atomic CAS-style claim of the 15-min dedup window for a specific
+   * (rule, device) pair.
    *
-   * Returns true if THIS caller successfully claimed the window (and should
-   * dispatch), false if another instance (PM2 cluster) already claimed it
-   * within the window.
+   * PR-review fix: dedup is per-device, not per-rule. A single rule scoped
+   * to `all` matching 20 offline devices must alert for EACH device, not
+   * just the first. Prior implementation used one `lastFiredAt` per rule
+   * which silently suppressed N-1 of N concurrent outages.
    *
-   * Implementation: `updateMany` with a predicate `lastFiredAt < threshold OR
-   * lastFiredAt IS NULL`. The `count` field tells us if the row was actually
-   * updated. Count === 1 means we won the race; count === 0 means we lost.
+   * Two-step pattern handles three states + the race cleanly:
+   *
+   *   1. Try to update an existing AlertRuleFire row whose lastFiredAt is
+   *      older than the window. `updateMany` returns count=1 if we claimed,
+   *      count=0 if the row exists but is still fresh, OR no row exists yet.
+   *   2. If count=0, attempt to create the row. If it already exists
+   *      (P2002 from the unique (alertRuleId, deviceId) index), another
+   *      instance created it just now — they win the race; we suppress.
+   *
+   * Outcomes:
+   *   - row missing, no race          → update miss → create succeeds → true
+   *   - row missing, lost race        → update miss → create P2002    → false
+   *   - row exists, lastFiredAt stale → update hit                    → true
+   *   - row exists, lastFiredAt fresh → update miss → create P2002    → false
+   *
+   * PM2 cluster safety: the unique index serializes concurrent creates;
+   * the updateMany predicate serializes concurrent updates. Exactly one
+   * instance dispatches per (rule, device, window).
    */
-  async tryClaimDedupWindow(ruleId: string, now: Date): Promise<boolean> {
+  async tryClaimDedupWindow(
+    ruleId: string,
+    deviceId: string,
+    now: Date,
+  ): Promise<boolean> {
     const threshold = new Date(now.getTime() - DEDUP_WINDOW_MS);
-    const result = await this.db.alertRule.updateMany({
-      where: {
-        id: ruleId,
-        OR: [{ lastFiredAt: null }, { lastFiredAt: { lt: threshold } }],
-      },
+
+    const updated = await this.db.alertRuleFire.updateMany({
+      where: { alertRuleId: ruleId, deviceId, lastFiredAt: { lt: threshold } },
       data: { lastFiredAt: now },
     });
-    return result.count === 1;
+    if (updated.count === 1) return true;
+
+    try {
+      await this.db.alertRuleFire.create({
+        data: { alertRuleId: ruleId, deviceId, lastFiredAt: now },
+      });
+      return true;
+    } catch (err) {
+      // P2002 = Prisma unique-constraint violation. Either we lost the
+      // create race with another instance, OR the row was created+fresh
+      // between our updateMany and our create. Both cases: do not dispatch.
+      if (this.isUniqueConstraintError(err)) return false;
+      throw err;
+    }
+  }
+
+  private isUniqueConstraintError(err: unknown): boolean {
+    return (
+      typeof err === 'object' &&
+      err !== null &&
+      'code' in err &&
+      (err as { code?: string }).code === 'P2002'
+    );
+  }
+
+  /**
+   * Seed the default downtime alert rule for a single org.
+   *
+   * Called from two places:
+   *   - The post-migration backfill script (`packages/database/scripts/
+   *     seed-default-alert-rules.ts`) — iterates over every existing org
+   *     and calls this once per org.
+   *   - `AuthService.register` — every NEW org registered post-deploy gets
+   *     the same default rule, so customer-1 / customer-2 / etc. don't lose
+   *     offline alerts after the hard-coded handler is removed.
+   *
+   * Idempotent — the unique `(organizationId, name)` index makes a re-call
+   * a no-op (P2002 caught and converted to a return-without-error).
+   *
+   * `adminUserIds` should be the list of admin users for the org. The
+   * default rule routes in-app notifications to each. If the list is empty,
+   * the rule is still created (zero recipients = silent no-op until an
+   * admin is added via the dedicated endpoint).
+   */
+  async seedDefaultRuleForOrg(
+    organizationId: string,
+    adminUserIds: string[],
+  ): Promise<void> {
+    try {
+      await this.db.alertRule.create({
+        data: {
+          organizationId,
+          name: 'Default offline alert (auto-migrated)',
+          triggerEvent: 'device.offline',
+          isActive: true,
+          scope: 'all',
+          minOfflineSec: 120,
+          recipients: {
+            create: adminUserIds.map((uid) => ({ channel: 'in_app', target: uid })),
+          },
+        },
+      });
+    } catch (err) {
+      // Idempotency: re-runs are safe.
+      if (this.isUniqueConstraintError(err)) return;
+      throw err;
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/middleware/src/modules/notifications/alert-rules/dto/create-alert-rule.dto.ts
+++ b/middleware/src/modules/notifications/alert-rules/dto/create-alert-rule.dto.ts
@@ -1,0 +1,77 @@
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsBoolean,
+  IsIn,
+  IsInt,
+  IsOptional,
+  IsString,
+  MaxLength,
+  Min,
+  MinLength,
+  ValidateNested,
+  ValidateIf,
+  ArrayMinSize,
+  ArrayMaxSize,
+} from 'class-validator';
+import {
+  TRIGGER_EVENTS,
+  TriggerEvent,
+  SCOPES,
+  Scope,
+  MIN_OFFLINE_SEC_FLOOR,
+  MAX_RECIPIENTS_PER_RULE,
+} from '../alert-rule.types';
+import { CreateRecipientDto } from './create-recipient.dto';
+
+export class CreateAlertRuleDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(120)
+  name!: string;
+
+  @IsIn(TRIGGER_EVENTS, { message: `triggerEvent must be one of: ${TRIGGER_EVENTS.join(', ')}` })
+  triggerEvent!: TriggerEvent;
+
+  @IsIn(SCOPES, { message: `scope must be one of: ${SCOPES.join(', ')}` })
+  scope!: Scope;
+
+  /** Required when scope=tag. Cross-org existence is checked at the service layer. */
+  @ValidateIf((o) => o.scope === 'tag')
+  @IsString()
+  scopeTagId?: string;
+
+  /** Required when scope=group. */
+  @ValidateIf((o) => o.scope === 'group')
+  @IsString()
+  scopeGroupId?: string;
+
+  /** Required when scope=display. */
+  @ValidateIf((o) => o.scope === 'display')
+  @IsString()
+  scopeDisplayId?: string;
+
+  /**
+   * Debounce floor. The stale-heartbeat cron only emits device.offline after
+   * 120s, so values below that would be silently no-ops.
+   */
+  @IsInt()
+  @Min(MIN_OFFLINE_SEC_FLOOR, {
+    message: `minOfflineSec must be >= ${MIN_OFFLINE_SEC_FLOOR} (stale-heartbeat cron threshold)`,
+  })
+  @IsOptional()
+  minOfflineSec?: number;
+
+  @IsArray()
+  @ArrayMinSize(1, { message: 'at least one recipient is required' })
+  @ArrayMaxSize(MAX_RECIPIENTS_PER_RULE, {
+    message: `at most ${MAX_RECIPIENTS_PER_RULE} recipients per rule`,
+  })
+  @ValidateNested({ each: true })
+  @Type(() => CreateRecipientDto)
+  recipients!: CreateRecipientDto[];
+
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+}

--- a/middleware/src/modules/notifications/alert-rules/dto/create-recipient.dto.ts
+++ b/middleware/src/modules/notifications/alert-rules/dto/create-recipient.dto.ts
@@ -1,4 +1,5 @@
 import {
+  IsEmail,
   IsIn,
   IsString,
   MaxLength,
@@ -12,23 +13,23 @@ import { CHANNELS, Channel, SLACK_WEBHOOK_REGEX } from '../alert-rule.types';
  * Recipient DTO used both as a standalone POST body (`POST /:id/recipients`)
  * AND inlined in CreateAlertRuleDto.
  *
- * Note: cross-tenant validation for `in_app` channel (target userId must be
- * in the same org as the rule) is enforced at the SERVICE layer, not here,
- * because the DTO doesn't know the caller's organizationId.
+ * Per-channel validation:
+ *   - in_app:        target = userId (UUID/CUID). Cross-tenant validation
+ *                    (userId belongs to the caller's org) lives at the SERVICE
+ *                    layer because the DTO doesn't know the caller's orgId.
+ *   - email:         target = RFC 5321 address. @IsEmail at the DTO catches
+ *                    CRLF injection / malformed input before it hits SMTP.
+ *   - slack_webhook: target = https://hooks.slack.com/services/... URL.
  */
 export class CreateRecipientDto {
   @IsIn(CHANNELS, { message: `channel must be one of: ${CHANNELS.join(', ')}` })
   channel!: Channel;
 
-  /**
-   * Per channel:
-   *   - in_app:        target = userId (UUID/CUID — must belong to the same org)
-   *   - email:         target = email address
-   *   - slack_webhook: target = a valid https://hooks.slack.com/services/... URL
-   */
   @IsString()
   @MinLength(1)
   @MaxLength(2000)
+  @ValidateIf((o) => o.channel === 'email')
+  @IsEmail({}, { message: 'email target must be a valid email address' })
   @ValidateIf((o) => o.channel === 'slack_webhook')
   @Matches(SLACK_WEBHOOK_REGEX, {
     message: 'slack_webhook target must be a https://hooks.slack.com/services/... URL',

--- a/middleware/src/modules/notifications/alert-rules/dto/create-recipient.dto.ts
+++ b/middleware/src/modules/notifications/alert-rules/dto/create-recipient.dto.ts
@@ -1,0 +1,37 @@
+import {
+  IsIn,
+  IsString,
+  MaxLength,
+  Matches,
+  ValidateIf,
+  MinLength,
+} from 'class-validator';
+import { CHANNELS, Channel, SLACK_WEBHOOK_REGEX } from '../alert-rule.types';
+
+/**
+ * Recipient DTO used both as a standalone POST body (`POST /:id/recipients`)
+ * AND inlined in CreateAlertRuleDto.
+ *
+ * Note: cross-tenant validation for `in_app` channel (target userId must be
+ * in the same org as the rule) is enforced at the SERVICE layer, not here,
+ * because the DTO doesn't know the caller's organizationId.
+ */
+export class CreateRecipientDto {
+  @IsIn(CHANNELS, { message: `channel must be one of: ${CHANNELS.join(', ')}` })
+  channel!: Channel;
+
+  /**
+   * Per channel:
+   *   - in_app:        target = userId (UUID/CUID — must belong to the same org)
+   *   - email:         target = email address
+   *   - slack_webhook: target = a valid https://hooks.slack.com/services/... URL
+   */
+  @IsString()
+  @MinLength(1)
+  @MaxLength(2000)
+  @ValidateIf((o) => o.channel === 'slack_webhook')
+  @Matches(SLACK_WEBHOOK_REGEX, {
+    message: 'slack_webhook target must be a https://hooks.slack.com/services/... URL',
+  })
+  target!: string;
+}

--- a/middleware/src/modules/notifications/alert-rules/dto/create-recipient.dto.ts
+++ b/middleware/src/modules/notifications/alert-rules/dto/create-recipient.dto.ts
@@ -1,25 +1,22 @@
-import {
-  IsEmail,
-  IsIn,
-  IsString,
-  MaxLength,
-  Matches,
-  ValidateIf,
-  MinLength,
-} from 'class-validator';
-import { CHANNELS, Channel, SLACK_WEBHOOK_REGEX } from '../alert-rule.types';
+import { IsIn, IsString, MaxLength, MinLength } from 'class-validator';
+import { CHANNELS, Channel } from '../alert-rule.types';
+import { IsValidRecipientTarget } from './is-valid-recipient-target.validator';
 
 /**
  * Recipient DTO used both as a standalone POST body (`POST /:id/recipients`)
  * AND inlined in CreateAlertRuleDto.
  *
- * Per-channel validation:
- *   - in_app:        target = userId (UUID/CUID). Cross-tenant validation
- *                    (userId belongs to the caller's org) lives at the SERVICE
- *                    layer because the DTO doesn't know the caller's orgId.
- *   - email:         target = RFC 5321 address. @IsEmail at the DTO catches
- *                    CRLF injection / malformed input before it hits SMTP.
- *   - slack_webhook: target = https://hooks.slack.com/services/... URL.
+ * Per-channel validation is delegated to the `IsValidRecipientTarget`
+ * custom validator. The previous stacked-@ValidateIf pattern was broken
+ * (class-validator's @ValidateIf is property-scoped, so two mutually
+ * exclusive conditions on the same property short-circuited to false
+ * for both validators — email targets had zero shape validation).
+ *
+ * Per-channel rules now live in the one validator:
+ *   - in_app:        non-empty string. Cross-tenant guard (userId belongs
+ *                    to the caller's org) lives at the service layer.
+ *   - email:         RFC 5321 address shape.
+ *   - slack_webhook: https://hooks.slack.com/services/... URL.
  */
 export class CreateRecipientDto {
   @IsIn(CHANNELS, { message: `channel must be one of: ${CHANNELS.join(', ')}` })
@@ -28,11 +25,6 @@ export class CreateRecipientDto {
   @IsString()
   @MinLength(1)
   @MaxLength(2000)
-  @ValidateIf((o) => o.channel === 'email')
-  @IsEmail({}, { message: 'email target must be a valid email address' })
-  @ValidateIf((o) => o.channel === 'slack_webhook')
-  @Matches(SLACK_WEBHOOK_REGEX, {
-    message: 'slack_webhook target must be a https://hooks.slack.com/services/... URL',
-  })
+  @IsValidRecipientTarget()
   target!: string;
 }

--- a/middleware/src/modules/notifications/alert-rules/dto/is-valid-recipient-target.validator.spec.ts
+++ b/middleware/src/modules/notifications/alert-rules/dto/is-valid-recipient-target.validator.spec.ts
@@ -1,0 +1,83 @@
+import { validate } from 'class-validator';
+import { CreateRecipientDto } from './create-recipient.dto';
+
+/**
+ * Tests for the IsValidRecipientTarget custom validator (via the DTO that
+ * uses it). The stacked-@ValidateIf pattern was broken before; this verifies
+ * each channel's target gets the right validation.
+ */
+describe('IsValidRecipientTarget (via CreateRecipientDto)', () => {
+  async function validateDto(channel: string, target: string) {
+    const dto = new CreateRecipientDto();
+    (dto as any).channel = channel;
+    dto.target = target;
+    return validate(dto);
+  }
+
+  describe('in_app channel', () => {
+    it('accepts any non-empty string (cross-tenant guard is at the service layer)', async () => {
+      const errors = await validateDto('in_app', 'user-cuid-123');
+      expect(errors).toHaveLength(0);
+    });
+
+    it('rejects empty string', async () => {
+      const errors = await validateDto('in_app', '');
+      expect(errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('email channel', () => {
+    it('accepts a valid email address', async () => {
+      const errors = await validateDto('email', 'ops@example.com');
+      expect(errors).toHaveLength(0);
+    });
+
+    it('rejects a non-email string (e.g. a userId)', async () => {
+      const errors = await validateDto('email', 'user-cuid-123');
+      expect(errors.length).toBeGreaterThan(0);
+      expect(JSON.stringify(errors)).toContain('email target');
+    });
+
+    it('rejects an email with CRLF injection attempt', async () => {
+      const errors = await validateDto('email', 'a@b.com\r\nBcc: attacker@evil.com');
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('rejects a Slack webhook URL pasted into the email channel', async () => {
+      const errors = await validateDto('email', 'https://hooks.slack.com/services/T/B/x');
+      expect(errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('slack_webhook channel', () => {
+    it('accepts a https://hooks.slack.com/services/... URL', async () => {
+      const errors = await validateDto('slack_webhook', 'https://hooks.slack.com/services/TABC/BDEF/xyz123');
+      expect(errors).toHaveLength(0);
+    });
+
+    it('rejects a different host (PagerDuty / Discord — must come in a follow-up)', async () => {
+      const errors = await validateDto('slack_webhook', 'https://events.pagerduty.com/v2/enqueue');
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('rejects http:// (would allow SSRF chains)', async () => {
+      const errors = await validateDto('slack_webhook', 'http://hooks.slack.com/services/T/B/x');
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('rejects an email pasted into the slack_webhook channel', async () => {
+      const errors = await validateDto('slack_webhook', 'ops@example.com');
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('rejects an internal URL (SSRF defense at the DTO layer)', async () => {
+      const errors = await validateDto('slack_webhook', 'https://internal-metadata.example/secret');
+      expect(errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('rejects unknown channel', async () => {
+    const errors = await validateDto('mystery-channel', 'whatever');
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/middleware/src/modules/notifications/alert-rules/dto/is-valid-recipient-target.validator.ts
+++ b/middleware/src/modules/notifications/alert-rules/dto/is-valid-recipient-target.validator.ts
@@ -1,0 +1,75 @@
+import {
+  registerDecorator,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  ValidationArguments,
+  isEmail,
+} from 'class-validator';
+import { Channel, SLACK_WEBHOOK_REGEX } from '../alert-rule.types';
+
+/**
+ * Custom class-validator constraint that validates `target` against the
+ * channel chosen on the same DTO.
+ *
+ * Replaces the previous stacked-@ValidateIf pattern, which was broken: in
+ * class-validator @ValidateIf is property-scoped (not decorator-scoped), so
+ * two @ValidateIf decorators with mutually-exclusive conditions resulted in
+ * NEITHER pair firing — leaving `target` validated only as @IsString.
+ *
+ * Per-channel rules:
+ *   - in_app:        non-empty string (the cross-tenant userId check lives
+ *                    at the service layer; the DTO can't see the caller's
+ *                    organizationId)
+ *   - email:         RFC 5321 address shape
+ *   - slack_webhook: matches SLACK_WEBHOOK_REGEX
+ *   - (unknown):     reject — channel is constrained by @IsIn(CHANNELS) on
+ *                    the channel property, so this branch shouldn't fire
+ *                    in practice, but defensive.
+ */
+@ValidatorConstraint({ name: 'IsValidRecipientTarget', async: false })
+export class IsValidRecipientTargetConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown, args: ValidationArguments): boolean {
+    if (typeof value !== 'string' || value.length === 0) return false;
+
+    const obj = args.object as { channel?: Channel };
+    const channel = obj.channel;
+
+    switch (channel) {
+      case 'in_app':
+        return true; // service-layer guard does the cross-tenant check
+      case 'email':
+        return isEmail(value);
+      case 'slack_webhook':
+        return SLACK_WEBHOOK_REGEX.test(value);
+      default:
+        return false;
+    }
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    const obj = args.object as { channel?: Channel };
+    switch (obj.channel) {
+      case 'email':
+        return 'email target must be a valid email address';
+      case 'slack_webhook':
+        return 'slack_webhook target must be a https://hooks.slack.com/services/... URL';
+      case 'in_app':
+        return 'in_app target must be a non-empty user id';
+      default:
+        return 'target failed validation for the chosen channel';
+    }
+  }
+}
+
+export function IsValidRecipientTarget(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      constraints: [],
+      validator: IsValidRecipientTargetConstraint,
+    });
+  };
+}

--- a/middleware/src/modules/notifications/alert-rules/dto/list-alert-rules-query.dto.ts
+++ b/middleware/src/modules/notifications/alert-rules/dto/list-alert-rules-query.dto.ts
@@ -1,0 +1,22 @@
+import { Transform } from 'class-transformer';
+import { IsBoolean, IsIn, IsOptional } from 'class-validator';
+import { TRIGGER_EVENTS, TriggerEvent } from '../alert-rule.types';
+
+export class ListAlertRulesQueryDto {
+  /**
+   * If supplied, returns only rules with matching `isActive`. Query strings
+   * arrive as text ("true" / "false") — Transform handles the coercion.
+   */
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (value === 'true' || value === true) return true;
+    if (value === 'false' || value === false) return false;
+    return value;
+  })
+  @IsBoolean()
+  isActive?: boolean;
+
+  @IsOptional()
+  @IsIn(TRIGGER_EVENTS)
+  triggerEvent?: TriggerEvent;
+}

--- a/middleware/src/modules/notifications/alert-rules/dto/update-alert-rule.dto.ts
+++ b/middleware/src/modules/notifications/alert-rules/dto/update-alert-rule.dto.ts
@@ -1,0 +1,14 @@
+import { OmitType, PartialType } from '@nestjs/mapped-types';
+import { CreateAlertRuleDto } from './create-alert-rule.dto';
+
+/**
+ * Update DTO — partial of CreateAlertRuleDto minus `recipients`.
+ *
+ * Recipients are managed via the dedicated /:id/recipients endpoints because:
+ *   - In-line replacement on PATCH would require either full-replace
+ *     (destroying audit trail) or merge semantics (complex DTO shape)
+ *   - The dedicated endpoints can apply their own RBAC (admin-only add)
+ *
+ * This DTO is reached only via the admin-gated PATCH /:id endpoint.
+ */
+export class UpdateAlertRuleDto extends PartialType(OmitType(CreateAlertRuleDto, ['recipients'] as const)) {}

--- a/middleware/src/modules/notifications/notifications.controller.spec.ts
+++ b/middleware/src/modules/notifications/notifications.controller.spec.ts
@@ -32,7 +32,6 @@ describe('NotificationsController', () => {
       markAsRead: jest.fn(),
       markAllAsRead: jest.fn(),
       dismiss: jest.fn(),
-      createDeviceOfflineNotification: jest.fn(),
       createDeviceOnlineNotification: jest.fn(),
       createContentExpiredNotification: jest.fn(),
       createSystemNotification: jest.fn(),

--- a/middleware/src/modules/notifications/notifications.module.ts
+++ b/middleware/src/modules/notifications/notifications.module.ts
@@ -3,11 +3,15 @@ import { HttpModule } from '@nestjs/axios';
 import { NotificationsController } from './notifications.controller';
 import { NotificationsService } from './notifications.service';
 import { DatabaseModule } from '../database/database.module';
+import { AlertRulesController } from './alert-rules/alert-rules.controller';
+import { AlertRulesService } from './alert-rules/alert-rules.service';
+import { AlertRuleEvaluator } from './alert-rules/alert-rule.evaluator';
 
 @Module({
+  // MailService is provided via the @Global() MailModule (see mail.module.ts).
   imports: [DatabaseModule, HttpModule],
-  controllers: [NotificationsController],
-  providers: [NotificationsService],
-  exports: [NotificationsService],
+  controllers: [NotificationsController, AlertRulesController],
+  providers: [NotificationsService, AlertRulesService, AlertRuleEvaluator],
+  exports: [NotificationsService, AlertRulesService],
 })
 export class NotificationsModule {}

--- a/middleware/src/modules/notifications/notifications.module.ts
+++ b/middleware/src/modules/notifications/notifications.module.ts
@@ -1,15 +1,19 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { HttpModule } from '@nestjs/axios';
 import { NotificationsController } from './notifications.controller';
 import { NotificationsService } from './notifications.service';
 import { DatabaseModule } from '../database/database.module';
+import { AuthModule } from '../auth/auth.module';
 import { AlertRulesController } from './alert-rules/alert-rules.controller';
 import { AlertRulesService } from './alert-rules/alert-rules.service';
 import { AlertRuleEvaluator } from './alert-rules/alert-rule.evaluator';
 
 @Module({
   // MailService is provided via the @Global() MailModule (see mail.module.ts).
-  imports: [DatabaseModule, HttpModule],
+  // forwardRef on AuthModule because AuthService now depends on
+  // AlertRulesService (for seed-default-rule-on-org-registration), and
+  // AlertRulesController uses RolesGuard from AuthModule.
+  imports: [DatabaseModule, HttpModule, forwardRef(() => AuthModule)],
   controllers: [NotificationsController, AlertRulesController],
   providers: [NotificationsService, AlertRulesService, AlertRuleEvaluator],
   exports: [NotificationsService, AlertRulesService],

--- a/middleware/src/modules/notifications/notifications.service.spec.ts
+++ b/middleware/src/modules/notifications/notifications.service.spec.ts
@@ -366,36 +366,10 @@ describe('NotificationsService', () => {
     });
   });
 
-  describe('createDeviceOfflineNotification', () => {
-    it('should create a device offline notification', async () => {
-      db.notification.create.mockResolvedValue({
-        id: 'notif-offline',
-        title: 'Device Offline',
-        message: 'Device "Lobby Screen" has gone offline.',
-        type: 'device_offline',
-        severity: 'warning',
-        metadata: { deviceId: 'device-123', deviceName: 'Lobby Screen' },
-        organizationId,
-      });
+  // createDeviceOfflineNotification test removed in O7 — the helper itself
+  // was deleted; offline notifications now flow through AlertRuleEvaluator
+  // (covered by middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.spec.ts).
 
-      const result = await service.createDeviceOfflineNotification(
-        'device-123',
-        'Lobby Screen',
-        organizationId,
-      );
-
-      expect(result.type).toBe('device_offline');
-      expect(result.severity).toBe('warning');
-      expect(db.notification.create).toHaveBeenCalledWith({
-        data: expect.objectContaining({
-          title: 'Device Offline',
-          type: 'device_offline',
-          severity: 'warning',
-          metadata: { deviceId: 'device-123', deviceName: 'Lobby Screen' },
-        }),
-      });
-    });
-  });
 
   describe('createDeviceOnlineNotification', () => {
     it('should create a device online notification', async () => {

--- a/middleware/src/modules/notifications/notifications.service.ts
+++ b/middleware/src/modules/notifications/notifications.service.ts
@@ -163,23 +163,10 @@ export class NotificationsService {
     return notification;
   }
 
-  /**
-   * Factory helper: Create a device offline notification
-   */
-  async createDeviceOfflineNotification(
-    deviceId: string,
-    deviceName: string,
-    organizationId: string,
-  ) {
-    return this.create({
-      title: 'Device Offline',
-      message: `Device "${deviceName}" has gone offline.`,
-      type: 'device_offline',
-      severity: 'warning',
-      metadata: { deviceId, deviceName },
-      organizationId,
-    });
-  }
+  // createDeviceOfflineNotification removed in O7 — the rule-driven evaluator
+  // (alert-rules/alert-rule.evaluator.ts) now writes Notification rows
+  // directly per-recipient. The device.online path still uses the factory
+  // helper below — recovery alerts are out of scope for O7 v1.
 
   /**
    * Factory helper: Create a device online notification
@@ -271,17 +258,10 @@ export class NotificationsService {
     }
   }
 
-  /**
-   * Event listener: device went offline
-   */
-  @OnEvent('device.offline')
-  async handleDeviceOffline(payload: { deviceId: string; deviceName: string; organizationId: string }) {
-    try {
-      await this.createDeviceOfflineNotification(payload.deviceId, payload.deviceName, payload.organizationId);
-    } catch (error) {
-      this.logger.warn(`Failed to create device offline notification: ${error instanceof Error ? error.message : 'unknown'}`);
-    }
-  }
+  // device.offline handler removed in O7 — replaced by AlertRuleEvaluator
+  // (middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.ts).
+  // The createDeviceOfflineNotification helper is also dead; the evaluator
+  // inlines the notification creation per matched recipient.
 
   /**
    * Delete old dismissed notifications (cleanup job)

--- a/packages/database/prisma/migrations/20260519050346_add_alert_rules/migration.sql
+++ b/packages/database/prisma/migrations/20260519050346_add_alert_rules/migration.sql
@@ -1,0 +1,83 @@
+-- Migration: add_alert_rules
+--
+-- O7 — Configurable downtime alert rules.
+--
+-- Creates two tables:
+--   * alert_rules — per-org rules with scope (all/tag/group/display),
+--     minOfflineSec debounce, lastFiredAt dedup window
+--   * alert_rule_recipients — N recipients per rule, one of three channels
+--     (in_app/email/slack_webhook)
+--
+-- The hard-coded `@OnEvent('device.offline')` handler in
+-- middleware/src/modules/notifications/notifications.service.ts is replaced
+-- by a rule-driven evaluator. A separate post-migrate seed script at
+-- packages/database/scripts/seed-default-alert-rules.ts inserts one default
+-- rule per existing org (preserving historical broadcast-to-all-admins
+-- behavior). Run via:
+--   npx tsx packages/database/scripts/seed-default-alert-rules.ts
+--
+-- See tasks/plans/o7-configurable-alert-rules-{plan,design}.md for the full
+-- rationale + per-step review record.
+
+-- CreateTable
+CREATE TABLE "alert_rules" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "triggerEvent" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "scope" TEXT NOT NULL,
+    "scopeTagId" TEXT,
+    "scopeGroupId" TEXT,
+    "scopeDisplayId" TEXT,
+    "minOfflineSec" INTEGER NOT NULL DEFAULT 120,
+    "lastFiredAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "alert_rules_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "alert_rule_recipients" (
+    "id" TEXT NOT NULL,
+    "alertRuleId" TEXT NOT NULL,
+    "channel" TEXT NOT NULL,
+    "target" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "alert_rule_recipients_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "alert_rules_organizationId_name_key" ON "alert_rules"("organizationId", "name");
+
+-- CreateIndex
+CREATE INDEX "alert_rules_organizationId_isActive_idx" ON "alert_rules"("organizationId", "isActive");
+
+-- CreateIndex
+CREATE INDEX "alert_rules_scopeTagId_idx" ON "alert_rules"("scopeTagId");
+
+-- CreateIndex
+CREATE INDEX "alert_rules_scopeGroupId_idx" ON "alert_rules"("scopeGroupId");
+
+-- CreateIndex
+CREATE INDEX "alert_rules_scopeDisplayId_idx" ON "alert_rules"("scopeDisplayId");
+
+-- CreateIndex
+CREATE INDEX "alert_rule_recipients_alertRuleId_idx" ON "alert_rule_recipients"("alertRuleId");
+
+-- AddForeignKey
+ALTER TABLE "alert_rules" ADD CONSTRAINT "alert_rules_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "alert_rules" ADD CONSTRAINT "alert_rules_scopeTagId_fkey" FOREIGN KEY ("scopeTagId") REFERENCES "Tag"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "alert_rules" ADD CONSTRAINT "alert_rules_scopeGroupId_fkey" FOREIGN KEY ("scopeGroupId") REFERENCES "DisplayGroup"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "alert_rules" ADD CONSTRAINT "alert_rules_scopeDisplayId_fkey" FOREIGN KEY ("scopeDisplayId") REFERENCES "devices"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "alert_rule_recipients" ADD CONSTRAINT "alert_rule_recipients_alertRuleId_fkey" FOREIGN KEY ("alertRuleId") REFERENCES "alert_rules"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/migrations/20260519121627_add_alert_rule_fires/migration.sql
+++ b/packages/database/prisma/migrations/20260519121627_add_alert_rule_fires/migration.sql
@@ -1,0 +1,49 @@
+-- Migration: add_alert_rule_fires
+--
+-- Follow-up to 20260519050346_add_alert_rules.
+--
+-- Per-(rule, device) dedup. The original O7 design used a single
+-- `lastFiredAt` column on alert_rules. A code review caught that a
+-- rule matching N devices would only fire for the FIRST device offline
+-- in the dedup window — the other N-1 outages would be silently
+-- suppressed. Per-device dedup fixes this.
+--
+-- - `alert_rule_fires` is mutable state (lastFiredAt), not an audit log.
+--   One row per historical (rule, device) pair, NOT one per fire.
+-- - `lastFiredAt` column is dropped from `alert_rules` (replaced by this
+--   table's column).
+-- - Both FKs cascade-delete: removing a rule or a display purges its
+--   fire-state rows.
+--
+-- Atomic claim in code: `AlertRulesService.tryClaimDedupWindow(ruleId,
+-- deviceId, now)` does updateMany with `lastFiredAt < threshold`
+-- predicate, falls back to create on count===0 + catches P2002 to
+-- collapse races.
+
+-- CreateTable
+CREATE TABLE "alert_rule_fires" (
+    "id" TEXT NOT NULL,
+    "alertRuleId" TEXT NOT NULL,
+    "deviceId" TEXT NOT NULL,
+    "lastFiredAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "alert_rule_fires_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex (one fire-state row per (rule, device) pair)
+CREATE UNIQUE INDEX "alert_rule_fires_alertRuleId_deviceId_key" ON "alert_rule_fires"("alertRuleId", "deviceId");
+
+-- CreateIndex (supports the future db-maintainer prune sweep on stale rows)
+CREATE INDEX "alert_rule_fires_lastFiredAt_idx" ON "alert_rule_fires"("lastFiredAt");
+
+-- AddForeignKey
+ALTER TABLE "alert_rule_fires" ADD CONSTRAINT "alert_rule_fires_alertRuleId_fkey" FOREIGN KEY ("alertRuleId") REFERENCES "alert_rules"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "alert_rule_fires" ADD CONSTRAINT "alert_rule_fires_deviceId_fkey" FOREIGN KEY ("deviceId") REFERENCES "devices"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Drop the now-unused per-rule dedup column.
+-- Safe to drop without a backfill — the rule-level dedup field is being
+-- replaced wholesale by per-(rule, device) state in alert_rule_fires.
+ALTER TABLE "alert_rules" DROP COLUMN "lastFiredAt";

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -150,6 +150,7 @@ model Display {
   auditLogs            AuditLog[]
   impressions          ContentImpression[]
   alertRulesScopedHere AlertRule[]
+  alertRuleFires       AlertRuleFire[]
 
   @@index([organizationId])
   @@index([deviceIdentifier])
@@ -1021,16 +1022,16 @@ model AlertRule {
   scopeTagId     String? // when scope="tag"
   scopeGroupId   String? // when scope="group"
   scopeDisplayId String? // when scope="display"
-  minOfflineSec  Int       @default(120) // floor — stale-heartbeat cron threshold is 2 min
-  lastFiredAt    DateTime? // dedup window (15 min) — atomic CAS via updateMany
-  createdAt      DateTime  @default(now())
-  updatedAt      DateTime  @updatedAt
+  minOfflineSec  Int      @default(120) // floor — stale-heartbeat cron threshold is 2 min
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   organization Organization         @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   scopeTag     Tag?                 @relation(fields: [scopeTagId], references: [id], onDelete: SetNull)
   scopeGroup   DisplayGroup?        @relation(fields: [scopeGroupId], references: [id], onDelete: SetNull)
   scopeDisplay Display?             @relation(fields: [scopeDisplayId], references: [id], onDelete: SetNull)
   recipients   AlertRuleRecipient[]
+  fires        AlertRuleFire[]
 
   @@unique([organizationId, name]) // idempotent seed + UI uniqueness
   @@index([organizationId, isActive])
@@ -1051,4 +1052,27 @@ model AlertRuleRecipient {
 
   @@index([alertRuleId])
   @@map("alert_rule_recipients")
+}
+
+// Per-(rule, device) dedup state. One row per historical rule/device pair
+// (NOT one row per fire — `lastFiredAt` is mutable state, not an audit log).
+// The 15-min dedup window is claimed via atomic upsert in
+// `AlertRulesService.tryClaimDedupWindow(ruleId, deviceId, now)`.
+//
+// Growth is bounded by `rules × devices ever matched`. A 90-day prune of
+// stale rows can be added to db-maintainer if the table size becomes a
+// concern; for v1 it's left untouched.
+model AlertRuleFire {
+  id          String   @id @default(cuid())
+  alertRuleId String
+  deviceId    String
+  lastFiredAt DateTime
+  createdAt   DateTime @default(now())
+
+  alertRule AlertRule @relation(fields: [alertRuleId], references: [id], onDelete: Cascade)
+  device    Display   @relation(fields: [deviceId], references: [id], onDelete: Cascade)
+
+  @@unique([alertRuleId, deviceId])
+  @@index([lastFiredAt])
+  @@map("alert_rule_fires")
 }

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -58,6 +58,7 @@ model Organization {
   contentRecommendations ContentRecommendation[]
   mcpTokens              McpToken[]
   agentRuns              AgentRun[]
+  alertRules             AlertRule[]
 
   @@index([slug])
   @@index([stripeCustomerId])
@@ -143,11 +144,12 @@ model Display {
   pairedAt             DateTime?
   unpairedAt           DateTime?
 
-  schedules   Schedule[]
-  tags        DisplayTag[]
-  groups      DisplayGroupMember[]
-  auditLogs   AuditLog[]
-  impressions ContentImpression[]
+  schedules            Schedule[]
+  tags                 DisplayTag[]
+  groups               DisplayGroupMember[]
+  auditLogs            AuditLog[]
+  impressions          ContentImpression[]
+  alertRulesScopedHere AlertRule[]
 
   @@index([organizationId])
   @@index([deviceIdentifier])
@@ -167,8 +169,9 @@ model DisplayGroup {
   organizationId String
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
-  displays  DisplayGroupMember[]
-  schedules Schedule[]
+  displays             DisplayGroupMember[]
+  schedules            Schedule[]
+  alertRulesScopedHere AlertRule[]
 
   @@index([organizationId])
 }
@@ -358,8 +361,9 @@ model Tag {
   organizationId String
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
-  content  ContentTag[]
-  displays DisplayTag[]
+  content              ContentTag[]
+  displays             DisplayTag[]
+  alertRulesScopedHere AlertRule[]
 
   @@unique([organizationId, name])
   @@index([organizationId])
@@ -1001,4 +1005,50 @@ model AgentRun {
   @@index([createdAt])
   @@index([organizationId, startedAt])
   @@map("agent_runs")
+}
+
+// ============================================================================
+// ALERT RULES (O7 — configurable downtime alert rules)
+// ============================================================================
+
+model AlertRule {
+  id             String    @id @default(cuid())
+  organizationId String
+  name           String // user-facing label
+  triggerEvent   String // "device.offline" (extensible)
+  isActive       Boolean   @default(true)
+  scope          String // "all" | "tag" | "group" | "display"
+  scopeTagId     String? // when scope="tag"
+  scopeGroupId   String? // when scope="group"
+  scopeDisplayId String? // when scope="display"
+  minOfflineSec  Int       @default(120) // floor — stale-heartbeat cron threshold is 2 min
+  lastFiredAt    DateTime? // dedup window (15 min) — atomic CAS via updateMany
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  organization Organization         @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  scopeTag     Tag?                 @relation(fields: [scopeTagId], references: [id], onDelete: SetNull)
+  scopeGroup   DisplayGroup?        @relation(fields: [scopeGroupId], references: [id], onDelete: SetNull)
+  scopeDisplay Display?             @relation(fields: [scopeDisplayId], references: [id], onDelete: SetNull)
+  recipients   AlertRuleRecipient[]
+
+  @@unique([organizationId, name]) // idempotent seed + UI uniqueness
+  @@index([organizationId, isActive])
+  @@index([scopeTagId])
+  @@index([scopeGroupId])
+  @@index([scopeDisplayId])
+  @@map("alert_rules")
+}
+
+model AlertRuleRecipient {
+  id          String   @id @default(cuid())
+  alertRuleId String
+  channel     String // "in_app" | "email" | "slack_webhook"
+  target      String // userId (in_app) | email | webhook URL
+  createdAt   DateTime @default(now())
+
+  alertRule AlertRule @relation(fields: [alertRuleId], references: [id], onDelete: Cascade)
+
+  @@index([alertRuleId])
+  @@map("alert_rule_recipients")
 }

--- a/packages/database/scripts/seed-default-alert-rules.ts
+++ b/packages/database/scripts/seed-default-alert-rules.ts
@@ -1,0 +1,98 @@
+/**
+ * O7 — Seed default alert rules for existing orgs.
+ *
+ * Run ONCE at deploy time after the `20260519050346_add_alert_rules` migration:
+ *
+ *     npx tsx packages/database/scripts/seed-default-alert-rules.ts
+ *
+ * For every existing Organization that does NOT already have a rule named
+ * "Default offline alert (auto-migrated)", inserts:
+ *   - One AlertRule row: scope=all, triggerEvent=device.offline,
+ *     minOfflineSec=120, isActive=true
+ *   - One AlertRuleRecipient per admin user (role='admin'): channel=in_app,
+ *     target=user.id
+ *
+ * This preserves the pre-O7 broadcast-to-all-admins behavior 1:1 for current
+ * orgs. New orgs created post-deploy get NO default rule — they explicitly
+ * opt in via the UI / API.
+ *
+ * Idempotent: re-running is safe because the unique index
+ * `(organizationId, name)` on alert_rules causes `prisma.alertRule.create`
+ * to throw P2002, which we catch and skip.
+ *
+ * Orgs with zero admin users get an AlertRule with zero recipients — the
+ * evaluator's dispatch loop iterates zero times → silent no-op. Logged at
+ * INFO so post-deploy ops can spot orgs that need a manual recipient added.
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+const DEFAULT_RULE_NAME = 'Default offline alert (auto-migrated)';
+
+async function main(): Promise<void> {
+  const prisma = new PrismaClient();
+  let created = 0;
+  let skippedExisting = 0;
+  let orgsWithNoAdmins = 0;
+
+  try {
+    const orgs = await prisma.organization.findMany({ select: { id: true, name: true } });
+    console.log(`[seed] Found ${orgs.length} organizations to evaluate`);
+
+    for (const org of orgs) {
+      // Cheap pre-check before the FK-heavy transaction
+      const existing = await prisma.alertRule.findUnique({
+        where: { organizationId_name: { organizationId: org.id, name: DEFAULT_RULE_NAME } },
+        select: { id: true },
+      });
+      if (existing) {
+        skippedExisting++;
+        continue;
+      }
+
+      const admins = await prisma.user.findMany({
+        where: { organizationId: org.id, role: 'admin', isActive: true },
+        select: { id: true },
+      });
+
+      if (admins.length === 0) {
+        orgsWithNoAdmins++;
+        console.log(`[seed] org=${org.id} (${org.name}) has zero admins — creating rule with zero recipients (no-op until an admin is added as recipient)`);
+      }
+
+      try {
+        await prisma.alertRule.create({
+          data: {
+            organizationId: org.id,
+            name: DEFAULT_RULE_NAME,
+            triggerEvent: 'device.offline',
+            isActive: true,
+            scope: 'all',
+            minOfflineSec: 120,
+            recipients: {
+              create: admins.map((a) => ({ channel: 'in_app', target: a.id })),
+            },
+          },
+        });
+        created++;
+      } catch (err: unknown) {
+        // P2002 is the unique-constraint violation — could happen if a parallel
+        // run beat us between the findUnique and the create. Treat as success.
+        if (err && typeof err === 'object' && 'code' in err && err.code === 'P2002') {
+          skippedExisting++;
+        } else {
+          throw err;
+        }
+      }
+    }
+
+    console.log(`[seed] Done. created=${created} skipped_existing=${skippedExisting} orgs_with_no_admins=${orgsWithNoAdmins}`);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  console.error('[seed] Fatal error:', err);
+  process.exit(1);
+});

--- a/packages/database/scripts/seed-default-alert-rules.ts
+++ b/packages/database/scripts/seed-default-alert-rules.ts
@@ -1,6 +1,15 @@
 /**
  * O7 — Seed default alert rules for existing orgs.
  *
+ * The same rule shape is also implemented in
+ * `middleware/src/modules/notifications/alert-rules/alert-rules.service.ts`
+ * → `seedDefaultRuleForOrg(orgId, adminUserIds)`. That path is what auto-seeds
+ * NEW orgs at registration time. This standalone script is the one-shot
+ * backfill for orgs that already existed before the migration landed.
+ *
+ * Both paths must stay in sync — if the default-rule shape changes (different
+ * scope, recipients, etc.), edit both.
+ *
  * Run ONCE at deploy time after the `20260519050346_add_alert_rules` migration:
  *
  *     npx tsx packages/database/scripts/seed-default-alert-rules.ts

--- a/packages/database/scripts/seed-default-alert-rules.ts
+++ b/packages/database/scripts/seed-default-alert-rules.ts
@@ -1,40 +1,45 @@
 /**
- * O7 — Seed default alert rules for existing orgs.
+ * O7 — Seed default alert rules for existing orgs (one-shot backfill).
  *
- * The same rule shape is also implemented in
- * `middleware/src/modules/notifications/alert-rules/alert-rules.service.ts`
- * → `seedDefaultRuleForOrg(orgId, adminUserIds)`. That path is what auto-seeds
- * NEW orgs at registration time. This standalone script is the one-shot
- * backfill for orgs that already existed before the migration landed.
+ * Runs ONCE at deploy time, AFTER `20260519050346_add_alert_rules` has been
+ * applied. For each existing Organization that does NOT already have a
+ * "Default offline alert (auto-migrated)" rule, inserts:
+ *   - One AlertRule: scope=all, triggerEvent=device.offline,
+ *     minOfflineSec=120, isActive=true
+ *   - One AlertRuleRecipient per active admin (role='admin'): channel=in_app,
+ *     target=user.id
  *
- * Both paths must stay in sync — if the default-rule shape changes (different
- * scope, recipients, etc.), edit both.
+ * Preserves the pre-O7 broadcast-to-all-admins behavior 1:1. NEW orgs created
+ * post-deploy are handled by `AuthService.register` → `seedDefaultRuleForOrg`
+ * (PR #63 follow-up); they get the same default rule automatically at
+ * registration time, so this backfill is needed only once for the orgs that
+ * pre-date the migration.
  *
- * Run ONCE at deploy time after the `20260519050346_add_alert_rules` migration:
+ * The runtime side of the same rule shape lives at
+ * `middleware/src/modules/notifications/alert-rules/alert-rules.service.ts` →
+ * `seedDefaultRuleForOrg(orgId, adminUserIds)`. The two paths MUST stay in
+ * sync — if the default-rule shape changes (different scope, recipients,
+ * etc.), edit both.
+ *
+ * Idempotent: the unique `(organizationId, name)` index causes the create to
+ * throw P2002 on re-run, which is caught and treated as success.
+ *
+ * Orgs with zero active admins get an AlertRule with zero recipients — the
+ * evaluator's dispatch loop iterates zero times (silent no-op). Logged at
+ * INFO so post-deploy ops can spot orgs that need a manual recipient added.
+ *
+ * Invocation:
  *
  *     npx tsx packages/database/scripts/seed-default-alert-rules.ts
  *
- * For every existing Organization that does NOT already have a rule named
- * "Default offline alert (auto-migrated)", inserts:
- *   - One AlertRule row: scope=all, triggerEvent=device.offline,
- *     minOfflineSec=120, isActive=true
- *   - One AlertRuleRecipient per admin user (role='admin'): channel=in_app,
- *     target=user.id
- *
- * This preserves the pre-O7 broadcast-to-all-admins behavior 1:1 for current
- * orgs. New orgs created post-deploy get NO default rule — they explicitly
- * opt in via the UI / API.
- *
- * Idempotent: re-running is safe because the unique index
- * `(organizationId, name)` on alert_rules causes `prisma.alertRule.create`
- * to throw P2002, which we catch and skip.
- *
- * Orgs with zero admin users get an AlertRule with zero recipients — the
- * evaluator's dispatch loop iterates zero times → silent no-op. Logged at
- * INFO so post-deploy ops can spot orgs that need a manual recipient added.
+ * The import path below resolves to this repo's generated Prisma client
+ * (output configured in `packages/database/prisma/schema.prisma` →
+ * `generator client { output = "../src/generated/prisma" }`). The script
+ * intentionally does NOT depend on `@prisma/client` or on `@vizora/database`
+ * being built — both have failed at deploy time in prior incidents.
  */
 
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from '../src/generated/prisma';
 
 const DEFAULT_RULE_NAME = 'Default offline alert (auto-migrated)';
 

--- a/tasks/.hermes-check-receipts/o7-configurable-alert-rules.json
+++ b/tasks/.hermes-check-receipts/o7-configurable-alert-rules.json
@@ -1,0 +1,17 @@
+{
+  "topic": "o7-configurable-alert-rules",
+  "task_text": "O7 — Configurable downtime alert rules: replace hard-coded device.offline handler with a rule table (AlertRule + AlertRuleRecipient Prisma models), per-org rules with scope (all/tag/group/display), recipient channels (in_app/email/slack_webhook), debounce threshold (minOfflineSec), 15-min dedup window. Audit ref P1 #6. This is a platform/runtime feature, not an agent.",
+  "completed_at": "2026-05-19T04:50:00Z",
+  "drift_check_tag": "extends-Hermes",
+  "net_new_step_count": 12,
+  "hermes_step_count": 0,
+  "files_to_read_first": [
+    "packages/database/prisma/schema.prisma",
+    "middleware/src/modules/notifications/notifications.service.ts",
+    "middleware/src/modules/displays/displays.service.ts",
+    "middleware/src/modules/notifications/notifications.service.spec.ts",
+    "middleware/src/modules/notifications/notifications.module.ts",
+    "middleware/src/modules/mail/mail.service.ts"
+  ],
+  "verdict": "All 12 steps net-new from Hermes substrate POV — expected for Vizora middleware/runtime work (not agent work). Hermes-first rule per CLAUDE.md applies to agent work; this is platform infrastructure for a domain Hermes doesn't own (NestJS event bus, Prisma schema, HTTP surface). Future agents may consume the new AlertRule table via an MCP read tool, but the table + evaluator themselves live in middleware."
+}

--- a/tasks/.hermes-check-receipts/o7-design.json
+++ b/tasks/.hermes-check-receipts/o7-design.json
@@ -1,0 +1,17 @@
+{
+  "topic": "o7-design",
+  "task_text": "O7 design — file shapes, code skeletons, migration SQL, test plan for configurable downtime alert rules. Follow-up to o7-configurable-alert-rules-plan.md after 2 parallel reviewers.",
+  "completed_at": "2026-05-19T05:00:00Z",
+  "drift_check_tag": "extends-Hermes",
+  "net_new_step_count": 12,
+  "hermes_step_count": 0,
+  "files_to_read_first": [
+    "middleware/src/modules/mail/mail.service.ts",
+    "middleware/src/modules/notifications/notifications.controller.ts",
+    "middleware/src/modules/agents/onboarding.service.ts",
+    "middleware/src/modules/notifications/notifications.module.ts",
+    "packages/database/prisma/schema.prisma",
+    "middleware/src/modules/displays/displays.service.ts"
+  ],
+  "verdict": "Design layer of O7. All structural patterns now read directly: MailService.wrapInTemplate/sendMail (no .hbs needed), OnboardingService async-OnEvent invariant (top-level try/catch + fire-and-forget), NotificationsController @CurrentUser+@Roles RBAC pattern, NotificationsModule's current DatabaseModule+HttpModule imports (needs MailModule added)."
+}

--- a/tasks/feature-backlog.md
+++ b/tasks/feature-backlog.md
@@ -6,6 +6,34 @@ Not a sprint tracker — see `todo.md` for in-flight work.
 
 ---
 
+## OptiSigns parity — deferred items (from 2026-05-17 audit)
+
+**Opened:** 2026-05-17
+**Status:** Parked — listed in the audit but consciously not on the active parity roadmap
+**Source:** `docs/plans/2026-05-17-optsigns-vizora-feature-gap.md`
+**Trigger to revisit (per item below).** Active parity items are tracked in `backlog.md` under "OptiSigns Parity Roadmap" (O1–O10).
+
+Each entry is what we chose NOT to build now, why, and what would flip the decision.
+
+| Item | Why deferred | Trigger to revisit |
+|---|---|---|
+| **Engage / interactive signage** — kiosk builder, touch navigation, QR scan-to-interact, content-library kiosk, check-in/SMS, sensor/AI camera hooks | Separate product surface; the operator-facing dashboard and the kiosk builder share little. High cost; niche audience until a concrete ask | Pilot customer with explicit kiosk use case (retail check-in, healthcare wayfinding) — quote the audit's P1 #9 to scope |
+| **Live remote view / remote control (WebRTC)** | Static screenshot already covers most operator troubleshooting (`displays.controller.ts:213-241`). WebRTC infra is a major platform lift (TURN/STUN, peer auth, bandwidth) | Customer asks for live troubleshooting view, OR enterprise security RFP requires it |
+| **Scheduled device-side commands** — power/volume/brightness/mute/download windows on `Schedule` | Feature, not foundational; today's playlist scheduling already covers the most-asked use cases | First customer who flags "displays still on overnight wasting power" as a deal-blocker |
+| **Advanced layout zones** — percentage/pixel zones, scrolling strips, audio zones, background music, primary-zone sync | Today's fixed presets in `web/src/app/dashboard/layouts/page.tsx` cover most observed use cases. Free-form zone editor is multi-week and competes for designer-extension cycles (O3) | After O3 ships and we have a real customer needing per-zone audio or scrolling tickers |
+| **Office / OpenOffice document playback + auto-conversion** | PDF support already exists; native PowerPoint/Word would require Aspose, Microsoft Graph, or LibreOffice headless conversion — all ongoing licensing/ops cost | Customer asks for native PowerPoint upload as a deal-blocker, OR free conversion-API path emerges |
+| **Template marketplace at thousands-scale + industry packs** | Today's ~78 templates plus the Designer (O3) cover early customers. Content scaling is a slow burn (hire content designer / contract OptiSigns-quality work), not a feature | Marketplace requests from enterprise plans, OR content-team hiring decision |
+| **White-label / branded portal** | Partial foundation already exists via `CustomizationProvider` (brand name + logo per org). Full white-label (sub-domains, branded portal, branded emails) is a marketing-driven build | Agency-partner ask, OR a reseller pricing tier decision |
+| **Nested playlists + playlist-item schedules + per-item fallback** | Today's flat playlists meet most needs; nesting is a model + UI + renderer change for marginal value | Customer ask, OR a real coverage gap surfaces in the schedule-doctor ops agent |
+| **Compliance exports** — richer audit/report exports for account deletion, advertiser reporting, enterprise governance | GDPR data export already in P2 (`M11`). Beyond that is enterprise-compliance RFP territory | First enterprise compliance RFP that names SOC 2 advertiser-reporting or HIPAA audit-export |
+| **SAML/OIDC enterprise SSO** | Already tracked at `F2` in `backlog.md` (P4). Same enterprise-plan dependency as O9 (Teams/folders) | Same enterprise customer that triggers O9 likely triggers this; consider bundling |
+
+### Why this list exists (not just absent from `backlog.md`)
+
+Without an explicit "deferred and why" record, every future Claude/Sri session that reads the audit risks re-proposing these. The audit names them as gaps; this entry documents that *we read the audit, considered each, and chose not to build now* — with the specific signal that would change the answer.
+
+---
+
 ## Adopt shift-agent / Hermes patterns for Vizora business agents (evaluation)
 
 **Opened:** 2026-05-03
@@ -250,9 +278,140 @@ Hardware video-wall controllers (Userful, Datapath, Christie Pandoras Box) handl
 No customer ask. The bulk of the "vertical screen" market (menu boards, wayfinding, lobby displays) is solved by today's portrait + DisplayGroups + per-screen playlists. Real video-wall sync serves a much smaller slice (stadium displays, broadcast studios, premium retail) and competes against entrenched hardware-layer players. Build only on a concrete pull.
 
 
+## Schema-tolerant comparison reader for Hermes shadow JSONL
+
+**Opened:** 2026-05-05
+**Status:** **Blocking** the customer-lifecycle and support-triage live cutover gates
+**Trigger to revisit:** Today — this is the next concrete piece of work for the agent migration, not a "may build."
+
+### What this is
+
+The cutover plan for both `customer-lifecycle` and `support-triage` requires comparing Hermes shadow output to the existing PM2 cron's records for ≥7 days before promoting. Today there is no comparison reader — and (critically) we now know there *can't* be a strict-schema one, because gpt-4o-mini doesn't reliably copy field names verbatim. See memory: `feedback_gpt4o_mini_schema_fidelity.md`.
+
+The blocker is not "wait for the model to comply." Three SKILL iterations on 2026-05-05 confirmed it won't. The blocker is "build a reader that's tolerant to model-side schema drift but still measures what we care about."
+
+### What the reader needs to do
+
+1. **Read both sides:**
+   - Hermes shadow JSONL: `/var/log/hermes/vizora-{customer-lifecycle,support-triage}-shadow.jsonl` (server-appended via `log_shadow_row` MCP tool — schema authoritative on the server side, but the *agent-supplied* fields inside `payload` are model-emitted)
+   - PM2 cron audit: `log_shadow_row` rows in `mcp_audit_log` (timestamps + tool + status) and the existing PM2 cron's own state files (`logs/agent-state/customer-lifecycle.json`)
+
+2. **Bucket by run_id (server-overridden, never trust agent):** Every shadow row has a server-stamped `timestamp` and `run_id`. Match Hermes runs to PM2 cron runs by wall-clock proximity (e.g. ±5 min window) — not by run_id, since they're different identifier spaces.
+
+3. **Tolerant field extraction:** For each Hermes row, try a list of synonyms (`hermes_template`, `decision`, `template`, `nudge_template_key`) and fall back to keyword search inside `message`/`summary` fields. Document which synonym hit per row so we can see model-side drift over time.
+
+4. **Compute the metric we actually care about:**
+   - **customer-lifecycle:** did Hermes pick the same `dayN` template as PM2 cron for the same org (or at least the same `dayN` bucket)? Tolerance = exact match on `day1`/`day3`/`day7`/`autocomplete`.
+   - **support-triage:** did Hermes pick the same priority bucket (P1/P2/P3) and same category-v2 as the heuristic classifier? Tolerance = exact match.
+
+5. **Output:** daily JSON summary + one-page Markdown — `agreement_rate`, `mismatch_examples`, `schema_drift_log`, `runs_with_no_extractable_decision` (this last one is the canary for "model went off-script entirely").
+
+### Where it lives
+
+`scripts/agents/hermes/compare-shadow.ts` — read-only script, scheduled as a daily PM2 cron. Writes to `logs/hermes-shadow-comparison/YYYY-MM-DD.{json,md}`. Surfaces in Slack only on `agreement_rate < 85%` or `runs_with_no_extractable_decision > 10%`.
+
+### Cutover-gate semantics
+
+The 7-day shadow comparison gates promote only if:
+- `agreement_rate >= 85%` for 7 consecutive days, AND
+- `runs_with_no_extractable_decision <= 5%` for 7 consecutive days, AND
+- Zero days where Hermes made a decision PM2 cron rejected (false positive on the LLM side)
+
+If gpt-4o-mini can't hit these, we know to swap models *with evidence*, not reflex.
+
+### Why deferred from this session
+
+Out of scope for the 2026-05-05 PM2-driven cutover (PR #60). That PR's job was to get *firings* reliable. The reader is the *evaluation* layer on top.
+
+### Estimated effort
+
+~1 day. The hard part (server-side authoritative timestamping) is already shipped; this is just a comparison script.
+
+---
+
+## hermes-cron-vs-`-z` context investigation
+
+**Opened:** 2026-05-05
+**Status:** Root-cause work — the workaround is shipped (PR #60), the cause is not understood
+**Trigger to revisit:** Adding a third Hermes skill (we now have a precedent that we can't lean on hermes-cron), OR Hermes upstream releases a runtime change touching cron-mode prompt assembly.
+
+### What this is
+
+`hermes cron create` and `hermes -z` are nominally the same: same skill, same prompt, same model. Empirically they aren't — under cron context, gpt-4o-mini exhibits different tool-calling behavior on identical SKILL files. The workaround (PR #60) bypasses hermes-cron entirely with a PM2 cron_restart + bash runner that calls `hermes -z` directly. This works, but we don't know *why* the cron path differs.
+
+### Why it matters
+
+We currently can't recommend `hermes cron` for any new Vizora skill — but the upstream pattern is to use it. If we can identify the difference (system-prompt assembly, env-var inheritance, working-directory discrepancy, signal handling, lock-file contention), we can either fix it in Hermes or document the precise reason for our deviation. Without root cause, every future Hermes-cron decision becomes a context-free "well it didn't work last time."
+
+### Hypotheses to test
+
+1. **System-prompt assembly difference** — does hermes-cron inject extra context (job metadata, cron-history hints) that `-z` doesn't?
+2. **Working directory** — does hermes-cron run with a different `cwd`, affecting MCP-tool config resolution?
+3. **Stdin/stdout binding** — `-z` uses one-shot mode; cron may keep an interactive-style channel that subtly changes prompt framing
+4. **Concurrent firings or lock contention** — if cron jobs overlap, do we see degraded behavior?
+
+### Approach
+
+Side-by-side capture: same skill, same prompt, model temperature 0, run via both paths 20 times each, diff the resulting tool-call sequences. Hermes ships verbose-logging flags that should reveal the assembled system prompt — start there.
+
+### Why deferred
+
+Operational fix shipped; root cause is investigative work that can be scheduled rather than rushed.
+
+---
+
+## support-triage gpt-4o-mini "cannot proceed" false-alarm cleanup
+
+**Opened:** 2026-05-05
+**Status:** Open — observed in 2026-05-05 PM2 cutover; non-blocking but noisy
+**Trigger to revisit:** Bundle with the schema-tolerant comparison reader, OR if the false-alarm rate climbs above ~20% of firings.
+
+### What this is
+
+`vizora-support-triage` runs every 5 min. When zero new tickets exist (the steady-state condition), gpt-4o-mini sometimes emits "The operation completed silently" or analogous "cannot proceed" framing instead of the expected "Zero support requests found during triage." line. The shadow JSONL row still gets written (server-side via `log_shadow_row`), but the runner log looks like an error.
+
+Observed example from 2026-05-05 PM2 firings:
+```
+=== runner log: support-triage ===
+The operation completed silently.
+[2026-05-05T12:15:02Z] start skill=vizora-support-triage pid=731281
+[2026-05-05T12:15:57Z] end skill=vizora-support-triage exit=0
+```
+And: `hermes-support-triage | log_shadow_row | error | 2026-05-05 12:15:42` — but exit=0 because the bash runner forces it.
+
+### Why it's a false alarm (today)
+
+The shadow row still lands. The agent did its job. The runner log is human-confusing but operationally fine. The `error` status on the audit row is a separate question — that's an actual recoverable error mapping issue (likely the agent calling `log_shadow_row` with a stale or empty payload that fails server-side validation, which we now reject correctly).
+
+### What needs to happen
+
+1. **Inventory the failure modes** — in the next 7 days of shadow JSONL, classify the "cannot proceed" runs: how many actually wrote a row vs how many silently no-op'd?
+2. **Fix the audit-row error** — if the agent is calling `log_shadow_row` with malformed args on the zero-tickets path, that's a SKILL-prompt issue (probably "do not call this tool when the input set is empty"). Fix in the SKILL.
+3. **Decide whether to suppress or display** — if "operation completed silently" is going to be a steady-state output, the runner log should explicitly note "no work this cycle" instead of leaving it as orphan text.
+
+### Why deferred
+
+Cosmetic + diagnostic, not breaking. The skill works. Worth bundling with the schema-tolerant comparison reader since both are "make the evaluation layer trustworthy" work.
+
+---
+
 ## customer-lifecycle Hermes migration
 
-**What**
+**Updated:** 2026-05-05 (was 2026-05-04)
+**Status:** Read tools deployed; PM2-driven shadow firings live; comparison reader pending (see entry above)
+
+**Latest progress (2026-05-05)**
+
+- `log_shadow_row` MCP tool shipped (PR #58) — server-side safe append to `/var/log/hermes/vizora-customer-lifecycle-shadow.jsonl`, server overrides agent-supplied `timestamp` and `run_id`, PIPE_BUF (4096) line-size cap, scope `shadow:write`, platform-scope tokens only.
+- MCP-spec empty handlers shipped (PR #59) — fixes the probe-loop bug where Hermes auto-discovered `mcp_vizora_list_resources` / `mcp_vizora_get_prompt` and gpt-4o-mini retried-and-looped on "Method not found." See memory: `mcp_server_empty_spec_handlers.md`.
+- PM2-driven scheduling shipped (PR #60) — `hermes-vizora-customer-lifecycle` PM2 entry, cron_restart `*/30 * * * *`, fires `bash scripts/agents/hermes/run-hermes-skill.sh customer-lifecycle <prompt>` which calls `hermes -z`. The old `hermes cron` jobs were removed to prevent duplicate firings. See memory: `hermes_cron_vs_pm2_cron.md`.
+- First production firings on 2026-05-05 12:15 logged 10 candidate-evaluation rows successfully — Hermes is doing the read+evaluate path end-to-end with no email sends.
+
+**Now blocking**
+
+The schema-tolerant comparison reader (above). Without it, we cannot run the 7-day comparison gate, so we cannot promote past shadow-mode. **gpt-4o-mini does not reliably copy field names verbatim** — three SKILL iterations confirmed this — so the gate cannot rely on strict-schema parsing.
+
+**Original design sketch (still accurate)**
 
 Migrate `scripts/agents/customer-lifecycle.ts` (463 lines, runs every 30 min, sends day-1/3/7 onboarding nudges) to a Hermes skill following the same shadow-then-cutover pattern as `vizora-support-triage`.
 

--- a/tasks/plans/2026-05-19-overnight-o7-summary.md
+++ b/tasks/plans/2026-05-19-overnight-o7-summary.md
@@ -1,0 +1,107 @@
+# Overnight Autonomous Run — 2026-05-19 — O7 shipped
+
+**Operator instruction:** "Implement as many new backlog items as possible. Plan → 2 parallel reviews → fix → Design → 2 parallel reviews → fix → Build → PR → 3 parallel reviews."
+
+**Result:** **1 of 3 attempted O-series items shipped end-to-end at full quality.** O4 + O1 deferred with honest handoff.
+
+## What shipped
+
+### O7 — Configurable downtime alert rules — PR #63
+- **Branch:** `feat/o7-configurable-alert-rules`
+- **PR:** https://github.com/Trivenidigital/Vizora/pull/63
+- **Commits:** 8 (1 audit roadmap + 1 plan/design + 5 build + 1 review-fix)
+- **Build state:** ✅ Full middleware suite passing — **125 / 125 suites, 2396 / 2396 tests** (+61 vs 2335 baseline, zero regressions)
+- **TypeScript:** clean
+- **Audit ref:** P1 #6 from `docs/plans/2026-05-17-optsigns-vizora-feature-gap.md`
+
+**Workflow completed (7 review cycles):**
+1. Plan written → 2 parallel reviewers (structural + strategy)
+2. 5 fixes applied (effort estimate, drop .hbs, admin-gate DELETE, defer non-Slack channels, zero-admin-org note)
+3. Design written → 2 parallel reviewers (security + test coverage)
+4. 10 fixes applied (cross-tenant in_app guard, admin-gate PATCH/recipient mutations, atomic CAS dedup, SSRF defenses, Jest config fix, expanded tests, prisma-side seed instead of raw SQL CTE)
+5. Build → 5 commits
+6. PR opened → 3 parallel reviewers (code quality + security + ops safety)
+7. 4 fixes applied (@IsEmail validator, escape email subject, runbook seed step, remove dead `_scopeMatchesForTest`)
+
+**Net new code:**
+- 2 Prisma models (`AlertRule`, `AlertRuleRecipient`)
+- 1 migration + 1 seed script
+- 1 mail method + helper
+- 1 service (8 methods)
+- 1 evaluator (replaces hard-coded handler)
+- 1 controller (7 endpoints, RBAC-gated mutations)
+- 4 DTOs + 1 types file
+- 4 spec files, 61 new test cases
+
+## What's deferred
+
+### O4 — Tag-rule auto-assignment engine
+### O1 — Unified Push to Screens with tag targeting
+
+**Why deferred:** The user-specified workflow (Plan → 2 reviews → fix → Design → 2 reviews → fix → Build → PR → 3 reviews) is **~7 review cycles per item**. Each cycle is substantial agent work + iteration. After O7 shipped, the realistic options were:
+
+- **(A) Ship O7 alone at full quality** → done.
+- **(B) Start O4 partway and stop mid-design/build** → leaves an inconsistent state worse than no start.
+- **(C) Abbreviate the review workflow on O4/O1** → violates the user's explicit quality bar.
+
+Chose (A). The honest math: 3 items × 7 review cycles = 21 substantial agent dispatches plus build + test + PR for each. Overnight budget doesn't realistically cover that at the quality the user specified.
+
+**Handoff state for the next session:**
+
+| Item | What exists | What's needed |
+|---|---|---|
+| **O4** Tag-rule auto-assignment | Inventory + audit reference in `backlog.md` "OptiSigns Parity Roadmap" row O4 | Full workflow per O7 template. Effort: M (2 dev-days code + ~10 review cycles) |
+| **O1** Unified Push with tag targeting | Same | Depends on O4 (tag-rule resolver). Should land in sequence O4 → O1 |
+
+**Recommended next session:** Either run O4 + O1 over a second overnight, OR (more efficient) bundle O4 + O1 into one PR since they share schema (`TagRule` model) — saves ~30% on review cycles.
+
+## Quality bar adhered to throughout
+
+- ✅ Drift-check + Hermes-first checklists on every plan/design doc (CLAUDE.md §7)
+- ✅ Read-receipt hook satisfied: every claimed file:line was actually Read in this session
+- ✅ Multi-vector reviewer dispatch on every cycle (CLAUDE.md §8 — structural + strategy / security + test / quality + security + ops)
+- ✅ Hard rules respected: no changes to `feat/design-explorations`; no force push; no `--no-verify`; no hook bypasses
+- ✅ Customer-1 launch path untouched: only `notifications/` module + new Prisma tables
+- ✅ Tests verified at every step (not just at the end)
+
+## Files added/modified
+
+```
+backlog.md                                                                       (+ O-series roadmap section)
+tasks/feature-backlog.md                                                          (+ deferred items)
+tasks/plans/o7-configurable-alert-rules-plan.md                                  (NEW)
+tasks/plans/o7-configurable-alert-rules-design.md                                (NEW)
+tasks/.hermes-check-receipts/o7-configurable-alert-rules.json                    (NEW)
+tasks/.hermes-check-receipts/o7-design.json                                      (NEW)
+tasks/plans/2026-05-19-overnight-o7-summary.md                                   (this file)
+packages/database/prisma/schema.prisma                                           (+ AlertRule, AlertRuleRecipient + 4 back-relations)
+packages/database/prisma/migrations/20260519050346_add_alert_rules/migration.sql (NEW)
+packages/database/scripts/seed-default-alert-rules.ts                            (NEW)
+middleware/src/modules/mail/mail.service.ts                                      (+ sendDeviceOfflineAlertEmail, escapeHtml)
+middleware/src/modules/mail/mail.service.spec.ts                                 (NEW — 7 tests)
+middleware/src/modules/notifications/alert-rules/alert-rule.types.ts             (NEW)
+middleware/src/modules/notifications/alert-rules/alert-rules.service.ts          (NEW)
+middleware/src/modules/notifications/alert-rules/alert-rules.service.spec.ts     (NEW — 20 tests)
+middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.ts         (NEW)
+middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.spec.ts    (NEW — 21 tests)
+middleware/src/modules/notifications/alert-rules/alert-rules.controller.ts       (NEW)
+middleware/src/modules/notifications/alert-rules/alert-rules.controller.spec.ts  (NEW — 14 tests)
+middleware/src/modules/notifications/alert-rules/dto/*.ts                        (NEW — 4 files)
+middleware/src/modules/notifications/notifications.service.ts                    (− hard-coded device.offline handler + createDeviceOfflineNotification)
+middleware/src/modules/notifications/notifications.service.spec.ts               (− test for the removed helper)
+middleware/src/modules/notifications/notifications.controller.spec.ts            (− jest.fn() for removed helper)
+middleware/src/modules/notifications/notifications.module.ts                     (+ register new controller + providers)
+docs/runbooks/first-customer-onboarding.md                                       (+ T-1 Check 2b — seed script step)
+```
+
+## Deployment instructions (for whoever merges PR #63)
+
+1. Merge PR #63 to main.
+2. On prod: `git pull && pnpm install`
+3. `cd packages/database && npx prisma migrate deploy`
+4. `cd /opt/vizora/app && export $(grep DATABASE_URL .env | xargs) && npx tsx packages/database/scripts/seed-default-alert-rules.ts`
+   - Expect: `[seed] Done. created=N skipped_existing=0 orgs_with_no_admins=M`
+5. `pm2 reload vizora-middleware --update-env`
+6. Verify: in dev, emit a `device.offline` event → org admin receives in-app notification matching pre-O7 behavior
+
+If the seed step is skipped, existing orgs lose their device-offline alerts silently. The runbook step (`docs/runbooks/first-customer-onboarding.md` T-1 Check 2b) catches this.

--- a/tasks/plans/o7-configurable-alert-rules-design.md
+++ b/tasks/plans/o7-configurable-alert-rules-design.md
@@ -1,0 +1,653 @@
+# O7 — Configurable Downtime Alert Rules — Design
+
+**Plan ref:** `tasks/plans/o7-configurable-alert-rules-plan.md`
+**Drift-check tag:** `extends-Hermes`
+**Branch:** `feat/o7-configurable-alert-rules`
+
+This is the implementation layer of the plan — concrete file shapes, code skeletons, migration SQL, test cases. The plan owns *what + why*; this owns *exactly how*.
+
+## Hermes-first capability checklist
+
+All design decisions stay inside Vizora middleware (NestJS, TypeScript, Prisma). Hermes substrate is orthogonal as documented in the plan.
+
+| # | Step | Tag | Why |
+|---|------|-----|-----|
+| 1 | Prisma model + migration | `[net-new]` | Vizora schema |
+| 2 | `AlertRulesService` (CRUD + cross-org guard) | `[net-new]` | NestJS DI |
+| 3 | `AlertRuleEvaluator` (`@OnEvent` handler) | `[net-new]` | NestJS event bus |
+| 4 | Channel dispatchers (in_app/email/slack) | `[net-new]` | Vizora MailService + Notification table |
+| 5 | REST controller + DTOs | `[net-new]` | NestJS controllers |
+| 6 | Migration data seed for existing orgs | `[net-new]` | Prisma migrate |
+| 7 | Unit tests | `[net-new]` | Jest + mocked Prisma |
+| 8 | Module wiring (add MailModule import) | `[net-new]` | NestJS module |
+| 9 | DTO validation (class-validator) | `[net-new]` | Existing pattern |
+| 10 | SSRF allowlist for slack_webhook URL | `[net-new]` | Application logic |
+| 11 | Dedup window state on AlertRule.lastFiredAt | `[net-new]` | Prisma write |
+| 12 | Remove old hard-coded `device.offline` handler | `[net-new]` | Source delete |
+
+## Drift-rule self-checks
+
+- ✅ Read `middleware/src/modules/mail/mail.service.ts` (1-373) — `wrapInTemplate(bodyContent)` exists (lines 96-128); `sendMail(to, subject, html, label, sender)` helper at line 65; `SENDERS` const has `noreply` / `auth` / `billing` / `support` (lines 5-10); password-reset uses `sender='auth'`, billing emails use `sender='billing'`. New `sendDeviceOfflineAlertEmail` will use `sender='noreply'`.
+- ✅ Read `middleware/src/modules/notifications/notifications.controller.ts` (1-105) — `@UseGuards(RolesGuard)` at controller level; `@CurrentUser('organizationId') organizationId: string` on every endpoint; `@Roles('admin')` on POST (line 30); `ParseIdPipe` used for path params (line 13).
+- ✅ Read `middleware/src/modules/agents/onboarding.service.ts` (1-115) — canonical async-OnEvent pattern: `@OnEvent('event.name', { async: true })`, top-level try/catch in handler, fire-and-forget, `this.logger.error(msg, err.stack)`. Will replicate exactly.
+- ✅ Read `middleware/src/modules/notifications/notifications.module.ts` (1-13) — currently imports `DatabaseModule + HttpModule`. Will add `MailModule`. (App-level injection of MailService would work but explicit module import is cleaner + matches existing patterns elsewhere.)
+
+## Test discoverability — Jest config constraint
+
+Jest config at `middleware/jest.config.js:5-7` has `testPathIgnorePatterns: ['/__tests__/']` — `__tests__/` subdirs are EXCLUDED from unit test runs (used for E2E). **All new `*.spec.ts` files must be siblings of the impl files, not nested under `__tests__/`.** This is a blocker if not followed — tests would silently not run.
+
+## File layout
+
+```
+middleware/src/modules/notifications/
+├── notifications.module.ts                                          (MODIFIED — add MailModule import, register alert-rules providers/controller)
+├── notifications.service.ts                                          (MODIFIED — remove device.offline @OnEvent handler at line 277-284)
+├── alert-rules/
+│   ├── alert-rules.service.ts                                        (NEW)
+│   ├── alert-rules.controller.ts                                     (NEW)
+│   ├── alert-rule.evaluator.ts                                       (NEW)
+│   ├── alert-rule.types.ts                                           (NEW — TriggerEvent / Scope / Channel literal unions + constants)
+│   ├── dto/
+│   │   ├── create-alert-rule.dto.ts                                  (NEW)
+│   │   ├── update-alert-rule.dto.ts                                  (NEW)
+│   │   ├── create-recipient.dto.ts                                   (NEW)
+│   │   └── alert-rule-response.dto.ts                                (NEW)
+│   ├── alert-rules.service.spec.ts                                   (NEW — sibling, NOT in __tests__/)
+│   ├── alert-rules.controller.spec.ts                                (NEW)
+│   └── alert-rule.evaluator.spec.ts                                  (NEW)
+
+packages/database/prisma/
+├── schema.prisma                                                     (MODIFIED — add AlertRule + AlertRuleRecipient)
+└── migrations/<timestamp>_add_alert_rules/
+    └── migration.sql                                                 (NEW — auto-generated + manual data-seed block)
+```
+
+## Prisma schema (literal)
+
+```prisma
+model AlertRule {
+  id             String   @id @default(cuid())
+  organizationId String
+  name           String
+  triggerEvent   String                                 // "device.offline" (extensible)
+  isActive       Boolean  @default(true)
+  scope          String                                 // "all" | "tag" | "group" | "display"
+  scopeTagId     String?
+  scopeGroupId   String?
+  scopeDisplayId String?
+  minOfflineSec  Int      @default(120)
+  lastFiredAt    DateTime?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  organization Organization        @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  scopeTag     Tag?                @relation(fields: [scopeTagId],     references: [id], onDelete: SetNull)
+  scopeGroup   DisplayGroup?       @relation(fields: [scopeGroupId],   references: [id], onDelete: SetNull)
+  scopeDisplay Display?            @relation(fields: [scopeDisplayId], references: [id], onDelete: SetNull)
+  recipients   AlertRuleRecipient[]
+
+  @@unique([organizationId, name])                      // for seed idempotency + UI uniqueness
+  @@index([organizationId, isActive])
+  @@index([scopeTagId])
+  @@index([scopeGroupId])
+  @@index([scopeDisplayId])
+  @@map("alert_rules")
+}
+
+model AlertRuleRecipient {
+  id          String   @id @default(cuid())
+  alertRuleId String
+  channel     String                                    // "in_app" | "email" | "slack_webhook"
+  target      String                                    // userId | email | webhook URL
+  createdAt   DateTime @default(now())
+
+  alertRule AlertRule @relation(fields: [alertRuleId], references: [id], onDelete: Cascade)
+
+  @@index([alertRuleId])
+  @@map("alert_rule_recipients")
+}
+```
+
+**Back-relations on existing models:** Organization, Tag, DisplayGroup, Display each gain one back-relation field:
+```prisma
+model Organization {
+  ...existing fields...
+  alertRules AlertRule[]
+}
+model Tag {
+  ...existing fields...
+  alertRulesScopedHere AlertRule[]
+}
+model DisplayGroup {
+  ...existing fields...
+  alertRulesScopedHere AlertRule[]
+}
+model Display {
+  ...existing fields...
+  alertRulesScopedHere AlertRule[]
+}
+```
+
+(Prisma 5 requires explicit back-relations when relations are bidirectional. Structural reviewer noted these are optional from the *user* API perspective, but Prisma errors at generation without them when forward relations are declared.)
+
+## `alert-rule.types.ts` (literal)
+
+```ts
+export const TRIGGER_EVENTS = ['device.offline'] as const;
+export type TriggerEvent = typeof TRIGGER_EVENTS[number];
+
+export const SCOPES = ['all', 'tag', 'group', 'display'] as const;
+export type Scope = typeof SCOPES[number];
+
+export const CHANNELS = ['in_app', 'email', 'slack_webhook'] as const;
+export type Channel = typeof CHANNELS[number];
+
+export const DEDUP_WINDOW_MS = 15 * 60 * 1000;             // 15 minutes
+export const MIN_OFFLINE_SEC_FLOOR = 120;                  // matches stale-heartbeat cron threshold
+export const MAX_RECIPIENTS_PER_RULE = 20;
+export const SLACK_WEBHOOK_REGEX = /^https:\/\/hooks\.slack\.com\/services\//;
+```
+
+## `AlertRulesService` shape
+
+```ts
+@Injectable()
+export class AlertRulesService {
+  constructor(private readonly db: DatabaseService) {}
+
+  async create(orgId: string, dto: CreateAlertRuleDto): Promise<AlertRule>;     // transaction: rule + recipients
+  async findAll(orgId: string, filters?: { isActive?: boolean; triggerEvent?: TriggerEvent }): Promise<AlertRule[]>;
+  async findOne(orgId: string, id: string): Promise<AlertRule>;                  // throws NotFoundException on cross-org
+  async update(orgId: string, id: string, dto: UpdateAlertRuleDto): Promise<AlertRule>;
+  async remove(orgId: string, id: string): Promise<void>;
+  async addRecipient(orgId: string, ruleId: string, dto: CreateRecipientDto): Promise<AlertRuleRecipient>;
+  async removeRecipient(orgId: string, ruleId: string, recipientId: string): Promise<void>;
+
+  // Internal helpers
+  async findActiveForEvent(
+    orgId: string,
+    triggerEvent: TriggerEvent
+  ): Promise<(AlertRule & { recipients: AlertRuleRecipient[] })[]>;    // evaluator's query
+
+  /**
+   * Atomic CAS-style claim of the 15-min dedup window. Returns true if THIS
+   * caller successfully claimed the window (and should dispatch), false if
+   * another instance (PM2 cluster) already claimed it within the window.
+   *
+   * Implementation: updateMany({ where: { id, OR: [lastFiredAt < threshold, lastFiredAt IS NULL] }, data: { lastFiredAt: now } })
+   * — count===1 means we won the race; count===0 means we lost.
+   */
+  async tryClaimDedupWindow(ruleId: string, now: Date): Promise<boolean>;
+
+  /**
+   * Validation helper called by `create` AND `addRecipient`.
+   * For `in_app` channel: verifies target userId exists AND belongs to the same org.
+   * For `email`: validates email shape (also done at DTO layer; belt-and-braces).
+   * For `slack_webhook`: re-checks the regex.
+   * Throws ForbiddenException on cross-tenant in_app target.
+   */
+  private async validateRecipient(orgId: string, dto: { channel: Channel; target: string }): Promise<void>;
+}
+```
+
+**Cross-org guard pattern:** `findOne` uses `{ where: { id, organizationId } }` so a cross-org lookup returns null and the service throws `NotFoundException`. Tested.
+
+**Cross-tenant in_app target guard (Critical):** when `dto.channel === 'in_app'`, both `create` and `addRecipient` MUST call `validateRecipient(orgId, dto)` which loads the target userId and asserts `targetUser.organizationId === orgId`. Without this guard an org-A admin could route an `in_app` notification to an org-B userId. DTO-layer validation can't catch this because the DTO doesn't know the caller's orgId. Tested with a dedicated case.
+
+## `AlertRuleEvaluator` shape
+
+```ts
+@Injectable()
+export class AlertRuleEvaluator {
+  private readonly logger = new Logger(AlertRuleEvaluator.name);
+
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly alertRulesService: AlertRulesService,
+    private readonly mail: MailService,
+    private readonly http: HttpService,
+  ) {}
+
+  @OnEvent('device.offline', { async: true })
+  async handleDeviceOffline(payload: {
+    deviceId: string;
+    deviceName: string;
+    organizationId: string;
+  }): Promise<void> {
+    try {
+      await this.evaluate(payload);
+    } catch (err) {
+      this.logger.error(
+        `Alert rule evaluation failed for device ${payload.deviceId}`,
+        err instanceof Error ? err.stack : String(err),
+      );
+    }
+  }
+
+  private async evaluate(payload: { ... }): Promise<void> {
+    // 1. Load device with tags + group (we need these for scope-match)
+    const device = await this.db.display.findUnique({
+      where: { id: payload.deviceId },
+      include: {
+        tags:   { select: { tagId: true } },
+        groups: { select: { displayGroupId: true } },
+      },
+    });
+    if (!device) {
+      this.logger.warn(`device.offline for unknown device ${payload.deviceId} — skipping rules`);
+      return;
+    }
+
+    // 2. Load active rules
+    const rules = await this.alertRulesService.findActiveForEvent(
+      payload.organizationId,
+      'device.offline',
+    );
+
+    const now = new Date();
+    const offlineSec = device.lastHeartbeat
+      ? Math.floor((now.getTime() - device.lastHeartbeat.getTime()) / 1000)
+      : Number.POSITIVE_INFINITY;
+
+    for (const rule of rules) {
+      if (!this.scopeMatches(rule, device)) continue;
+      if (offlineSec < rule.minOfflineSec) continue;
+
+      // ATOMIC dedup claim — under PM2 cluster, two instances reading rule.lastFiredAt
+      // simultaneously and both passing the check would both dispatch. The CAS-style
+      // updateMany makes the claim atomic at the DB level: only the instance whose
+      // UPDATE affects 1 row dispatches.
+      const claimed = await this.alertRulesService.tryClaimDedupWindow(rule.id, now);
+      if (!claimed) continue;
+
+      await this.dispatchAll(rule, device, payload);
+    }
+  }
+
+  private scopeMatches(rule: AlertRule, device: { id: string; tags: {tagId:string}[]; groups: {displayGroupId:string}[] }): boolean {
+    switch (rule.scope) {
+      case 'all':     return true;
+      case 'tag':
+        if (rule.scopeTagId == null) {
+          this.logger.warn(`Rule ${rule.id} has scope=tag but scopeTagId=null (referenced Tag was deleted). Rule will never fire — consider disabling it or fixing the scope.`);
+          return false;
+        }
+        return device.tags.some(t => t.tagId === rule.scopeTagId);
+      case 'group':
+        if (rule.scopeGroupId == null) {
+          this.logger.warn(`Rule ${rule.id} has scope=group but scopeGroupId=null (referenced DisplayGroup was deleted).`);
+          return false;
+        }
+        return device.groups.some(g => g.displayGroupId === rule.scopeGroupId);
+      case 'display':
+        if (rule.scopeDisplayId == null) {
+          this.logger.warn(`Rule ${rule.id} has scope=display but scopeDisplayId=null (referenced Display was deleted).`);
+          return false;
+        }
+        return rule.scopeDisplayId === device.id;
+      default:
+        this.logger.warn(`Unknown scope ${rule.scope} on rule ${rule.id} — skipping`);
+        return false;
+    }
+  }
+
+  private async dispatchAll(rule: AlertRule & { recipients: AlertRuleRecipient[] }, device, payload): Promise<void> {
+    for (const r of rule.recipients) {
+      try {
+        switch (r.channel) {
+          case 'in_app':        await this.dispatchInApp(r, payload); break;
+          case 'email':         await this.dispatchEmail(r, payload); break;
+          case 'slack_webhook': await this.dispatchSlack(r, payload); break;
+          default:
+            this.logger.warn(`Unknown channel ${r.channel} on recipient ${r.id} — skipping`);
+        }
+      } catch (err) {
+        this.logger.error(
+          `Recipient dispatch failed (rule=${rule.id}, recipient=${r.id}, channel=${r.channel})`,
+          err instanceof Error ? err.stack : String(err),
+        );
+      }
+    }
+  }
+
+  private async dispatchInApp(r, payload): Promise<void> {
+    await this.db.notification.create({
+      data: {
+        organizationId: payload.organizationId,
+        userId: r.target,                    // recipient user id
+        type: 'device_offline',
+        severity: 'warning',
+        title: 'Device offline',
+        message: `${payload.deviceName} is offline`,
+        metadata: { deviceId: payload.deviceId },
+      },
+    });
+  }
+
+  private async dispatchEmail(r, payload): Promise<void> {
+    await this.mail.sendDeviceOfflineAlertEmail(r.target, payload.deviceName);
+  }
+
+  private async dispatchSlack(r, payload): Promise<void> {
+    if (!SLACK_WEBHOOK_REGEX.test(r.target)) {
+      // SSRF guard: defense in depth — DTO validates at create-time, but a tampered
+      // record or an admin who pasted a non-Slack URL via direct DB write is rejected here.
+      this.logger.error(`Slack webhook ${r.id} rejected at dispatch — URL fails allowlist`);
+      return;
+    }
+    // SSRF defense: maxRedirects=0 prevents Slack 302 → attacker chain.
+    // timeout=5000 prevents slow-loris hold-open.
+    await firstValueFrom(this.http.post(
+      r.target,
+      { text: `🔴 *${escapeSlackText(payload.deviceName)}* is offline` },
+      { maxRedirects: 0, timeout: 5000 },
+    ));
+  }
+}
+
+// Helper (lives in alert-rule.types.ts or alongside the evaluator):
+// Slack `text` field renders backticks/`*_~|` as markdown. Escape user-controlled
+// names before interpolation so a device named "*pwn*" doesn't break the layout.
+export function escapeSlackText(s: string): string {
+  return s.replace(/[`*_~|]/g, (c) => `\\${c}`);
+}
+```
+
+## `AlertRulesController` shape
+
+```ts
+@UseGuards(RolesGuard)
+@Controller('notifications/alert-rules')
+export class AlertRulesController {
+  constructor(private readonly service: AlertRulesService) {}
+
+  @Post()
+  create(@CurrentUser('organizationId') orgId: string, @Body() dto: CreateAlertRuleDto) {
+    return this.service.create(orgId, dto);
+  }
+
+  @Get()
+  findAll(@CurrentUser('organizationId') orgId: string, @Query() q: ListAlertRulesQueryDto) {
+    return this.service.findAll(orgId, q);
+  }
+
+  @Get(':id')
+  findOne(@CurrentUser('organizationId') orgId: string, @Param('id', ParseIdPipe) id: string) {
+    return this.service.findOne(orgId, id);
+  }
+
+  @Patch(':id')
+  @Roles('admin')                                                  // <-- gated: PATCH can flip isActive, change scope, change minOfflineSec — effectively rule disablement
+  update(@CurrentUser('organizationId') orgId: string, @Param('id', ParseIdPipe) id: string, @Body() dto: UpdateAlertRuleDto) {
+    return this.service.update(orgId, id, dto);
+  }
+
+  @Delete(':id')
+  @Roles('admin')                                                  // <-- gated per plan revision
+  @HttpCode(HttpStatus.NO_CONTENT)
+  remove(@CurrentUser('organizationId') orgId: string, @Param('id', ParseIdPipe) id: string) {
+    return this.service.remove(orgId, id);
+  }
+
+  @Post(':id/recipients')
+  @Roles('admin')                                                  // <-- gated: adding a recipient is privileged (could route alerts to attacker)
+  addRecipient(@CurrentUser('organizationId') orgId: string, @Param('id', ParseIdPipe) id: string, @Body() dto: CreateRecipientDto) {
+    return this.service.addRecipient(orgId, id, dto);
+  }
+
+  @Delete(':id/recipients/:recipientId')
+  @Roles('admin')                                                  // <-- gated per plan revision
+  @HttpCode(HttpStatus.NO_CONTENT)
+  removeRecipient(
+    @CurrentUser('organizationId') orgId: string,
+    @Param('id', ParseIdPipe) id: string,
+    @Param('recipientId', ParseIdPipe) recipientId: string,
+  ) {
+    return this.service.removeRecipient(orgId, id, recipientId);
+  }
+}
+```
+
+## DTOs (class-validator)
+
+```ts
+// create-alert-rule.dto.ts
+export class CreateRecipientInlineDto {
+  @IsIn(CHANNELS)
+  channel!: Channel;
+
+  @IsString()
+  @MaxLength(2000)
+  @ValidateIf((o) => o.channel === 'slack_webhook')
+  @Matches(SLACK_WEBHOOK_REGEX, { message: 'slack_webhook target must match https://hooks.slack.com/services/' })
+  target!: string;
+}
+
+export class CreateAlertRuleDto {
+  @IsString() @MinLength(1) @MaxLength(120)
+  name!: string;
+
+  @IsIn(TRIGGER_EVENTS)
+  triggerEvent!: TriggerEvent;
+
+  @IsIn(SCOPES)
+  scope!: Scope;
+
+  @ValidateIf((o) => o.scope === 'tag')      @IsString() scopeTagId?: string;
+  @ValidateIf((o) => o.scope === 'group')    @IsString() scopeGroupId?: string;
+  @ValidateIf((o) => o.scope === 'display')  @IsString() scopeDisplayId?: string;
+
+  @IsInt() @Min(MIN_OFFLINE_SEC_FLOOR)
+  minOfflineSec: number = MIN_OFFLINE_SEC_FLOOR;
+
+  @IsArray() @ArrayMinSize(1) @ArrayMaxSize(MAX_RECIPIENTS_PER_RULE)
+  @ValidateNested({ each: true }) @Type(() => CreateRecipientInlineDto)
+  recipients!: CreateRecipientInlineDto[];
+
+  @IsBoolean() @IsOptional()
+  isActive?: boolean;
+}
+```
+
+`UpdateAlertRuleDto` = `PartialType(CreateAlertRuleDto)` minus `recipients` (recipients are managed via the dedicated endpoints).
+
+## New MailService method (literal addition)
+
+Append to `mail.service.ts` after `sendPasswordResetEmail`:
+
+```ts
+async sendDeviceOfflineAlertEmail(to: string, deviceName: string): Promise<void> {
+  const subject = `Device offline: ${deviceName}`;
+  const html = this.wrapInTemplate(`
+        <h1 style="color:#F0ECE8;font-size:22px;font-weight:700;margin:0 0 8px 0;">Device offline</h1>
+        <p style="color:#8A9BA3;font-size:14px;line-height:1.6;margin:0 0 24px 0;">
+          The display <strong style="color:#F0ECE8;">${escapeHtml(deviceName)}</strong> is currently offline.
+          You're receiving this because an alert rule on your Vizora account matches this device.
+        </p>
+        ${this.ctaButton('View Devices', `${this.appUrl}/dashboard/devices`)}
+        <p style="color:#5A6B73;font-size:12px;line-height:1.5;margin:16px 0 0 0;">
+          Manage your alert rules in Settings &rarr; Alerts.
+        </p>
+  `);
+  await this.sendMail(to, subject, html, 'Device offline alert', 'noreply');
+}
+```
+
+`escapeHtml` is a tiny helper added to `mail.service.ts` to escape device names in HTML (XSS defense — device names are user-controlled). Implementation: standard `&`/`<`/`>`/`"`/`'` replacement.
+
+## Migration approach (verified)
+
+**Decision:** `gen_random_uuid()` is NOT used anywhere in `packages/database/prisma/migrations/` (verified by grep). The codebase uses Prisma's `@default(cuid())` (application-side CUID generation). So the data seed cannot use a raw SQL CTE — the IDs would have a different shape from Prisma-generated CUIDs.
+
+**Approach:** Two migrations.
+
+1. **`<ts>_add_alert_rules`** — Prisma-generated schema migration only (tables, indexes, FKs). No data step.
+2. **`<ts+1>_seed_default_alert_rules`** — a custom migration that includes a Prisma-client-side data seed step. The seed runs as part of the migration's lifecycle (e.g. via a TS script invoked from the migration directory, or a separate one-shot npx script we document and run at deploy time).
+
+**Seed script (TypeScript, runs once at deploy):**
+
+```ts
+// packages/database/scripts/seed-default-alert-rules.ts
+import { PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient();
+
+async function main() {
+  const orgs = await prisma.organization.findMany({ select: { id: true } });
+  for (const org of orgs) {
+    const admins = await prisma.user.findMany({
+      where: { organizationId: org.id, role: 'admin' },
+      select: { id: true },
+    });
+
+    // Idempotent: skip if a rule with this name already exists (the unique index enforces it)
+    const existing = await prisma.alertRule.findUnique({
+      where: { organizationId_name: { organizationId: org.id, name: 'Default offline alert (auto-migrated)' } },
+    });
+    if (existing) continue;
+
+    await prisma.alertRule.create({
+      data: {
+        organizationId: org.id,
+        name: 'Default offline alert (auto-migrated)',
+        triggerEvent: 'device.offline',
+        isActive: true,
+        scope: 'all',
+        minOfflineSec: 120,
+        recipients: { create: admins.map(a => ({ channel: 'in_app', target: a.id })) },
+      },
+    });
+
+    if (admins.length === 0) {
+      console.log(`[seed] org=${org.id} has no admins — default rule created with 0 recipients (no-op until admins added)`);
+    }
+  }
+}
+
+main().finally(() => prisma.$disconnect());
+```
+
+Invoke at deploy time: `npx tsx packages/database/scripts/seed-default-alert-rules.ts`. Document in `docs/runbooks/deploy.md` as a post-migration step (one-time, idempotent — safe to re-run).
+
+## Module wiring (literal diff)
+
+`notifications.module.ts`:
+
+```diff
+ import { Module } from '@nestjs/common';
+ import { HttpModule } from '@nestjs/axios';
+ import { NotificationsController } from './notifications.controller';
+ import { NotificationsService } from './notifications.service';
+ import { DatabaseModule } from '../database/database.module';
++import { MailModule } from '../mail/mail.module';
++import { AlertRulesController } from './alert-rules/alert-rules.controller';
++import { AlertRulesService }    from './alert-rules/alert-rules.service';
++import { AlertRuleEvaluator }   from './alert-rules/alert-rule.evaluator';
+
+ @Module({
+-  imports: [DatabaseModule, HttpModule],
+-  controllers: [NotificationsController],
+-  providers: [NotificationsService],
+-  exports: [NotificationsService],
++  imports: [DatabaseModule, HttpModule, MailModule],
++  controllers: [NotificationsController, AlertRulesController],
++  providers: [NotificationsService, AlertRulesService, AlertRuleEvaluator],
++  exports: [NotificationsService, AlertRulesService],
+ })
+ export class NotificationsModule {}
+```
+
+## Removal of old handler
+
+`notifications.service.ts`:
+- Delete lines 274-284 (the `@OnEvent('device.offline') handleDeviceOffline` method + its `/** ... */` doc)
+- Keep lines 262-272 (`@OnEvent('device.online') handleDeviceOnline`) — `device.online` recovery alerts are out of scope per the plan
+- Delete the corresponding test block in `middleware/src/modules/notifications/notifications.service.spec.ts` (test reviewer confirmed: lines 369-398, `describe('createDeviceOfflineNotification', ...)` — verify exact range during build before deleting)
+- Keep `createDeviceOfflineNotification` factory method only IF it's still used by the new evaluator; otherwise delete it too. Decision at build time once the evaluator's `dispatchInApp` is wired — the evaluator inlines the Notification creation, so the helper is likely dead-code-eligible.
+
+## Test plan
+
+### `alert-rules.service.spec.ts` (~14 cases)
+- `create` happy path → rule + N recipients in one transaction
+- `create` with `MAX_RECIPIENTS_PER_RULE + 1` recipients → 400 (DTO rejects)
+- `create` with `in_app` recipient referencing a userId from another org → ForbiddenException (the cross-tenant guard)
+- `findOne` with foreign orgId → NotFoundException
+- `update` with foreign orgId → NotFoundException
+- `remove` with foreign orgId → NotFoundException (cross-org guard)
+- `findActiveForEvent` filters by isActive + triggerEvent
+- `addRecipient` happy path
+- `addRecipient` with `in_app` target from another org → ForbiddenException
+- `removeRecipient` with foreign orgId → NotFoundException
+- `tryClaimDedupWindow` returns true on first call within window
+- `tryClaimDedupWindow` returns false on second call within window (atomic CAS verified via setting lastFiredAt in fixture)
+- `tryClaimDedupWindow` returns true after window elapses
+
+### `alert-rule.evaluator.spec.ts` (~19 cases)
+- Unknown device id → skip (warn logged)
+- Device with `lastHeartbeat=null` (never sent heartbeat) → `offlineSec=Infinity` → fires any rule with minOfflineSec >= 120
+- No active rules → no-op
+- `scope=all` matches every device in org
+- `scope=tag` matches device with that tag, skips device without
+- `scope=tag` with `scopeTagId=null` (Tag was deleted, SetNull tripped) → skip with WARN log
+- `scope=group` matches device in that group; `scopeGroupId=null` → skip with WARN log
+- `scope=display` matches only that specific display; `scopeDisplayId=null` → skip with WARN log
+- `minOfflineSec=300` and device offline 200s → skip
+- `minOfflineSec=300` and device offline 400s → fire
+- Atomic dedup: `tryClaimDedupWindow` returns false → skip dispatch even if scope matches
+- Atomic dedup: same rule fires for device A; then fires for device B within 15min → BOTH events evaluate the rule; second one's `tryClaimDedupWindow` returns false (rule-level dedup is intentional — documented limitation, see plan)
+- Rule with `isActive=true` but zero recipients → no error, no notifications, no warn (silent no-op)
+- One recipient throws (e.g. `in_app` target userId no longer exists → FK error) → other recipients still dispatch (per-recipient try/catch)
+- `slack_webhook` with non-Slack URL at dispatch time → log error + skip dispatch (defense in depth even though DTO validates)
+- Slack dispatch includes `maxRedirects: 0` and `timeout: 5000` (verified via HttpService mock spy)
+- All three channels dispatch independently (assert each was called exactly once on same rule)
+- `device.online` events do NOT invoke this evaluator (only `device.offline` decorator)
+- Top-level try/catch swallows DB failure → no unhandled rejection
+
+### `alert-rules.controller.spec.ts` (~14 cases)
+- `POST /alert-rules` happy path (logged-in non-admin user can create)
+- `POST /alert-rules` bad DTO (`minOfflineSec=60` below floor) → 400
+- `POST /alert-rules` with `slack_webhook` non-Slack URL → 400
+- `GET /alert-rules` returns only this org's rules
+- `GET /alert-rules/:id` cross-org → 404
+- `GET /alert-rules/:id` happy path
+- `PATCH /alert-rules/:id` as non-admin → 403 (RolesGuard)
+- `PATCH /alert-rules/:id` as admin → 200 + updatedAt timestamp moved
+- `PATCH /alert-rules/:id` cross-org → 404
+- `DELETE /alert-rules/:id` non-admin → 403
+- `DELETE /alert-rules/:id` admin → 204
+- `POST /alert-rules/:id/recipients` as non-admin → 403
+- `POST /alert-rules/:id/recipients` admin happy path
+- `DELETE /alert-rules/:id/recipients/:rid` cross-org → 404
+
+## Risks discovered during design
+
+1. **`gen_random_uuid()` is unused in repo** — RESOLVED: switched to a TypeScript Prisma-client seed script (`packages/database/scripts/seed-default-alert-rules.ts`) invoked as a documented post-migration deploy step.
+2. **`HttpModule` already in NotificationsModule but no current consumer** — the Slack dispatch will be the first real use. No risk; just noting.
+3. **`escapeHtml` helper is net-new in MailService** — small, but new utility. Will live as a private method on MailService (not exported).
+4. **`AlertRule.lastFiredAt` race condition under PM2 cluster (2 instances)** — RESOLVED: switched to atomic CAS via `tryClaimDedupWindow`. Only the instance whose `updateMany(where: lastFiredAt < threshold OR null)` returns count=1 dispatches.
+5. **Test suite size growth** — ~47 new test cases (revised after design review). Existing middleware suite is 2335 tests; impact is +2%. Negligible.
+6. **Per-device vs per-rule dedup semantics** — dedup is per-rule, not per-(rule, device). The 15-min window applies to the rule as a whole. If a single rule with `scope=all` fires for device A, then 5 min later device B goes offline, the rule will NOT fire for B. This is intentional v1 behavior (prevents alert storms during a region-wide outage). Per-(rule, device) dedup is a fast-follow if customers report missed alerts.
+
+## Build sequence (commits)
+
+1. `feat(db): add AlertRule + AlertRuleRecipient models + migration + seed script`
+2. `feat(mail): sendDeviceOfflineAlertEmail + escapeHtml helper`
+3. `feat(notifications): alert-rules types + DTOs + AlertRulesService + tests`
+4. `feat(notifications): AlertRuleEvaluator + tests + remove hard-coded device.offline handler`
+5. `feat(notifications): AlertRulesController + tests + wire in NotificationsModule`
+
+If a commit's tests reveal a bug, fix is its own commit, never `--amend`.
+
+## Acceptance criteria (refined from plan + reviews)
+
+- [ ] All 4 new file types compile with `tsc --noEmit`
+- [ ] All ~47 new test cases pass (revised after review)
+- [ ] Existing 2335-test middleware suite has 0 regressions
+- [ ] Migration applies forward + reset cleanly on a dev DB
+- [ ] `npx tsx packages/database/scripts/seed-default-alert-rules.ts` runs idempotently and seeds one default rule + N admin recipients per existing org (verified via Prisma client query)
+- [ ] Manually fire `device.offline` via `eventEmitter.emit(...)` from a debug REPL → in-app notification appears + email logged in DEV mode
+- [ ] Cross-org isolation: rule in org A doesn't fire for org B's device (covered by evaluator unit test)
+- [ ] Cross-tenant in_app guard: POST recipient with userId from another org returns 403 (service test)
+- [ ] SSRF guard: POST recipient with `http://internal/...` returns 400 (DTO test); Slack dispatch uses `maxRedirects:0` + `timeout:5000`
+- [ ] DELETE rule as non-admin returns 403; PATCH rule as non-admin returns 403; POST recipient as non-admin returns 403 (controller tests)
+- [ ] Atomic dedup: two simulated evaluator instances racing → exactly one dispatches (service test)
+- [ ] Test files are SIBLINGS of impl files (NOT in `__tests__/` — Jest excludes that dir per `middleware/jest.config.js:5-7`)

--- a/tasks/plans/o7-configurable-alert-rules-plan.md
+++ b/tasks/plans/o7-configurable-alert-rules-plan.md
@@ -1,0 +1,233 @@
+# O7 — Configurable Downtime Alert Rules — Plan
+
+**Date:** 2026-05-19
+**Audit ref:** P1 #6 (`docs/plans/2026-05-17-optsigns-vizora-feature-gap.md`)
+**Backlog ref:** `backlog.md` → "OptiSigns Parity Roadmap" → O7
+**Branch:** `feat/o7-configurable-alert-rules`
+**Effort:** S (1.5 dev-days — revised after plan review; original 1d understated test + email work)
+**Drift-check tag:** `extends-Hermes`
+
+This work builds Vizora middleware infrastructure for a domain Hermes does not own (NestJS event bus + Prisma schema + HTTP surface). Hermes substrate (WhatsApp ingestion, vision, skill dispatch, multi-channel response from a Python runtime) is orthogonal. Future agents that want to *read* these rules can do so via a new MCP tool over the same table; the table + evaluator themselves live in middleware. See `tasks/.hermes-check-receipts/o7-configurable-alert-rules.json` for the per-step checklist receipt.
+
+## Hermes-first capability checklist
+
+Per `CLAUDE.md §7b`. All 12 steps of the end-to-end flow are `[net-new]` against the Hermes capability list because this is Vizora *platform/middleware* work, not *agent* work. The Hermes capabilities (WhatsApp ingest, vision OCR, skill chain, log-decision-direct, etc.) operate inside the Hermes Python runtime — none of them substitute for NestJS `@OnEvent`, Prisma queries, or Vizora's MailService.
+
+| # | Step | Tag | Why |
+|---|------|-----|-----|
+| 1 | Stale-device sweep emits `device.offline` event (existing `displays.service.ts:305-332`) | `[net-new]` | Vizora middleware cron + Redis state — Hermes substrate cannot reach |
+| 2 | `AlertRuleEvaluator` `@OnEvent('device.offline')` handler | `[net-new]` | NestJS decorator, not Hermes skill dispatch |
+| 3 | Prisma query against new `AlertRule` table | `[net-new]` | Vizora Prisma schema, not Hermes per-VPS state |
+| 4 | Scope matching (all / tag / group / display) | `[net-new]` | Vizora domain (Tag, DisplayGroup, Display) |
+| 5 | `minOfflineSec` debounce + 15-min dedup window | `[net-new]` | Application logic in TypeScript |
+| 6 | Recipient dispatch — `in_app` channel | `[net-new]` | Vizora's `Notification` table; not Hermes audit chain |
+| 7 | Recipient dispatch — `email` channel | `[net-new]` | Vizora `MailService` (SMTP/Resend); Hermes email is *from* the Hermes runtime, not from inside NestJS |
+| 8 | Recipient dispatch — `slack_webhook` channel | `[net-new]` | Direct HTTPS POST; Hermes has no Slack channel |
+| 9 | REST CRUD endpoints under `/api/v1/notifications/alert-rules` | `[net-new]` | NestJS controllers |
+| 10 | Zod/class-validator DTO validation | `[net-new]` | NestJS standard; existing pattern |
+| 11 | Prisma migration + data seed (preserve historical behavior) | `[net-new]` | Vizora Prisma migration scripts |
+| 12 | Remove hard-coded `handleDeviceOffline` in `notifications.service.ts:277` | `[net-new]` | Vizora source change |
+
+**Red-flag check:** 12/12 `[net-new]` is the correct disposition. Re-examined common misses (state files → using Prisma not Hermes SKILL state; audit rows → existing `AuditLog` interceptor stays; operator script → CRUD via REST; input validation → DTO layer). Hermes is not a substitute for NestJS+Prisma here.
+
+## Drift-rule self-checks
+
+Per `CLAUDE.md §7a`: read deployed code before drafting schema/handler/tests.
+
+- ✅ Read `packages/database/prisma/schema.prisma` (Organization at line 17; Display at line 118; DisplayGroup at line 160; Tag at line 352; DisplayTag at line 383; Notification at line 454) — confirmed model shapes, relations, and indexes used in scope-match path
+- ✅ Read `middleware/src/modules/notifications/notifications.service.ts` (lines 260-302 — existing `@OnEvent('device.online')` and `@OnEvent('device.offline')` handlers; only the `device.offline` handler is being replaced)
+- ✅ Read `middleware/src/modules/displays/displays.service.ts` (lines 280-332 — confirmed `device.offline` is emitted from `detectOfflineDevices()` cron with payload `{ deviceId, deviceName, organizationId }`; **field is `lastHeartbeat` not `lastSeenAt`**; threshold is hardcoded 2 minutes, so `minOfflineSec` below 120 is meaningless — documented below)
+- ✅ Read `middleware/src/app/app.module.ts` (lines 36-56 — `EventEmitterModule.forRoot({ ignoreErrors: false, verboseMemoryLeak: true })`; the INVARIANT in the comment says async handlers must wrap in try/catch — applied below)
+
+## Problem
+
+Today every org user receives the same in-app `device.offline` notification when any display in their org transitions to offline. This is fired by a hard-coded `@OnEvent('device.offline')` handler at `middleware/src/modules/notifications/notifications.service.ts:277`. There is:
+
+- No way to route alerts to specific recipients (only the store-ops team, not the whole org)
+- No way to scope by tag (only lobby displays) or by display group
+- No way to add a debounce / minimum-duration threshold (one flap → one alert)
+- No way to send to external channels (email, Slack webhook) instead of / in addition to in-app
+- No way to disable alerts for specific displays without disabling the org-wide handler
+
+OptiSigns customers running multi-region fleets need these. So do Vizora customers, but until now there was nowhere to express the rule.
+
+## Goals
+
+1. Replace the hard-coded `device.offline` handler with a **rule-driven evaluator** that reads `AlertRule` rows for the org and dispatches notifications per rule.
+2. Each rule defines: scope (all / tag / group / display), recipients (in-app + email + Slack webhook), and a minimum-offline-duration threshold.
+3. Migration seeds a default rule per existing org → existing behavior preserved.
+4. Provide CRUD API for rules.
+
+## Non-goals (out of scope for this PR)
+
+- `device.online` recovery alerts (defer — most ops teams want offline only; future `triggerEvent` enum extension)
+- Quiet hours / day-of-week schedules (would require an `AlertSchedule` model — defer)
+- Per-rule escalation chains ("if not ack'd in 15 min, page on-call") — defer
+- Per-recipient delivery preferences / unsubscribe — defer
+- SMS / PagerDuty / Opsgenie — out of scope; Slack webhook is the bridge
+
+## Affected files (predicted)
+
+```
+packages/database/prisma/schema.prisma                                       (add AlertRule + AlertRuleRecipient models)
+packages/database/prisma/migrations/<timestamp>_add_alert_rules/migration.sql
+middleware/src/modules/notifications/notifications.module.ts                 (wire new providers)
+middleware/src/modules/notifications/notifications.service.ts                (REMOVE hard-coded device.offline handler)
+middleware/src/modules/notifications/alert-rules/alert-rules.service.ts      (NEW)
+middleware/src/modules/notifications/alert-rules/alert-rules.controller.ts   (NEW)
+middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.ts     (NEW — owns @OnEvent handler)
+middleware/src/modules/notifications/alert-rules/dto/*.ts                    (NEW — DTOs)
+middleware/src/modules/notifications/alert-rules/__tests__/*.spec.ts         (NEW)
+```
+
+## Schema (Prisma)
+
+```prisma
+model AlertRule {
+  id             String   @id @default(cuid())
+  organizationId String
+  name           String                        // user-facing label
+  triggerEvent   String                        // enum-like: "device.offline" (extensible)
+  isActive       Boolean  @default(true)
+  scope          String                        // "all" | "tag" | "group" | "display"
+  scopeTagId     String?                       // FK to Tag — when scope="tag"
+  scopeGroupId   String?                       // FK to DisplayGroup — when scope="group"
+  scopeDisplayId String?                       // FK to Display — when scope="display"
+  minOfflineSec  Int      @default(120)        // debounce; minimum 120 because the stale-heartbeat cron threshold is 2min
+  recipients     AlertRuleRecipient[]
+  lastFiredAt    DateTime?                     // dedup window
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  organization Organization  @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  scopeTag     Tag?          @relation(fields: [scopeTagId], references: [id], onDelete: SetNull)
+  scopeGroup   DisplayGroup? @relation(fields: [scopeGroupId], references: [id], onDelete: SetNull)
+  scopeDisplay Display?      @relation(fields: [scopeDisplayId], references: [id], onDelete: SetNull)
+
+  @@index([organizationId, isActive])
+  @@index([scopeTagId])
+  @@index([scopeGroupId])
+  @@index([scopeDisplayId])
+  @@map("alert_rules")
+}
+
+model AlertRuleRecipient {
+  id          String   @id @default(cuid())
+  alertRuleId String
+  channel     String                        // "in_app" | "email" | "slack_webhook"
+  target      String                        // userId (in_app) | email | webhook URL
+  createdAt   DateTime @default(now())
+
+  alertRule AlertRule @relation(fields: [alertRuleId], references: [id], onDelete: Cascade)
+
+  @@index([alertRuleId])
+  @@map("alert_rule_recipients")
+}
+```
+
+**`minOfflineSec` floor of 120:** the stale-heartbeat cron at `displays.service.ts:305-332` only emits `device.offline` once a device's `lastHeartbeat` is >2 min stale. Setting `minOfflineSec < 120` does nothing extra. The DTO layer rejects values <120 with a 400.
+
+**Two-table over JSON column for recipients:** simpler queries ("find rules emailing X"), referential integrity for in-app channel, easier to extend (per-recipient quiet-hours later).
+
+**String not enum for `triggerEvent` / `scope` / `channel`:** Prisma `String` keeps schema flexible for `device.online` / `content.expired` / `storage.full` extensions without migrations. Validated at DTO layer.
+
+## Service shape
+
+`AlertRulesService` (org-scoped CRUD):
+- `create(orgId, dto)` — rule + recipients in transaction
+- `findAll(orgId, { isActive?, triggerEvent? })`
+- `findOne(orgId, id)` — cross-org guard via compound where
+- `update(orgId, id, dto)`
+- `remove(orgId, id)`
+- `addRecipient(orgId, ruleId, dto)`
+- `removeRecipient(orgId, ruleId, recipientId)`
+
+`AlertRuleEvaluator`:
+- `@OnEvent('device.offline')` handler — takes over from `notifications.service.ts:277`
+- Wrapped in `try/catch` per `app.module.ts:42-54` INVARIANT — uncaught rejection becomes process error under PM2
+- Loads active rules: `WHERE organizationId = ? AND triggerEvent = 'device.offline' AND isActive = true`
+- For each rule:
+  - Match scope against the offline device (skip if no match)
+  - Check `minOfflineSec` against `now - device.lastHeartbeat` (skip if below threshold). NB: by the time the event fires, the cron has already passed its own 120s threshold, so most rules with `minOfflineSec=120` will trivially match
+  - Check dedup: if `lastFiredAt > now - 15min` for this rule, skip
+  - Dispatch to each recipient with per-recipient try/catch (one failure doesn't kill others)
+    - `in_app` → insert `Notification` row scoped to `recipient.target` (= userId) — reuses existing Notification schema, not the old broadcast helper
+    - `email` → new `MailService.sendAlertEmail(to, rule, device)` method that inlines HTML via the existing `wrapInTemplate(bodyContent)` pattern (no new `.hbs` file — Vizora's MailService inlines HTML in TS, see `sendPasswordResetEmail` for the precedent)
+    - `slack_webhook` → POST to recipient.target with `{"text": "..."}` shape
+  - Update `lastFiredAt = now`
+
+**Dedup constant:** `DEDUP_WINDOW_MS = 15 * 60 * 1000` (hard-coded v1; per-rule override is a future enhancement).
+
+## Controller / API
+
+```
+POST   /api/v1/notifications/alert-rules                — create rule + recipients
+GET    /api/v1/notifications/alert-rules                — list (filter: isActive, triggerEvent)
+GET    /api/v1/notifications/alert-rules/:id            — detail
+PATCH  /api/v1/notifications/alert-rules/:id            — update
+DELETE /api/v1/notifications/alert-rules/:id            — hard delete (cascades to recipients)
+POST   /api/v1/notifications/alert-rules/:id/recipients
+DELETE /api/v1/notifications/alert-rules/:id/recipients/:recipientId
+```
+
+All under existing `JwtAuthGuard` + org-scope via `@CurrentUser('organizationId')` decorator (existing pattern, confirmed in `notifications.controller.ts:29-32`).
+
+RBAC:
+- `POST` / `GET` / `PATCH` / `POST recipients` — any logged-in org user (allows team self-service)
+- `DELETE` rule + `DELETE recipient` — gated behind `@Roles('admin')` to prevent accidental teardown of admin-configured rules (matches the pattern on `notifications.controller.ts` manual-notification create at lines 29-31)
+
+(Future: full `manage:alerts` permission once O9 lands.)
+
+## Migration / behavior change
+
+**Behavior change:** today every org gets implicit alerts; post-deploy only orgs with explicit rules do.
+
+**Mitigation:** the migration includes a data step that seeds a default `AlertRule` per existing org:
+- `name = "Default offline alert (auto-migrated)"`
+- `scope = "all"`, `triggerEvent = "device.offline"`, `isActive = true`, `minOfflineSec = 120`
+- One recipient per org admin (channel=`in_app`, target=admin's userId)
+
+Preserves existing per-admin in-app notification behavior 1:1. New orgs created after deploy get no default rule.
+
+**Zero-admin orgs:** an org with no users having `role='admin'` gets the AlertRule row created but zero recipients. The evaluator iterates zero recipients → no-op. Logged at INFO level so post-deploy ops can spot orgs that need a manual recipient added.
+
+**Idempotency:** seed runs as raw SQL `INSERT ... ON CONFLICT DO NOTHING` keyed on `(organizationId, name)`.
+
+## Tests
+
+Unit (Jest, mocked DB):
+- `alert-rules.service.spec.ts` — CRUD + cross-org guard (any operation with wrong orgId → NotFound)
+- `alert-rule.evaluator.spec.ts` — fires/skips per scope; dedup window; per-recipient try/catch; debounce threshold; SSRF guard rejects non-Slack hosts
+- `alert-rules.controller.spec.ts` — happy path + 404 cross-org + 400 bad DTO
+
+Removed:
+- The existing `handleDeviceOffline` unit tests in `notifications.service.spec.ts` (handler being deleted)
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Behavior change to existing orgs | Data migration seeds default rule per org |
+| Webhook target is hostile URL (SSRF) | Validate `slack_webhook` target against `^https://hooks\.slack\.com/services/` regex; reject anything else for v1. **Channel expansion to PagerDuty / Discord / Teams is deferred** — each needs its own URL allowlist, payload shape, and integration tests; explicit follow-up PR required |
+| Email storm from misconfigured rule | 15-min dedup per (rule, device); `MAX_RECIPIENTS_PER_RULE = 20` enforced at DTO layer |
+| Cascade delete: rule deleted while evaluator running | Evaluator loads snapshot at event time; in-flight dispatches complete using snapshot |
+| Scope FK target deleted (tag/group/display) | `onDelete: SetNull` + evaluator skips with `WARN` log when scope=tag but scopeTagId=null |
+| Uncaught rejection in async `@OnEvent` | Per `app.module.ts:42-54` INVARIANT — wrap handler body in try/catch (existing pattern; copy from `OnboardingService`) |
+| `minOfflineSec` set below 120 (no extra debounce because cron threshold) | DTO validation rejects values <120 with 400 |
+| O1 (unified push) ships first and changes `Tag` / `DisplayTag` schema | Both O1 and O7 query `DisplayTag` for scope matching. Treat tag schema as a contract — coordinate any change to it across both PRs. If O1 lands first, re-verify O7's scope-tag query shape before merging |
+
+## Acceptance criteria
+
+- [ ] Migration applies cleanly forward (Prisma migrate dev) AND reset
+- [ ] All new unit tests pass; no existing tests regress
+- [ ] `tsc --noEmit` clean on middleware
+- [ ] One default rule seeded per existing org (verified in dev DB)
+- [ ] Emit `device.offline` in dev → recipient gets in-app notification matching pre-O7 behavior
+- [ ] Cross-org isolation verified (rule in org A doesn't fire for org B's device)
+- [ ] SSRF guard verified by test (reject `http://internal/...`)
+
+## Open questions (to resolve in design phase)
+
+1. **Should `in_app` recipient `target` be a `userId` or `null` (= all org users)?** Lean: explicit `userId`; UI can offer "All org admins" as a sugar option expanded at create-time.
+2. **Slack webhook payload shape — reuse `scripts/ops/lib/alerting.ts` Slack helper or inline?** Lean: minimal inline payload `{"text": "..."}` for v1; share later if both grow.
+3. **Should the seed-default-rule migration retain the existing in-app handler as a fallback?** Lean: no — clean cutover with data migration. Falling back means two code paths.


### PR DESCRIPTION
## Summary
- Replaces the hard-coded `@OnEvent('device.offline')` handler in `notifications.service.ts:277` with a rule-driven evaluator.
- New `AlertRule` + `AlertRuleRecipient` Prisma models: per-org rules with scope (all / tag / group / display), recipient channels (in_app / email / slack_webhook), `minOfflineSec` debounce (floor 120s — matches the stale-heartbeat cron threshold), atomic 15-min dedup window.
- New REST API under `/api/v1/notifications/alert-rules` — CRUD + add/remove recipients. PATCH + DELETE + recipient mutations gated behind `@Roles('admin')`.
- Migration data-seed script preserves historical broadcast-to-all-admins behavior 1:1 for existing orgs.

First slice of the **OptiSigns Parity Roadmap** in `backlog.md` (audit ref: `docs/plans/2026-05-17-optsigns-vizora-feature-gap.md` P1 #6). Closes the audit gap "configurable downtime alert rules per tag/group with custom recipients."

## Test plan
- [x] 61 new unit tests across mail (7), alert-rules service (20), evaluator (21), controller (14) — see commits 2-5.
- [x] Full middleware suite: **125 / 125 suites, 2396 / 2396 tests pass, zero regressions** (baseline was 2335 — gain of +61).
- [x] `tsc --noEmit` clean on middleware.
- [x] Cross-tenant guard verified: an org-A admin cannot route `in_app` notifications to an org-B userId.
- [x] Atomic CAS dedup verified: two simulated instances racing — exactly one dispatches.
- [x] SSRF defense verified: non-Slack webhook URL rejected at DTO time AND at dispatch time; Slack POST uses `maxRedirects:0` + `timeout:5000`.
- [x] Slack markdown escape: device names with `*_~|`backtick rendered safely.
- [x] RBAC: PATCH/DELETE/recipient mutations carry `@Roles('admin')` metadata (verified via Reflector).

## Deployment notes
- Run the migration: `npx prisma migrate deploy` from `packages/database/`.
- Then run the seed ONCE: `npx tsx packages/database/scripts/seed-default-alert-rules.ts` to preserve historical behavior for existing orgs. Idempotent — safe to re-run.
- Zero-admin orgs get a default rule with zero recipients (logged at INFO).

## Plan + design artifacts
- `tasks/plans/o7-configurable-alert-rules-plan.md` — plan, reviewed by 2 parallel agents (structural + strategy)
- `tasks/plans/o7-configurable-alert-rules-design.md` — design, reviewed by 2 parallel agents (security + test coverage)
- 10 fixes applied across both rounds:
  - Critical: cross-tenant `in_app` userId guard; admin-gate on PATCH/DELETE/recipient mutations
  - High: atomic CAS dedup (was naive read-then-write); `maxRedirects:0` + `timeout:5000` on Slack POST; switch from raw SQL `gen_random_uuid()` (not used in repo) to Prisma TS seed; move test files out of `__tests__/` which Jest excludes
  - Medium: WARN log when scope FK is null (zombie rule detection); escape Slack markdown in deviceName; expand controller tests to cover RBAC metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)