### PR TITLE
feat(tag-rules): O4 — tag-rule auto-assignment engine

### DIFF
--- a/middleware/src/app/app.module.ts
+++ b/middleware/src/app/app.module.ts
@@ -32,6 +32,7 @@ import { SupportModule } from '../modules/support/support.module';
 import { FleetModule } from '../modules/fleet/fleet.module';
 import { AgentsModule } from '../modules/agents/agents.module';
 import { McpModule } from '../modules/mcp/mcp.module';
+import { TagRulesModule } from '../modules/tag-rules/tag-rules.module';
 
 @Module({
   imports: [
@@ -119,6 +120,7 @@ import { McpModule } from '../modules/mcp/mcp.module';
     FleetModule,
     AgentsModule,
     McpModule,
+    TagRulesModule,
   ],
   controllers: [AppController],
   providers: [

--- a/middleware/src/modules/displays/displays.service.tag-events.spec.ts
+++ b/middleware/src/modules/displays/displays.service.tag-events.spec.ts
@@ -1,0 +1,63 @@
+import { DisplaysService } from './displays.service';
+import { DatabaseService } from '../database/database.service';
+
+/**
+ * O4 — Verifies that `addTags`/`removeTags` emit `display.tags.changed` so the
+ * TagRuleEvaluator can react. Sibling spec rather than additions to the big
+ * displays.service.spec.ts — keeps the dependency-mock surface tiny.
+ */
+describe('DisplaysService — display.tags.changed emission (O4)', () => {
+  let service: DisplaysService;
+  let db: any;
+  let eventEmitter: { emit: jest.Mock };
+
+  const orgId = 'org-1';
+  const displayId = 'display-1';
+
+  beforeEach(() => {
+    db = {
+      display: { findFirst: jest.fn().mockResolvedValue({ id: displayId, organizationId: orgId }) },
+      displayTag: {
+        upsert: jest.fn().mockResolvedValue({ tag: { id: 'tag-1', name: 'lobby' } }),
+        deleteMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+    };
+    eventEmitter = { emit: jest.fn() };
+
+    // Constructor: (db, jwt, http, circuitBreaker, storage, eventEmitter)
+    service = new DisplaysService(
+      db as unknown as DatabaseService,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      eventEmitter as any,
+    );
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('addTags emits display.tags.changed with { organizationId, displayId }', async () => {
+    await service.addTags(orgId, displayId, ['tag-1']);
+
+    expect(eventEmitter.emit).toHaveBeenCalledWith('display.tags.changed', {
+      organizationId: orgId,
+      displayId,
+    });
+  });
+
+  it('removeTags emits display.tags.changed with { organizationId, displayId }', async () => {
+    await service.removeTags(orgId, displayId, ['tag-1']);
+
+    expect(eventEmitter.emit).toHaveBeenCalledWith('display.tags.changed', {
+      organizationId: orgId,
+      displayId,
+    });
+  });
+
+  it('addTags emits exactly once even with multiple tagIds (one event per call, not per tag)', async () => {
+    await service.addTags(orgId, displayId, ['tag-1', 'tag-2', 'tag-3']);
+
+    expect(eventEmitter.emit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/middleware/src/modules/displays/displays.service.ts
+++ b/middleware/src/modules/displays/displays.service.ts
@@ -419,6 +419,10 @@ export class DisplaysService {
     );
 
     const results = await Promise.all(createPromises);
+
+    // O4: notify tag-rule evaluator that this display's tag set changed.
+    this.eventEmitter.emit('display.tags.changed', { organizationId, displayId });
+
     return results.map((dt) => dt.tag);
   }
 
@@ -431,6 +435,9 @@ export class DisplaysService {
         tagId: { in: tagIds },
       },
     });
+
+    // O4: notify tag-rule evaluator that this display's tag set changed.
+    this.eventEmitter.emit('display.tags.changed', { organizationId, displayId });
 
     return { success: true, removed: tagIds.length };
   }

--- a/middleware/src/modules/tag-rules/dto/create-tag-rule.dto.ts
+++ b/middleware/src/modules/tag-rules/dto/create-tag-rule.dto.ts
@@ -1,0 +1,41 @@
+import {
+  IsBoolean,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  MinLength,
+} from 'class-validator';
+import { PRIORITY_MAX, PRIORITY_MIN } from '../tag-rule.types';
+
+export class CreateTagRuleDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(120)
+  name!: string;
+
+  @IsString()
+  @MinLength(1)
+  tagId!: string;
+
+  /**
+   * Required at create time. Becomes nullable only via the playlist-delete
+   * SetNull cascade after the row exists. The evaluator detects null and
+   * logs WARN.
+   */
+  @IsString()
+  @MinLength(1)
+  playlistId!: string;
+
+  @IsInt()
+  @Min(PRIORITY_MIN, { message: `priority must be >= ${PRIORITY_MIN}` })
+  @Max(PRIORITY_MAX, { message: `priority must be <= ${PRIORITY_MAX}` })
+  @IsOptional()
+  priority?: number;
+
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+}

--- a/middleware/src/modules/tag-rules/dto/list-tag-rules-query.dto.ts
+++ b/middleware/src/modules/tag-rules/dto/list-tag-rules-query.dto.ts
@@ -1,0 +1,21 @@
+import { Transform } from 'class-transformer';
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
+
+export class ListTagRulesQueryDto {
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (value === 'true' || value === true) return true;
+    if (value === 'false' || value === false) return false;
+    return value;
+  })
+  @IsBoolean()
+  isActive?: boolean;
+
+  @IsOptional()
+  @IsString()
+  tagId?: string;
+
+  @IsOptional()
+  @IsString()
+  playlistId?: string;
+}

--- a/middleware/src/modules/tag-rules/dto/update-tag-rule.dto.ts
+++ b/middleware/src/modules/tag-rules/dto/update-tag-rule.dto.ts
@@ -1,0 +1,11 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateTagRuleDto } from './create-tag-rule.dto';
+
+/**
+ * All fields optional via PartialType. Each retains its @IsX decorators
+ * from CreateTagRuleDto.
+ *
+ * The service-layer `update()` also implements the "if priority OR isActive
+ * OR tagId OR playlistId changes → re-sweep affected displays" rule.
+ */
+export class UpdateTagRuleDto extends PartialType(CreateTagRuleDto) {}

--- a/middleware/src/modules/tag-rules/tag-rule.evaluator.spec.ts
+++ b/middleware/src/modules/tag-rules/tag-rule.evaluator.spec.ts
@@ -1,0 +1,69 @@
+import { TagRuleEvaluator } from './tag-rule.evaluator';
+import { TagRulesService } from './tag-rules.service';
+
+describe('TagRuleEvaluator', () => {
+  let evaluator: TagRuleEvaluator;
+  let service: jest.Mocked<Pick<TagRulesService, 'evaluateForDisplay'>>;
+
+  const orgId = 'org-123';
+  const displayId = 'display-1';
+  const payload = { organizationId: orgId, displayId };
+
+  beforeEach(() => {
+    service = { evaluateForDisplay: jest.fn() } as any;
+    evaluator = new TagRuleEvaluator(service as unknown as TagRulesService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('display.tags.changed → evaluateForDisplay with correct payload', async () => {
+    service.evaluateForDisplay.mockResolvedValue(true);
+    await evaluator.onTagsChanged(payload);
+    expect(service.evaluateForDisplay).toHaveBeenCalledWith(orgId, displayId);
+  });
+
+  it('display.paired → evaluateForDisplay with correct payload', async () => {
+    service.evaluateForDisplay.mockResolvedValue(true);
+    await evaluator.onDisplayPaired(payload);
+    expect(service.evaluateForDisplay).toHaveBeenCalledWith(orgId, displayId);
+  });
+
+  it('top-level try/catch in onTagsChanged swallows service failures (no unhandled rejection)', async () => {
+    service.evaluateForDisplay.mockRejectedValue(new Error('DB down'));
+    await expect(evaluator.onTagsChanged(payload)).resolves.toBeUndefined();
+  });
+
+  it('top-level try/catch in onDisplayPaired swallows service failures', async () => {
+    service.evaluateForDisplay.mockRejectedValue(new Error('DB down'));
+    await expect(evaluator.onDisplayPaired(payload)).resolves.toBeUndefined();
+  });
+
+  it('the two handlers crash-independently (one throwing does not block the other)', async () => {
+    service.evaluateForDisplay
+      .mockRejectedValueOnce(new Error('first call boom'))
+      .mockResolvedValueOnce(true);
+
+    await evaluator.onTagsChanged(payload);
+    await evaluator.onDisplayPaired(payload);
+
+    expect(service.evaluateForDisplay).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT consume display.playlist.assigned events (no infinite loop)', () => {
+    // The evaluator must not have a handler for display.playlist.assigned —
+    // otherwise the service's own emission would re-trigger evaluation forever.
+    // Verify by inspecting the prototype's @OnEvent metadata via reflect-metadata.
+    const proto = Object.getPrototypeOf(evaluator);
+    const methodNames = Object.getOwnPropertyNames(proto).filter((n) => n !== 'constructor');
+
+    for (const name of methodNames) {
+      const meta = Reflect.getMetadata?.('OnEvent', proto, name) as { event?: string } | undefined;
+      if (meta?.event) {
+        expect(meta.event).not.toBe('display.playlist.assigned');
+      }
+    }
+
+    // Belt-and-braces: structurally there should be exactly 2 @OnEvent methods.
+    expect(methodNames.filter((n) => n.startsWith('on')).length).toBe(2);
+  });
+});

--- a/middleware/src/modules/tag-rules/tag-rule.evaluator.ts
+++ b/middleware/src/modules/tag-rules/tag-rule.evaluator.ts
@@ -1,0 +1,60 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { TagRulesService } from './tag-rules.service';
+
+interface DisplayLifecyclePayload {
+  organizationId: string;
+  displayId: string;
+}
+
+/**
+ * O4 — Reactive evaluator for tag-rule auto-assignment.
+ *
+ * Subscribes to:
+ *   - `display.tags.changed` (new event emitted by DisplaysService.addTags
+ *     and DisplaysService.removeTags after this PR)
+ *   - `display.paired` (existing event emitted by PairingService:294 —
+ *     covers the case where a newly-paired display already carries tags
+ *     from pre-pairing config)
+ *
+ * Both handlers wrap the service call in a top-level try/catch per the
+ * `app.module.ts:42-54` INVARIANT — async @OnEvent handlers MUST swallow
+ * errors because EventEmitter2's `ignoreErrors:false` config turns uncaught
+ * rejections into process-level errors (= PM2 restart storm).
+ *
+ * Event delivery is in-process (NestJS EventEmitter2). If `addTags` commits
+ * but the process crashes before the event fires, the evaluator never runs
+ * and the display stays unassigned. Accepted eventual-consistency tradeoff
+ * for v1 — any subsequent tag-change or rule-update on the same display
+ * (or its tag) will re-trigger evaluation.
+ */
+@Injectable()
+export class TagRuleEvaluator {
+  private readonly logger = new Logger(TagRuleEvaluator.name);
+
+  constructor(private readonly tagRulesService: TagRulesService) {}
+
+  @OnEvent('display.tags.changed', { async: true })
+  async onTagsChanged(payload: DisplayLifecyclePayload): Promise<void> {
+    try {
+      await this.tagRulesService.evaluateForDisplay(payload.organizationId, payload.displayId);
+    } catch (err) {
+      this.logger.error(
+        `Tag-rule evaluation failed for display ${payload.displayId}`,
+        err instanceof Error ? err.stack : String(err),
+      );
+    }
+  }
+
+  @OnEvent('display.paired', { async: true })
+  async onDisplayPaired(payload: DisplayLifecyclePayload): Promise<void> {
+    try {
+      await this.tagRulesService.evaluateForDisplay(payload.organizationId, payload.displayId);
+    } catch (err) {
+      this.logger.error(
+        `Tag-rule evaluation failed for newly-paired display ${payload.displayId}`,
+        err instanceof Error ? err.stack : String(err),
+      );
+    }
+  }
+}

--- a/middleware/src/modules/tag-rules/tag-rule.types.ts
+++ b/middleware/src/modules/tag-rules/tag-rule.types.ts
@@ -1,0 +1,22 @@
+/**
+ * O4 — Tag-rule auto-assignment engine.
+ *
+ * Constants for DTO validation + service-internal sweep timeout. Centralized
+ * so changing a bound (e.g. priority range) requires editing exactly one file.
+ */
+
+/** Lower number = higher priority. 1 = highest, 100 = default, 999 = lowest. */
+export const PRIORITY_MIN = 1;
+export const PRIORITY_MAX = 999;
+export const PRIORITY_DEFAULT = 100;
+
+/**
+ * Synchronous re-evaluation sweep timeout for `TagRulesService.sweepDisplaysForTag`.
+ *
+ * If admin creates a rule that matches >> displays, the sequential
+ * `evaluateForDisplay` loop could run long. Beyond this threshold the sweep
+ * throws `GatewayTimeoutException` carrying `{ scanned, assigned, total }`
+ * partial counts so operators see how far it got. Natural
+ * `display.tags.changed` events converge over time.
+ */
+export const REEVAL_TIMEOUT_MS = 30 * 1000;

--- a/middleware/src/modules/tag-rules/tag-rules.controller.spec.ts
+++ b/middleware/src/modules/tag-rules/tag-rules.controller.spec.ts
@@ -1,0 +1,114 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Reflector } from '@nestjs/core';
+import { TagRulesController } from './tag-rules.controller';
+import { TagRulesService } from './tag-rules.service';
+import { RolesGuard } from '../auth/guards/roles.guard';
+
+describe('TagRulesController', () => {
+  let controller: TagRulesController;
+  let service: jest.Mocked<TagRulesService>;
+
+  const orgId = 'org-123';
+
+  beforeEach(async () => {
+    service = {
+      create: jest.fn(),
+      findAll: jest.fn(),
+      findOne: jest.fn(),
+      update: jest.fn(),
+      remove: jest.fn(),
+      reEvaluateRule: jest.fn(),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TagRulesController],
+      providers: [{ provide: TagRulesService, useValue: service }, Reflector],
+    })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get(TagRulesController);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ---------------------------------------------------------------------------
+  // Delegation correctness — each endpoint forwards orgId
+  // ---------------------------------------------------------------------------
+  it('POST / forwards to service.create with orgId', async () => {
+    service.create.mockResolvedValue({ id: 'rule-1' } as any);
+    const dto: any = { name: 'r', tagId: 'tag-1', playlistId: 'pl-1' };
+    await controller.create(orgId, dto);
+    expect(service.create).toHaveBeenCalledWith(orgId, dto);
+  });
+
+  it('GET / forwards filters to service.findAll', async () => {
+    service.findAll.mockResolvedValue([]);
+    const query: any = { isActive: true };
+    await controller.findAll(orgId, query);
+    expect(service.findAll).toHaveBeenCalledWith(orgId, query);
+  });
+
+  it('GET /:id forwards to service.findOne', async () => {
+    service.findOne.mockResolvedValue({ id: 'rule-1' } as any);
+    await controller.findOne(orgId, 'rule-1');
+    expect(service.findOne).toHaveBeenCalledWith(orgId, 'rule-1');
+  });
+
+  it('PATCH /:id forwards to service.update (admin-gated)', async () => {
+    service.update.mockResolvedValue({ id: 'rule-1' } as any);
+    const dto: any = { priority: 50 };
+    await controller.update(orgId, 'rule-1', dto);
+    expect(service.update).toHaveBeenCalledWith(orgId, 'rule-1', dto);
+  });
+
+  it('DELETE /:id forwards to service.remove (admin-gated)', async () => {
+    service.remove.mockResolvedValue(undefined);
+    await controller.remove(orgId, 'rule-1');
+    expect(service.remove).toHaveBeenCalledWith(orgId, 'rule-1');
+  });
+
+  it('POST /:id/re-evaluate forwards to service.reEvaluateRule (admin-gated)', async () => {
+    service.reEvaluateRule.mockResolvedValue({ scanned: 5, assigned: 3 });
+    await controller.reEvaluate(orgId, 'rule-1');
+    expect(service.reEvaluateRule).toHaveBeenCalledWith(orgId, 'rule-1');
+  });
+
+  // ---------------------------------------------------------------------------
+  // RBAC metadata check
+  // ---------------------------------------------------------------------------
+  describe('RBAC decorators', () => {
+    const reflector = new Reflector();
+
+    it('POST create requires @Roles("admin") (mutation = admin-gated, matches O7)', () => {
+      const roles = reflector.get<string[]>('roles', controller.create);
+      expect(roles).toContain('admin');
+    });
+
+    it('PATCH update requires @Roles("admin")', () => {
+      const roles = reflector.get<string[]>('roles', controller.update);
+      expect(roles).toContain('admin');
+    });
+
+    it('DELETE remove requires @Roles("admin")', () => {
+      const roles = reflector.get<string[]>('roles', controller.remove);
+      expect(roles).toContain('admin');
+    });
+
+    it('POST re-evaluate requires @Roles("admin")', () => {
+      const roles = reflector.get<string[]>('roles', controller.reEvaluate);
+      expect(roles).toContain('admin');
+    });
+
+    it('GET findAll does NOT require admin (any org user)', () => {
+      const roles = reflector.get<string[]>('roles', controller.findAll);
+      expect(roles).toBeUndefined();
+    });
+
+    it('GET findOne does NOT require admin (any org user)', () => {
+      const roles = reflector.get<string[]>('roles', controller.findOne);
+      expect(roles).toBeUndefined();
+    });
+  });
+});

--- a/middleware/src/modules/tag-rules/tag-rules.controller.ts
+++ b/middleware/src/modules/tag-rules/tag-rules.controller.ts
@@ -1,0 +1,92 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ParseIdPipe } from '../common/pipes/parse-id.pipe';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { TagRulesService } from './tag-rules.service';
+import { CreateTagRuleDto } from './dto/create-tag-rule.dto';
+import { UpdateTagRuleDto } from './dto/update-tag-rule.dto';
+import { ListTagRulesQueryDto } from './dto/list-tag-rules-query.dto';
+
+/**
+ * O4 — CRUD API for tag-assignment rules.
+ *
+ * RBAC (same shape as O7 alert-rules):
+ *   - GET endpoints: any logged-in org user
+ *   - POST / PATCH / DELETE / re-evaluate: @Roles('admin')
+ *
+ * POST is admin-gated because rule creation directly affects which
+ * playlist plays on every display matching the tag — a non-admin should
+ * not be able to globally redirect content.
+ */
+@UseGuards(RolesGuard)
+@Controller('tag-rules')
+export class TagRulesController {
+  constructor(private readonly service: TagRulesService) {}
+
+  @Post()
+  @Roles('admin')
+  create(
+    @CurrentUser('organizationId') organizationId: string,
+    @Body() dto: CreateTagRuleDto,
+  ) {
+    return this.service.create(organizationId, dto);
+  }
+
+  @Get()
+  findAll(
+    @CurrentUser('organizationId') organizationId: string,
+    @Query() query: ListTagRulesQueryDto,
+  ) {
+    return this.service.findAll(organizationId, query);
+  }
+
+  @Get(':id')
+  findOne(
+    @CurrentUser('organizationId') organizationId: string,
+    @Param('id', ParseIdPipe) id: string,
+  ) {
+    return this.service.findOne(organizationId, id);
+  }
+
+  @Patch(':id')
+  @Roles('admin')
+  update(
+    @CurrentUser('organizationId') organizationId: string,
+    @Param('id', ParseIdPipe) id: string,
+    @Body() dto: UpdateTagRuleDto,
+  ) {
+    return this.service.update(organizationId, id, dto);
+  }
+
+  @Delete(':id')
+  @Roles('admin')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  remove(
+    @CurrentUser('organizationId') organizationId: string,
+    @Param('id', ParseIdPipe) id: string,
+  ) {
+    return this.service.remove(organizationId, id);
+  }
+
+  @Post(':id/re-evaluate')
+  @Roles('admin')
+  reEvaluate(
+    @CurrentUser('organizationId') organizationId: string,
+    @Param('id', ParseIdPipe) id: string,
+  ) {
+    return this.service.reEvaluateRule(organizationId, id);
+  }
+}

--- a/middleware/src/modules/tag-rules/tag-rules.module.ts
+++ b/middleware/src/modules/tag-rules/tag-rules.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '../database/database.module';
+import { TagRulesController } from './tag-rules.controller';
+import { TagRulesService } from './tag-rules.service';
+import { TagRuleEvaluator } from './tag-rule.evaluator';
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [TagRulesController],
+  providers: [TagRulesService, TagRuleEvaluator],
+  exports: [TagRulesService],
+})
+export class TagRulesModule {}

--- a/middleware/src/modules/tag-rules/tag-rules.service.spec.ts
+++ b/middleware/src/modules/tag-rules/tag-rules.service.spec.ts
@@ -109,6 +109,17 @@ describe('TagRulesService', () => {
       expect(db.displayTag.findMany).toHaveBeenCalledTimes(1); // sweep ran
     });
 
+    it('priority-only update persists the new priority value via Prisma update', async () => {
+      // PR-review gap: prove the priority change actually reaches the DB
+      // (not just that the sweep was triggered as a side effect).
+      db.tagAssignmentRule.update.mockResolvedValue({ ...before, priority: 50 });
+      await service.update(orgId, 'rule-1', { priority: 50 });
+      expect(db.tagAssignmentRule.update).toHaveBeenCalledWith({
+        where: { id: 'rule-1' },
+        data: { priority: 50 },
+      });
+    });
+
     it('name-only update does NOT trigger sweep (cosmetic)', async () => {
       db.tagAssignmentRule.update.mockResolvedValue({ ...before, name: 'renamed' });
       await service.update(orgId, 'rule-1', { name: 'renamed' });

--- a/middleware/src/modules/tag-rules/tag-rules.service.spec.ts
+++ b/middleware/src/modules/tag-rules/tag-rules.service.spec.ts
@@ -1,0 +1,306 @@
+import { ForbiddenException, GatewayTimeoutException, NotFoundException } from '@nestjs/common';
+import { TagRulesService } from './tag-rules.service';
+import { DatabaseService } from '../database/database.service';
+import { REEVAL_TIMEOUT_MS } from './tag-rule.types';
+
+describe('TagRulesService', () => {
+  let service: TagRulesService;
+  let db: any;
+  let events: any;
+
+  const orgId = 'org-123';
+  const tagId = 'tag-1';
+  const playlistId = 'playlist-1';
+
+  beforeEach(() => {
+    db = {
+      tagAssignmentRule: {
+        create: jest.fn(),
+        findFirst: jest.fn(),
+        findMany: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+      tag: { findFirst: jest.fn() },
+      playlist: { findFirst: jest.fn() },
+      display: { findFirst: jest.fn(), updateMany: jest.fn() },
+      displayTag: { findMany: jest.fn() },
+    };
+    events = { emit: jest.fn() };
+    service = new TagRulesService(db as unknown as DatabaseService, events);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ---------------------------------------------------------------------------
+  // create
+  // ---------------------------------------------------------------------------
+  describe('create', () => {
+    const baseDto = { name: 'lobby auto', tagId, playlistId };
+
+    it('happy path — creates the rule with defaults + sweeps the tag', async () => {
+      db.tag.findFirst.mockResolvedValue({ id: tagId, organizationId: orgId });
+      db.playlist.findFirst.mockResolvedValue({ id: playlistId, organizationId: orgId });
+      db.tagAssignmentRule.create.mockResolvedValue({ id: 'rule-1', tagId, organizationId: orgId, isActive: true });
+      db.displayTag.findMany.mockResolvedValue([]); // no tagged displays — sweep is no-op
+
+      await service.create(orgId, baseDto);
+
+      expect(db.tagAssignmentRule.create).toHaveBeenCalledTimes(1);
+      expect(db.displayTag.findMany).toHaveBeenCalledTimes(1); // sweep ran
+    });
+
+    it('rejects tagId from another org (cross-tenant guard)', async () => {
+      db.tag.findFirst.mockResolvedValue(null); // tag not in caller's org
+      await expect(service.create(orgId, baseDto)).rejects.toThrow(ForbiddenException);
+      expect(db.tagAssignmentRule.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects playlistId from another org (cross-tenant guard)', async () => {
+      db.tag.findFirst.mockResolvedValue({ id: tagId, organizationId: orgId });
+      db.playlist.findFirst.mockResolvedValue(null); // playlist not in caller's org
+      await expect(service.create(orgId, baseDto)).rejects.toThrow(ForbiddenException);
+      expect(db.tagAssignmentRule.create).not.toHaveBeenCalled();
+    });
+
+    it('skips sweep when isActive=false', async () => {
+      db.tag.findFirst.mockResolvedValue({ id: tagId, organizationId: orgId });
+      db.playlist.findFirst.mockResolvedValue({ id: playlistId, organizationId: orgId });
+      db.tagAssignmentRule.create.mockResolvedValue({ id: 'rule-1', tagId, organizationId: orgId, isActive: false });
+
+      await service.create(orgId, { ...baseDto, isActive: false });
+
+      expect(db.displayTag.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // findOne / cross-org
+  // ---------------------------------------------------------------------------
+  describe('findOne', () => {
+    it('returns the rule when in the caller org', async () => {
+      db.tagAssignmentRule.findFirst.mockResolvedValue({ id: 'rule-1', organizationId: orgId });
+      await expect(service.findOne(orgId, 'rule-1')).resolves.toEqual(expect.objectContaining({ id: 'rule-1' }));
+    });
+
+    it('throws NotFound when rule belongs to another org', async () => {
+      db.tagAssignmentRule.findFirst.mockResolvedValue(null);
+      await expect(service.findOne(orgId, 'rule-foreign')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    const before = { id: 'rule-1', organizationId: orgId, name: 'old', tagId, playlistId, isActive: true, priority: 100 };
+
+    beforeEach(() => {
+      db.tagAssignmentRule.findFirst.mockResolvedValue(before);
+      db.displayTag.findMany.mockResolvedValue([]);
+    });
+
+    it('throws NotFound on cross-org PATCH', async () => {
+      db.tagAssignmentRule.findFirst.mockResolvedValue(null);
+      await expect(service.update(orgId, 'rule-x', { name: 'y' })).rejects.toThrow(NotFoundException);
+      expect(db.tagAssignmentRule.update).not.toHaveBeenCalled();
+    });
+
+    it('priority-only update STILL triggers a sweep (PR-review fix)', async () => {
+      db.tagAssignmentRule.update.mockResolvedValue({ ...before, priority: 50 });
+      await service.update(orgId, 'rule-1', { priority: 50 });
+      expect(db.displayTag.findMany).toHaveBeenCalledTimes(1); // sweep ran
+    });
+
+    it('name-only update does NOT trigger sweep (cosmetic)', async () => {
+      db.tagAssignmentRule.update.mockResolvedValue({ ...before, name: 'renamed' });
+      await service.update(orgId, 'rule-1', { name: 'renamed' });
+      expect(db.displayTag.findMany).not.toHaveBeenCalled();
+    });
+
+    it('tagId change sweeps BOTH the old tag (if active) and the new tag', async () => {
+      db.tag.findFirst.mockResolvedValue({ id: 'tag-NEW', organizationId: orgId });
+      db.tagAssignmentRule.update.mockResolvedValue({ ...before, tagId: 'tag-NEW' });
+      await service.update(orgId, 'rule-1', { tagId: 'tag-NEW' });
+      expect(db.displayTag.findMany).toHaveBeenCalledTimes(2); // old tag + new tag
+    });
+
+    it('isActive false→true triggers sweep', async () => {
+      const beforeInactive = { ...before, isActive: false };
+      db.tagAssignmentRule.findFirst.mockResolvedValue(beforeInactive);
+      db.tagAssignmentRule.update.mockResolvedValue({ ...beforeInactive, isActive: true });
+      await service.update(orgId, 'rule-1', { isActive: true });
+      expect(db.displayTag.findMany).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('remove', () => {
+    it('throws NotFound on cross-org DELETE', async () => {
+      db.tagAssignmentRule.findFirst.mockResolvedValue(null);
+      await expect(service.remove(orgId, 'rule-x')).rejects.toThrow(NotFoundException);
+      expect(db.tagAssignmentRule.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // evaluateForDisplay
+  // ---------------------------------------------------------------------------
+  describe('evaluateForDisplay', () => {
+    const displayId = 'display-1';
+
+    it('skips when display does not exist in this org', async () => {
+      db.display.findFirst.mockResolvedValue(null);
+      const result = await service.evaluateForDisplay(orgId, displayId);
+      expect(result).toBe(false);
+    });
+
+    it('skips when currentPlaylistId is already set (first-write-wins)', async () => {
+      db.display.findFirst.mockResolvedValue({ id: displayId, currentPlaylistId: 'manual-X', tags: [{ tagId }] });
+      const result = await service.evaluateForDisplay(orgId, displayId);
+      expect(result).toBe(false);
+      expect(db.display.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('skips when display has no tags', async () => {
+      db.display.findFirst.mockResolvedValue({ id: displayId, currentPlaylistId: null, tags: [] });
+      const result = await service.evaluateForDisplay(orgId, displayId);
+      expect(result).toBe(false);
+    });
+
+    it('picks lowest priority rule (tie broken by oldest createdAt)', async () => {
+      db.display.findFirst.mockResolvedValue({ id: displayId, currentPlaylistId: null, tags: [{ tagId }] });
+      db.tagAssignmentRule.findMany.mockResolvedValue([
+        // findMany already returns in [priority ASC, createdAt ASC] order via orderBy
+        { id: 'rule-high', tagId, playlistId: 'p-high', priority: 10 },
+        { id: 'rule-low', tagId, playlistId: 'p-low', priority: 100 },
+      ]);
+      db.display.updateMany.mockResolvedValue({ count: 1 });
+
+      const result = await service.evaluateForDisplay(orgId, displayId);
+
+      expect(result).toBe(true);
+      expect(db.display.updateMany).toHaveBeenCalledWith({
+        where: { id: displayId, organizationId: orgId, currentPlaylistId: null },
+        data: { currentPlaylistId: 'p-high' },
+      });
+    });
+
+    it('skips a rule whose playlistId is null (post-SetNull) and falls through to next', async () => {
+      db.display.findFirst.mockResolvedValue({ id: displayId, currentPlaylistId: null, tags: [{ tagId }] });
+      db.tagAssignmentRule.findMany.mockResolvedValue([
+        { id: 'rule-broken', tagId, playlistId: null, priority: 10 }, // playlist deleted
+        { id: 'rule-ok', tagId, playlistId: 'p-good', priority: 50 },
+      ]);
+      db.display.updateMany.mockResolvedValue({ count: 1 });
+
+      const result = await service.evaluateForDisplay(orgId, displayId);
+
+      expect(result).toBe(true);
+      expect(db.display.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { currentPlaylistId: 'p-good' },
+        }),
+      );
+    });
+
+    it('returns false when updateMany predicate misses (another writer won)', async () => {
+      db.display.findFirst.mockResolvedValue({ id: displayId, currentPlaylistId: null, tags: [{ tagId }] });
+      db.tagAssignmentRule.findMany.mockResolvedValue([
+        { id: 'rule-1', tagId, playlistId, priority: 50 },
+      ]);
+      db.display.updateMany.mockResolvedValue({ count: 0 }); // raced and lost
+
+      const result = await service.evaluateForDisplay(orgId, displayId);
+
+      expect(result).toBe(false);
+      expect(events.emit).not.toHaveBeenCalled();
+    });
+
+    it('emits display.playlist.assigned event on success with source=tag_rule', async () => {
+      db.display.findFirst.mockResolvedValue({ id: displayId, currentPlaylistId: null, tags: [{ tagId }] });
+      db.tagAssignmentRule.findMany.mockResolvedValue([
+        { id: 'rule-1', tagId, playlistId, priority: 50 },
+      ]);
+      db.display.updateMany.mockResolvedValue({ count: 1 });
+
+      await service.evaluateForDisplay(orgId, displayId);
+
+      expect(events.emit).toHaveBeenCalledWith('display.playlist.assigned', {
+        organizationId: orgId,
+        displayId,
+        playlistId,
+        ruleId: 'rule-1',
+        source: 'tag_rule',
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // reEvaluateRule (POST :id/re-evaluate)
+  // ---------------------------------------------------------------------------
+  describe('reEvaluateRule', () => {
+    it('throws GatewayTimeoutException with partial counts when sweep exceeds REEVAL_TIMEOUT_MS', async () => {
+      db.tagAssignmentRule.findFirst.mockResolvedValue({ id: 'rule-1', organizationId: orgId, tagId, isActive: true });
+      db.displayTag.findMany.mockResolvedValue([
+        { displayId: 'd1' },
+        { displayId: 'd2' },
+        { displayId: 'd3' },
+      ]);
+      // Each evaluateForDisplay returns quickly with no work
+      db.display.findFirst.mockResolvedValue(null);
+
+      // Mock Date.now to step past the threshold on the second access (inside the loop)
+      const start = 1_000_000;
+      let calls = 0;
+      const spy = jest.spyOn(Date, 'now').mockImplementation(() => {
+        calls++;
+        // First call (loop init) sees start; subsequent calls are post-timeout
+        return calls === 1 ? start : start + REEVAL_TIMEOUT_MS + 1000;
+      });
+
+      try {
+        await expect(service.reEvaluateRule(orgId, 'rule-1')).rejects.toThrow(GatewayTimeoutException);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('GatewayTimeoutException response carries { scanned, assigned, total } partial counts', async () => {
+      db.tagAssignmentRule.findFirst.mockResolvedValue({ id: 'rule-1', organizationId: orgId, tagId, isActive: true });
+      db.displayTag.findMany.mockResolvedValue([
+        { displayId: 'd1' },
+        { displayId: 'd2' },
+        { displayId: 'd3' },
+      ]);
+      db.display.findFirst.mockResolvedValue(null);
+
+      const start = 1_000_000;
+      let calls = 0;
+      const spy = jest.spyOn(Date, 'now').mockImplementation(() => {
+        calls++;
+        return calls === 1 ? start : start + REEVAL_TIMEOUT_MS + 1000;
+      });
+
+      try {
+        try {
+          await service.reEvaluateRule(orgId, 'rule-1');
+          fail('Expected GatewayTimeoutException');
+        } catch (err) {
+          expect(err).toBeInstanceOf(GatewayTimeoutException);
+          const body = (err as GatewayTimeoutException).getResponse() as Record<string, unknown>;
+          expect(body).toMatchObject({
+            scanned: expect.any(Number),
+            assigned: expect.any(Number),
+            total: 3,
+          });
+        }
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('returns { scanned: 0, assigned: 0 } when the rule is inactive (no sweep)', async () => {
+      db.tagAssignmentRule.findFirst.mockResolvedValue({ id: 'rule-1', organizationId: orgId, tagId, isActive: false });
+      const result = await service.reEvaluateRule(orgId, 'rule-1');
+      expect(result).toEqual({ scanned: 0, assigned: 0 });
+      expect(db.displayTag.findMany).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/middleware/src/modules/tag-rules/tag-rules.service.ts
+++ b/middleware/src/modules/tag-rules/tag-rules.service.ts
@@ -198,6 +198,14 @@ export class TagRulesService {
 
       // Atomic CAS: only assigns if currentPlaylistId is still null. Under
       // PM2 cluster mode this guarantees exactly one writer wins.
+      //
+      // CONTRACT FOR FUTURE O1 (unified push): O1 is the OPPOSITE side of
+      // this contract — it overwrites currentPlaylistId unconditionally (push
+      // always wins). O1 implementers MUST NOT adopt this `currentPlaylistId:
+      // null` predicate; doing so would silently make manual pushes fail when
+      // a tag-rule already won. The two writers are coordinated by:
+      //   - O4 (here): only writes when null  → respects manual / O1 pushes
+      //   - O1 (future): always writes        → overrides O4's assignment
       const updated = await this.db.display.updateMany({
         where: { id: displayId, organizationId, currentPlaylistId: null },
         data: { currentPlaylistId: rule.playlistId },

--- a/middleware/src/modules/tag-rules/tag-rules.service.ts
+++ b/middleware/src/modules/tag-rules/tag-rules.service.ts
@@ -1,0 +1,292 @@
+import {
+  ForbiddenException,
+  GatewayTimeoutException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { DatabaseService } from '../database/database.service';
+import { CreateTagRuleDto } from './dto/create-tag-rule.dto';
+import { UpdateTagRuleDto } from './dto/update-tag-rule.dto';
+import { ListTagRulesQueryDto } from './dto/list-tag-rules-query.dto';
+import { PRIORITY_DEFAULT, REEVAL_TIMEOUT_MS } from './tag-rule.types';
+
+/**
+ * O4 — Tag-rule auto-assignment engine.
+ *
+ * Per-org rule: "every Display with tag X auto-assigns Playlist Y as its
+ * currentPlaylistId" — first-write-wins (manual assignments never overwritten).
+ *
+ * Patterns mirror O7 (`alert-rules.service.ts`):
+ *   - Cross-org guards: every read/write filters by organizationId
+ *   - Cross-tenant validation at the service layer (DTO can't see caller's orgId)
+ *   - Atomic CAS via `updateMany({ where: { ..., currentPlaylistId: null }, data: ... })`
+ *   - Idempotency on (organizationId, name) UNIQUE index
+ *
+ * Sweep timing: `sweepDisplaysForTag` is wrapped in `REEVAL_TIMEOUT_MS`.
+ * On exceed, throws `GatewayTimeoutException` carrying `{ scanned, assigned,
+ * total }` partial counts so the controller can surface them to operators.
+ */
+@Injectable()
+export class TagRulesService {
+  private readonly logger = new Logger(TagRulesService.name);
+
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly events: EventEmitter2,
+  ) {}
+
+  // ---------------------------------------------------------------------------
+  // CRUD
+  // ---------------------------------------------------------------------------
+
+  async create(organizationId: string, dto: CreateTagRuleDto) {
+    await this.validateRuleRefs(organizationId, dto.tagId, dto.playlistId);
+
+    const rule = await this.db.tagAssignmentRule.create({
+      data: {
+        organizationId,
+        name: dto.name,
+        tagId: dto.tagId,
+        playlistId: dto.playlistId,
+        isActive: dto.isActive ?? true,
+        priority: dto.priority ?? PRIORITY_DEFAULT,
+      },
+    });
+
+    // Sweep matched displays. Errors do NOT roll back the rule — the rule
+    // exists and natural display.tags.changed events will converge over time.
+    if (rule.isActive) {
+      try {
+        await this.sweepDisplaysForTag(organizationId, rule.tagId);
+      } catch (err) {
+        if (err instanceof GatewayTimeoutException) throw err;
+        this.logger.warn(
+          `Sweep after creating rule ${rule.id} failed: ${err instanceof Error ? err.message : 'unknown'}. Natural events will converge.`,
+        );
+      }
+    }
+
+    return rule;
+  }
+
+  async findAll(organizationId: string, query?: ListTagRulesQueryDto) {
+    return this.db.tagAssignmentRule.findMany({
+      where: {
+        organizationId,
+        ...(query?.isActive !== undefined ? { isActive: query.isActive } : {}),
+        ...(query?.tagId ? { tagId: query.tagId } : {}),
+        ...(query?.playlistId ? { playlistId: query.playlistId } : {}),
+      },
+      orderBy: [{ priority: 'asc' }, { createdAt: 'asc' }],
+    });
+  }
+
+  async findOne(organizationId: string, id: string) {
+    const rule = await this.db.tagAssignmentRule.findFirst({
+      where: { id, organizationId },
+    });
+    if (!rule) {
+      throw new NotFoundException(`Tag assignment rule ${id} not found`);
+    }
+    return rule;
+  }
+
+  async update(organizationId: string, id: string, dto: UpdateTagRuleDto) {
+    const before = await this.findOne(organizationId, id);
+
+    // Re-validate any tagId/playlistId pointing at potentially-different
+    // resources — they must still belong to the same org.
+    if (dto.tagId !== undefined || dto.playlistId !== undefined) {
+      await this.validateRuleRefs(organizationId, dto.tagId, dto.playlistId);
+    }
+
+    const after = await this.db.tagAssignmentRule.update({
+      where: { id },
+      data: {
+        ...(dto.name !== undefined ? { name: dto.name } : {}),
+        ...(dto.tagId !== undefined ? { tagId: dto.tagId } : {}),
+        ...(dto.playlistId !== undefined ? { playlistId: dto.playlistId } : {}),
+        ...(dto.isActive !== undefined ? { isActive: dto.isActive } : {}),
+        ...(dto.priority !== undefined ? { priority: dto.priority } : {}),
+      },
+    });
+
+    // Re-sweep when ANY of these change — including priority, since a
+    // priority drop can promote this rule past an existing rule for a
+    // display where both match.
+    const sweepTriggers: Array<keyof UpdateTagRuleDto> = ['isActive', 'tagId', 'playlistId', 'priority'];
+    const changed = sweepTriggers.some(
+      (k) => dto[k] !== undefined && dto[k] !== (before as unknown as Record<string, unknown>)[k],
+    );
+
+    if (changed && after.isActive) {
+      try {
+        // If tagId changed and the rule was active, sweep the OLD tag too so
+        // displays no longer covered are re-evaluated against remaining rules.
+        // (We don't unassign — but a different rule may now win for them.)
+        if (before.tagId !== after.tagId && before.isActive) {
+          await this.sweepDisplaysForTag(organizationId, before.tagId);
+        }
+        await this.sweepDisplaysForTag(organizationId, after.tagId);
+      } catch (err) {
+        if (err instanceof GatewayTimeoutException) throw err;
+        this.logger.warn(
+          `Sweep after updating rule ${id} failed: ${err instanceof Error ? err.message : 'unknown'}. Natural events will converge.`,
+        );
+      }
+    }
+
+    return after;
+  }
+
+  async remove(organizationId: string, id: string): Promise<void> {
+    await this.findOne(organizationId, id);
+    await this.db.tagAssignmentRule.delete({ where: { id } });
+    // Note: currently-assigned playlists STAY on displays. Intentional v1
+    // behavior — assignments persist independently of the rule that set them.
+  }
+
+  /**
+   * POST /:id/re-evaluate — force re-run of one rule against every matched
+   * display. Idempotent (predicate-protected UPDATE).
+   */
+  async reEvaluateRule(organizationId: string, id: string) {
+    const rule = await this.findOne(organizationId, id);
+    if (!rule.isActive) return { scanned: 0, assigned: 0 };
+    return this.sweepDisplaysForTag(organizationId, rule.tagId);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Evaluator entry point
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Called by TagRuleEvaluator. Returns true iff THIS call assigned a playlist.
+   *
+   * Algorithm: pick the highest-priority active rule whose tag matches one of
+   * the display's tags AND whose playlistId is non-null. Atomic CAS via
+   * `updateMany` with `currentPlaylistId: null` predicate ensures only one
+   * writer wins under PM2 cluster mode.
+   */
+  async evaluateForDisplay(organizationId: string, displayId: string): Promise<boolean> {
+    const display = await this.db.display.findFirst({
+      where: { id: displayId, organizationId },
+      include: { tags: { select: { tagId: true } } },
+    });
+    if (!display) return false;
+    if (display.currentPlaylistId !== null) return false;                  // first-write-wins
+    if (display.tags.length === 0) return false;
+
+    const candidateRules = await this.db.tagAssignmentRule.findMany({
+      where: {
+        organizationId,
+        isActive: true,
+        tagId: { in: display.tags.map((t) => t.tagId) },
+      },
+      orderBy: [{ priority: 'asc' }, { createdAt: 'asc' }],
+    });
+
+    for (const rule of candidateRules) {
+      if (rule.playlistId === null) {
+        this.logger.warn(
+          `Rule ${rule.id} (org=${organizationId}) has playlistId=null — referenced Playlist was deleted (SetNull cascade). Skipping; admin must fix the rule.`,
+        );
+        continue;
+      }
+
+      // Atomic CAS: only assigns if currentPlaylistId is still null. Under
+      // PM2 cluster mode this guarantees exactly one writer wins.
+      const updated = await this.db.display.updateMany({
+        where: { id: displayId, organizationId, currentPlaylistId: null },
+        data: { currentPlaylistId: rule.playlistId },
+      });
+      if (updated.count === 0) return false;                               // another writer won
+
+      this.events.emit('display.playlist.assigned', {
+        organizationId,
+        displayId,
+        playlistId: rule.playlistId,
+        ruleId: rule.id,
+        source: 'tag_rule',
+      });
+      return true;
+    }
+
+    return false;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Cross-org + cross-tenant validation. The DTO can't enforce this because
+   * the DTO doesn't know the caller's organizationId.
+   */
+  private async validateRuleRefs(
+    organizationId: string,
+    tagId: string | undefined,
+    playlistId: string | undefined,
+  ): Promise<void> {
+    if (tagId !== undefined) {
+      const tag = await this.db.tag.findFirst({
+        where: { id: tagId, organizationId },
+      });
+      if (!tag) {
+        throw new ForbiddenException(`Tag ${tagId} does not belong to this organization`);
+      }
+    }
+    if (playlistId !== undefined) {
+      const playlist = await this.db.playlist.findFirst({
+        where: { id: playlistId, organizationId },
+      });
+      if (!playlist) {
+        throw new ForbiddenException(
+          `Playlist ${playlistId} does not belong to this organization`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Re-evaluate every display in the org currently carrying `tagId` whose
+   * `currentPlaylistId` is null. Each call to `evaluateForDisplay` is
+   * predicate-protected — duplicate sweeps are safe (idempotent).
+   *
+   * Wrapped in REEVAL_TIMEOUT_MS. On exceed, throws GatewayTimeoutException
+   * whose response payload carries `{ scanned, assigned, total }` so the
+   * caller sees how far the sweep got.
+   */
+  private async sweepDisplaysForTag(
+    organizationId: string,
+    tagId: string,
+  ): Promise<{ scanned: number; assigned: number }> {
+    const start = Date.now();
+
+    const taggedDisplays = await this.db.displayTag.findMany({
+      where: { tagId, display: { organizationId, currentPlaylistId: null } },
+      select: { displayId: true },
+    });
+
+    let assigned = 0;
+    for (let i = 0; i < taggedDisplays.length; i++) {
+      if (Date.now() - start > REEVAL_TIMEOUT_MS) {
+        throw new GatewayTimeoutException({
+          message: `Tag-rule re-evaluation sweep exceeded ${REEVAL_TIMEOUT_MS}ms for tag ${tagId} in org ${organizationId}`,
+          scanned: i,
+          assigned,
+          total: taggedDisplays.length,
+          hint: 'Natural display.tags.changed events will converge over time. Optionally re-trigger via POST /tag-rules/:id/re-evaluate.',
+        });
+      }
+
+      if (await this.evaluateForDisplay(organizationId, taggedDisplays[i].displayId)) {
+        assigned++;
+      }
+    }
+
+    return { scanned: taggedDisplays.length, assigned };
+  }
+}

--- a/packages/database/prisma/migrations/20260519131130_add_tag_assignment_rules/migration.sql
+++ b/packages/database/prisma/migrations/20260519131130_add_tag_assignment_rules/migration.sql
@@ -1,0 +1,52 @@
+-- Migration: add_tag_assignment_rules
+--
+-- O4 — Tag-rule auto-assignment engine.
+--
+-- Per-org rule: "every Display with tag X auto-assigns Playlist Y as its
+-- currentPlaylistId" — first-write-wins (manual assignments never overwritten).
+--
+-- - Lower priority number = higher precedence (1 = highest, 100 = default,
+--   999 = lowest). Ties broken by createdAt (older wins).
+-- - playlistId uses ON DELETE SET NULL so playlist deletion preserves the
+--   rule in a broken state (evaluator logs WARN and skips it).
+-- - tagId uses ON DELETE CASCADE (no tag = no trigger; rule is meaningless
+--   without its tag).
+-- - organizationId uses ON DELETE CASCADE (standard tenant cleanup pattern).
+--
+-- Plan + design: tasks/plans/o4-tag-rule-auto-assignment-{plan,design}.md
+-- Audit ref: docs/plans/2026-05-17-optsigns-vizora-feature-gap.md P0 #2
+-- Pattern reference: PR #63 (O7 alert rules — same shape for rule engines).
+
+-- CreateTable
+CREATE TABLE "tag_assignment_rules" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "tagId" TEXT NOT NULL,
+    "playlistId" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "priority" INTEGER NOT NULL DEFAULT 100,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "tag_assignment_rules_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex (UI uniqueness + idempotent create on (org, name))
+CREATE UNIQUE INDEX "tag_assignment_rules_organizationId_name_key" ON "tag_assignment_rules"("organizationId", "name");
+
+-- CreateIndex (evaluator query: WHERE organizationId = ? AND isActive = true)
+CREATE INDEX "tag_assignment_rules_organizationId_isActive_idx" ON "tag_assignment_rules"("organizationId", "isActive");
+
+-- CreateIndex (evaluator IN clause + future SetNull cascade lookups)
+CREATE INDEX "tag_assignment_rules_tagId_idx" ON "tag_assignment_rules"("tagId");
+CREATE INDEX "tag_assignment_rules_playlistId_idx" ON "tag_assignment_rules"("playlistId");
+
+-- AddForeignKey
+ALTER TABLE "tag_assignment_rules" ADD CONSTRAINT "tag_assignment_rules_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey (tag delete removes the rule)
+ALTER TABLE "tag_assignment_rules" ADD CONSTRAINT "tag_assignment_rules_tagId_fkey" FOREIGN KEY ("tagId") REFERENCES "Tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey (playlist delete leaves the rule with playlistId=null; evaluator detects + skips + logs WARN)
+ALTER TABLE "tag_assignment_rules" ADD CONSTRAINT "tag_assignment_rules_playlistId_fkey" FOREIGN KEY ("playlistId") REFERENCES "Playlist"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -58,6 +58,7 @@ model Organization {
   contentRecommendations ContentRecommendation[]
   mcpTokens              McpToken[]
   agentRuns              AgentRun[]
+  tagAssignmentRules     TagAssignmentRule[]
 
   @@index([slug])
   @@index([stripeCustomerId])
@@ -255,6 +256,7 @@ model Playlist {
   schedules        Schedule[]
   assignedDisplays Display[]           @relation("DisplayCurrentPlaylist")
   impressions      ContentImpression[]
+  assignmentRules  TagAssignmentRule[]
 
   @@index([organizationId])
   @@index([organizationId, updatedAt])
@@ -358,8 +360,9 @@ model Tag {
   organizationId String
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
-  content  ContentTag[]
-  displays DisplayTag[]
+  content         ContentTag[]
+  displays        DisplayTag[]
+  assignmentRules TagAssignmentRule[]
 
   @@unique([organizationId, name])
   @@index([organizationId])
@@ -1001,4 +1004,41 @@ model AgentRun {
   @@index([createdAt])
   @@index([organizationId, startedAt])
   @@map("agent_runs")
+}
+
+// ============================================================================
+// TAG-RULE AUTO-ASSIGNMENT (O4 — auto-assign Playlist to Display by Tag)
+// ============================================================================
+
+/// Per-org rule: "every Display with `tag = scopeTagId` auto-assigns `playlist
+/// = scopePlaylistId` as its `currentPlaylistId`, IF the display has no
+/// playlist assigned yet (first-write-wins; manual assignments are NEVER
+/// overwritten by the evaluator).
+///
+/// Priority lower = higher precedence (1 = highest, 100 = default, 999 = lowest).
+/// Ties broken by createdAt (older wins).
+///
+/// `playlistId` uses SetNull cascade so playlist deletion preserves the rule
+/// in a broken state — the evaluator logs WARN and skips it; admin must fix.
+/// (See `TagRulesService.evaluateForDisplay`.)
+model TagAssignmentRule {
+  id             String    @id @default(cuid())
+  organizationId String
+  name           String
+  tagId          String                                    // when a Display has this tag...
+  playlistId     String?                                   // ...auto-assign this playlist (nullable for SetNull cascade)
+  isActive       Boolean   @default(true)
+  priority       Int       @default(100)                   // lower = higher priority
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  tag          Tag          @relation(fields: [tagId],          references: [id], onDelete: Cascade)
+  playlist     Playlist?    @relation(fields: [playlistId],     references: [id], onDelete: SetNull)
+
+  @@unique([organizationId, name])                         // UI uniqueness + idempotent create
+  @@index([organizationId, isActive])
+  @@index([tagId])
+  @@index([playlistId])
+  @@map("tag_assignment_rules")
 }

--- a/tasks/.hermes-check-receipts/o4-design.json
+++ b/tasks/.hermes-check-receipts/o4-design.json
@@ -1,0 +1,16 @@
+{
+  "topic": "o4-design",
+  "task_text": "O4 design — file shapes + code skeletons + migration SQL + test plan for TagAssignmentRule auto-assignment engine. Follow-up to o4-tag-rule-auto-assignment-plan.md after 2 parallel reviewers.",
+  "completed_at": "2026-05-19T13:50:00Z",
+  "drift_check_tag": "extends-Hermes",
+  "net_new_step_count": 11,
+  "hermes_step_count": 0,
+  "files_to_read_first": [
+    "middleware/src/modules/notifications/alert-rules/alert-rules.service.ts",
+    "middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.ts",
+    "middleware/src/modules/notifications/alert-rules/alert-rules.controller.ts",
+    "middleware/src/modules/displays/displays.service.ts",
+    "middleware/src/modules/displays/pairing.service.ts"
+  ],
+  "verdict": "Design mirrors O7 shape (PR #63) — net-new at the Hermes-substrate level but pattern-reuse at the Vizora-middleware level. Notable design decision: playlistId FK is SetNull (not Cascade) per PR-review fix, evaluator detects null-playlist rules with WARN. Subscribe to existing display.paired event rather than inventing display.created."
+}

--- a/tasks/.hermes-check-receipts/o4-tag-rule-auto-assignment.json
+++ b/tasks/.hermes-check-receipts/o4-tag-rule-auto-assignment.json
@@ -1,0 +1,17 @@
+{
+  "topic": "o4-tag-rule-auto-assignment",
+  "task_text": "O4 — Tag-rule auto-assignment engine: if a Display has Tag X (DisplayTag join) then auto-assign Playlist Y as that display's currentPlaylist. Rule model is per-org. Evaluator runs on tag-change events + new-display events. CRUD API admin-gated on mutations.",
+  "completed_at": "2026-05-19T13:30:00Z",
+  "drift_check_tag": "extends-Hermes",
+  "net_new_step_count": 11,
+  "hermes_step_count": 0,
+  "files_to_read_first": [
+    "packages/database/prisma/schema.prisma",
+    "middleware/src/modules/displays/displays.service.ts",
+    "middleware/src/modules/displays/displays.controller.ts",
+    "middleware/src/modules/notifications/alert-rules/alert-rules.service.ts",
+    "middleware/src/modules/playlists/playlists.service.ts",
+    "middleware/src/app/app.module.ts"
+  ],
+  "verdict": "All 11 steps net-new from Hermes substrate POV — same disposition as O7. Tag-rule engine is Vizora middleware/Prisma/NestJS work; Hermes agent runtime doesn't own DisplayTag joins, currentPlaylist mutation, or domain events. Pattern reference: O7 (PR #63) shipped first rule-driven evaluator in this codebase — reuse the @OnEvent + service + controller + RBAC pattern from there."
+}

--- a/tasks/plans/o4-tag-rule-auto-assignment-design.md
+++ b/tasks/plans/o4-tag-rule-auto-assignment-design.md
@@ -1,0 +1,379 @@
+# O4 — Tag-Rule Auto-Assignment — Design
+
+**Plan ref:** `tasks/plans/o4-tag-rule-auto-assignment-plan.md`
+**Drift-check tag:** `extends-Hermes`
+**Pattern reference:** O7 (PR #63) — `middleware/src/modules/notifications/alert-rules/*` is the canonical rule-driven-evaluator shape in this codebase. O4 mirrors it.
+
+## Hermes-first capability checklist
+
+All build steps are `[net-new]` against Hermes substrate. Same disposition as O7 (PR #63) — Vizora middleware/Prisma/NestJS work; Hermes agent runtime doesn't own NestJS event bus, Prisma schema, or display assignment.
+
+| # | Step | Tag | Why |
+|---|------|-----|-----|
+| 1 | Add `TagAssignmentRule` Prisma model + migration | `[net-new]` | Vizora schema |
+| 2 | `TagRulesService` CRUD + cross-org/tenant guards | `[net-new]` | NestJS DI + Prisma |
+| 3 | `TagRuleEvaluator` `@OnEvent` handlers for `display.tags.changed` and `display.paired` | `[net-new]` | NestJS event bus |
+| 4 | Atomic CAS via `updateMany` predicate on `currentPlaylistId IS NULL` | `[net-new]` | First-write-wins guarantee |
+| 5 | Sweep-after-create with `REEVAL_TIMEOUT_MS` | `[net-new]` | Application logic in TS |
+| 6 | `TagRulesController` 6 endpoints with `@Roles('admin')` on mutations | `[net-new]` | NestJS controllers |
+| 7 | Emit new `display.tags.changed` event from `displays.service.ts` `addTags`/`removeTags` | `[net-new]` | Vizora source change |
+| 8 | Subscribe to existing `display.paired` event (no new emission — `pairing.service.ts:294` already fires it) | `[net-new]` | Subscriber side; reuses existing event |
+| 9 | DTO validation: `priority` clamped to [1, 999]; required tagId + playlistId strings | `[net-new]` | class-validator at DTO layer |
+| 10 | Emit `display.playlist.assigned` event with `{ ..., source: 'tag_rule', ruleId }` for downstream listeners | `[net-new]` | Future audit/observability hook |
+| 11 | Unit tests (~32 cases) as siblings of impl files | `[net-new]` | Jest config excludes `__tests__/` |
+
+**Red-flag check:** 11/11 net-new is the correct disposition for Vizora middleware platform work, matching O7's verdict.
+
+## Drift-rule self-checks
+
+- ✅ Read `middleware/src/modules/notifications/alert-rules/alert-rules.service.ts` (full file — O7 service pattern: cross-org guards via `findFirst({where:{id, organizationId}})`, cross-tenant validation via `validateRecipient`, atomic CAS via `updateMany` with predicate. Mirror this for `validateRuleRefs(orgId, dto)` and `evaluateForDisplay(orgId, displayId)`).
+- ✅ Read `middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.ts` (full file — O7 evaluator pattern: top-level try/catch per `@OnEvent`, per-recipient try/catch on dispatch).
+- ✅ Read `middleware/src/modules/notifications/alert-rules/alert-rules.controller.ts` (full file — RBAC pattern: `@UseGuards(RolesGuard)` at class level; `@Roles('admin')` on mutations including POST; `@CurrentUser('organizationId')` decorator; `ParseIdPipe` for path params).
+- ✅ Read `middleware/src/modules/displays/displays.service.ts` lines 1-50 + 400-450 (`addTags`/`removeTags` are the hook points for event emission; both currently no events. Constructor already injects `EventEmitter2`).
+- ✅ Read `middleware/src/modules/displays/pairing.service.ts` lines 285-308 (confirmed: emits `display.paired` with `{ organizationId, displayId }` at line 294 — exactly the payload shape my evaluator expects).
+
+## File layout
+
+```
+middleware/src/modules/tag-rules/
+├── tag-rules.module.ts                                  (NEW)
+├── tag-rules.service.ts                                 (NEW)
+├── tag-rules.service.spec.ts                            (NEW)
+├── tag-rule.evaluator.ts                                (NEW)
+├── tag-rule.evaluator.spec.ts                           (NEW)
+├── tag-rules.controller.ts                              (NEW)
+├── tag-rules.controller.spec.ts                         (NEW)
+├── tag-rule.types.ts                                    (NEW)
+└── dto/
+    ├── create-tag-rule.dto.ts                           (NEW)
+    ├── update-tag-rule.dto.ts                           (NEW)
+    └── list-tag-rules-query.dto.ts                      (NEW)
+
+middleware/src/modules/displays/displays.service.ts      (MODIFIED — emit display.tags.changed after addTags/removeTags)
+middleware/src/modules/displays/displays.service.spec.ts (MODIFIED — assert emission)
+
+middleware/src/app/app.module.ts                         (MODIFIED — register TagRulesModule)
+
+packages/database/prisma/schema.prisma                   (MODIFIED — add TagAssignmentRule model + back-relations)
+packages/database/prisma/migrations/<ts>_add_tag_assignment_rules/migration.sql (NEW)
+```
+
+All `*.spec.ts` files are SIBLINGS of impl files (NOT under `__tests__/` — Jest excludes that dir per `middleware/jest.config.js:5-7`).
+
+## `tag-rule.types.ts` (literal)
+
+```ts
+/** Lower number = higher priority. 1 = highest, 100 = default, 999 = lowest. */
+export const PRIORITY_MIN = 1;
+export const PRIORITY_MAX = 999;
+export const PRIORITY_DEFAULT = 100;
+
+/**
+ * Synchronous re-evaluation sweep timeout. If an admin creates a rule that
+ * matches 5000 displays, the sweep is sequential and could exceed this.
+ * Beyond it, the controller returns 504; natural display.tags.changed events
+ * will converge eventually.
+ */
+export const REEVAL_TIMEOUT_MS = 30 * 1000;
+```
+
+## Prisma schema additions (literal)
+
+```prisma
+model TagAssignmentRule {
+  id             String   @id @default(cuid())
+  organizationId String
+  name           String
+  tagId          String
+  playlistId     String?
+  isActive       Boolean  @default(true)
+  priority       Int      @default(100)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  tag          Tag          @relation(fields: [tagId],          references: [id], onDelete: Cascade)
+  playlist     Playlist?    @relation(fields: [playlistId],     references: [id], onDelete: SetNull)
+
+  @@unique([organizationId, name])
+  @@index([organizationId, isActive])
+  @@index([tagId])
+  @@index([playlistId])
+  @@map("tag_assignment_rules")
+}
+```
+
+Back-relations added to `Organization`, `Tag`, `Playlist`.
+
+## Service shape — key methods
+
+`TagRulesService.evaluateForDisplay(orgId, displayId): Promise<boolean>`:
+
+```ts
+const display = await this.db.display.findFirst({
+  where: { id: displayId, organizationId: orgId },
+  include: { tags: { select: { tagId: true } } },
+});
+if (!display) return false;
+if (display.currentPlaylistId !== null) return false;          // first-write-wins
+if (display.tags.length === 0) return false;
+
+const candidateRules = await this.db.tagAssignmentRule.findMany({
+  where: {
+    organizationId: orgId,
+    isActive: true,
+    tagId: { in: display.tags.map((t) => t.tagId) },
+  },
+  orderBy: [{ priority: 'asc' }, { createdAt: 'asc' }],
+});
+
+for (const rule of candidateRules) {
+  if (rule.playlistId === null) {
+    this.logger.warn(`Rule ${rule.id} has playlistId=null (Playlist was deleted; SetNull cascade). Skipping.`);
+    continue;
+  }
+  const updated = await this.db.display.updateMany({
+    where: { id: displayId, organizationId: orgId, currentPlaylistId: null },
+    data: { currentPlaylistId: rule.playlistId },
+  });
+  if (updated.count === 0) return false;                       // raced and lost
+  this.events.emit('display.playlist.assigned', {
+    organizationId: orgId,
+    displayId,
+    playlistId: rule.playlistId,
+    ruleId: rule.id,
+    source: 'tag_rule',
+  });
+  return true;
+}
+return false;
+```
+
+`TagRulesService.create(orgId, dto)`:
+
+```ts
+await this.validateRuleRefs(orgId, dto.tagId, dto.playlistId);
+const rule = await this.db.tagAssignmentRule.create({ data: { organizationId: orgId, ...dto } });
+try {
+  if (rule.isActive) await this.sweepDisplaysForTag(orgId, rule.tagId);
+} catch (err) {
+  this.logger.warn(`Sweep after creating rule ${rule.id} failed: ${err}. Natural events will converge.`);
+  if (err instanceof GatewayTimeoutException) throw err;     // surface 504
+}
+return rule;
+```
+
+`TagRulesService.update(orgId, id, dto)` — PR-review fix: re-sweep when ANY of `isActive`, `tagId`, `playlistId`, or `priority` changes. Priority matters because lowering a rule's priority can promote it past an existing rule for displays where both match:
+
+```ts
+const before = await this.findOne(orgId, id);                  // throws NotFound on cross-org
+if (dto.tagId || dto.playlistId) await this.validateRuleRefs(orgId, dto.tagId, dto.playlistId);
+
+const after = await this.db.tagAssignmentRule.update({
+  where: { id },
+  data: { ...dto },
+});
+
+// Trigger sweep if the change could affect WHICH rule wins for matched displays.
+const sweepTriggers: Array<keyof typeof dto> = ['isActive', 'tagId', 'playlistId', 'priority'];
+const changed = sweepTriggers.some((k) => dto[k] !== undefined && (dto[k] as unknown) !== (before as Record<string, unknown>)[k]);
+
+if (changed && after.isActive) {
+  // Sweep both the old tag (if tagId changed and old was active) and new tag,
+  // so the new rule has a chance to win for newly-relevant displays.
+  // Note: this never UNASSIGNS playlists set by the now-replaced rule — that's
+  // intentional v1 behavior ("assignments persist").
+  try {
+    if (before.tagId !== after.tagId && before.isActive) await this.sweepDisplaysForTag(orgId, before.tagId);
+    await this.sweepDisplaysForTag(orgId, after.tagId);
+  } catch (err) {
+    this.logger.warn(`Sweep after updating rule ${id} failed: ${err}. Natural events will converge.`);
+    if (err instanceof GatewayTimeoutException) throw err;
+  }
+}
+
+return after;
+```
+
+`TagRulesService.sweepDisplaysForTag(orgId, tagId)`: loops tagged displays with `currentPlaylistId=null`, calls `evaluateForDisplay` for each, respects `REEVAL_TIMEOUT_MS`, and on timeout throws `GatewayTimeoutException` whose `cause` carries `{ scanned, assigned, total }` so the controller can surface partial-progress counts to the caller.
+
+```ts
+// sweep timeout path
+if (Date.now() - start > REEVAL_TIMEOUT_MS) {
+  throw new GatewayTimeoutException({
+    message: `Tag-rule re-evaluation sweep exceeded ${REEVAL_TIMEOUT_MS}ms for tag ${tagId} in org ${orgId}`,
+    scanned: i,
+    assigned,
+    total: taggedDisplays.length,
+    hint: 'Natural display.tags.changed events will converge over time. Optionally re-trigger via POST /:id/re-evaluate.',
+  });
+}
+```
+
+## Evaluator shape
+
+```ts
+@Injectable()
+export class TagRuleEvaluator {
+  private readonly logger = new Logger(TagRuleEvaluator.name);
+
+  constructor(private readonly tagRulesService: TagRulesService) {}
+
+  @OnEvent('display.tags.changed', { async: true })
+  async onTagsChanged(payload: { organizationId: string; displayId: string }) {
+    try {
+      await this.tagRulesService.evaluateForDisplay(payload.organizationId, payload.displayId);
+    } catch (err) {
+      this.logger.error(
+        `Tag-rule evaluation failed for display ${payload.displayId}`,
+        err instanceof Error ? err.stack : String(err),
+      );
+    }
+  }
+
+  @OnEvent('display.paired', { async: true })
+  async onDisplayPaired(payload: { organizationId: string; displayId: string }) {
+    try {
+      await this.tagRulesService.evaluateForDisplay(payload.organizationId, payload.displayId);
+    } catch (err) {
+      this.logger.error(
+        `Tag-rule evaluation failed for newly-paired display ${payload.displayId}`,
+        err instanceof Error ? err.stack : String(err),
+      );
+    }
+  }
+}
+```
+
+## Controller shape
+
+```ts
+@UseGuards(RolesGuard)
+@Controller('tag-rules')
+export class TagRulesController {
+  constructor(private readonly service: TagRulesService) {}
+
+  @Post()                          @Roles('admin')                                    create(...)
+  @Get()                                                                              findAll(...)
+  @Get(':id')                                                                         findOne(...)
+  @Patch(':id')                    @Roles('admin')                                    update(...)
+  @Delete(':id')                   @Roles('admin') @HttpCode(HttpStatus.NO_CONTENT)   remove(...)
+  @Post(':id/re-evaluate')         @Roles('admin')                                    reEvaluate(...)
+}
+```
+
+## DTOs
+
+```ts
+export class CreateTagRuleDto {
+  @IsString() @MinLength(1) @MaxLength(120) name!: string;
+  @IsString() @MinLength(1) tagId!: string;
+  @IsString() @MinLength(1) playlistId!: string;
+  @IsInt() @Min(PRIORITY_MIN) @Max(PRIORITY_MAX) @IsOptional() priority?: number;
+  @IsBoolean() @IsOptional() isActive?: boolean;
+}
+
+export class UpdateTagRuleDto extends PartialType(CreateTagRuleDto) {}
+```
+
+## DisplaysService event-emission diff
+
+```ts
+// displays.service.ts:addTags — after `const results = await Promise.all(createPromises);`
+this.eventEmitter.emit('display.tags.changed', { organizationId, displayId });
+return results.map((dt) => dt.tag);
+
+// displays.service.ts:removeTags — after `await this.db.displayTag.deleteMany(...)`
+this.eventEmitter.emit('display.tags.changed', { organizationId, displayId });
+return { success: true, removed: tagIds.length };
+```
+
+## Migration SQL skeleton
+
+```sql
+CREATE TABLE "tag_assignment_rules" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "tagId" TEXT NOT NULL,
+    "playlistId" TEXT,                                       -- nullable for SetNull cascade
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "priority" INTEGER NOT NULL DEFAULT 100,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "tag_assignment_rules_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "tag_assignment_rules_organizationId_name_key" ON "tag_assignment_rules"("organizationId", "name");
+CREATE INDEX "tag_assignment_rules_organizationId_isActive_idx" ON "tag_assignment_rules"("organizationId", "isActive");
+CREATE INDEX "tag_assignment_rules_tagId_idx" ON "tag_assignment_rules"("tagId");
+CREATE INDEX "tag_assignment_rules_playlistId_idx" ON "tag_assignment_rules"("playlistId");
+
+ALTER TABLE "tag_assignment_rules" ADD CONSTRAINT "tag_assignment_rules_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "tag_assignment_rules" ADD CONSTRAINT "tag_assignment_rules_tagId_fkey" FOREIGN KEY ("tagId") REFERENCES "Tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "tag_assignment_rules" ADD CONSTRAINT "tag_assignment_rules_playlistId_fkey" FOREIGN KEY ("playlistId") REFERENCES "playlists"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+```
+
+Table-name convention: `organizations` and `playlists` are lowercase via `@@map`; `Tag` is PascalCase (no `@@map`). Verified against `prisma/migrations/20260127044226_init/migration.sql`.
+
+## Test plan
+
+### `tag-rules.service.spec.ts` (~17 cases)
+- `create` happy path
+- `create` with tagId from another org → ForbiddenException
+- `create` with playlistId from another org → ForbiddenException
+- `create` with priority below 1 or above 999 → DTO 400
+- `findOne` / `update` / `remove` cross-org → NotFoundException (each)
+- `update` of isActive false→true triggers sweep
+- `update` of tagId triggers BOTH old-tag and new-tag sweeps
+- `update` of `priority` ONLY (no other field changes) still triggers sweep — PR-review fix
+- `update` of `name` ONLY does NOT trigger sweep (cosmetic)
+- `evaluateForDisplay` skips when currentPlaylistId is already set
+- `evaluateForDisplay` skips when display has no tags
+- `evaluateForDisplay` picks lowest-priority rule (tie = oldest createdAt)
+- `evaluateForDisplay` skips a rule whose playlistId is null with WARN; falls through to next-ranked rule
+- `evaluateForDisplay` UPDATE returns count=0 (another writer won) → returns false without error
+- `reEvaluateRule` throws GatewayTimeoutException with `{ scanned, assigned, total }` partial counts when sweep exceeds `REEVAL_TIMEOUT_MS` — uses jest fake timers to simulate (PR-review fix)
+- `evaluateForDisplay` outer try/catch swallows FK violations (e.g. playlist deleted between findMany and updateMany) — defensive test pinned by the @OnEvent handler's try/catch
+
+### `tag-rule.evaluator.spec.ts` (~7 cases)
+- `display.tags.changed` triggers evaluateForDisplay with correct payload
+- `display.paired` triggers evaluateForDisplay
+- Top-level try/catch swallows DB failures (no unhandled rejection)
+- Handlers crash-independently of each other
+- Event payload missing displayId → service throws → caught + logged
+- `display.playlist.assigned` event is emitted via the service (spy)
+- evaluator does NOT consume `display.playlist.assigned` (no infinite loop) — explicit test: emit the event, assert neither `onTagsChanged` nor `onDisplayPaired` was called (mock the service to prove no call reached it)
+
+### `tag-rules.controller.spec.ts` (~10 cases)
+- Each of 6 endpoints forwards orgId correctly
+- @Roles('admin') metadata present on POST, PATCH, DELETE, re-evaluate
+- GET endpoints do NOT require admin
+- POST with invalid priority → 400
+- DELETE non-admin → 403
+
+### `displays.service.spec.ts` additions (~1 case)
+- `addTags` emits `display.tags.changed` after upsert (jest.spyOn on eventEmitter.emit)
+
+## Risks summary (refined from plan + PR review)
+
+| Risk | Mitigation |
+|---|---|
+| Event delivery loss on process crash | Accepted v1 — eventual consistency |
+| Concurrent rule creates → priority inversion | Documented; operator uses POST re-evaluate to converge |
+| Re-evaluation sweep blocks request for large fleets | 30s timeout → 504 with `{ scanned, assigned, total }` partial counts; natural events converge |
+| Re-evaluate endpoint double-click → parallel sweeps | Idempotent (predicate-protected updates) |
+| Playlist deleted → rule.playlistId becomes null | Evaluator detects, logs WARN, skips, tries next |
+| O1 push vs O4 evaluator race | O1 always overwrites; O4 only sets when null |
+| Priority-only update silently doesn't reorder rule precedence | PR-review fix: `update` triggers sweep when `priority` changes (in addition to `isActive`/`tagId`/`playlistId`) |
+
+## Acceptance criteria
+
+- [ ] Migration applies forward + reset cleanly
+- [ ] All ~32 new tests pass; existing 2419 middleware tests pass with 0 regressions
+- [ ] `tsc --noEmit` clean
+- [ ] `addTags` emits `display.tags.changed` (test asserts)
+- [ ] Display with non-null `currentPlaylistId` is never overwritten
+- [ ] Cross-org tagId/playlistId rejected at create
+- [ ] DELETE/PATCH/POST without admin → 403
+- [ ] All test files are siblings, NOT under `__tests__/`

--- a/tasks/plans/o4-tag-rule-auto-assignment-plan.md
+++ b/tasks/plans/o4-tag-rule-auto-assignment-plan.md
@@ -1,0 +1,250 @@
+# O4 — Tag-Rule Auto-Assignment — Plan
+
+**Date:** 2026-05-19
+**Audit ref:** P0 #2 (`docs/plans/2026-05-17-optsigns-vizora-feature-gap.md`) — supports the unified push from O1
+**Backlog ref:** `backlog.md` → "OptiSigns Parity Roadmap" → O4
+**Branch:** `feat/o4-tag-rule-auto-assignment`
+**Effort:** M (2 dev-days)
+**Drift-check tag:** `extends-Hermes`
+
+Tag-rule auto-assignment engine: declarative rule says "every Display tagged X gets Playlist Y auto-assigned." Same domain Hermes doesn't own — this is Vizora middleware/Prisma/NestJS work. Pattern mirrors O7 (PR #63): new Prisma table, CRUD service with cross-org + cross-tenant guards, `@OnEvent` evaluator, RBAC-gated controller.
+
+## Hermes-first capability checklist
+
+All 11 steps are `[net-new]` against the Hermes capability list — Vizora runtime infrastructure, not agent work.
+
+| # | Step | Tag | Why |
+|---|------|-----|-----|
+| 1 | Display gains/loses a tag via `addTags`/`removeTags` (existing at `displays.service.ts:406-436`) | `[net-new]` | Existing Vizora middleware mutation |
+| 2 | DisplaysService emits `display.tags.changed` event | `[net-new]` | EventEmitter2 in-process bus (currently NOT emitted on tag changes — new event) |
+| 3 | Display becomes paired (existing `display.paired` event at `pairing.service.ts:294`) → evaluator also fires on it (re-uses existing event, no new emission needed) | `[net-new]` | Subscribe to existing event; do NOT invent a parallel `display.created` (verified by grep) |
+| 4 | TagAssignmentRule is created/updated/deleted → service re-evaluates all currently-tagged displays in the affected scope | `[net-new]` | Service-internal sweep, not Hermes |
+| 5 | `TagAssignmentRuleEvaluator` `@OnEvent('display.tags.changed')` handler runs | `[net-new]` | NestJS decorator |
+| 6 | Evaluator queries active rules for the org with matching tagId | `[net-new]` | Prisma query |
+| 7 | Evaluator picks the winning rule (lowest priority number; tie = oldest createdAt) | `[net-new]` | Application logic |
+| 8 | Evaluator writes `Display.currentPlaylistId` ONLY if it's null (no overwrite of manual assignment) | `[net-new]` | Prisma updateMany with predicate |
+| 9 | Evaluator emits `display.playlist.assigned` event for downstream listeners | `[net-new]` | Domain event |
+| 10 | REST CRUD endpoints under `/api/v1/tag-rules` | `[net-new]` | NestJS controllers |
+| 11 | Cross-org + cross-tenant guards: tagId and playlistId both validated to belong to caller's org | `[net-new]` | Service-layer validation |
+
+**Red-flag check:** 11/11 net-new is the correct disposition for Vizora middleware platform work, consistent with O7's verdict. Hermes orthogonal.
+
+## Drift-rule self-checks
+
+- ✅ Read `packages/database/prisma/schema.prisma` (Display at line 118 with `currentPlaylistId String?` field and `currentPlaylist Playlist? @relation("DisplayCurrentPlaylist")`; Tag at line 352; DisplayTag at line 383; Playlist) — confirmed the `currentPlaylistId` is the right write target; FK to Playlist already exists.
+- ✅ Read `middleware/src/modules/displays/displays.service.ts` (lines 1-50 + lines 400-450 — `addTags()` upserts to `DisplayTag` table at line 411; `removeTags()` deleteMany at line 428; `pushContent()` at line 438; neither currently emits domain events for tag changes).
+- ✅ Read `middleware/src/modules/notifications/alert-rules/alert-rules.service.ts` (from O7 PR #63 — established pattern: cross-org guards via `findFirst({where:{id, organizationId}})`, atomic CAS via `updateMany`/`upsert`+`P2002` catch, idempotent seed helpers, validation in service layer).
+- ✅ Read `middleware/src/app/app.module.ts` (lines 36-56 — `EventEmitterModule.forRoot({ ignoreErrors: false })` INVARIANT: async `@OnEvent` handlers MUST wrap body in try/catch).
+
+## Problem
+
+Today, assigning a Playlist to a Display is purely manual:
+- Direct write: `PATCH /displays/{id}` sets `currentPlaylistId` → one playlist on one screen at a time
+- Bulk write: `POST /displays/bulk-assign-playlist` → one playlist applied to a list of selected displays
+- Schedule: a `Schedule` row with `playlistId` and `displayId`/`displayGroupId` → time-based playback
+
+What's missing: **declarative auto-assignment based on tag membership**. OptiSigns and competitors ship this as standard — operators tag displays by purpose (`lobby`, `cafeteria`, `lobby-tv-7`, `digital-menu`) and the system handles playlist routing automatically. Without it, customers with growing fleets manage playlists per-display, which doesn't scale.
+
+## Goals
+
+1. New `TagAssignmentRule` model: per-org, `tagId + playlistId + isActive + priority`.
+2. New `@OnEvent` evaluator listens for `display.tags.changed` and writes `Display.currentPlaylistId` based on matching rule.
+3. **First-write-wins semantics:** evaluator only sets `currentPlaylistId` if currently null. Manual assignments are NEVER overwritten by the evaluator.
+4. Multiple rules matching the same display → resolve by `priority` field (lower = higher priority); tie-break by `createdAt` (older wins).
+5. CRUD API admin-gated on mutations (per O7 pattern).
+
+## Non-goals (out of scope for this PR)
+
+- **Bulk overwrite of existing manual assignments.** A separate "reset to rule-engine assignment" endpoint can land later; for v1 the evaluator never overwrites a non-null `currentPlaylistId`.
+- **Per-display priority overrides** (e.g. "ignore tag rule for this one display") — defer; can be added via a `Display.ignoreTagRules` boolean later if real demand.
+- **Cross-tag composition** ("if has tag A AND tag B → playlist C"). v1 is one-tag-one-rule. Composite rules would need a different schema shape.
+- **Rule scheduling** (only apply between 9am-5pm). Schedules are a different model; cross-pollination is a future enhancement.
+- **Rule conditions beyond tag membership** (status, location, OS version, etc.). Tag is the v1 lever.
+
+## Affected files (predicted)
+
+```
+packages/database/prisma/schema.prisma                                          (add TagAssignmentRule + indexes + back-relations on Tag, Playlist, Organization)
+packages/database/prisma/migrations/<ts>_add_tag_assignment_rules/migration.sql (create table + FKs + indexes)
+middleware/src/modules/displays/displays.service.ts                             (emit display.tags.changed event after add/remove + after pairing)
+middleware/src/modules/playlists/playlists.module.ts                            (import new TagRules module if needed for cross-org guard)
+middleware/src/modules/tag-rules/tag-rules.module.ts                            (NEW)
+middleware/src/modules/tag-rules/tag-rules.service.ts                           (NEW — CRUD + cross-org/tenant guards + rule-change re-evaluation)
+middleware/src/modules/tag-rules/tag-rules.controller.ts                        (NEW — RBAC-gated mutations)
+middleware/src/modules/tag-rules/tag-rule.evaluator.ts                          (NEW — @OnEvent handler, never overwrites non-null currentPlaylistId)
+middleware/src/modules/tag-rules/tag-rule.types.ts                              (NEW — constants for priority bounds)
+middleware/src/modules/tag-rules/dto/*.ts                                       (NEW)
+middleware/src/modules/tag-rules/*.spec.ts                                      (NEW — sibling spec files per Jest config)
+middleware/src/app/app.module.ts                                                (register TagRulesModule)
+```
+
+## Schema (Prisma)
+
+```prisma
+model TagAssignmentRule {
+  id             String   @id @default(cuid())
+  organizationId String
+  name           String                          // user-facing label
+  tagId          String                          // when a Display has this tag...
+  playlistId     String?                         // ...auto-assign this playlist. Nullable for SetNull cascade on playlist delete (PR-review fix)
+  isActive       Boolean  @default(true)
+  priority       Int      @default(100)          // lower = higher priority; ties broken by createdAt (older wins)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  tag          Tag          @relation(fields: [tagId],          references: [id], onDelete: Cascade)
+  playlist     Playlist     @relation(fields: [playlistId],     references: [id], onDelete: SetNull)
+  //                                                                              ^^^^^^^
+  //  PR-review fix: SetNull instead of Cascade, matches O7's philosophy for
+  //  non-core FK targets. Playlist deletion is a routine operation; silently
+  //  removing all rules pointing at it would surprise admins who manage many
+  //  rules. With SetNull, the rule survives in a broken state and the
+  //  evaluator logs a WARN on encountering playlistId=null (zombie rule —
+  //  admin must fix). Note this requires `playlistId String?` (nullable).
+
+  @@unique([organizationId, name])               // UI uniqueness
+  @@index([organizationId, isActive])
+  @@index([tagId])
+  @@index([playlistId])
+  @@map("tag_assignment_rules")
+}
+```
+
+**FK cascade choice:**
+- `tagId`: `Cascade` — when a Tag is deleted, rules pointing at it are removed. A rule without a tag has no trigger; nothing to preserve.
+- `playlistId`: `SetNull` (PR-review fix) — playlist deletion is a routine admin op. Silently removing N rules would surprise the admin. With `SetNull`, the rule survives with `playlistId=null`; the evaluator detects this at evaluate time and logs a `WARN` (zombie rule — admin must fix). Same philosophy as O7's `SetNull` on scope FKs.
+- `organizationId`: `Cascade` — org delete is a major action that cascades everything; aligned with every other model.
+
+**`priority` semantics:** lower number = higher priority (1 = highest, 100 = default, 999 = lowest). DTO clamps to `[1, 999]`. Ties resolved by `createdAt` ascending (older wins). UI can surface this; the field defaults to 100.
+
+## Service shape
+
+`TagRulesService`:
+- `create(orgId, dto)` — validates tagId + playlistId belong to org; creates rule; **triggers re-evaluation of all displays with the matched tag**
+- `findAll(orgId, { isActive?, tagId?, playlistId? })`
+- `findOne(orgId, id)` — cross-org guard via compound where
+- `update(orgId, id, dto)` — also triggers re-evaluation if `isActive`/`tagId`/`playlistId` changed
+- `remove(orgId, id)` — deletes rule (cascade removes any auto-assigned playlists? NO — assigned playlists stay; only the *rule* is removed)
+- `evaluateForDisplay(orgId, displayId)` — entry point called by the evaluator; loads the display's tags + active rules, picks the winner, writes `currentPlaylistId` IF currently null
+
+`TagRuleEvaluator`:
+- `@OnEvent('display.tags.changed', { async: true })` — payload: `{ organizationId, displayId }`. Calls `evaluateForDisplay`.
+- `@OnEvent('display.paired', { async: true })` — payload `{ organizationId, displayId }` per `pairing.service.ts:294` (already emitted — we subscribe; do NOT invent a parallel `display.created`). Triggers evaluation for newly-paired devices that may already carry tags.
+- Top-level try/catch in each handler (per `app.module.ts:42-54` INVARIANT)
+
+## Evaluator algorithm (literal)
+
+```
+1. Load Display with id=displayId in organizationId; include tags (DisplayTag[]).
+   If display.currentPlaylistId IS NOT NULL → return (do not overwrite manual assignment).
+
+2. If display.tags is empty → return.
+
+3. Load active TagAssignmentRules for this org with tagId IN display.tags.tagId,
+   ordered by priority ASC, createdAt ASC.
+
+4. If no rules → return.
+
+5. Pick the FIRST rule (lowest priority, oldest creation date).
+
+6. If rule.playlistId IS NULL (its playlist was deleted; SetNull triggered) →
+   log WARN ("rule X has playlistId=null — referenced Playlist was deleted;
+   admin must fix") and try the NEXT-ranked rule. If all rules have null
+   playlistId → return.
+
+7. UPDATE Display SET currentPlaylistId = rule.playlistId WHERE id = displayId
+      AND currentPlaylistId IS NULL.
+   If update count === 0, another writer set it first — log INFO + return.
+
+8. Emit `display.playlist.assigned` event with { organizationId, displayId,
+   playlistId, source: 'tag_rule', ruleId } so downstream (e.g. future audit
+   log, future Slack notification, O1's push tracking) can react.
+```
+
+**The "IF currently NULL" predicate at step 7 is the key safety guarantee:** under PM2 cluster mode, two evaluator instances racing on the same display can both pass step 1's null-check but the `updateMany` predicate ensures only one write lands. The loser sees `count === 0` and backs off.
+
+## Controller / API
+
+```
+POST   /api/v1/tag-rules                 — create rule           [admin only]
+GET    /api/v1/tag-rules                 — list (filters: isActive, tagId, playlistId)
+GET    /api/v1/tag-rules/:id             — detail
+PATCH  /api/v1/tag-rules/:id             — update                [admin only]
+DELETE /api/v1/tag-rules/:id             — delete                [admin only]
+POST   /api/v1/tag-rules/:id/re-evaluate — re-run rule against all matched displays [admin only — ops button for "I just changed the playlist content"]
+```
+
+POST + PATCH + DELETE + re-evaluate are `@Roles('admin')`. GET endpoints open to any org user (matches O7's PR-review fix).
+
+## Migration / behavior change
+
+**Before:** no auto-assignment exists; every playlist assignment is manual.
+**After:** when an admin creates a TagAssignmentRule, displays with the matching tag whose `currentPlaylistId` is null get auto-assigned. Existing manual assignments are NEVER touched.
+
+This is purely additive. No data migration required. Migration is just `CREATE TABLE`.
+
+## Tests
+
+Unit (Jest, mocked DB):
+- `tag-rules.service.spec.ts` (~14 cases)
+  - `create` happy path + cross-org tagId rejected + cross-org playlistId rejected
+  - `priority` clamped to [1, 999] at DTO layer
+  - `findOne`/`update`/`remove` cross-org → NotFound
+  - rule create triggers re-evaluation for displays with the matched tag
+  - rule deactivate does NOT roll back already-assigned playlists (intentional v1)
+- `tag-rule.evaluator.spec.ts` (~16 cases)
+  - display with non-null `currentPlaylistId` → skip (no overwrite)
+  - display with null `currentPlaylistId` + matching active rule → assign
+  - two matching rules → lowest priority wins; tie → older createdAt wins
+  - no matching rules → no-op
+  - rule's playlist was deleted (shouldn't happen due to cascade, but defense in depth) → log warn + skip
+  - `display.paired` event triggers evaluation just like `display.tags.changed`
+  - PM2-cluster race: predicate-protected updateMany ensures only one wins
+  - top-level try/catch swallows DB failure → no unhandled rejection
+- `tag-rules.controller.spec.ts` (~10 cases)
+  - all 6 endpoints forward orgId correctly
+  - POST/PATCH/DELETE/re-evaluate carry `@Roles('admin')` metadata
+  - GET endpoints do not require admin
+
+New event emission in `displays.service.ts`:
+- After `addTags()` and `removeTags()` (at `displays.service.ts:406-436`): emit `display.tags.changed` with `{ organizationId, displayId }`. **NEW event** — verified via grep that nothing else uses this name.
+- `display.paired` is already emitted by `pairing.service.ts:294` — we just subscribe to it; no new emission code on the pairing path.
+
+Existing displays.service.spec.ts gets ~1 new test case pinning the `display.tags.changed` emission.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Cross-org leak: rule references tagId/playlistId from another org | Service-layer validation: load tag + playlist with `findFirst({where:{id, organizationId}})`; throw ForbiddenException on miss (same pattern as O7's `validateRecipient`) |
+| Existing manual assignments silently overwritten | Evaluator's `WHERE currentPlaylistId IS NULL` predicate. Tested. |
+| Two rules match same display, infinite loop | No loop possible — evaluator is reactive, not iterative. Multiple rules → priority order picks one and writes. Done. |
+| PM2 cluster race on first assignment | `UPDATE ... WHERE currentPlaylistId IS NULL` returns count=0 for the loser → backs off |
+| Tag deleted with N rules pointing at it | `onDelete: Cascade` on `tagId` FK — rules are removed |
+| Playlist deleted with N rules pointing at it | `onDelete: Cascade` on `playlistId` FK — rules are removed |
+| Rule deletion → currently-assigned playlists stay | Intentional v1 behavior. A separate "clear all rule-assignments" endpoint can land later if requested. Documented in the API response shape. |
+| Rule re-evaluation sweep is expensive for a large fleet | For each affected display in scope, the evaluator's per-display SQL is one query. For an org with 10,000 displays and a rule scoped to a tag covering 500 → 500 sequential queries. Acceptable for v1; batched if it becomes a hot path. |
+| O1 (unified push) sets `currentPlaylistId` directly → would race with rule evaluator | O1 is push-on-demand (operator action); O4's evaluator triggers reactively on tag-change. They don't race — but both write to the same field. O1 SHOULD overwrite (push wins); O4 respects the IS-NULL predicate (rule defers to manual). Documented contract enforced by the evaluator's WHERE clause. |
+| Concurrent rule creates with same tagId can produce priority inversion under cluster mode | Rule A (priority=50) committed at T1; rule B (priority=30, higher priority) committed at T2 by a parallel admin. A's post-create sweep runs at T1.5, finds only A's rule, assigns to all `lobby`-tagged displays with null `currentPlaylistId`. B's later sweep finds both rules, picks B as winner, but UPDATE WHERE IS NULL fails — A's playlist stays. Mitigation: admins use `POST /:id/re-evaluate` after B to force re-sweep. Documented in OpenAPI as v1 limitation. |
+| Re-evaluation sweep on rule create can block the request for an org with 10k+ displays | Plan §"Open questions 1": acceptable for v1 (synchronous, single-threaded loop). The controller wraps the sweep in a 30s timeout — if it exceeds, return 504 and rely on natural `display.tags.changed` events to converge. Batched queue is a future enhancement. |
+| Double-clicked re-evaluate endpoint spawns parallel sweeps | Accepted for v1 (idempotent — duplicate work, no incorrect outcome). A Redis lock per-rule can be added later if ops sees real load. |
+| `playlistId` becomes null via SetNull cascade → silent broken rule | Evaluator logs WARN at evaluate time (step 6 above). Admin sees the warn in logs; rule list endpoint includes `playlistId: null` so UI can flag it. |
+
+## Acceptance criteria
+
+- [ ] Migration applies forward + reset cleanly
+- [ ] All ~40 new test cases pass; existing middleware suite has zero regressions
+- [ ] `tsc --noEmit` clean
+- [ ] Tag-add on a display with a matching active rule → display's `currentPlaylistId` updates (verified via integration test or manual REPL)
+- [ ] Tag-add on a display whose `currentPlaylistId` is already set → NO change (manual assignment preserved)
+- [ ] Cross-org isolation: rule in org A with tagId/playlistId from org B is rejected at create
+- [ ] DELETE/PATCH/POST without admin role → 403
+- [ ] `display.paired` event emission + handler verified
+
+## Open questions
+
+1. **Re-evaluation scope on rule create/update — how much work?** When admin creates a rule for `tagId=lobby`, the service finds all displays with that tag and calls `evaluateForDisplay` for each. For an org with 10,000 displays and a tag covering 500, that's 500 sequential evaluator calls. Acceptable for v1 (with 30s timeout); needs a batched fast-path if customer fleets grow past ~5k.
+2. **Should the API return a preview of what will change before the create commits?** Useful UX but adds another endpoint. Defer to follow-up unless asked.
+3. **Should `priority` allow negatives?** Lean: no. Clamp to [1, 999]. Simpler mental model.
+4. **Should there be an audit table (`TagRuleAssignment` like O7's `AlertRuleFire`)?** Reviewer flagged this — useful for "why does display X have playlist Y" debugging. Hook already exists via the `display.playlist.assigned` event in step 8. Defer building the consumer until ops asks for it; the event is the durable contract.


### PR DESCRIPTION
## Summary
- Declarative auto-assignment: per-org rule says "every Display with tag X auto-assigns Playlist Y as its `currentPlaylistId`."
- **First-write-wins:** evaluator only writes when `currentPlaylistId` is null; manual assignments are NEVER overwritten.
- Atomic CAS via `updateMany` predicate — PM2-cluster-safe under concurrent writes.
- Same shape as **O7** (PR #63) for code review continuity: Prisma model + migration, NestJS service with cross-org/tenant guards, `@OnEvent` evaluator with top-level try/catch per `app.module.ts:42-54` INVARIANT, RBAC-gated controller.

Second item in the OptiSigns parity roadmap (`backlog.md` → O4 / audit P0 #2).

## What's in
- **Schema:** new `TagAssignmentRule` model. `playlistId` is `SetNull` cascade (PR-review choice — playlist delete preserves rule in broken state, evaluator WARNs and skips). `tagId` is Cascade (no tag = no trigger).
- **Service:** CRUD + `evaluateForDisplay` + `sweepDisplaysForTag` + `reEvaluateRule`. Update triggers sweep when `isActive`/`tagId`/`playlistId`/**`priority`** changes (priority included — a drop can promote this rule past an existing one). Sweep timeout is 30s; on exceed throws `GatewayTimeoutException` carrying `{ scanned, assigned, total }` so operators see how far it got.
- **Evaluator:** subscribes to new `display.tags.changed` event (emitted by `DisplaysService.addTags`/`removeTags` after this PR) AND the existing `display.paired` event from `pairing.service.ts:294`. Does NOT consume `display.playlist.assigned` (structural test verifies no infinite loop).
- **Controller:** 6 endpoints under `/api/v1/tag-rules`. POST + PATCH + DELETE + re-evaluate gated `@Roles('admin')`.
- **Migration:** `20260519131130_add_tag_assignment_rules`. Table-naming conventions verified against `20260127044226_init/migration.sql` (`Tag` and `Playlist` PascalCase; `organizations` lowercase via `@@map`).

## Test plan
- [x] 44 new tests across service (22), evaluator (6), controller (12), displays-emit (3 — sibling spec, not __tests__/).
- [x] **Full middleware suite: 125 / 125 suites, 2378 / 2378 tests pass** (+43 vs 2335 main baseline).
- [x] `tsc --noEmit` clean.
- [x] Migration applied locally on dev DB (postgres in docker-compose); seed not needed (rules are opt-in per org).
- [x] Cross-tenant tagId / playlistId rejected at create.
- [x] PM2-cluster CAS proven via 4-branch service test (update hit / lost race / create succeed / create P2002).
- [x] Re-evaluation timeout proven with `Date.now` spy.

## Deployment notes
- Run migration: `pnpm --filter @vizora/database exec prisma migrate deploy`
- Run `pnpm --filter @vizora/database exec prisma generate` after — needed so the runtime client knows about `tagAssignmentRule` / `tagAssignmentRules` models (same generator-staleness gotcha O7 added to the runbook at T-1 Check 2b).
- No data seed — rules are opt-in per org. Existing displays carry on with whatever `currentPlaylistId` they had.
- `pm2 reload vizora-middleware --update-env`

## Plan + design artifacts
- `tasks/plans/o4-tag-rule-auto-assignment-plan.md`
- `tasks/plans/o4-tag-rule-auto-assignment-design.md`
- 4 review cycles total (plan: edge-cases + cross-PR / race + data integrity; design: schema + migration / logic + test coverage). 6 actionable findings applied:
  - `playlistId` FK → `SetNull` (was `Cascade`)
  - Subscribe to existing `display.paired` event (not new `display.created`)
  - Priority-only updates trigger sweep
  - 504 timeout carries `{ scanned, assigned, total }` partial counts
  - Explicit structural test: no `@OnEvent` handler listens for `display.playlist.assigned`
  - Cross-org `tagId` AND `playlistId` validation at service layer

## Known v1 limits (documented in code + plan)
- Sweep is synchronous; 30s timeout on a 10k-display fleet may need a queue. Documented in design §"Open questions 1."
- `display.tags.changed` event delivery is in-process (NestJS `EventEmitter2`); a process crash between commit and emit means the evaluator doesn't run for that change. Eventual consistency: any subsequent tag-change or rule-update on the same display re-triggers evaluation. Same eventual-consistency posture as O7.
- Concurrent rule creates with same `tagId` and different priorities can produce priority inversion: A's sweep at T1.5 lands before B's commit at T2. Operator uses POST `/tag-rules/:id/re-evaluate` to converge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)