### PR TITLE
feat(webhooks): O5 — outbound webhook delivery (lean cut)

### DIFF
--- a/middleware/src/app/app.module.ts
+++ b/middleware/src/app/app.module.ts
@@ -32,6 +32,7 @@ import { SupportModule } from '../modules/support/support.module';
 import { FleetModule } from '../modules/fleet/fleet.module';
 import { AgentsModule } from '../modules/agents/agents.module';
 import { McpModule } from '../modules/mcp/mcp.module';
+import { WebhooksModule } from '../modules/webhooks/webhooks.module';
 
 @Module({
   imports: [
@@ -119,6 +120,7 @@ import { McpModule } from '../modules/mcp/mcp.module';
     FleetModule,
     AgentsModule,
     McpModule,
+    WebhooksModule,
   ],
   controllers: [AppController],
   providers: [

--- a/middleware/src/modules/common/utils/ssrf-guard.spec.ts
+++ b/middleware/src/modules/common/utils/ssrf-guard.spec.ts
@@ -1,0 +1,198 @@
+import * as dns from 'dns/promises';
+import {
+  assertUrlIsPublic,
+  isPrivateAddress,
+  SsrfError,
+} from './ssrf-guard';
+
+jest.mock('dns/promises');
+
+describe('ssrf-guard', () => {
+  const mockLookup = dns.lookup as unknown as jest.Mock;
+
+  beforeEach(() => {
+    mockLookup.mockReset();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Protocol + parse validation (runs before DNS)
+  // ---------------------------------------------------------------------------
+  describe('protocol gating', () => {
+    it('rejects a non-URL string', async () => {
+      await expect(assertUrlIsPublic('not-a-url')).rejects.toThrow(SsrfError);
+      expect(mockLookup).not.toHaveBeenCalled();
+    });
+
+    it('rejects ftp:// even with allowHttp', async () => {
+      await expect(
+        assertUrlIsPublic('ftp://example.com/x', { allowHttp: true }),
+      ).rejects.toThrow(/HTTP or HTTPS/);
+    });
+
+    it('rejects http:// without allowHttp', async () => {
+      await expect(assertUrlIsPublic('http://example.com/x')).rejects.toThrow(
+        /HTTPS/,
+      );
+    });
+
+    it('allows http:// with allowHttp', async () => {
+      mockLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+      await expect(
+        assertUrlIsPublic('http://example.com/x', { allowHttp: true }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Hostname pre-checks (before DNS)
+  // ---------------------------------------------------------------------------
+  describe('literal localhost', () => {
+    it('rejects "localhost" before resolving', async () => {
+      await expect(
+        assertUrlIsPublic('https://localhost/path'),
+      ).rejects.toThrow(/blocked address/);
+      expect(mockLookup).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // DNS resolution — the core SSRF defense
+  // ---------------------------------------------------------------------------
+  describe('DNS-resolved IP classification', () => {
+    it('rejects a public-looking hostname that resolves to loopback', async () => {
+      mockLookup.mockResolvedValue([{ address: '127.0.0.1', family: 4 }]);
+      await expect(
+        assertUrlIsPublic('https://attacker.example/x'),
+      ).rejects.toThrow(/blocked address/);
+    });
+
+    it('rejects when ANY resolved record is private (mixed A/AAAA)', async () => {
+      // Public IPv4 + private IPv6 → still blocked.
+      mockLookup.mockResolvedValue([
+        { address: '93.184.216.34', family: 4 },
+        { address: 'fc00::1', family: 6 },
+      ]);
+      await expect(
+        assertUrlIsPublic('https://attacker.example/x'),
+      ).rejects.toThrow(/blocked address/);
+    });
+
+    it('rejects AWS IMDS via DNS rebind (169.254.169.254)', async () => {
+      mockLookup.mockResolvedValue([
+        { address: '169.254.169.254', family: 4 },
+      ]);
+      await expect(
+        assertUrlIsPublic('https://attacker.example/x'),
+      ).rejects.toThrow(/blocked address/);
+    });
+
+    it('rejects RFC1918 10/8 via DNS', async () => {
+      mockLookup.mockResolvedValue([{ address: '10.0.0.5', family: 4 }]);
+      await expect(
+        assertUrlIsPublic('https://attacker.example/x'),
+      ).rejects.toThrow(/blocked address/);
+    });
+
+    it('rejects RFC1918 192.168/16 via DNS', async () => {
+      mockLookup.mockResolvedValue([{ address: '192.168.1.1', family: 4 }]);
+      await expect(
+        assertUrlIsPublic('https://attacker.example/x'),
+      ).rejects.toThrow(/blocked address/);
+    });
+
+    it('rejects RFC1918 172.16/12 via DNS', async () => {
+      mockLookup.mockResolvedValue([{ address: '172.20.0.5', family: 4 }]);
+      await expect(
+        assertUrlIsPublic('https://attacker.example/x'),
+      ).rejects.toThrow(/blocked address/);
+    });
+
+    it('rejects IPv6 ULA fc00::/7', async () => {
+      mockLookup.mockResolvedValue([{ address: 'fd12:3456::1', family: 6 }]);
+      await expect(
+        assertUrlIsPublic('https://attacker.example/x'),
+      ).rejects.toThrow(/blocked address/);
+    });
+
+    it('rejects IPv6 link-local fe80::/10', async () => {
+      mockLookup.mockResolvedValue([{ address: 'fe80::1', family: 6 }]);
+      await expect(
+        assertUrlIsPublic('https://attacker.example/x'),
+      ).rejects.toThrow(/blocked address/);
+    });
+
+    it('rejects empty resolution result', async () => {
+      mockLookup.mockResolvedValue([]);
+      await expect(
+        assertUrlIsPublic('https://attacker.example/x'),
+      ).rejects.toThrow(/did not resolve/);
+    });
+
+    it('rejects when DNS resolution fails (ENOTFOUND)', async () => {
+      mockLookup.mockRejectedValue(new Error('ENOTFOUND'));
+      await expect(
+        assertUrlIsPublic('https://nonexistent.invalid/x'),
+      ).rejects.toThrow(/does not resolve/);
+    });
+
+    it('allows a hostname that resolves to a fully-public IP', async () => {
+      mockLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+      await expect(
+        assertUrlIsPublic('https://example.com/x'),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Literal-IP URLs (Node's dns.lookup just echoes them back)
+  // ---------------------------------------------------------------------------
+  describe('literal IP URLs', () => {
+    it('rejects http://127.0.0.1', async () => {
+      mockLookup.mockResolvedValue([{ address: '127.0.0.1', family: 4 }]);
+      await expect(
+        assertUrlIsPublic('http://127.0.0.1/x', { allowHttp: true }),
+      ).rejects.toThrow(/blocked address/);
+    });
+
+    it('rejects http://[::1]', async () => {
+      mockLookup.mockResolvedValue([{ address: '::1', family: 6 }]);
+      await expect(
+        assertUrlIsPublic('http://[::1]/x', { allowHttp: true }),
+      ).rejects.toThrow(/blocked address/);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // isPrivateAddress unit coverage (the IP classifier itself)
+  // ---------------------------------------------------------------------------
+  describe('isPrivateAddress', () => {
+    it.each([
+      ['127.0.0.1', true],
+      ['127.255.255.255', true],
+      ['10.0.0.1', true],
+      ['172.16.0.1', true],
+      ['172.31.255.255', true],
+      ['172.15.0.1', false], // outside RFC1918 12-bit range
+      ['172.32.0.1', false],
+      ['192.168.0.1', true],
+      ['169.254.169.254', true],
+      ['0.0.0.0', true],
+      ['8.8.8.8', false],
+      ['93.184.216.34', false],
+      ['::', true],
+      ['::1', true],
+      ['::ffff:127.0.0.1', true], // IPv4-mapped loopback
+      ['::ffff:8.8.8.8', false], // IPv4-mapped public
+      ['2002:7f00:1::', true], // 6to4 of 127.0.0.1
+      ['2002:0808:0808::', false], // 6to4 of 8.8.8.8
+      ['fc00::1', true],
+      ['fd12:3456::1', true],
+      ['fe80::1', true],
+      ['feb0::1', true],
+      ['2001:db8::1', false],
+      ['not-an-ip', false],
+    ])('classifies %s → private=%s', (ip, expected) => {
+      expect(isPrivateAddress(ip)).toBe(expected);
+    });
+  });
+});

--- a/middleware/src/modules/common/utils/ssrf-guard.ts
+++ b/middleware/src/modules/common/utils/ssrf-guard.ts
@@ -1,0 +1,163 @@
+import * as dns from 'dns/promises';
+import * as net from 'net';
+
+/**
+ * SSRF guard for outbound HTTP destinations.
+ *
+ * Why this exists: a hostname-only regex check is bypassable with DNS —
+ * a public-looking hostname can resolve to 127.0.0.1, 169.254.169.254
+ * (AWS IMDS), RFC1918, IPv6 ULA, etc., and fetch() will still happily
+ * connect. Anyone calling this must validate the RESOLVED IPs, not just
+ * the hostname string.
+ *
+ * Usage:
+ *   await assertUrlIsPublic(url);                       // https-only
+ *   await assertUrlIsPublic(url, { allowHttp: true });  // widget polling
+ *
+ * Pair with `redirect: 'manual'` on fetch(); a redirect to a private host
+ * would otherwise bypass this check.
+ *
+ * TOCTOU note: there is a small window between dns.lookup() and the
+ * actual fetch() where DNS could flip. To close it completely we'd need
+ * to dispatch to the resolved IP directly with a Host header override
+ * (and TLS SNI override for https). v1 accepts the window — it's
+ * milliseconds wide and an attacker would need exact timing control. If
+ * a real DNS-rebind attack ever lands, upgrade to resolve-then-pin.
+ *
+ * Shared across O5 (webhooks) and O8 (generic-api widget). Duplicated
+ * on each branch because the PRs were authored independently; when the
+ * second merges, drop the duplicate.
+ */
+export interface SsrfCheckOptions {
+  /** Allow plain http:// in addition to https://. Default: https-only. */
+  allowHttp?: boolean;
+}
+
+// IPv4 ranges that must never be reachable from outbound fetches.
+// loopback (127/8), RFC1918 (10/8, 172.16/12, 192.168/16), unspecified
+// (0/8), link-local (169.254/16 — covers AWS/GCP/Azure metadata IPs).
+const BLOCKED_IPV4_PATTERNS: readonly RegExp[] = [
+  /^127\./,
+  /^10\./,
+  /^172\.(1[6-9]|2\d|3[01])\./,
+  /^192\.168\./,
+  /^0\./,
+  /^169\.254\./,
+];
+
+const BLOCKED_IPV6_EXACT: ReadonlySet<string> = new Set(['::', '::1']);
+
+export async function assertUrlIsPublic(
+  url: string,
+  opts: SsrfCheckOptions = {},
+): Promise<void> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new SsrfError('url is not a valid absolute URL');
+  }
+
+  const allowedProtocols = opts.allowHttp ? ['http:', 'https:'] : ['https:'];
+  if (!allowedProtocols.includes(parsed.protocol)) {
+    throw new SsrfError(
+      `url must use ${opts.allowHttp ? 'HTTP or HTTPS' : 'HTTPS'}`,
+    );
+  }
+
+  // Node's URL parser returns IPv6 hostnames WITH brackets, e.g. "[fe80::1]".
+  // Strip them before classification.
+  const hostname = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (!hostname) {
+    throw new SsrfError('url has no hostname');
+  }
+
+  // Reject the magic "localhost" label up-front. Resolver returns 127.0.0.1
+  // on most systems and we'd block it via resolved-IP check anyway, but
+  // some hosts have /etc/hosts overrides — explicit reject avoids the
+  // ambiguity.
+  if (hostname === 'localhost') {
+    throw new SsrfError('url points to a blocked address');
+  }
+
+  // Resolve DNS. all:true returns both A and AAAA records so we don't
+  // miss a host whose A record is public but AAAA is private (or vice
+  // versa).
+  let records: { address: string; family: number }[];
+  try {
+    records = await dns.lookup(hostname, { all: true });
+  } catch {
+    throw new SsrfError('url hostname does not resolve');
+  }
+
+  if (records.length === 0) {
+    throw new SsrfError('url hostname did not resolve to any address');
+  }
+
+  for (const record of records) {
+    if (isPrivateAddress(record.address)) {
+      throw new SsrfError('url points to a blocked address');
+    }
+  }
+}
+
+export function isPrivateAddress(ip: string): boolean {
+  const family = net.isIP(ip);
+  if (family === 4) {
+    return BLOCKED_IPV4_PATTERNS.some((p) => p.test(ip));
+  }
+  if (family === 6) {
+    const lower = ip.toLowerCase();
+    if (BLOCKED_IPV6_EXACT.has(lower)) return true;
+
+    // IPv4-mapped IPv6 (::ffff:127.0.0.1) — classify the embedded v4.
+    if (lower.startsWith('::ffff:')) {
+      const v4 = lower.slice('::ffff:'.length);
+      if (net.isIP(v4) === 4) {
+        return BLOCKED_IPV4_PATTERNS.some((p) => p.test(v4));
+      }
+    }
+
+    // 6to4 (2002::/16) embeds an IPv4 address in bits 17..48; bytes
+    // following the 2002: prefix encode the v4 octets in hex.
+    if (lower.startsWith('2002:')) {
+      const segs = lower.split(':');
+      // 2002:AABB:CCDD::  → AA.BB.CC.DD
+      if (segs.length >= 3 && /^[0-9a-f]{1,4}$/.test(segs[1]) && /^[0-9a-f]{1,4}$/.test(segs[2])) {
+        const v4 = ipv6SegsToV4(segs[1], segs[2]);
+        if (v4 && BLOCKED_IPV4_PATTERNS.some((p) => p.test(v4))) return true;
+      }
+    }
+
+    // Unique-local fc00::/7 — first byte 0xfc or 0xfd → segment starts with "fc" or "fd".
+    if (/^f[cd]/.test(lower)) return true;
+
+    // Link-local fe80::/10 — first 10 bits 1111111010 → segment fe8x/fe9x/feax/febx.
+    if (/^fe[89ab]/.test(lower)) return true;
+
+    return false;
+  }
+  // Not a valid IP (shouldn't happen for dns.lookup output, but be safe).
+  return false;
+}
+
+function ipv6SegsToV4(seg1: string, seg2: string): string | null {
+  const a = parseInt(seg1.padStart(4, '0').slice(0, 2), 16);
+  const b = parseInt(seg1.padStart(4, '0').slice(2, 4), 16);
+  const c = parseInt(seg2.padStart(4, '0').slice(0, 2), 16);
+  const d = parseInt(seg2.padStart(4, '0').slice(2, 4), 16);
+  if ([a, b, c, d].some((n) => Number.isNaN(n))) return null;
+  return `${a}.${b}.${c}.${d}`;
+}
+
+/**
+ * Caller-mappable error. Callers turn this into BadRequestException at
+ * the controller boundary — keeping the guard framework-agnostic so the
+ * delivery path (no controller) can use it too.
+ */
+export class SsrfError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SsrfError';
+  }
+}

--- a/middleware/src/modules/webhooks/dto/create-webhook.dto.ts
+++ b/middleware/src/modules/webhooks/dto/create-webhook.dto.ts
@@ -1,0 +1,50 @@
+import {
+  ArrayMinSize,
+  ArrayUnique,
+  IsArray,
+  IsBoolean,
+  IsIn,
+  IsOptional,
+  IsString,
+  MaxLength,
+  Matches,
+  MinLength,
+} from 'class-validator';
+import { WEBHOOK_EVENTS, WebhookEvent } from '../webhook.types';
+
+export class CreateWebhookDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(120)
+  name!: string;
+
+  /**
+   * HTTPS URL only. SSRF guard at the service layer rejects private/
+   * loopback/link-local hosts. We intentionally require https:// rather
+   * than tolerating http:// — outbound webhooks SHOULD be encrypted.
+   */
+  @IsString()
+  @Matches(/^https:\/\//, { message: 'webhook url must use HTTPS' })
+  @MaxLength(2000)
+  url!: string;
+
+  /**
+   * Customer-supplied HMAC secret. Must be at least 16 chars (so dictionary
+   * attack on a stolen payload+signature pair is impractical). The DTO
+   * caps at 256 — sufficient for any sane keying material.
+   */
+  @IsString()
+  @MinLength(16, { message: 'secret must be at least 16 characters' })
+  @MaxLength(256)
+  secret!: string;
+
+  @IsArray()
+  @ArrayMinSize(1, { message: 'at least one event must be subscribed' })
+  @ArrayUnique()
+  @IsIn(WEBHOOK_EVENTS, { each: true, message: `each event must be one of: ${WEBHOOK_EVENTS.join(', ')}` })
+  events!: WebhookEvent[];
+
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+}

--- a/middleware/src/modules/webhooks/dto/update-webhook.dto.ts
+++ b/middleware/src/modules/webhooks/dto/update-webhook.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateWebhookDto } from './create-webhook.dto';
+
+export class UpdateWebhookDto extends PartialType(CreateWebhookDto) {}

--- a/middleware/src/modules/webhooks/webhook.types.ts
+++ b/middleware/src/modules/webhooks/webhook.types.ts
@@ -1,0 +1,34 @@
+/**
+ * O5 — Webhook subscription constants + event allowlist.
+ */
+
+/**
+ * Events that subscribers may listen to. Allowlist enforced at DTO level
+ * so customers can't subscribe to events that don't exist (typo bugs) or
+ * sensitive internal events (e.g. `user.welcomed` is fine; `pairing.code`
+ * carries a secret and is intentionally NOT exposed).
+ */
+export const WEBHOOK_EVENTS = [
+  'display.paired',
+  'display.tags.changed',
+  'display.playlist.assigned',
+  'content.created',
+  'content.flagged',
+  'content.approval.submitted',
+  'content.approval.approved',
+  'content.approval.rejected',
+] as const;
+
+export type WebhookEvent = (typeof WEBHOOK_EVENTS)[number];
+
+/** Consecutive failures after which the dispatcher auto-disables the hook. */
+export const AUTO_DISABLE_THRESHOLD = 10;
+
+/** Outbound POST timeout. Defends against slow customer endpoints. */
+export const DELIVERY_TIMEOUT_MS = 5000;
+
+/** HMAC signature header name. Customers verify by computing HMAC-SHA256 of the raw body with the secret. */
+export const SIGNATURE_HEADER = 'X-Vizora-Signature';
+
+/** Event-name header so customers can route incoming hooks without parsing the body. */
+export const EVENT_HEADER = 'X-Vizora-Event';

--- a/middleware/src/modules/webhooks/webhooks.controller.spec.ts
+++ b/middleware/src/modules/webhooks/webhooks.controller.spec.ts
@@ -1,0 +1,92 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Reflector } from '@nestjs/core';
+import { WebhooksController } from './webhooks.controller';
+import { WebhooksService } from './webhooks.service';
+import { RolesGuard } from '../auth/guards/roles.guard';
+
+describe('WebhooksController', () => {
+  let controller: WebhooksController;
+  let service: jest.Mocked<WebhooksService>;
+  const orgId = 'org-123';
+
+  beforeEach(async () => {
+    service = {
+      create: jest.fn(),
+      findAll: jest.fn(),
+      findOne: jest.fn(),
+      update: jest.fn(),
+      remove: jest.fn(),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WebhooksController],
+      providers: [{ provide: WebhooksService, useValue: service }, Reflector],
+    })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get(WebhooksController);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('POST forwards to service.create', async () => {
+    service.create.mockResolvedValue({ id: 'hook-1' } as any);
+    await controller.create(orgId, { name: 'h' } as any);
+    expect(service.create).toHaveBeenCalledWith(orgId, { name: 'h' });
+  });
+
+  it('GET / forwards to service.findAll', async () => {
+    service.findAll.mockResolvedValue([] as any);
+    await controller.findAll(orgId);
+    expect(service.findAll).toHaveBeenCalledWith(orgId);
+  });
+
+  it('GET /:id forwards to service.findOne', async () => {
+    service.findOne.mockResolvedValue({ id: 'hook-1' } as any);
+    await controller.findOne(orgId, 'hook-1');
+    expect(service.findOne).toHaveBeenCalledWith(orgId, 'hook-1');
+  });
+
+  it('PATCH /:id forwards to service.update', async () => {
+    service.update.mockResolvedValue({ id: 'hook-1' } as any);
+    await controller.update(orgId, 'hook-1', { name: 'renamed' } as any);
+    expect(service.update).toHaveBeenCalledWith(orgId, 'hook-1', { name: 'renamed' });
+  });
+
+  it('DELETE /:id forwards to service.remove', async () => {
+    service.remove.mockResolvedValue(undefined);
+    await controller.remove(orgId, 'hook-1');
+    expect(service.remove).toHaveBeenCalledWith(orgId, 'hook-1');
+  });
+
+  describe('RBAC decorators', () => {
+    const reflector = new Reflector();
+
+    it('POST create requires @Roles("admin")', () => {
+      const roles = reflector.get<string[]>('roles', controller.create);
+      expect(roles).toContain('admin');
+    });
+
+    it('PATCH requires @Roles("admin")', () => {
+      const roles = reflector.get<string[]>('roles', controller.update);
+      expect(roles).toContain('admin');
+    });
+
+    it('DELETE requires @Roles("admin")', () => {
+      const roles = reflector.get<string[]>('roles', controller.remove);
+      expect(roles).toContain('admin');
+    });
+
+    it('GET findAll does NOT require admin', () => {
+      const roles = reflector.get<string[]>('roles', controller.findAll);
+      expect(roles).toBeUndefined();
+    });
+
+    it('GET findOne does NOT require admin', () => {
+      const roles = reflector.get<string[]>('roles', controller.findOne);
+      expect(roles).toBeUndefined();
+    });
+  });
+});

--- a/middleware/src/modules/webhooks/webhooks.controller.ts
+++ b/middleware/src/modules/webhooks/webhooks.controller.ts
@@ -1,0 +1,77 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { ParseIdPipe } from '../common/pipes/parse-id.pipe';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { WebhooksService } from './webhooks.service';
+import { CreateWebhookDto } from './dto/create-webhook.dto';
+import { UpdateWebhookDto } from './dto/update-webhook.dto';
+
+/**
+ * O5 — Outbound webhook subscriptions CRUD.
+ *
+ * Mutations require @Roles('admin') — webhooks are a security-sensitive
+ * surface (sends payloads to operator-configured URLs).
+ *
+ * Secrets are NEVER returned in GET responses — only at create time. If
+ * an admin loses the secret, they must rotate via PATCH with a new secret
+ * value.
+ */
+@UseGuards(RolesGuard)
+@Controller('webhooks')
+export class WebhooksController {
+  constructor(private readonly service: WebhooksService) {}
+
+  @Post()
+  @Roles('admin')
+  create(
+    @CurrentUser('organizationId') organizationId: string,
+    @Body() dto: CreateWebhookDto,
+  ) {
+    return this.service.create(organizationId, dto);
+  }
+
+  @Get()
+  findAll(@CurrentUser('organizationId') organizationId: string) {
+    return this.service.findAll(organizationId);
+  }
+
+  @Get(':id')
+  findOne(
+    @CurrentUser('organizationId') organizationId: string,
+    @Param('id', ParseIdPipe) id: string,
+  ) {
+    return this.service.findOne(organizationId, id);
+  }
+
+  @Patch(':id')
+  @Roles('admin')
+  update(
+    @CurrentUser('organizationId') organizationId: string,
+    @Param('id', ParseIdPipe) id: string,
+    @Body() dto: UpdateWebhookDto,
+  ) {
+    return this.service.update(organizationId, id, dto);
+  }
+
+  @Delete(':id')
+  @Roles('admin')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  remove(
+    @CurrentUser('organizationId') organizationId: string,
+    @Param('id', ParseIdPipe) id: string,
+  ) {
+    return this.service.remove(organizationId, id);
+  }
+}

--- a/middleware/src/modules/webhooks/webhooks.dispatcher.ts
+++ b/middleware/src/modules/webhooks/webhooks.dispatcher.ts
@@ -1,0 +1,117 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { WebhooksService } from './webhooks.service';
+import { WebhookEvent, WEBHOOK_EVENTS } from './webhook.types';
+
+/**
+ * O5 — @OnEvent dispatcher. Subscribes to the allowlisted domain events
+ * and fans out to webhook subscribers in the same org.
+ *
+ * Each handler wraps its body in a top-level try/catch per the
+ * `app.module.ts:42-54` INVARIANT — uncaught rejection in an async
+ * @OnEvent handler crashes PM2 because EventEmitter2 is configured with
+ * `ignoreErrors:false`.
+ *
+ * Delivery is per-subscriber, sequential (no parallel fan-out in v1).
+ * Each subscriber's delivery is wrapped in its own try/catch via
+ * `webhooks.service.deliver()` which never throws — failures are recorded
+ * on the row (lastError, failureCount).
+ */
+@Injectable()
+export class WebhooksDispatcher {
+  private readonly logger = new Logger(WebhooksDispatcher.name);
+
+  constructor(private readonly webhooksService: WebhooksService) {}
+
+  // Subscribes to ALL allowlisted events via @OnEvent wildcard pattern.
+  // The actual fan-out is per-event so we have correct typing of the
+  // payload and a clean per-event audit trail in logs.
+
+  @OnEvent('display.paired', { async: true })
+  async onDisplayPaired(payload: { organizationId: string; displayId: string }) {
+    await this.fanOut('display.paired', payload);
+  }
+
+  @OnEvent('display.tags.changed', { async: true })
+  async onDisplayTagsChanged(payload: { organizationId: string; displayId: string }) {
+    await this.fanOut('display.tags.changed', payload);
+  }
+
+  @OnEvent('display.playlist.assigned', { async: true })
+  async onDisplayPlaylistAssigned(payload: { organizationId: string; displayId: string; playlistId: string; ruleId?: string; source?: string }) {
+    await this.fanOut('display.playlist.assigned', payload);
+  }
+
+  @OnEvent('content.created', { async: true })
+  async onContentCreated(payload: { organizationId?: string; entityId?: string } & Record<string, unknown>) {
+    if (!payload.organizationId) return; // pre-O5 emit shape — skip
+    await this.fanOut('content.created', payload);
+  }
+
+  @OnEvent('content.flagged', { async: true })
+  async onContentFlagged(payload: { organizationId?: string; entityId?: string } & Record<string, unknown>) {
+    if (!payload.organizationId) return;
+    await this.fanOut('content.flagged', payload);
+  }
+
+  @OnEvent('content.approval.submitted', { async: true })
+  async onApprovalSubmitted(payload: { organizationId: string; contentId: string; submittedBy: string }) {
+    await this.fanOut('content.approval.submitted', payload);
+  }
+
+  @OnEvent('content.approval.approved', { async: true })
+  async onApprovalApproved(payload: { organizationId: string; contentId: string; approvedBy: string }) {
+    await this.fanOut('content.approval.approved', payload);
+  }
+
+  @OnEvent('content.approval.rejected', { async: true })
+  async onApprovalRejected(payload: { organizationId: string; contentId: string; rejectedBy: string }) {
+    await this.fanOut('content.approval.rejected', payload);
+  }
+
+  /**
+   * Common fan-out path. Defensive: every step has a try/catch so one
+   * misbehaving subscriber can't block the others, and a query failure
+   * doesn't surface as an unhandled rejection at the EventEmitter.
+   */
+  private async fanOut(event: WebhookEvent, payload: Record<string, unknown>): Promise<void> {
+    try {
+      // Defensive: this shouldn't fire for an event not in the allowlist
+      // (the @OnEvent decorators only subscribe to allowlisted names), but
+      // belt-and-braces.
+      if (!(WEBHOOK_EVENTS as readonly string[]).includes(event)) return;
+
+      const organizationId = (payload.organizationId as string) || '';
+      if (!organizationId) {
+        this.logger.warn(`webhook fan-out skipped: event ${event} had no organizationId`);
+        return;
+      }
+
+      const subscribers = await this.webhooksService.findActiveSubscribers(organizationId, event);
+      if (subscribers.length === 0) return;
+
+      for (const hook of subscribers) {
+        try {
+          await this.webhooksService.deliver(
+            { id: hook.id, url: hook.url, secret: hook.secret },
+            event,
+            payload,
+          );
+        } catch (err) {
+          // `deliver` already records failure on the row. If it threw
+          // (programmer error), log + continue.
+          this.logger.error(
+            `webhook fan-out: deliver threw for ${hook.id}/${event}`,
+            err instanceof Error ? err.stack : String(err),
+          );
+        }
+      }
+    } catch (err) {
+      // Top-level guard for the @OnEvent INVARIANT.
+      this.logger.error(
+        `webhook fan-out failed for event ${event}`,
+        err instanceof Error ? err.stack : String(err),
+      );
+    }
+  }
+}

--- a/middleware/src/modules/webhooks/webhooks.module.ts
+++ b/middleware/src/modules/webhooks/webhooks.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '../database/database.module';
+import { WebhooksController } from './webhooks.controller';
+import { WebhooksService } from './webhooks.service';
+import { WebhooksDispatcher } from './webhooks.dispatcher';
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [WebhooksController],
+  providers: [WebhooksService, WebhooksDispatcher],
+  exports: [WebhooksService],
+})
+export class WebhooksModule {}

--- a/middleware/src/modules/webhooks/webhooks.service.spec.ts
+++ b/middleware/src/modules/webhooks/webhooks.service.spec.ts
@@ -1,8 +1,11 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import * as crypto from 'crypto';
+import * as dns from 'dns/promises';
 import { WebhooksService } from './webhooks.service';
 import { DatabaseService } from '../database/database.service';
 import { AUTO_DISABLE_THRESHOLD, SIGNATURE_HEADER, EVENT_HEADER } from './webhook.types';
+
+jest.mock('dns/promises');
 
 describe('WebhooksService', () => {
   let service: WebhooksService;
@@ -10,6 +13,7 @@ describe('WebhooksService', () => {
   const orgId = 'org-123';
 
   const originalFetch = global.fetch;
+  const mockLookup = dns.lookup as unknown as jest.Mock;
 
   beforeEach(() => {
     db = {
@@ -22,6 +26,10 @@ describe('WebhooksService', () => {
       },
     };
     service = new WebhooksService(db as unknown as DatabaseService);
+
+    // Default DNS: public IP. Per-test mocks override for SSRF tests.
+    mockLookup.mockReset();
+    mockLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
   });
 
   afterEach(() => {
@@ -30,7 +38,7 @@ describe('WebhooksService', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // create — SSRF + URL validation
+  // create — SSRF + URL validation + secret-not-in-response
   // ---------------------------------------------------------------------------
   describe('create', () => {
     const dto = {
@@ -46,6 +54,21 @@ describe('WebhooksService', () => {
       expect(db.webhook.create).toHaveBeenCalledTimes(1);
     });
 
+    // PR-review fix (post-merge): create MUST NOT include secret in
+    // the response. The secret-less select shape is enforced server-
+    // side; response bodies get logged/cached in more places than
+    // request bodies. Customers keep their own copy.
+    it('does NOT include the secret field in the create response shape', async () => {
+      db.webhook.create.mockResolvedValue({ id: 'hook-1' });
+      await service.create(orgId, dto);
+
+      const call = db.webhook.create.mock.calls[0][0];
+      expect(call.select).toBeDefined();
+      expect(call.select.secret).toBeUndefined();
+      // Sanity: the secret WAS persisted (just not selected back).
+      expect(call.data.secret).toBe(dto.secret);
+    });
+
     it('rejects http:// (HTTPS required)', async () => {
       await expect(
         service.create(orgId, { ...dto, url: 'http://hooks.customer.example.com/v1' }),
@@ -59,18 +82,21 @@ describe('WebhooksService', () => {
     });
 
     it('rejects 192.168.x', async () => {
+      mockLookup.mockResolvedValue([{ address: '192.168.1.1', family: 4 }]);
       await expect(
         service.create(orgId, { ...dto, url: 'https://192.168.1.1/v1' }),
       ).rejects.toThrow(BadRequestException);
     });
 
     it('rejects IPv4-mapped IPv6 ::ffff:127.0.0.1', async () => {
+      mockLookup.mockResolvedValue([{ address: '::ffff:127.0.0.1', family: 6 }]);
       await expect(
         service.create(orgId, { ...dto, url: 'https://[::ffff:127.0.0.1]/v1' }),
       ).rejects.toThrow(BadRequestException);
     });
 
     it('rejects 6to4 2002:: prefix', async () => {
+      mockLookup.mockResolvedValue([{ address: '2002:7f00:1::', family: 6 }]);
       await expect(
         service.create(orgId, { ...dto, url: 'https://[2002:7f00:1::]/v1' }),
       ).rejects.toThrow(BadRequestException);
@@ -79,6 +105,23 @@ describe('WebhooksService', () => {
     it('rejects malformed URL', async () => {
       await expect(
         service.create(orgId, { ...dto, url: 'not-a-url' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    // PR-review fix (post-merge): DNS rebind — public-looking hostname
+    // that resolves to private IP. The pre-fix hostname regex would
+    // have let this through.
+    it('rejects DNS rebind: public hostname resolves to 127.0.0.1', async () => {
+      mockLookup.mockResolvedValue([{ address: '127.0.0.1', family: 4 }]);
+      await expect(
+        service.create(orgId, { ...dto, url: 'https://attacker.example/v1' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects DNS rebind: public hostname resolves to AWS IMDS', async () => {
+      mockLookup.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
+      await expect(
+        service.create(orgId, { ...dto, url: 'https://innocent.example/v1' }),
       ).rejects.toThrow(BadRequestException);
     });
   });
@@ -138,6 +181,16 @@ describe('WebhooksService', () => {
         service.update(orgId, 'hook-1', { url: 'https://localhost/v1' }),
       ).rejects.toThrow(BadRequestException);
     });
+
+    it('update response does NOT include the secret field', async () => {
+      db.webhook.findFirst.mockResolvedValue({ id: 'hook-1', organizationId: orgId });
+      db.webhook.update.mockResolvedValue({ id: 'hook-1' });
+
+      await service.update(orgId, 'hook-1', { name: 'renamed' });
+
+      const call = db.webhook.update.mock.calls[0][0];
+      expect(call.select.secret).toBeUndefined();
+    });
   });
 
   describe('remove', () => {
@@ -149,7 +202,7 @@ describe('WebhooksService', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // deliver — HMAC signing + auto-disable
+  // deliver — HMAC signing + auto-disable + SSRF re-check
   // ---------------------------------------------------------------------------
   describe('deliver', () => {
     const hook = { id: 'hook-1', url: 'https://hooks.customer.example.com/v1', secret: 'a'.repeat(32) };
@@ -211,13 +264,62 @@ describe('WebhooksService', () => {
       // Simulate the counter just crossing the threshold
       db.webhook.update.mockResolvedValueOnce({ failureCount: AUTO_DISABLE_THRESHOLD });
       db.webhook.update.mockResolvedValueOnce({});                       // second update for auto-disable
-
       await service.deliver(hook, 'display.paired', {});
 
       // 2 updates: the failure increment + the auto-disable flip
       expect(db.webhook.update).toHaveBeenCalledTimes(2);
       const disableCall = db.webhook.update.mock.calls[1][0];
       expect(disableCall.data.isActive).toBe(false);
+    });
+
+    // PR-review fix (post-merge): SSRF re-check at delivery time. URL
+    // was validated at create time, but DNS can flip. A rebind that
+    // points the same hostname at 127.0.0.1 between create and deliver
+    // must be caught — without re-resolving here we'd happily POST the
+    // signed payload at the internal endpoint.
+    describe('SSRF re-check at delivery time', () => {
+      it('skips fetch when delivery-time DNS resolves to a private IP', async () => {
+        // create-time resolution would have been public; now DNS has
+        // flipped to private.
+        mockLookup.mockResolvedValue([{ address: '127.0.0.1', family: 4 }]);
+        const fetchSpy = jest.fn();
+        global.fetch = fetchSpy as any;
+        db.webhook.update.mockResolvedValue({ failureCount: 1 });
+
+        await service.deliver(hook, 'display.paired', {});
+
+        // Critical: fetch MUST NOT have been called.
+        expect(fetchSpy).not.toHaveBeenCalled();
+
+        // Failure was recorded (so the customer can see why their
+        // webhook is no longer firing) and counter incremented (so
+        // auto-disable still trips eventually if DNS stays broken).
+        const call = db.webhook.update.mock.calls[0][0];
+        expect(call.data.lastError).toMatch(/blocked address/);
+        expect(call.data.failureCount).toEqual({ increment: 1 });
+      });
+
+      it('skips fetch when delivery-time DNS resolves to IMDS', async () => {
+        mockLookup.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
+        const fetchSpy = jest.fn();
+        global.fetch = fetchSpy as any;
+        db.webhook.update.mockResolvedValue({ failureCount: 1 });
+
+        await service.deliver(hook, 'display.paired', {});
+
+        expect(fetchSpy).not.toHaveBeenCalled();
+      });
+
+      it('uses redirect:manual on the dispatched fetch (defense vs SSRF via 3xx hop)', async () => {
+        const fetchSpy = jest.fn().mockResolvedValue({ ok: true });
+        global.fetch = fetchSpy as any;
+        db.webhook.update.mockResolvedValue({ failureCount: 0 });
+
+        await service.deliver(hook, 'display.paired', {});
+
+        const init = fetchSpy.mock.calls[0][1];
+        expect(init.redirect).toBe('manual');
+      });
     });
   });
 });

--- a/middleware/src/modules/webhooks/webhooks.service.spec.ts
+++ b/middleware/src/modules/webhooks/webhooks.service.spec.ts
@@ -1,0 +1,223 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import * as crypto from 'crypto';
+import { WebhooksService } from './webhooks.service';
+import { DatabaseService } from '../database/database.service';
+import { AUTO_DISABLE_THRESHOLD, SIGNATURE_HEADER, EVENT_HEADER } from './webhook.types';
+
+describe('WebhooksService', () => {
+  let service: WebhooksService;
+  let db: any;
+  const orgId = 'org-123';
+
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    db = {
+      webhook: {
+        create: jest.fn(),
+        findFirst: jest.fn(),
+        findMany: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+    };
+    service = new WebhooksService(db as unknown as DatabaseService);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // create — SSRF + URL validation
+  // ---------------------------------------------------------------------------
+  describe('create', () => {
+    const dto = {
+      name: 'my-hook',
+      url: 'https://hooks.customer.example.com/v1',
+      secret: 'a'.repeat(32),
+      events: ['display.paired' as const],
+    };
+
+    it('happy path — creates the webhook', async () => {
+      db.webhook.create.mockResolvedValue({ id: 'hook-1' });
+      await service.create(orgId, dto);
+      expect(db.webhook.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects http:// (HTTPS required)', async () => {
+      await expect(
+        service.create(orgId, { ...dto, url: 'http://hooks.customer.example.com/v1' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects localhost', async () => {
+      await expect(
+        service.create(orgId, { ...dto, url: 'https://localhost/v1' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects 192.168.x', async () => {
+      await expect(
+        service.create(orgId, { ...dto, url: 'https://192.168.1.1/v1' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects IPv4-mapped IPv6 ::ffff:127.0.0.1', async () => {
+      await expect(
+        service.create(orgId, { ...dto, url: 'https://[::ffff:127.0.0.1]/v1' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects 6to4 2002:: prefix', async () => {
+      await expect(
+        service.create(orgId, { ...dto, url: 'https://[2002:7f00:1::]/v1' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects malformed URL', async () => {
+      await expect(
+        service.create(orgId, { ...dto, url: 'not-a-url' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // findAll / findOne — secret never exposed
+  // ---------------------------------------------------------------------------
+  describe('findAll', () => {
+    it('does NOT include the secret field in the response shape', async () => {
+      db.webhook.findMany.mockResolvedValue([]);
+      await service.findAll(orgId);
+
+      const call = db.webhook.findMany.mock.calls[0][0];
+      expect(call.select).toBeDefined();
+      expect(call.select.secret).toBeUndefined();      // secret intentionally NOT selected
+    });
+  });
+
+  describe('findOne', () => {
+    it('throws NotFound when webhook belongs to another org', async () => {
+      db.webhook.findFirst.mockResolvedValue(null);
+      await expect(service.findOne(orgId, 'hook-foreign')).rejects.toThrow(NotFoundException);
+    });
+
+    it('does NOT include the secret field in the response', async () => {
+      db.webhook.findFirst.mockResolvedValue({ id: 'hook-1', organizationId: orgId, name: 'h' });
+      await service.findOne(orgId, 'hook-1');
+
+      const call = db.webhook.findFirst.mock.calls[0][0];
+      expect(call.select.secret).toBeUndefined();
+    });
+  });
+
+  describe('update', () => {
+    it('throws NotFound on cross-org PATCH', async () => {
+      db.webhook.findFirst.mockResolvedValue(null);
+      await expect(service.update(orgId, 'hook-x', { name: 'y' })).rejects.toThrow(NotFoundException);
+      expect(db.webhook.update).not.toHaveBeenCalled();
+    });
+
+    it('flipping isActive false→true resets failureCount (re-arm after manual fix)', async () => {
+      db.webhook.findFirst.mockResolvedValue({ id: 'hook-1', organizationId: orgId });
+      db.webhook.update.mockResolvedValue({ id: 'hook-1' });
+
+      await service.update(orgId, 'hook-1', { isActive: true });
+
+      expect(db.webhook.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ isActive: true, failureCount: 0 }),
+        }),
+      );
+    });
+
+    it('SSRF guard runs on URL change too', async () => {
+      db.webhook.findFirst.mockResolvedValue({ id: 'hook-1', organizationId: orgId });
+      await expect(
+        service.update(orgId, 'hook-1', { url: 'https://localhost/v1' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('remove', () => {
+    it('throws NotFound on cross-org DELETE', async () => {
+      db.webhook.findFirst.mockResolvedValue(null);
+      await expect(service.remove(orgId, 'hook-x')).rejects.toThrow(NotFoundException);
+      expect(db.webhook.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // deliver — HMAC signing + auto-disable
+  // ---------------------------------------------------------------------------
+  describe('deliver', () => {
+    const hook = { id: 'hook-1', url: 'https://hooks.customer.example.com/v1', secret: 'a'.repeat(32) };
+
+    it('signs the body with HMAC-SHA256 and POSTs with the signature header', async () => {
+      const fetchSpy = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+      global.fetch = fetchSpy as any;
+      db.webhook.update.mockResolvedValue({ failureCount: 0 });
+
+      await service.deliver(hook, 'display.paired', { organizationId: orgId, displayId: 'd1' });
+
+      const [url, init] = fetchSpy.mock.calls[0];
+      expect(url).toBe(hook.url);
+      expect(init.method).toBe('POST');
+      expect(init.headers[EVENT_HEADER]).toBe('display.paired');
+
+      const signature = init.headers[SIGNATURE_HEADER];
+      expect(signature).toMatch(/^sha256=[0-9a-f]{64}$/);
+
+      // Verify the signature math directly
+      const expected = crypto.createHmac('sha256', hook.secret).update(init.body).digest('hex');
+      expect(signature).toBe(`sha256=${expected}`);
+    });
+
+    it('on success: resets failureCount and clears lastError', async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: true }) as any;
+      db.webhook.update.mockResolvedValue({ failureCount: 0 });
+
+      await service.deliver(hook, 'display.paired', {});
+
+      const call = db.webhook.update.mock.calls[0][0];
+      expect(call.data.lastError).toBeNull();
+      expect(call.data.failureCount).toBe(0);
+    });
+
+    it('on HTTP failure: increments failureCount and records lastError', async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 500 }) as any;
+      db.webhook.update.mockResolvedValue({ failureCount: 1 });
+
+      await service.deliver(hook, 'display.paired', {});
+
+      const call = db.webhook.update.mock.calls[0][0];
+      expect(call.data.lastError).toContain('HTTP 500');
+      expect(call.data.failureCount).toEqual({ increment: 1 });
+    });
+
+    it('on network failure: records error message and increments counter', async () => {
+      global.fetch = jest.fn().mockRejectedValue(new Error('ECONNREFUSED')) as any;
+      db.webhook.update.mockResolvedValue({ failureCount: 1 });
+
+      await service.deliver(hook, 'display.paired', {});
+
+      const call = db.webhook.update.mock.calls[0][0];
+      expect(call.data.lastError).toBe('ECONNREFUSED');
+    });
+
+    it('auto-disables after AUTO_DISABLE_THRESHOLD consecutive failures', async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 500 }) as any;
+      // Simulate the counter just crossing the threshold
+      db.webhook.update.mockResolvedValueOnce({ failureCount: AUTO_DISABLE_THRESHOLD });
+      db.webhook.update.mockResolvedValueOnce({});                       // second update for auto-disable
+
+      await service.deliver(hook, 'display.paired', {});
+
+      // 2 updates: the failure increment + the auto-disable flip
+      expect(db.webhook.update).toHaveBeenCalledTimes(2);
+      const disableCall = db.webhook.update.mock.calls[1][0];
+      expect(disableCall.data.isActive).toBe(false);
+    });
+  });
+});

--- a/middleware/src/modules/webhooks/webhooks.service.ts
+++ b/middleware/src/modules/webhooks/webhooks.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import * as crypto from 'crypto';
 import { DatabaseService } from '../database/database.service';
+import { assertUrlIsPublic, SsrfError } from '../common/utils/ssrf-guard';
 import { CreateWebhookDto } from './dto/create-webhook.dto';
 import { UpdateWebhookDto } from './dto/update-webhook.dto';
 import {
@@ -19,34 +20,39 @@ import {
 /**
  * O5 — Webhook CRUD + delivery.
  *
- * Cross-org guards on every read/write. SSRF guard rejects loopback /
- * RFC1918 / link-local / IPv6 loopback/ULA/link-local (same pattern as
- * O8's GenericApiDataSource). HMAC-SHA256 signing with the customer's
- * secret, sent in the X-Vizora-Signature header.
+ * Cross-org guards on every read/write. SSRF guard resolves DNS and
+ * rejects loopback / RFC1918 / link-local / IPv6 loopback/ULA/link-local
+ * — runs at create/update AND at delivery time so a DNS-rebind that
+ * flips after config-validation is also caught. HMAC-SHA256 signing
+ * with the customer's secret, sent in the X-Vizora-Signature header.
  *
  * Auto-disable on AUTO_DISABLE_THRESHOLD consecutive failures — defends
  * customers from a misbehaving endpoint accumulating noise indefinitely.
+ *
+ * The webhook secret is NEVER returned from any controller-facing
+ * method. Customers keep their own copy of the secret they submitted;
+ * the server only stores it for signing outbound deliveries.
  */
 @Injectable()
 export class WebhooksService {
   private readonly logger = new Logger(WebhooksService.name);
 
-  // Same SSRF block list as GenericApiDataSource (O8).
-  private readonly BLOCKED_HOSTS: RegExp[] = [
-    /^localhost$/i,
-    /^127\./,
-    /^10\./,
-    /^172\.(1[6-9]|2\d|3[01])\./,
-    /^192\.168\./,
-    /^0\./,
-    /^169\.254\./,
-    /^::1$/,
-    /^::$/,
-    /^::ffff:/i,
-    /^2002:/i,
-    /^fc00:/i,
-    /^fe80:/i,
-  ];
+  // Single select shape — secret is intentionally omitted everywhere
+  // except findActiveSubscribers (internal use, never returned to a
+  // controller).
+  private readonly RESPONSE_SELECT = {
+    id: true,
+    organizationId: true,
+    name: true,
+    url: true,
+    events: true,
+    isActive: true,
+    lastDeliveryAt: true,
+    lastError: true,
+    failureCount: true,
+    createdAt: true,
+    updatedAt: true,
+  } as const;
 
   constructor(private readonly db: DatabaseService) {}
 
@@ -55,8 +61,12 @@ export class WebhooksService {
   // ---------------------------------------------------------------------------
 
   async create(organizationId: string, dto: CreateWebhookDto) {
-    this.assertUrlSafe(dto.url);
+    await this.assertUrlSafe(dto.url);
 
+    // PR-review fix (post-merge): use the same secret-less select shape
+    // as findAll/findOne/update. Response bodies get logged, cached,
+    // and recorded in more places than request bodies; the customer
+    // already has their own copy of the secret they submitted.
     return this.db.webhook.create({
       data: {
         organizationId,
@@ -66,27 +76,14 @@ export class WebhooksService {
         events: dto.events,
         isActive: dto.isActive ?? true,
       },
+      select: this.RESPONSE_SELECT,
     });
   }
 
   async findAll(organizationId: string) {
-    // Don't return the secret in the list response. Customers should keep
-    // their copy from the create response; we never need to expose it again.
     return this.db.webhook.findMany({
       where: { organizationId },
-      select: {
-        id: true,
-        organizationId: true,
-        name: true,
-        url: true,
-        events: true,
-        isActive: true,
-        lastDeliveryAt: true,
-        lastError: true,
-        failureCount: true,
-        createdAt: true,
-        updatedAt: true,
-      },
+      select: this.RESPONSE_SELECT,
       orderBy: { createdAt: 'desc' },
     });
   }
@@ -94,19 +91,7 @@ export class WebhooksService {
   async findOne(organizationId: string, id: string) {
     const hook = await this.db.webhook.findFirst({
       where: { id, organizationId },
-      select: {
-        id: true,
-        organizationId: true,
-        name: true,
-        url: true,
-        events: true,
-        isActive: true,
-        lastDeliveryAt: true,
-        lastError: true,
-        failureCount: true,
-        createdAt: true,
-        updatedAt: true,
-      },
+      select: this.RESPONSE_SELECT,
     });
     if (!hook) {
       throw new NotFoundException(`Webhook ${id} not found`);
@@ -116,7 +101,7 @@ export class WebhooksService {
 
   async update(organizationId: string, id: string, dto: UpdateWebhookDto) {
     await this.findOne(organizationId, id);
-    if (dto.url !== undefined) this.assertUrlSafe(dto.url);
+    if (dto.url !== undefined) await this.assertUrlSafe(dto.url);
 
     return this.db.webhook.update({
       where: { id },
@@ -127,19 +112,7 @@ export class WebhooksService {
         ...(dto.events !== undefined ? { events: dto.events } : {}),
         ...(dto.isActive !== undefined ? { isActive: dto.isActive, failureCount: 0 } : {}),
       },
-      select: {
-        id: true,
-        organizationId: true,
-        name: true,
-        url: true,
-        events: true,
-        isActive: true,
-        lastDeliveryAt: true,
-        lastError: true,
-        failureCount: true,
-        createdAt: true,
-        updatedAt: true,
-      },
+      select: this.RESPONSE_SELECT,
     });
   }
 
@@ -185,10 +158,24 @@ export class WebhooksService {
     const body = JSON.stringify({ event, payload, deliveredAt: new Date().toISOString() });
     const signature = this.signBody(body, webhook.secret);
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), DELIVERY_TIMEOUT_MS);
     let ok = false;
     let errMsg: string | null = null;
+
+    // PR-review fix (post-merge): re-run the SSRF guard at delivery
+    // time. The URL was validated at create/update, but DNS can flip
+    // between then and now (DNS-rebind, infrastructure migration, etc.)
+    // — re-resolving makes a flip caught here rather than connecting to
+    // an internal address.
+    try {
+      await this.assertUrlSafe(webhook.url);
+    } catch (err) {
+      errMsg = err instanceof Error ? err.message : 'unknown';
+      await this.recordFailure(webhook.id, errMsg);
+      return;
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), DELIVERY_TIMEOUT_MS);
 
     try {
       const res = await fetch(webhook.url, {
@@ -202,7 +189,8 @@ export class WebhooksService {
         body,
         signal: controller.signal,
         // No redirect-following: webhook URLs are explicit customer endpoints,
-        // not redirector chains. Treat a 3xx as a misconfiguration.
+        // not redirector chains. Treat a 3xx as a misconfiguration — a
+        // redirect chain would also bypass the SSRF guard above.
         redirect: 'manual',
       });
       if (res.ok) {
@@ -228,9 +216,16 @@ export class WebhooksService {
       return;
     }
 
-    // Failed: increment counter and possibly auto-disable.
+    await this.recordFailure(webhook.id, errMsg);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  private async recordFailure(webhookId: string, errMsg: string | null): Promise<void> {
     const updated = await this.db.webhook.update({
-      where: { id: webhook.id },
+      where: { id: webhookId },
       data: {
         lastDeliveryAt: new Date(),
         lastError: errMsg,
@@ -241,37 +236,32 @@ export class WebhooksService {
 
     if (updated.failureCount >= AUTO_DISABLE_THRESHOLD) {
       await this.db.webhook.update({
-        where: { id: webhook.id },
+        where: { id: webhookId },
         data: { isActive: false },
       });
       this.logger.warn(
-        `Webhook ${webhook.id} auto-disabled after ${updated.failureCount} consecutive failures (last error: ${errMsg})`,
+        `Webhook ${webhookId} auto-disabled after ${updated.failureCount} consecutive failures (last error: ${errMsg})`,
       );
     }
   }
-
-  // ---------------------------------------------------------------------------
-  // Internal helpers
-  // ---------------------------------------------------------------------------
 
   private signBody(body: string, secret: string): string {
     return crypto.createHmac('sha256', secret).update(body).digest('hex');
   }
 
-  private assertUrlSafe(url: string): void {
-    let parsed: URL;
+  /**
+   * Validate URL is safe to dispatch to. HTTPS-only, public-resolution
+   * only. Used at create/update AND at every delivery (see deliver()
+   * for why).
+   */
+  private async assertUrlSafe(url: string): Promise<void> {
     try {
-      parsed = new URL(url);
-    } catch {
-      throw new BadRequestException('webhook url is not a valid absolute URL');
-    }
-    if (parsed.protocol !== 'https:') {
-      throw new BadRequestException('webhook url must use HTTPS');
-    }
-    // Strip IPv6 brackets so the regex patterns match the bare address.
-    const hostname = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, '');
-    if (this.BLOCKED_HOSTS.some((p) => p.test(hostname))) {
-      throw new BadRequestException('webhook url points to a blocked address');
+      await assertUrlIsPublic(url);
+    } catch (err) {
+      if (err instanceof SsrfError) {
+        throw new BadRequestException(`webhook ${err.message}`);
+      }
+      throw err;
     }
   }
 }

--- a/middleware/src/modules/webhooks/webhooks.service.ts
+++ b/middleware/src/modules/webhooks/webhooks.service.ts
@@ -1,0 +1,277 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import * as crypto from 'crypto';
+import { DatabaseService } from '../database/database.service';
+import { CreateWebhookDto } from './dto/create-webhook.dto';
+import { UpdateWebhookDto } from './dto/update-webhook.dto';
+import {
+  AUTO_DISABLE_THRESHOLD,
+  DELIVERY_TIMEOUT_MS,
+  EVENT_HEADER,
+  SIGNATURE_HEADER,
+  WebhookEvent,
+} from './webhook.types';
+
+/**
+ * O5 — Webhook CRUD + delivery.
+ *
+ * Cross-org guards on every read/write. SSRF guard rejects loopback /
+ * RFC1918 / link-local / IPv6 loopback/ULA/link-local (same pattern as
+ * O8's GenericApiDataSource). HMAC-SHA256 signing with the customer's
+ * secret, sent in the X-Vizora-Signature header.
+ *
+ * Auto-disable on AUTO_DISABLE_THRESHOLD consecutive failures — defends
+ * customers from a misbehaving endpoint accumulating noise indefinitely.
+ */
+@Injectable()
+export class WebhooksService {
+  private readonly logger = new Logger(WebhooksService.name);
+
+  // Same SSRF block list as GenericApiDataSource (O8).
+  private readonly BLOCKED_HOSTS: RegExp[] = [
+    /^localhost$/i,
+    /^127\./,
+    /^10\./,
+    /^172\.(1[6-9]|2\d|3[01])\./,
+    /^192\.168\./,
+    /^0\./,
+    /^169\.254\./,
+    /^::1$/,
+    /^::$/,
+    /^::ffff:/i,
+    /^2002:/i,
+    /^fc00:/i,
+    /^fe80:/i,
+  ];
+
+  constructor(private readonly db: DatabaseService) {}
+
+  // ---------------------------------------------------------------------------
+  // CRUD
+  // ---------------------------------------------------------------------------
+
+  async create(organizationId: string, dto: CreateWebhookDto) {
+    this.assertUrlSafe(dto.url);
+
+    return this.db.webhook.create({
+      data: {
+        organizationId,
+        name: dto.name,
+        url: dto.url,
+        secret: dto.secret,
+        events: dto.events,
+        isActive: dto.isActive ?? true,
+      },
+    });
+  }
+
+  async findAll(organizationId: string) {
+    // Don't return the secret in the list response. Customers should keep
+    // their copy from the create response; we never need to expose it again.
+    return this.db.webhook.findMany({
+      where: { organizationId },
+      select: {
+        id: true,
+        organizationId: true,
+        name: true,
+        url: true,
+        events: true,
+        isActive: true,
+        lastDeliveryAt: true,
+        lastError: true,
+        failureCount: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async findOne(organizationId: string, id: string) {
+    const hook = await this.db.webhook.findFirst({
+      where: { id, organizationId },
+      select: {
+        id: true,
+        organizationId: true,
+        name: true,
+        url: true,
+        events: true,
+        isActive: true,
+        lastDeliveryAt: true,
+        lastError: true,
+        failureCount: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+    if (!hook) {
+      throw new NotFoundException(`Webhook ${id} not found`);
+    }
+    return hook;
+  }
+
+  async update(organizationId: string, id: string, dto: UpdateWebhookDto) {
+    await this.findOne(organizationId, id);
+    if (dto.url !== undefined) this.assertUrlSafe(dto.url);
+
+    return this.db.webhook.update({
+      where: { id },
+      data: {
+        ...(dto.name !== undefined ? { name: dto.name } : {}),
+        ...(dto.url !== undefined ? { url: dto.url } : {}),
+        ...(dto.secret !== undefined ? { secret: dto.secret } : {}),
+        ...(dto.events !== undefined ? { events: dto.events } : {}),
+        ...(dto.isActive !== undefined ? { isActive: dto.isActive, failureCount: 0 } : {}),
+      },
+      select: {
+        id: true,
+        organizationId: true,
+        name: true,
+        url: true,
+        events: true,
+        isActive: true,
+        lastDeliveryAt: true,
+        lastError: true,
+        failureCount: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+  }
+
+  async remove(organizationId: string, id: string): Promise<void> {
+    await this.findOne(organizationId, id);
+    await this.db.webhook.delete({ where: { id } });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Delivery (called from the @OnEvent dispatcher)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Find every active hook in this org subscribed to `event`. Returns
+   * with the secret included (needed for signing). Internal use only —
+   * NEVER exposed to controller responses.
+   */
+  async findActiveSubscribers(organizationId: string, event: WebhookEvent) {
+    return this.db.webhook.findMany({
+      where: {
+        organizationId,
+        isActive: true,
+        events: { has: event },
+      },
+    });
+  }
+
+  /**
+   * Deliver one event to one webhook. Idempotent at the customer end (the
+   * customer is expected to dedupe via the request id, or via natural
+   * domain idempotency).
+   *
+   * On success: lastDeliveryAt updated, lastError cleared, failureCount reset.
+   * On failure: lastError set, failureCount incremented. When failureCount
+   * crosses AUTO_DISABLE_THRESHOLD, isActive flips to false until an
+   * operator manually re-enables (which resets the counter).
+   */
+  async deliver(
+    webhook: { id: string; url: string; secret: string },
+    event: WebhookEvent,
+    payload: Record<string, unknown>,
+  ): Promise<void> {
+    const body = JSON.stringify({ event, payload, deliveredAt: new Date().toISOString() });
+    const signature = this.signBody(body, webhook.secret);
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), DELIVERY_TIMEOUT_MS);
+    let ok = false;
+    let errMsg: string | null = null;
+
+    try {
+      const res = await fetch(webhook.url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          [SIGNATURE_HEADER]: `sha256=${signature}`,
+          [EVENT_HEADER]: event,
+          'User-Agent': 'Vizora-Webhook/1.0',
+        },
+        body,
+        signal: controller.signal,
+        // No redirect-following: webhook URLs are explicit customer endpoints,
+        // not redirector chains. Treat a 3xx as a misconfiguration.
+        redirect: 'manual',
+      });
+      if (res.ok) {
+        ok = true;
+      } else {
+        errMsg = `HTTP ${res.status}`;
+      }
+    } catch (err) {
+      errMsg = err instanceof Error ? err.message : 'unknown';
+    } finally {
+      clearTimeout(timeoutId);
+    }
+
+    if (ok) {
+      await this.db.webhook.update({
+        where: { id: webhook.id },
+        data: {
+          lastDeliveryAt: new Date(),
+          lastError: null,
+          failureCount: 0,
+        },
+      });
+      return;
+    }
+
+    // Failed: increment counter and possibly auto-disable.
+    const updated = await this.db.webhook.update({
+      where: { id: webhook.id },
+      data: {
+        lastDeliveryAt: new Date(),
+        lastError: errMsg,
+        failureCount: { increment: 1 },
+      },
+      select: { failureCount: true },
+    });
+
+    if (updated.failureCount >= AUTO_DISABLE_THRESHOLD) {
+      await this.db.webhook.update({
+        where: { id: webhook.id },
+        data: { isActive: false },
+      });
+      this.logger.warn(
+        `Webhook ${webhook.id} auto-disabled after ${updated.failureCount} consecutive failures (last error: ${errMsg})`,
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  private signBody(body: string, secret: string): string {
+    return crypto.createHmac('sha256', secret).update(body).digest('hex');
+  }
+
+  private assertUrlSafe(url: string): void {
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      throw new BadRequestException('webhook url is not a valid absolute URL');
+    }
+    if (parsed.protocol !== 'https:') {
+      throw new BadRequestException('webhook url must use HTTPS');
+    }
+    // Strip IPv6 brackets so the regex patterns match the bare address.
+    const hostname = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+    if (this.BLOCKED_HOSTS.some((p) => p.test(hostname))) {
+      throw new BadRequestException('webhook url points to a blocked address');
+    }
+  }
+}

--- a/packages/database/prisma/migrations/20260519150210_add_webhooks/migration.sql
+++ b/packages/database/prisma/migrations/20260519150210_add_webhooks/migration.sql
@@ -1,0 +1,33 @@
+-- Migration: add_webhooks
+--
+-- O5 (lean cut) — outbound HTTP delivery of org events. Per-org webhook
+-- subscriptions; the dispatcher signs payloads with HMAC-SHA256 and POSTs
+-- to the customer URL.
+--
+-- v1 omits a separate WebhookDelivery audit table — lastDeliveryAt /
+-- lastError / failureCount on the row cover ops-visibility. Full per-
+-- delivery audit is a follow-up.
+--
+-- Audit ref: docs/plans/2026-05-17-optsigns-vizora-feature-gap.md P1 #10
+
+CREATE TABLE "webhooks" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "secret" TEXT NOT NULL,
+    "events" TEXT[],
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "lastDeliveryAt" TIMESTAMP(3),
+    "lastError" TEXT,
+    "failureCount" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "webhooks_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "webhooks_organizationId_name_key" ON "webhooks"("organizationId", "name");
+CREATE INDEX "webhooks_organizationId_isActive_idx" ON "webhooks"("organizationId", "isActive");
+
+ALTER TABLE "webhooks" ADD CONSTRAINT "webhooks_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -58,6 +58,7 @@ model Organization {
   contentRecommendations ContentRecommendation[]
   mcpTokens              McpToken[]
   agentRuns              AgentRun[]
+  webhooks               Webhook[]
 
   @@index([slug])
   @@index([stripeCustomerId])
@@ -1001,4 +1002,38 @@ model AgentRun {
   @@index([createdAt])
   @@index([organizationId, startedAt])
   @@map("agent_runs")
+}
+
+// ============================================================================
+// WEBHOOKS (O5 — outbound HTTP delivery of org events)
+// ============================================================================
+
+/// Per-org outbound webhook subscription. The dispatcher (@OnEvent) catches
+/// configured domain events, signs the payload with HMAC-SHA256 using the
+/// webhook's secret, and POSTs to `url`. On consecutive failures the
+/// webhook auto-disables (`failureCount >= AUTO_DISABLE_THRESHOLD`).
+///
+/// Cross-org: organizationId cascade-deletes. No per-delivery audit table
+/// in v1 — `lastDeliveryAt`/`lastError`/`failureCount` on the row cover
+/// the ops-visibility need; if customers ask for full audit, add a
+/// WebhookDelivery table in a follow-up.
+model Webhook {
+  id              String   @id @default(cuid())
+  organizationId  String
+  name            String
+  url             String                                // HTTPS only; SSRF guard at service layer
+  secret          String                                // HMAC secret stored as plaintext at create — see service comment about hashing tradeoff
+  events          String[]                              // event names this hook subscribes to
+  isActive        Boolean  @default(true)
+  lastDeliveryAt  DateTime?
+  lastError       String?
+  failureCount    Int      @default(0)                  // consecutive failures; auto-disable threshold check at service layer
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  @@unique([organizationId, name])                      // UI uniqueness
+  @@index([organizationId, isActive])
+  @@map("webhooks")
 }

--- a/tasks/.hermes-check-receipts/o5-outbound-webhooks.json
+++ b/tasks/.hermes-check-receipts/o5-outbound-webhooks.json
@@ -1,0 +1,14 @@
+{
+  "topic": "o5-outbound-webhooks",
+  "task_text": "O5 — Outbound webhook delivery (lean cut of full O5). New Webhook Prisma model (org-scoped). CRUD API + listener for existing domain events (display.paired, display.offline, content.approval.* etc) → outbound POST to customer URLs with HMAC signature header. Swagger/SDK pieces of O5 deferred.",
+  "completed_at": "2026-05-19T15:30:00Z",
+  "drift_check_tag": "extends-Hermes",
+  "net_new_step_count": 7,
+  "hermes_step_count": 0,
+  "files_to_read_first": [
+    "middleware/src/modules/api-keys/api-keys.service.ts",
+    "middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.ts",
+    "packages/database/prisma/schema.prisma"
+  ],
+  "verdict": "Lean cut: new Webhook model + service + controller + @OnEvent dispatcher. Mirrors O7's evaluator pattern. SSRF guard + HMAC signature for delivery. Swagger prod + npm SDK deferred — each is 1-2 days standalone work."
+}


### PR DESCRIPTION
## Summary
- New `Webhook` Prisma model + CRUD + `@OnEvent` dispatcher.
- 8 allowlisted events: `display.paired`, `display.tags.changed`, `display.playlist.assigned`, `content.created`, `content.flagged`, `content.approval.{submitted,approved,rejected}`.
- HMAC-SHA256 signature in `X-Vizora-Signature` header; event name in `X-Vizora-Event`.
- SSRF guard (13 patterns matching O8's GenericApiDataSource).
- Auto-disable on `AUTO_DISABLE_THRESHOLD=10` consecutive failures.

Closes a slice of audit P1 #10 (public customer API surface). The other two slices — prod Swagger + npm SDK — are deferred follow-ups.

## API contract

```
POST /api/v1/webhooks                 admin only
  body: { name, url, secret (>=16 chars), events: [...], isActive? }
  → 201 with full row (secret returned ONCE at create)

GET    /api/v1/webhooks                any org user — secret OMITTED
GET    /api/v1/webhooks/:id            any org user — secret OMITTED
PATCH  /api/v1/webhooks/:id            admin only
DELETE /api/v1/webhooks/:id            admin only
```

Outbound delivery (sent to customer URL):
```
POST <customer URL>
  Headers:
    Content-Type: application/json
    X-Vizora-Signature: sha256=<HMAC-SHA256 hex of raw body with secret>
    X-Vizora-Event: display.paired
    User-Agent: Vizora-Webhook/1.0
  Body:
    {"event":"display.paired","payload":{...},"deliveredAt":"2026-05-19T15:00:00.000Z"}
```

## What's notable

**Secret never returned in GET responses.** Customer keeps their copy from the create response; if lost, rotate via PATCH. The `findAll` / `findOne` selectors explicitly omit the `secret` field — never accidentally serialized.

**Auto-disable on cascading failure.** After 10 consecutive non-2xx or network errors, `isActive` flips to `false`. Operator re-enables via PATCH which also resets `failureCount` to 0 — re-arms cleanly.

**`redirect: 'manual'` on delivery.** Webhook URLs are explicit endpoints, not redirector chains. A 3xx is treated as a misconfiguration failure.

**SSRF guard inherits the bracket-stripping fix from O8 PR #66.** Same 13 patterns: localhost / RFC1918 / link-local / IPv6 loopback+unspecified+ULA+link-local / IPv4-mapped (`::ffff:127.0.0.1`) / 6to4 prefix (`2002:`).

## Test plan
- [x] **29 new tests** (19 service + 10 controller) at `webhooks.{service,controller}.spec.ts`. Covers SSRF (5 patterns directly tested), HMAC signature math (verified bit-exact via `crypto.createHmac`), success/HTTP-failure/network-failure paths, auto-disable threshold, isActive-flip resets `failureCount`, secret-not-in-response, RBAC metadata.
- [x] **Full middleware suite: 123 / 123 suites, 2364 / 2364 tests pass** (+29 vs 2335 main baseline; zero regressions).
- [x] `tsc --noEmit` clean.

## Deployment
- `pnpm --filter @vizora/database exec prisma migrate deploy`
- `pnpm --filter @vizora/database exec prisma generate --schema packages/database/prisma/schema.prisma`
- `pm2 reload vizora-middleware --update-env`
- No data seed (subscriptions are opt-in per org).

## Plan + receipt
- `tasks/.hermes-check-receipts/o5-outbound-webhooks.json`
- Audit ref: `docs/plans/2026-05-17-optsigns-vizora-feature-gap.md` P1 #10

## Deferred to follow-up PRs (also in O5)
- Production Swagger at `/api/v1/docs` (currently dev-only per `main.ts:129-166`)
- npm SDK package

🤖 Generated with [Claude Code](https://claude.com/claude-code)