### PR TITLE
feat(provisioning): O6 — provisioning templates (apply-at-pairing MVP)

### DIFF
--- a/middleware/src/app/app.module.ts
+++ b/middleware/src/app/app.module.ts
@@ -32,6 +32,7 @@ import { SupportModule } from '../modules/support/support.module';
 import { FleetModule } from '../modules/fleet/fleet.module';
 import { AgentsModule } from '../modules/agents/agents.module';
 import { McpModule } from '../modules/mcp/mcp.module';
+import { ProvisioningTemplatesModule } from '../modules/provisioning-templates/provisioning-templates.module';
 
 @Module({
   imports: [
@@ -119,6 +120,7 @@ import { McpModule } from '../modules/mcp/mcp.module';
     FleetModule,
     AgentsModule,
     McpModule,
+    ProvisioningTemplatesModule,
   ],
   controllers: [AppController],
   providers: [

--- a/middleware/src/modules/displays/displays.module.ts
+++ b/middleware/src/modules/displays/displays.module.ts
@@ -7,6 +7,7 @@ import { PairingService } from './pairing.service';
 import { PairingController } from './pairing.controller';
 import { StorageModule } from '../storage/storage.module';
 import { BillingModule } from '../billing/billing.module';
+import { ProvisioningTemplatesModule } from '../provisioning-templates/provisioning-templates.module';
 
 @Module({
   imports: [
@@ -21,6 +22,9 @@ import { BillingModule } from '../billing/billing.module';
     }),
     HttpModule,
     StorageModule,
+    // O6 — PairingService.completePairing pulls defaults from the
+    // ProvisioningTemplate model when a templateId is supplied.
+    ProvisioningTemplatesModule,
   ],
   controllers: [DisplaysController, PairingController],
   providers: [DisplaysService, PairingService],

--- a/middleware/src/modules/displays/dto/complete-pairing.dto.ts
+++ b/middleware/src/modules/displays/dto/complete-pairing.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, Length } from 'class-validator';
+import { IsString, IsOptional, Length, MinLength } from 'class-validator';
 
 export class CompletePairingDto {
   @IsString()
@@ -12,4 +12,15 @@ export class CompletePairingDto {
   @IsString()
   @IsOptional()
   location?: string;
+
+  /**
+   * O6 — Optional reference to a per-org ProvisioningTemplate. When set,
+   * the template's defaultOrientation / defaultTimezone / defaultPlaylistId
+   * are applied to the new Display at pair-complete time. Cross-org guard
+   * runs at the service layer.
+   */
+  @IsString()
+  @MinLength(1)
+  @IsOptional()
+  provisioningTemplateId?: string;
 }

--- a/middleware/src/modules/displays/pairing.service.ts
+++ b/middleware/src/modules/displays/pairing.service.ts
@@ -3,6 +3,7 @@ import { JwtService } from '@nestjs/jwt';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { DatabaseService } from '../database/database.service';
 import { RedisService } from '../redis/redis.service';
+import { ProvisioningTemplatesService } from '../provisioning-templates/provisioning-templates.service';
 import { RequestPairingDto } from './dto/request-pairing.dto';
 import { CompletePairingDto } from './dto/complete-pairing.dto';
 import * as crypto from 'crypto';
@@ -34,6 +35,7 @@ export class PairingService implements OnModuleDestroy {
     private readonly jwtService: JwtService,
     private readonly redisService: RedisService,
     private readonly events: EventEmitter2,
+    private readonly provisioningTemplatesService: ProvisioningTemplatesService,
   ) {
     // Cleanup interval as safety net — Redis TTL handles most expiration,
     // but this catches edge cases if Redis is temporarily unavailable.
@@ -211,7 +213,7 @@ export class PairingService implements OnModuleDestroy {
     userId: string,
     completeDto: CompletePairingDto,
   ) {
-    const { code, nickname } = completeDto;
+    const { code, nickname, provisioningTemplateId } = completeDto;
 
     const request = await this.getPairingRequest(code);
 
@@ -224,6 +226,17 @@ export class PairingService implements OnModuleDestroy {
       await this.deletePairingRequest(code);
       throw new BadRequestException('Pairing code has expired');
     }
+
+    // O6 — Resolve provisioning-template defaults if the operator specified
+    // one. Cross-org guard lives inside resolveForPairing (throws NotFound
+    // if the template belongs to another org). If unspecified, this resolves
+    // to undefined and the Display falls back to Vizora-level defaults.
+    const provisioningDefaults = provisioningTemplateId
+      ? await this.provisioningTemplatesService.resolveForPairing(
+          organizationId,
+          provisioningTemplateId,
+        )
+      : undefined;
 
     // Check if device already exists
     let display = await this.db.display.findUnique({
@@ -266,6 +279,9 @@ export class PairingService implements OnModuleDestroy {
           lastHeartbeat: new Date(),
           status: 'pairing',
           location: completeDto.location || display.location,
+          // O6 — apply provisioning-template defaults. Spread last so they
+          // override the Vizora-level defaults but NOT explicit fields above.
+          ...(provisioningDefaults ?? {}),
         },
       });
     } else {
@@ -283,6 +299,10 @@ export class PairingService implements OnModuleDestroy {
           status: 'pairing',
           location: request.metadata?.hostname || null,
           metadata: request.metadata,
+          // O6 — apply provisioning-template defaults. Spread last so they
+          // override the Display model's Prisma defaults (orientation=
+          // 'landscape', timezone='UTC') with the operator's preference.
+          ...(provisioningDefaults ?? {}),
         },
       });
     }

--- a/middleware/src/modules/provisioning-templates/dto/create-provisioning-template.dto.ts
+++ b/middleware/src/modules/provisioning-templates/dto/create-provisioning-template.dto.ts
@@ -1,0 +1,51 @@
+import {
+  IsBoolean,
+  IsIn,
+  IsOptional,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+
+const VALID_ORIENTATIONS = ['landscape', 'portrait'] as const;
+export const PROVISIONING_TEMPLATE_NAME_MAX = 120;
+export const PROVISIONING_TEMPLATE_DESCRIPTION_MAX = 500;
+
+export class CreateProvisioningTemplateDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(PROVISIONING_TEMPLATE_NAME_MAX)
+  name!: string;
+
+  @IsString()
+  @MaxLength(PROVISIONING_TEMPLATE_DESCRIPTION_MAX)
+  @IsOptional()
+  description?: string;
+
+  @IsIn(VALID_ORIENTATIONS, { message: `defaultOrientation must be one of: ${VALID_ORIENTATIONS.join(', ')}` })
+  @IsOptional()
+  defaultOrientation?: 'landscape' | 'portrait';
+
+  @IsString()
+  @MinLength(1)
+  @MaxLength(64)
+  @IsOptional()
+  defaultTimezone?: string;
+
+  /**
+   * Optional default playlist applied to displays paired with this template.
+   * Cross-org guard at the service layer.
+   */
+  @IsString()
+  @MinLength(1)
+  @IsOptional()
+  defaultPlaylistId?: string;
+
+  /**
+   * UI hint: the operator's "go-to" template. Not unique-enforced; the UI
+   * picks one to highlight. Multiple defaults are tolerated.
+   */
+  @IsBoolean()
+  @IsOptional()
+  isDefault?: boolean;
+}

--- a/middleware/src/modules/provisioning-templates/dto/update-provisioning-template.dto.ts
+++ b/middleware/src/modules/provisioning-templates/dto/update-provisioning-template.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateProvisioningTemplateDto } from './create-provisioning-template.dto';
+
+export class UpdateProvisioningTemplateDto extends PartialType(CreateProvisioningTemplateDto) {}

--- a/middleware/src/modules/provisioning-templates/provisioning-templates.controller.spec.ts
+++ b/middleware/src/modules/provisioning-templates/provisioning-templates.controller.spec.ts
@@ -1,0 +1,94 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Reflector } from '@nestjs/core';
+import { ProvisioningTemplatesController } from './provisioning-templates.controller';
+import { ProvisioningTemplatesService } from './provisioning-templates.service';
+import { RolesGuard } from '../auth/guards/roles.guard';
+
+describe('ProvisioningTemplatesController', () => {
+  let controller: ProvisioningTemplatesController;
+  let service: jest.Mocked<ProvisioningTemplatesService>;
+
+  const orgId = 'org-123';
+
+  beforeEach(async () => {
+    service = {
+      create: jest.fn(),
+      findAll: jest.fn(),
+      findOne: jest.fn(),
+      update: jest.fn(),
+      remove: jest.fn(),
+      resolveForPairing: jest.fn(),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ProvisioningTemplatesController],
+      providers: [{ provide: ProvisioningTemplatesService, useValue: service }, Reflector],
+    })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get(ProvisioningTemplatesController);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('POST forwards to service.create with orgId', async () => {
+    service.create.mockResolvedValue({ id: 'tpl-1' } as any);
+    await controller.create(orgId, { name: 'Lobby TVs' } as any);
+    expect(service.create).toHaveBeenCalledWith(orgId, { name: 'Lobby TVs' });
+  });
+
+  it('GET / forwards to service.findAll', async () => {
+    service.findAll.mockResolvedValue([] as any);
+    await controller.findAll(orgId);
+    expect(service.findAll).toHaveBeenCalledWith(orgId);
+  });
+
+  it('GET /:id forwards to service.findOne', async () => {
+    service.findOne.mockResolvedValue({ id: 'tpl-1' } as any);
+    await controller.findOne(orgId, 'tpl-1');
+    expect(service.findOne).toHaveBeenCalledWith(orgId, 'tpl-1');
+  });
+
+  it('PATCH /:id forwards to service.update', async () => {
+    service.update.mockResolvedValue({ id: 'tpl-1' } as any);
+    await controller.update(orgId, 'tpl-1', { name: 'renamed' } as any);
+    expect(service.update).toHaveBeenCalledWith(orgId, 'tpl-1', { name: 'renamed' });
+  });
+
+  it('DELETE /:id forwards to service.remove', async () => {
+    service.remove.mockResolvedValue(undefined);
+    await controller.remove(orgId, 'tpl-1');
+    expect(service.remove).toHaveBeenCalledWith(orgId, 'tpl-1');
+  });
+
+  describe('RBAC decorators', () => {
+    const reflector = new Reflector();
+
+    it('POST create requires @Roles("admin")', () => {
+      const roles = reflector.get<string[]>('roles', controller.create);
+      expect(roles).toContain('admin');
+    });
+
+    it('PATCH requires @Roles("admin")', () => {
+      const roles = reflector.get<string[]>('roles', controller.update);
+      expect(roles).toContain('admin');
+    });
+
+    it('DELETE requires @Roles("admin")', () => {
+      const roles = reflector.get<string[]>('roles', controller.remove);
+      expect(roles).toContain('admin');
+    });
+
+    it('GET findAll does NOT require admin (any org user)', () => {
+      const roles = reflector.get<string[]>('roles', controller.findAll);
+      expect(roles).toBeUndefined();
+    });
+
+    it('GET findOne does NOT require admin (any org user)', () => {
+      const roles = reflector.get<string[]>('roles', controller.findOne);
+      expect(roles).toBeUndefined();
+    });
+  });
+});

--- a/middleware/src/modules/provisioning-templates/provisioning-templates.controller.ts
+++ b/middleware/src/modules/provisioning-templates/provisioning-templates.controller.ts
@@ -1,0 +1,71 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { ParseIdPipe } from '../common/pipes/parse-id.pipe';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { ProvisioningTemplatesService } from './provisioning-templates.service';
+import { CreateProvisioningTemplateDto } from './dto/create-provisioning-template.dto';
+import { UpdateProvisioningTemplateDto } from './dto/update-provisioning-template.dto';
+
+/**
+ * O6 — Provisioning template CRUD. RBAC: mutations require admin; GETs
+ * open to any logged-in org user (matches O4/O7 controller pattern).
+ */
+@UseGuards(RolesGuard)
+@Controller('provisioning-templates')
+export class ProvisioningTemplatesController {
+  constructor(private readonly service: ProvisioningTemplatesService) {}
+
+  @Post()
+  @Roles('admin')
+  create(
+    @CurrentUser('organizationId') organizationId: string,
+    @Body() dto: CreateProvisioningTemplateDto,
+  ) {
+    return this.service.create(organizationId, dto);
+  }
+
+  @Get()
+  findAll(@CurrentUser('organizationId') organizationId: string) {
+    return this.service.findAll(organizationId);
+  }
+
+  @Get(':id')
+  findOne(
+    @CurrentUser('organizationId') organizationId: string,
+    @Param('id', ParseIdPipe) id: string,
+  ) {
+    return this.service.findOne(organizationId, id);
+  }
+
+  @Patch(':id')
+  @Roles('admin')
+  update(
+    @CurrentUser('organizationId') organizationId: string,
+    @Param('id', ParseIdPipe) id: string,
+    @Body() dto: UpdateProvisioningTemplateDto,
+  ) {
+    return this.service.update(organizationId, id, dto);
+  }
+
+  @Delete(':id')
+  @Roles('admin')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  remove(
+    @CurrentUser('organizationId') organizationId: string,
+    @Param('id', ParseIdPipe) id: string,
+  ) {
+    return this.service.remove(organizationId, id);
+  }
+}

--- a/middleware/src/modules/provisioning-templates/provisioning-templates.module.ts
+++ b/middleware/src/modules/provisioning-templates/provisioning-templates.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '../database/database.module';
+import { ProvisioningTemplatesController } from './provisioning-templates.controller';
+import { ProvisioningTemplatesService } from './provisioning-templates.service';
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [ProvisioningTemplatesController],
+  providers: [ProvisioningTemplatesService],
+  exports: [ProvisioningTemplatesService],
+})
+export class ProvisioningTemplatesModule {}

--- a/middleware/src/modules/provisioning-templates/provisioning-templates.service.spec.ts
+++ b/middleware/src/modules/provisioning-templates/provisioning-templates.service.spec.ts
@@ -1,0 +1,166 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { ProvisioningTemplatesService } from './provisioning-templates.service';
+import { DatabaseService } from '../database/database.service';
+
+describe('ProvisioningTemplatesService', () => {
+  let service: ProvisioningTemplatesService;
+  let db: any;
+
+  const orgId = 'org-123';
+
+  beforeEach(() => {
+    db = {
+      provisioningTemplate: {
+        create: jest.fn(),
+        findFirst: jest.fn(),
+        findMany: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+      playlist: { findFirst: jest.fn() },
+    };
+    service = new ProvisioningTemplatesService(db as unknown as DatabaseService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ---------------------------------------------------------------------------
+  // create
+  // ---------------------------------------------------------------------------
+  describe('create', () => {
+    it('happy path — creates with default orientation/timezone when omitted', async () => {
+      db.provisioningTemplate.create.mockResolvedValue({ id: 'tpl-1' });
+
+      await service.create(orgId, { name: 'Lobby TVs' });
+
+      expect(db.provisioningTemplate.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          organizationId: orgId,
+          name: 'Lobby TVs',
+          defaultOrientation: 'landscape',
+          defaultTimezone: 'UTC',
+          isDefault: false,
+        }),
+      });
+    });
+
+    it('rejects defaultPlaylistId from another org (cross-tenant guard)', async () => {
+      db.playlist.findFirst.mockResolvedValue(null); // playlist not in caller's org
+
+      await expect(
+        service.create(orgId, { name: 'X', defaultPlaylistId: 'playlist-foreign' }),
+      ).rejects.toThrow(ForbiddenException);
+      expect(db.provisioningTemplate.create).not.toHaveBeenCalled();
+    });
+
+    it('accepts defaultPlaylistId when it belongs to the caller org', async () => {
+      db.playlist.findFirst.mockResolvedValue({ id: 'pl-1', organizationId: orgId });
+      db.provisioningTemplate.create.mockResolvedValue({ id: 'tpl-1' });
+
+      await service.create(orgId, { name: 'X', defaultPlaylistId: 'pl-1' });
+
+      expect(db.provisioningTemplate.create).toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // findOne — cross-org guard
+  // ---------------------------------------------------------------------------
+  describe('findOne', () => {
+    it('returns template when it belongs to the caller org', async () => {
+      db.provisioningTemplate.findFirst.mockResolvedValue({ id: 'tpl-1', organizationId: orgId });
+      await expect(service.findOne(orgId, 'tpl-1')).resolves.toEqual(
+        expect.objectContaining({ id: 'tpl-1' }),
+      );
+    });
+
+    it('throws NotFound when template belongs to another org', async () => {
+      db.provisioningTemplate.findFirst.mockResolvedValue(null);
+      await expect(service.findOne(orgId, 'tpl-foreign')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // update + remove — cross-org guards
+  // ---------------------------------------------------------------------------
+  describe('update', () => {
+    it('throws NotFound on cross-org PATCH', async () => {
+      db.provisioningTemplate.findFirst.mockResolvedValue(null);
+      await expect(service.update(orgId, 'tpl-x', { name: 'new' })).rejects.toThrow(NotFoundException);
+      expect(db.provisioningTemplate.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects PATCH with cross-org defaultPlaylistId', async () => {
+      db.provisioningTemplate.findFirst.mockResolvedValue({ id: 'tpl-1', organizationId: orgId });
+      db.playlist.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.update(orgId, 'tpl-1', { defaultPlaylistId: 'playlist-foreign' }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('allows PATCH defaultPlaylistId to null (clear the default playlist)', async () => {
+      db.provisioningTemplate.findFirst.mockResolvedValue({ id: 'tpl-1', organizationId: orgId });
+      db.provisioningTemplate.update.mockResolvedValue({ id: 'tpl-1', defaultPlaylistId: null });
+
+      await service.update(orgId, 'tpl-1', { defaultPlaylistId: null as unknown as string });
+
+      // No cross-org check is run when clearing (defaultPlaylistId is null, not undefined)
+      expect(db.playlist.findFirst).not.toHaveBeenCalled();
+      expect(db.provisioningTemplate.update).toHaveBeenCalled();
+    });
+  });
+
+  describe('remove', () => {
+    it('throws NotFound on cross-org DELETE', async () => {
+      db.provisioningTemplate.findFirst.mockResolvedValue(null);
+      await expect(service.remove(orgId, 'tpl-x')).rejects.toThrow(NotFoundException);
+      expect(db.provisioningTemplate.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // resolveForPairing — apply-at-pairing helper
+  // ---------------------------------------------------------------------------
+  describe('resolveForPairing', () => {
+    it('returns { orientation, timezone, currentPlaylistId } when template has all set', async () => {
+      db.provisioningTemplate.findFirst.mockResolvedValue({
+        id: 'tpl-1',
+        organizationId: orgId,
+        defaultOrientation: 'portrait',
+        defaultTimezone: 'America/Los_Angeles',
+        defaultPlaylistId: 'pl-1',
+      });
+
+      const result = await service.resolveForPairing(orgId, 'tpl-1');
+
+      expect(result).toEqual({
+        orientation: 'portrait',
+        timezone: 'America/Los_Angeles',
+        currentPlaylistId: 'pl-1',
+      });
+    });
+
+    it('omits currentPlaylistId when template defaultPlaylistId is null (playlist was deleted)', async () => {
+      db.provisioningTemplate.findFirst.mockResolvedValue({
+        id: 'tpl-1',
+        organizationId: orgId,
+        defaultOrientation: 'landscape',
+        defaultTimezone: 'UTC',
+        defaultPlaylistId: null,
+      });
+
+      const result = await service.resolveForPairing(orgId, 'tpl-1');
+
+      expect(result).toEqual({ orientation: 'landscape', timezone: 'UTC' });
+      expect(result).not.toHaveProperty('currentPlaylistId');
+    });
+
+    it('throws NotFound for cross-org template (template belongs to another org)', async () => {
+      db.provisioningTemplate.findFirst.mockResolvedValue(null);
+      await expect(service.resolveForPairing(orgId, 'tpl-foreign')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/middleware/src/modules/provisioning-templates/provisioning-templates.service.ts
+++ b/middleware/src/modules/provisioning-templates/provisioning-templates.service.ts
@@ -1,0 +1,132 @@
+import {
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { DatabaseService } from '../database/database.service';
+import { CreateProvisioningTemplateDto } from './dto/create-provisioning-template.dto';
+import { UpdateProvisioningTemplateDto } from './dto/update-provisioning-template.dto';
+
+/**
+ * O6 — Provisioning template CRUD + apply-at-pairing helper.
+ *
+ * Pattern mirrors O7 alert-rules / O4 tag-rules:
+ *   - Cross-org guards: every read/write filters by organizationId
+ *   - Cross-tenant validation at the service layer (DTO doesn't know orgId)
+ *   - Idempotent (organizationId, name) unique index for clean UI semantics
+ */
+@Injectable()
+export class ProvisioningTemplatesService {
+  private readonly logger = new Logger(ProvisioningTemplatesService.name);
+
+  constructor(private readonly db: DatabaseService) {}
+
+  async create(organizationId: string, dto: CreateProvisioningTemplateDto) {
+    if (dto.defaultPlaylistId !== undefined) {
+      await this.validatePlaylistInOrg(organizationId, dto.defaultPlaylistId);
+    }
+
+    return this.db.provisioningTemplate.create({
+      data: {
+        organizationId,
+        name: dto.name,
+        description: dto.description,
+        defaultOrientation: dto.defaultOrientation ?? 'landscape',
+        defaultTimezone: dto.defaultTimezone ?? 'UTC',
+        defaultPlaylistId: dto.defaultPlaylistId,
+        isDefault: dto.isDefault ?? false,
+      },
+    });
+  }
+
+  async findAll(organizationId: string) {
+    return this.db.provisioningTemplate.findMany({
+      where: { organizationId },
+      orderBy: [{ isDefault: 'desc' }, { createdAt: 'desc' }],
+    });
+  }
+
+  async findOne(organizationId: string, id: string) {
+    const tpl = await this.db.provisioningTemplate.findFirst({
+      where: { id, organizationId },
+    });
+    if (!tpl) {
+      throw new NotFoundException(`Provisioning template ${id} not found`);
+    }
+    return tpl;
+  }
+
+  async update(organizationId: string, id: string, dto: UpdateProvisioningTemplateDto) {
+    await this.findOne(organizationId, id);
+
+    if (dto.defaultPlaylistId !== undefined && dto.defaultPlaylistId !== null) {
+      await this.validatePlaylistInOrg(organizationId, dto.defaultPlaylistId);
+    }
+
+    return this.db.provisioningTemplate.update({
+      where: { id },
+      data: {
+        ...(dto.name !== undefined ? { name: dto.name } : {}),
+        ...(dto.description !== undefined ? { description: dto.description } : {}),
+        ...(dto.defaultOrientation !== undefined ? { defaultOrientation: dto.defaultOrientation } : {}),
+        ...(dto.defaultTimezone !== undefined ? { defaultTimezone: dto.defaultTimezone } : {}),
+        ...(dto.defaultPlaylistId !== undefined ? { defaultPlaylistId: dto.defaultPlaylistId } : {}),
+        ...(dto.isDefault !== undefined ? { isDefault: dto.isDefault } : {}),
+      },
+    });
+  }
+
+  async remove(organizationId: string, id: string): Promise<void> {
+    await this.findOne(organizationId, id);
+    await this.db.provisioningTemplate.delete({ where: { id } });
+  }
+
+  /**
+   * Resolve a template + apply its defaults at pairing time.
+   *
+   * Returns the override fields to merge into the Display.create / update
+   * payload: `{ orientation, timezone, currentPlaylistId? }`. Cross-org
+   * guard: the template must belong to the caller's org. If the template's
+   * defaultPlaylistId was set non-null at create but the Playlist was
+   * deleted (SetNull cascade), the orientation/timezone defaults still
+   * apply and currentPlaylistId is omitted (Display.currentPlaylistId stays
+   * at its prior value).
+   */
+  async resolveForPairing(
+    organizationId: string,
+    templateId: string,
+  ): Promise<{
+    orientation: string;
+    timezone: string;
+    currentPlaylistId?: string;
+  }> {
+    const tpl = await this.findOne(organizationId, templateId);
+    return {
+      orientation: tpl.defaultOrientation,
+      timezone: tpl.defaultTimezone,
+      ...(tpl.defaultPlaylistId
+        ? { currentPlaylistId: tpl.defaultPlaylistId }
+        : {}),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Cross-tenant guard. Service layer (not DTO) because the DTO doesn't
+   * know the caller's organizationId.
+   */
+  private async validatePlaylistInOrg(organizationId: string, playlistId: string): Promise<void> {
+    const playlist = await this.db.playlist.findFirst({
+      where: { id: playlistId, organizationId },
+    });
+    if (!playlist) {
+      throw new ForbiddenException(
+        `Playlist ${playlistId} does not belong to this organization`,
+      );
+    }
+  }
+}

--- a/packages/database/prisma/migrations/20260519142834_add_provisioning_templates/migration.sql
+++ b/packages/database/prisma/migrations/20260519142834_add_provisioning_templates/migration.sql
@@ -1,0 +1,37 @@
+-- Migration: add_provisioning_templates
+--
+-- O6 — per-org reusable Display provisioning config. Operator creates a
+-- template once (default orientation, timezone, default playlist), then
+-- references it when pairing N displays. Eliminates per-device config for
+-- growing fleets.
+--
+-- - organizationId FK ON DELETE CASCADE: org delete cascades everything.
+-- - defaultPlaylistId FK ON DELETE SET NULL: playlist delete preserves the
+--   template in a broken-but-recoverable state (admin must pick a new
+--   playlist). Same philosophy as O4's tag-rule playlistId cascade choice.
+-- - (organizationId, name) unique for UI uniqueness + idempotent backfill.
+--
+-- Plan: tasks/.hermes-check-receipts/o6-mass-provisioning.json
+-- Audit ref: docs/plans/2026-05-17-optsigns-vizora-feature-gap.md P1 #7
+
+CREATE TABLE "provisioning_templates" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "defaultOrientation" TEXT NOT NULL DEFAULT 'landscape',
+    "defaultTimezone" TEXT NOT NULL DEFAULT 'UTC',
+    "defaultPlaylistId" TEXT,
+    "isDefault" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "provisioning_templates_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "provisioning_templates_organizationId_name_key" ON "provisioning_templates"("organizationId", "name");
+CREATE INDEX "provisioning_templates_organizationId_idx" ON "provisioning_templates"("organizationId");
+CREATE INDEX "provisioning_templates_defaultPlaylistId_idx" ON "provisioning_templates"("defaultPlaylistId");
+
+ALTER TABLE "provisioning_templates" ADD CONSTRAINT "provisioning_templates_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "provisioning_templates" ADD CONSTRAINT "provisioning_templates_defaultPlaylistId_fkey" FOREIGN KEY ("defaultPlaylistId") REFERENCES "Playlist"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -58,6 +58,7 @@ model Organization {
   contentRecommendations ContentRecommendation[]
   mcpTokens              McpToken[]
   agentRuns              AgentRun[]
+  provisioningTemplates  ProvisioningTemplate[]
 
   @@index([slug])
   @@index([stripeCustomerId])
@@ -251,10 +252,11 @@ model Playlist {
   organizationId String
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
-  items            PlaylistItem[]
-  schedules        Schedule[]
-  assignedDisplays Display[]           @relation("DisplayCurrentPlaylist")
-  impressions      ContentImpression[]
+  items                 PlaylistItem[]
+  schedules             Schedule[]
+  assignedDisplays      Display[]              @relation("DisplayCurrentPlaylist")
+  impressions           ContentImpression[]
+  provisioningTemplates ProvisioningTemplate[]
 
   @@index([organizationId])
   @@index([organizationId, updatedAt])
@@ -1001,4 +1003,41 @@ model AgentRun {
   @@index([createdAt])
   @@index([organizationId, startedAt])
   @@map("agent_runs")
+}
+
+// ============================================================================
+// PROVISIONING TEMPLATES (O6 — bulk-friendly Display defaults)
+// ============================================================================
+
+/// Per-org reusable provisioning config. Operator creates a template (e.g.
+/// "Lobby TVs" with portrait + UTC-8 + default playlist "Welcome reel") then
+/// references it when pairing N displays — eliminates per-device config for
+/// growing fleets.
+///
+/// At pairing time (`PairingService.completePairing`), if the DTO carries a
+/// `provisioningTemplateId`, the template's defaults are applied to the
+/// newly-created Display. Cross-org validation: tag/playlist must belong
+/// to the caller's org (service-layer guard, same pattern as O4/O7).
+///
+/// `defaultPlaylistId` uses SetNull cascade so playlist deletion preserves
+/// the template (matches O4's choice and rationale).
+model ProvisioningTemplate {
+  id                 String   @id @default(cuid())
+  organizationId     String
+  name               String
+  description        String?
+  defaultOrientation String   @default("landscape")        // "landscape" | "portrait"
+  defaultTimezone    String   @default("UTC")
+  defaultPlaylistId  String?
+  isDefault          Boolean  @default(false)              // one default per org (UI hint; not unique-enforced)
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  organization    Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  defaultPlaylist Playlist?    @relation(fields: [defaultPlaylistId], references: [id], onDelete: SetNull)
+
+  @@unique([organizationId, name])                          // UI uniqueness
+  @@index([organizationId])
+  @@index([defaultPlaylistId])
+  @@map("provisioning_templates")
 }

--- a/tasks/.hermes-check-receipts/o6-mass-provisioning.json
+++ b/tasks/.hermes-check-receipts/o6-mass-provisioning.json
@@ -1,0 +1,14 @@
+{
+  "topic": "o6-mass-provisioning",
+  "task_text": "O6 — Mass provisioning (lean MVP cut). ProvisioningTemplate Prisma model + CRUD + apply at pairing time. Customers create one template (default orientation, timezone, default playlist) and reference it when pairing N displays — eliminates per-device config for growing fleets. Bulk pre-pair via CSV deferred to follow-up.",
+  "completed_at": "2026-05-19T14:30:00Z",
+  "drift_check_tag": "extends-Hermes",
+  "net_new_step_count": 6,
+  "hermes_step_count": 0,
+  "files_to_read_first": [
+    "middleware/src/modules/displays/pairing.service.ts",
+    "middleware/src/modules/displays/dto/complete-pairing.dto.ts",
+    "packages/database/prisma/schema.prisma"
+  ],
+  "verdict": "New Prisma model + module + CRUD service/controller, with one wiring point at pairing-complete to apply template defaults. Cross-org/tenant validation at the service layer mirrors O4/O7 pattern."
+}


### PR DESCRIPTION
## Summary
- New `ProvisioningTemplate` Prisma model. Operator creates one template per fleet category (e.g. "Lobby TVs" → portrait + UTC-8 + "Welcome reel" playlist) then references it when pairing N displays.
- `CompletePairingDto` now accepts optional `provisioningTemplateId`; `PairingService.completePairing` applies the template's defaults to the new Display.
- 5 CRUD endpoints under `/api/v1/provisioning-templates`. POST/PATCH/DELETE `@Roles('admin')`; GETs open to any logged-in org user.

Closes the audit's P1 #7 headline gap (mass provisioning). Deferred follow-up: bulk pre-pair via CSV (generate N device tokens upfront) — same shape as adding another endpoint to this module.

## What's notable

**FK cascade choices:**
- `organizationId` → CASCADE (standard tenant cleanup).
- `defaultPlaylistId` → **SetNull** (matches O4's rationale — playlist delete preserves the template in broken-but-recoverable state; admin must pick a new playlist).

**`resolveForPairing` apply-at-pairing helper:**
- Returns `{ orientation, timezone, currentPlaylistId? }` — the override fields PairingService merges into the Display payload.
- **`currentPlaylistId` is OMITTED (not null)** when the template's `defaultPlaylistId` was nulled by SetNull cascade. So the Display keeps its prior value rather than getting unassigned.
- Cross-org guard: foreign-org templateId → NotFoundException on the pairing endpoint.

**Defaults spread last in pair-complete:**
- In `pairing.service.ts` the provisioning defaults spread AT THE END of the Display create/update payload — so they override the Display's Prisma-level defaults (`landscape`/`UTC`) but never overwrite explicit fields above (nickname, location).

## Test plan
- [x] **22 new tests**: service.spec.ts (12 cases — create happy + cross-org/tenant guards on every op + resolveForPairing scenarios), controller.spec.ts (10 cases — delegation + RBAC metadata).
- [x] **Full middleware suite: 123 / 123 suites, 2357 / 2357 tests pass** (+22 vs 2335 main baseline; zero regressions).
- [x] `tsc --noEmit` clean.
- [x] Migration applied locally + Prisma client regenerated. Schema diff matches the hand-written SQL exactly.

## Deployment notes
- `pnpm --filter @vizora/database exec prisma migrate deploy` (applies `20260519142834_add_provisioning_templates`).
- `pnpm --filter @vizora/database exec prisma generate --schema packages/database/prisma/schema.prisma` (regen runtime client — same pattern as the O7 runbook step Sri added at T-1 Check 2b).
- `pm2 reload vizora-middleware --update-env`.
- No data seed needed (templates are opt-in per org).

## Plan + review receipt
- `tasks/.hermes-check-receipts/o6-mass-provisioning.json`
- Audit ref: `docs/plans/2026-05-17-optsigns-vizora-feature-gap.md` P1 #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)