### PR TITLE
feat(webhooks): O5 follow-up — per-delivery audit table

### DIFF
--- a/middleware/src/modules/metrics/metrics.service.ts
+++ b/middleware/src/modules/metrics/metrics.service.ts
@@ -9,6 +9,20 @@ export class MetricsService implements OnModuleInit {
   readonly httpRequestDuration: client.Histogram<string>;
   readonly httpErrorsTotal: client.Counter<string>;
 
+  // Webhook delivery audit — see WebhooksService.recordAttempt.
+  // Two counters by design:
+  //   - webhookDeliveriesTotal — every attempted dispatch, labeled by
+  //     status (success | failure | blocked) and event. Used for
+  //     dashboards + as a freshness signal: if this counter stalls
+  //     while customers have active webhooks, dispatch is broken.
+  //   - webhookAuditFailuresTotal — audit row insert failed (table
+  //     missing, FK drift, transient DB issue). Recorded separately
+  //     so the operator can alert on ANY non-zero value (per the
+  //     CLAUDE.md §12 silent-failure prevention rule — audit losing
+  //     rows must surface immediately).
+  readonly webhookDeliveriesTotal: client.Counter<string>;
+  readonly webhookAuditFailuresTotal: client.Counter<string>;
+
   constructor() {
     this.register = new client.Registry();
 
@@ -33,6 +47,20 @@ export class MetricsService implements OnModuleInit {
       name: 'vizora_http_errors_total',
       help: 'Total number of HTTP error responses (4xx + 5xx)',
       labelNames: ['method', 'path', 'status'],
+      registers: [this.register],
+    });
+
+    this.webhookDeliveriesTotal = new client.Counter({
+      name: 'vizora_webhook_deliveries_total',
+      help: 'Webhook delivery attempts, by outcome status and event name',
+      labelNames: ['status', 'event'],
+      registers: [this.register],
+    });
+
+    this.webhookAuditFailuresTotal = new client.Counter({
+      name: 'vizora_webhook_audit_failures_total',
+      help: 'Webhook delivery audit row insert failed — alert on any non-zero value (silent-failure prevention)',
+      labelNames: ['event'],
       registers: [this.register],
     });
   }

--- a/middleware/src/modules/webhooks/dto/list-deliveries.dto.spec.ts
+++ b/middleware/src/modules/webhooks/dto/list-deliveries.dto.spec.ts
@@ -1,0 +1,45 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { ListDeliveriesDto } from './list-deliveries.dto';
+import { WEBHOOK_DELIVERY_STATUSES } from '../webhook.types';
+
+describe('ListDeliveriesDto', () => {
+  const buildAndValidate = async (input: Record<string, unknown>) => {
+    const dto = plainToInstance(ListDeliveriesDto, input);
+    return validate(dto);
+  };
+
+  it.each([...WEBHOOK_DELIVERY_STATUSES])('accepts status=%s', async (status) => {
+    const errors = await buildAndValidate({ status });
+    expect(errors).toEqual([]);
+  });
+
+  it('rejects unknown status', async () => {
+    const errors = await buildAndValidate({ status: 'definitely-not-a-status' });
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].constraints).toHaveProperty('isIn');
+  });
+
+  it('omits status (optional)', async () => {
+    const errors = await buildAndValidate({});
+    expect(errors).toEqual([]);
+  });
+
+  it('enforces PaginationDto cap: limit > 100 rejected', async () => {
+    const errors = await buildAndValidate({ limit: 500 });
+    const limitError = errors.find((e) => e.property === 'limit');
+    expect(limitError).toBeDefined();
+    expect(limitError!.constraints).toHaveProperty('max');
+  });
+
+  it('limit=100 is accepted (boundary)', async () => {
+    const errors = await buildAndValidate({ limit: 100 });
+    expect(errors).toEqual([]);
+  });
+
+  it('page < 1 rejected', async () => {
+    const errors = await buildAndValidate({ page: 0 });
+    const pageError = errors.find((e) => e.property === 'page');
+    expect(pageError).toBeDefined();
+  });
+});

--- a/middleware/src/modules/webhooks/dto/list-deliveries.dto.ts
+++ b/middleware/src/modules/webhooks/dto/list-deliveries.dto.ts
@@ -1,0 +1,17 @@
+import { IsIn, IsOptional, IsString } from 'class-validator';
+import { PaginationDto } from '../../common/dto/pagination.dto';
+import { WEBHOOK_DELIVERY_STATUSES } from '../webhook.types';
+
+/**
+ * Query DTO for GET /webhooks/:id/deliveries.
+ *
+ * Extends PaginationDto (page + limit, limit capped at 100 globally).
+ * Optional status filter — the @IsIn enum is the closed set defined in
+ * webhook.types.ts, so DTO + service stay in sync without duplication.
+ */
+export class ListDeliveriesDto extends PaginationDto {
+  @IsOptional()
+  @IsString()
+  @IsIn(WEBHOOK_DELIVERY_STATUSES as readonly string[])
+  status?: string;
+}

--- a/middleware/src/modules/webhooks/webhook.types.ts
+++ b/middleware/src/modules/webhooks/webhook.types.ts
@@ -32,3 +32,15 @@ export const SIGNATURE_HEADER = 'X-Vizora-Signature';
 
 /** Event-name header so customers can route incoming hooks without parsing the body. */
 export const EVENT_HEADER = 'X-Vizora-Event';
+
+/**
+ * Per-delivery audit status. Closed enum — repo style avoids Prisma
+ * enums, so we enforce the closed set at the DTO + service layer.
+ *
+ * - `success` — endpoint returned 2xx.
+ * - `failure` — HTTP non-2xx OR network error OR timeout.
+ * - `blocked` — SSRF guard rejected at delivery time (DNS rebind or
+ *   stale config). fetch() was never attempted.
+ */
+export const WEBHOOK_DELIVERY_STATUSES = ['success', 'failure', 'blocked'] as const;
+export type WebhookDeliveryStatus = (typeof WEBHOOK_DELIVERY_STATUSES)[number];

--- a/middleware/src/modules/webhooks/webhooks.controller.spec.ts
+++ b/middleware/src/modules/webhooks/webhooks.controller.spec.ts
@@ -16,6 +16,7 @@ describe('WebhooksController', () => {
       findOne: jest.fn(),
       update: jest.fn(),
       remove: jest.fn(),
+      findDeliveries: jest.fn(),
     } as any;
 
     const module: TestingModule = await Test.createTestingModule({
@@ -61,6 +62,16 @@ describe('WebhooksController', () => {
     expect(service.remove).toHaveBeenCalledWith(orgId, 'hook-1');
   });
 
+  it('GET /:id/deliveries forwards to service.findDeliveries with query', async () => {
+    service.findDeliveries.mockResolvedValue({ data: [], meta: {} } as any);
+    await controller.findDeliveries(orgId, 'hook-1', { status: 'blocked', page: 2, limit: 25 });
+    expect(service.findDeliveries).toHaveBeenCalledWith(orgId, 'hook-1', {
+      status: 'blocked',
+      page: 2,
+      limit: 25,
+    });
+  });
+
   describe('RBAC decorators', () => {
     const reflector = new Reflector();
 
@@ -87,6 +98,12 @@ describe('WebhooksController', () => {
     it('GET findOne does NOT require admin', () => {
       const roles = reflector.get<string[]>('roles', controller.findOne);
       expect(roles).toBeUndefined();
+    });
+
+    it('GET findDeliveries requires admin OR manager (NOT viewer)', () => {
+      const roles = reflector.get<string[]>('roles', controller.findDeliveries);
+      expect(roles).toEqual(expect.arrayContaining(['admin', 'manager']));
+      expect(roles).not.toContain('viewer');
     });
   });
 });

--- a/middleware/src/modules/webhooks/webhooks.controller.ts
+++ b/middleware/src/modules/webhooks/webhooks.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import { ParseIdPipe } from '../common/pipes/parse-id.pipe';
@@ -16,17 +17,22 @@ import { Roles } from '../auth/decorators/roles.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { WebhooksService } from './webhooks.service';
 import { CreateWebhookDto } from './dto/create-webhook.dto';
+import { ListDeliveriesDto } from './dto/list-deliveries.dto';
 import { UpdateWebhookDto } from './dto/update-webhook.dto';
 
 /**
- * O5 — Outbound webhook subscriptions CRUD.
+ * O5 — Outbound webhook subscriptions CRUD + delivery audit.
  *
  * Mutations require @Roles('admin') — webhooks are a security-sensitive
  * surface (sends payloads to operator-configured URLs).
  *
- * Secrets are NEVER returned in GET responses — only at create time. If
- * an admin loses the secret, they must rotate via PATCH with a new secret
- * value.
+ * Secrets are NEVER returned in any response — customers keep their own
+ * copy of the secret they submitted at create time. To rotate, PATCH
+ * with a new secret value.
+ *
+ * Delivery audit (GET /:id/deliveries) is admin/manager only — delivery
+ * rows expose endpoint health and error messages; not as sensitive as
+ * secrets, but still operational/security-adjacent.
  */
 @UseGuards(RolesGuard)
 @Controller('webhooks')
@@ -73,5 +79,23 @@ export class WebhooksController {
     @Param('id', ParseIdPipe) id: string,
   ) {
     return this.service.remove(organizationId, id);
+  }
+
+  /**
+   * Paginated audit log for one webhook. Newest-first. Returns rows for
+   * every delivery attempt — success, failure, or SSRF-blocked — so
+   * customers can debug their endpoint.
+   *
+   * Admin or manager only. Viewer is intentionally excluded — delivery
+   * details leak endpoint health and upstream error text.
+   */
+  @Get(':id/deliveries')
+  @Roles('admin', 'manager')
+  findDeliveries(
+    @CurrentUser('organizationId') organizationId: string,
+    @Param('id', ParseIdPipe) id: string,
+    @Query() query: ListDeliveriesDto,
+  ) {
+    return this.service.findDeliveries(organizationId, id, query);
   }
 }

--- a/middleware/src/modules/webhooks/webhooks.dispatcher.ts
+++ b/middleware/src/modules/webhooks/webhooks.dispatcher.ts
@@ -93,7 +93,7 @@ export class WebhooksDispatcher {
       for (const hook of subscribers) {
         try {
           await this.webhooksService.deliver(
-            { id: hook.id, url: hook.url, secret: hook.secret },
+            { id: hook.id, organizationId: hook.organizationId, url: hook.url, secret: hook.secret },
             event,
             payload,
           );

--- a/middleware/src/modules/webhooks/webhooks.service.spec.ts
+++ b/middleware/src/modules/webhooks/webhooks.service.spec.ts
@@ -1,19 +1,26 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
+import * as Sentry from '@sentry/nestjs';
 import * as crypto from 'crypto';
 import * as dns from 'dns/promises';
 import { WebhooksService } from './webhooks.service';
 import { DatabaseService } from '../database/database.service';
+import { MetricsService } from '../metrics/metrics.service';
 import { AUTO_DISABLE_THRESHOLD, SIGNATURE_HEADER, EVENT_HEADER } from './webhook.types';
 
 jest.mock('dns/promises');
+jest.mock('@sentry/nestjs', () => ({
+  captureException: jest.fn(),
+}));
 
 describe('WebhooksService', () => {
   let service: WebhooksService;
   let db: any;
+  let metrics: any;
   const orgId = 'org-123';
 
   const originalFetch = global.fetch;
   const mockLookup = dns.lookup as unknown as jest.Mock;
+  const mockSentryCapture = Sentry.captureException as unknown as jest.Mock;
 
   beforeEach(() => {
     db = {
@@ -30,11 +37,19 @@ describe('WebhooksService', () => {
         count: jest.fn(),
       },
     };
-    service = new WebhooksService(db as unknown as DatabaseService);
+    metrics = {
+      webhookDeliveriesTotal: { inc: jest.fn() },
+      webhookAuditFailuresTotal: { inc: jest.fn() },
+    };
+    service = new WebhooksService(
+      db as unknown as DatabaseService,
+      metrics as unknown as MetricsService,
+    );
 
     // Default DNS: public IP. Per-test mocks override for SSRF tests.
     mockLookup.mockReset();
     mockLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+    mockSentryCapture.mockReset();
   });
 
   afterEach(() => {
@@ -330,6 +345,14 @@ describe('WebhooksService', () => {
         expect(row.errorMessage).toBeNull();
         expect(typeof row.durationMs).toBe('number');
         expect(row.durationMs).toBeGreaterThanOrEqual(0);
+
+        // Every successful audit insert increments the deliveries
+        // counter — gives Grafana a delivery-rate signal and acts as
+        // independent evidence that the dispatch path reached the DB.
+        expect(metrics.webhookDeliveriesTotal.inc).toHaveBeenCalledWith({
+          status: 'success',
+          event: 'display.paired',
+        });
       });
 
       it('records failure row on HTTP non-2xx with statusCode + errorMessage', async () => {
@@ -382,15 +405,47 @@ describe('WebhooksService', () => {
         expect(row.errorMessage.endsWith('...')).toBe(true);
       });
 
-      it('audit insert failure does NOT block summary-row update (best-effort)', async () => {
-        // If the audit table is missing or constraints fail, we still
-        // want the summary row updated so the customer sees lastError.
-        db.webhookDelivery.create.mockRejectedValue(new Error('audit table missing'));
-        global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 }) as any;
-        db.webhook.update.mockResolvedValue({ failureCount: 0 });
+      // Silent-failure prevention (CLAUDE.md §12). Best-effort behaviour
+      // is preserved (transient audit failure doesn't block delivery),
+      // but the failure surfaces via THREE independent signals so it
+      // cannot be missed by the operator.
+      describe('audit insert failure surfaces loudly (§12 silent-failure prevention)', () => {
+        beforeEach(() => {
+          db.webhookDelivery.create.mockRejectedValue(new Error('audit table missing'));
+          global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 }) as any;
+          db.webhook.update.mockResolvedValue({ failureCount: 0 });
+        });
 
-        await expect(service.deliver(hook, 'display.paired', {})).resolves.toBeUndefined();
-        expect(db.webhook.update).toHaveBeenCalled();
+        it('does NOT block the summary-row update (best-effort delivery preserved)', async () => {
+          await expect(service.deliver(hook, 'display.paired', {})).resolves.toBeUndefined();
+          expect(db.webhook.update).toHaveBeenCalled();
+        });
+
+        it('increments the audit-failure Prom counter (Grafana / watchdog hook)', async () => {
+          await service.deliver(hook, 'display.paired', {});
+          expect(metrics.webhookAuditFailuresTotal.inc).toHaveBeenCalledWith({
+            event: 'display.paired',
+          });
+          // Deliveries counter must NOT increment — the audit row did
+          // not land.
+          expect(metrics.webhookDeliveriesTotal.inc).not.toHaveBeenCalled();
+        });
+
+        it('emits a Sentry capture with component+webhook context (alert-at-write-site)', async () => {
+          await service.deliver(hook, 'display.paired', {});
+
+          expect(mockSentryCapture).toHaveBeenCalledTimes(1);
+          const [err, ctx] = mockSentryCapture.mock.calls[0];
+          expect(err).toBeInstanceOf(Error);
+          expect((err as Error).message).toBe('audit table missing');
+          expect(ctx.tags).toEqual({ component: 'webhooks', subsystem: 'delivery-audit' });
+          expect(ctx.extra.webhookId).toBe(hook.id);
+          expect(ctx.extra.organizationId).toBe(orgId);
+          expect(ctx.extra.event).toBe('display.paired');
+          // Intentionally NOT including errorMessage from the upstream
+          // delivery — Sentry capture is about THIS insert failing.
+          expect(ctx.extra.errorMessage).toBeUndefined();
+        });
       });
     });
   });

--- a/middleware/src/modules/webhooks/webhooks.service.spec.ts
+++ b/middleware/src/modules/webhooks/webhooks.service.spec.ts
@@ -24,6 +24,11 @@ describe('WebhooksService', () => {
         update: jest.fn(),
         delete: jest.fn(),
       },
+      webhookDelivery: {
+        create: jest.fn().mockResolvedValue({}),
+        findMany: jest.fn(),
+        count: jest.fn(),
+      },
     };
     service = new WebhooksService(db as unknown as DatabaseService);
 
@@ -54,10 +59,6 @@ describe('WebhooksService', () => {
       expect(db.webhook.create).toHaveBeenCalledTimes(1);
     });
 
-    // PR-review fix (post-merge): create MUST NOT include secret in
-    // the response. The secret-less select shape is enforced server-
-    // side; response bodies get logged/cached in more places than
-    // request bodies. Customers keep their own copy.
     it('does NOT include the secret field in the create response shape', async () => {
       db.webhook.create.mockResolvedValue({ id: 'hook-1' });
       await service.create(orgId, dto);
@@ -65,7 +66,6 @@ describe('WebhooksService', () => {
       const call = db.webhook.create.mock.calls[0][0];
       expect(call.select).toBeDefined();
       expect(call.select.secret).toBeUndefined();
-      // Sanity: the secret WAS persisted (just not selected back).
       expect(call.data.secret).toBe(dto.secret);
     });
 
@@ -108,9 +108,6 @@ describe('WebhooksService', () => {
       ).rejects.toThrow(BadRequestException);
     });
 
-    // PR-review fix (post-merge): DNS rebind — public-looking hostname
-    // that resolves to private IP. The pre-fix hostname regex would
-    // have let this through.
     it('rejects DNS rebind: public hostname resolves to 127.0.0.1', async () => {
       mockLookup.mockResolvedValue([{ address: '127.0.0.1', family: 4 }]);
       await expect(
@@ -136,7 +133,7 @@ describe('WebhooksService', () => {
 
       const call = db.webhook.findMany.mock.calls[0][0];
       expect(call.select).toBeDefined();
-      expect(call.select.secret).toBeUndefined();      // secret intentionally NOT selected
+      expect(call.select.secret).toBeUndefined();
     });
   });
 
@@ -202,10 +199,15 @@ describe('WebhooksService', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // deliver — HMAC signing + auto-disable + SSRF re-check
+  // deliver — HMAC + auto-disable + SSRF re-check + audit row
   // ---------------------------------------------------------------------------
   describe('deliver', () => {
-    const hook = { id: 'hook-1', url: 'https://hooks.customer.example.com/v1', secret: 'a'.repeat(32) };
+    const hook = {
+      id: 'hook-1',
+      organizationId: orgId,
+      url: 'https://hooks.customer.example.com/v1',
+      secret: 'a'.repeat(32),
+    };
 
     it('signs the body with HMAC-SHA256 and POSTs with the signature header', async () => {
       const fetchSpy = jest.fn().mockResolvedValue({ ok: true, status: 200 });
@@ -222,13 +224,12 @@ describe('WebhooksService', () => {
       const signature = init.headers[SIGNATURE_HEADER];
       expect(signature).toMatch(/^sha256=[0-9a-f]{64}$/);
 
-      // Verify the signature math directly
       const expected = crypto.createHmac('sha256', hook.secret).update(init.body).digest('hex');
       expect(signature).toBe(`sha256=${expected}`);
     });
 
     it('on success: resets failureCount and clears lastError', async () => {
-      global.fetch = jest.fn().mockResolvedValue({ ok: true }) as any;
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 }) as any;
       db.webhook.update.mockResolvedValue({ failureCount: 0 });
 
       await service.deliver(hook, 'display.paired', {});
@@ -261,26 +262,17 @@ describe('WebhooksService', () => {
 
     it('auto-disables after AUTO_DISABLE_THRESHOLD consecutive failures', async () => {
       global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 500 }) as any;
-      // Simulate the counter just crossing the threshold
       db.webhook.update.mockResolvedValueOnce({ failureCount: AUTO_DISABLE_THRESHOLD });
-      db.webhook.update.mockResolvedValueOnce({});                       // second update for auto-disable
+      db.webhook.update.mockResolvedValueOnce({});
       await service.deliver(hook, 'display.paired', {});
 
-      // 2 updates: the failure increment + the auto-disable flip
       expect(db.webhook.update).toHaveBeenCalledTimes(2);
       const disableCall = db.webhook.update.mock.calls[1][0];
       expect(disableCall.data.isActive).toBe(false);
     });
 
-    // PR-review fix (post-merge): SSRF re-check at delivery time. URL
-    // was validated at create time, but DNS can flip. A rebind that
-    // points the same hostname at 127.0.0.1 between create and deliver
-    // must be caught — without re-resolving here we'd happily POST the
-    // signed payload at the internal endpoint.
     describe('SSRF re-check at delivery time', () => {
       it('skips fetch when delivery-time DNS resolves to a private IP', async () => {
-        // create-time resolution would have been public; now DNS has
-        // flipped to private.
         mockLookup.mockResolvedValue([{ address: '127.0.0.1', family: 4 }]);
         const fetchSpy = jest.fn();
         global.fetch = fetchSpy as any;
@@ -288,12 +280,8 @@ describe('WebhooksService', () => {
 
         await service.deliver(hook, 'display.paired', {});
 
-        // Critical: fetch MUST NOT have been called.
         expect(fetchSpy).not.toHaveBeenCalled();
 
-        // Failure was recorded (so the customer can see why their
-        // webhook is no longer firing) and counter incremented (so
-        // auto-disable still trips eventually if DNS stays broken).
         const call = db.webhook.update.mock.calls[0][0];
         expect(call.data.lastError).toMatch(/blocked address/);
         expect(call.data.failureCount).toEqual({ increment: 1 });
@@ -320,6 +308,147 @@ describe('WebhooksService', () => {
         const init = fetchSpy.mock.calls[0][1];
         expect(init.redirect).toBe('manual');
       });
+    });
+
+    // -------------------------------------------------------------------------
+    // Audit table — records a row at every exit (success, failure, blocked)
+    // -------------------------------------------------------------------------
+    describe('audit row recording', () => {
+      it('records success row with statusCode, no error, status=success', async () => {
+        global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 }) as any;
+        db.webhook.update.mockResolvedValue({ failureCount: 0 });
+
+        await service.deliver(hook, 'display.paired', {});
+
+        expect(db.webhookDelivery.create).toHaveBeenCalledTimes(1);
+        const row = db.webhookDelivery.create.mock.calls[0][0].data;
+        expect(row.webhookId).toBe(hook.id);
+        expect(row.organizationId).toBe(orgId);
+        expect(row.event).toBe('display.paired');
+        expect(row.status).toBe('success');
+        expect(row.statusCode).toBe(200);
+        expect(row.errorMessage).toBeNull();
+        expect(typeof row.durationMs).toBe('number');
+        expect(row.durationMs).toBeGreaterThanOrEqual(0);
+      });
+
+      it('records failure row on HTTP non-2xx with statusCode + errorMessage', async () => {
+        global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 503 }) as any;
+        db.webhook.update.mockResolvedValue({ failureCount: 1 });
+
+        await service.deliver(hook, 'display.paired', {});
+
+        const row = db.webhookDelivery.create.mock.calls[0][0].data;
+        expect(row.status).toBe('failure');
+        expect(row.statusCode).toBe(503);
+        expect(row.errorMessage).toBe('HTTP 503');
+      });
+
+      it('records failure row on network error with errorMessage, no statusCode', async () => {
+        global.fetch = jest.fn().mockRejectedValue(new Error('ETIMEDOUT')) as any;
+        db.webhook.update.mockResolvedValue({ failureCount: 1 });
+
+        await service.deliver(hook, 'display.paired', {});
+
+        const row = db.webhookDelivery.create.mock.calls[0][0].data;
+        expect(row.status).toBe('failure');
+        expect(row.statusCode).toBeNull();
+        expect(row.errorMessage).toBe('ETIMEDOUT');
+      });
+
+      it('records blocked row when SSRF guard rejects at delivery time', async () => {
+        mockLookup.mockResolvedValue([{ address: '127.0.0.1', family: 4 }]);
+        global.fetch = jest.fn();
+        db.webhook.update.mockResolvedValue({ failureCount: 1 });
+
+        await service.deliver(hook, 'display.paired', {});
+
+        const row = db.webhookDelivery.create.mock.calls[0][0].data;
+        expect(row.status).toBe('blocked');
+        expect(row.statusCode).toBeNull();
+        expect(row.errorMessage).toMatch(/blocked address/);
+        expect(global.fetch).not.toHaveBeenCalled();
+      });
+
+      it('truncates errorMessage longer than MAX_ERROR_MSG_LENGTH (500)', async () => {
+        const longErr = 'x'.repeat(700);
+        global.fetch = jest.fn().mockRejectedValue(new Error(longErr)) as any;
+        db.webhook.update.mockResolvedValue({ failureCount: 1 });
+
+        await service.deliver(hook, 'display.paired', {});
+
+        const row = db.webhookDelivery.create.mock.calls[0][0].data;
+        expect(row.errorMessage.length).toBe(500);
+        expect(row.errorMessage.endsWith('...')).toBe(true);
+      });
+
+      it('audit insert failure does NOT block summary-row update (best-effort)', async () => {
+        // If the audit table is missing or constraints fail, we still
+        // want the summary row updated so the customer sees lastError.
+        db.webhookDelivery.create.mockRejectedValue(new Error('audit table missing'));
+        global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 }) as any;
+        db.webhook.update.mockResolvedValue({ failureCount: 0 });
+
+        await expect(service.deliver(hook, 'display.paired', {})).resolves.toBeUndefined();
+        expect(db.webhook.update).toHaveBeenCalled();
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // findDeliveries — paginated audit log read
+  // ---------------------------------------------------------------------------
+  describe('findDeliveries', () => {
+    const webhookId = 'hook-1';
+
+    it('throws NotFound when webhook belongs to another org (cross-org guard)', async () => {
+      db.webhook.findFirst.mockResolvedValue(null);
+      await expect(
+        service.findDeliveries(orgId, 'hook-foreign', {}),
+      ).rejects.toThrow(NotFoundException);
+      expect(db.webhookDelivery.findMany).not.toHaveBeenCalled();
+    });
+
+    it('returns paginated newest-first results scoped to the webhook', async () => {
+      db.webhook.findFirst.mockResolvedValue({ id: webhookId, organizationId: orgId });
+      db.webhookDelivery.findMany.mockResolvedValue([{ id: 'd-1' }, { id: 'd-2' }]);
+      db.webhookDelivery.count.mockResolvedValue(42);
+
+      const result = await service.findDeliveries(orgId, webhookId, { page: 1, limit: 10 });
+
+      const findCall = db.webhookDelivery.findMany.mock.calls[0][0];
+      expect(findCall.where.webhookId).toBe(webhookId);
+      expect(findCall.orderBy).toEqual({ attemptedAt: 'desc' });
+      expect(findCall.skip).toBe(0);
+      expect(findCall.take).toBe(10);
+      expect(result.meta.total).toBe(42);
+      expect(result.meta.totalPages).toBe(5);
+    });
+
+    it('forwards status filter to the WHERE clause (find + count)', async () => {
+      db.webhook.findFirst.mockResolvedValue({ id: webhookId, organizationId: orgId });
+      db.webhookDelivery.findMany.mockResolvedValue([]);
+      db.webhookDelivery.count.mockResolvedValue(0);
+
+      await service.findDeliveries(orgId, webhookId, { status: 'blocked' });
+
+      const findCall = db.webhookDelivery.findMany.mock.calls[0][0];
+      expect(findCall.where.status).toBe('blocked');
+
+      const countCall = db.webhookDelivery.count.mock.calls[0][0];
+      expect(countCall.where.status).toBe('blocked');
+    });
+
+    it('respects custom page/limit (page 3 of size 20 → skip 40)', async () => {
+      db.webhook.findFirst.mockResolvedValue({ id: webhookId, organizationId: orgId });
+      db.webhookDelivery.findMany.mockResolvedValue([]);
+      db.webhookDelivery.count.mockResolvedValue(0);
+
+      await service.findDeliveries(orgId, webhookId, { page: 3, limit: 20 });
+
+      const findCall = db.webhookDelivery.findMany.mock.calls[0][0];
+      expect(findCall.skip).toBe(40);
+      expect(findCall.take).toBe(20);
     });
   });
 });

--- a/middleware/src/modules/webhooks/webhooks.service.ts
+++ b/middleware/src/modules/webhooks/webhooks.service.ts
@@ -4,8 +4,10 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
+import * as Sentry from '@sentry/nestjs';
 import * as crypto from 'crypto';
 import { DatabaseService } from '../database/database.service';
+import { MetricsService } from '../metrics/metrics.service';
 import { PaginatedResponse } from '../common/dto/pagination.dto';
 import { assertUrlIsPublic, SsrfError } from '../common/utils/ssrf-guard';
 import { CreateWebhookDto } from './dto/create-webhook.dto';
@@ -67,7 +69,10 @@ export class WebhooksService {
     updatedAt: true,
   } as const;
 
-  constructor(private readonly db: DatabaseService) {}
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly metrics: MetricsService,
+  ) {}
 
   // ---------------------------------------------------------------------------
   // CRUD
@@ -278,10 +283,23 @@ export class WebhooksService {
     errorMessage: string | null,
     durationMs: number,
   ): Promise<void> {
-    // Audit row first — best-effort. If audit insert fails for any
-    // reason (table missing, schema drift), we still want to update
-    // the summary row so the customer sees lastError move. Log and
-    // continue.
+    // Audit row first. Best-effort vs the summary-row update because a
+    // transient audit-insert failure shouldn't block the customer's
+    // dashboard from showing fresh lastError — but per CLAUDE.md §12
+    // (silent-failure prevention) "best-effort with log only" is too
+    // quiet: a missing migration / FK drift / table permissions issue
+    // would silently lose every audit row while customers keep seeing
+    // their summary fields move.
+    //
+    // Three signals at the write site so the divergence surfaces:
+    //   1. Sentry capture — pages the operator (§12b alert-at-write-site).
+    //   2. Prom counter vizora_webhook_audit_failures_total — alert on
+    //      ANY non-zero value via Grafana (§12a watchdog hook).
+    //   3. Structured log.error — for journalctl correlation.
+    //
+    // Every successful audit insert also increments
+    // vizora_webhook_deliveries_total{status,event} so a stalled counter
+    // is independent evidence that dispatch is broken.
     try {
       await this.db.webhookDelivery.create({
         data: {
@@ -294,7 +312,21 @@ export class WebhooksService {
           durationMs,
         },
       });
+      this.metrics.webhookDeliveriesTotal.inc({ status, event });
     } catch (err) {
+      this.metrics.webhookAuditFailuresTotal.inc({ event });
+      Sentry.captureException(err, {
+        tags: { component: 'webhooks', subsystem: 'delivery-audit' },
+        extra: {
+          webhookId: webhook.id,
+          organizationId: webhook.organizationId,
+          event,
+          status,
+          // Intentionally NOT including errorMessage — the upstream
+          // error text might mention internal hostnames; the Sentry
+          // capture is about THIS insert failing, not the delivery.
+        },
+      });
       this.logger.error(
         `Failed to record WebhookDelivery audit row for ${webhook.id}/${event}`,
         err instanceof Error ? err.stack : String(err),

--- a/middleware/src/modules/webhooks/webhooks.service.ts
+++ b/middleware/src/modules/webhooks/webhooks.service.ts
@@ -6,8 +6,10 @@ import {
 } from '@nestjs/common';
 import * as crypto from 'crypto';
 import { DatabaseService } from '../database/database.service';
+import { PaginatedResponse } from '../common/dto/pagination.dto';
 import { assertUrlIsPublic, SsrfError } from '../common/utils/ssrf-guard';
 import { CreateWebhookDto } from './dto/create-webhook.dto';
+import { ListDeliveriesDto } from './dto/list-deliveries.dto';
 import { UpdateWebhookDto } from './dto/update-webhook.dto';
 import {
   AUTO_DISABLE_THRESHOLD,
@@ -15,10 +17,11 @@ import {
   EVENT_HEADER,
   SIGNATURE_HEADER,
   WebhookEvent,
+  WebhookDeliveryStatus,
 } from './webhook.types';
 
 /**
- * O5 — Webhook CRUD + delivery.
+ * O5 — Webhook CRUD + delivery + per-delivery audit.
  *
  * Cross-org guards on every read/write. SSRF guard resolves DNS and
  * rejects loopback / RFC1918 / link-local / IPv6 loopback/ULA/link-local
@@ -29,6 +32,12 @@ import {
  * Auto-disable on AUTO_DISABLE_THRESHOLD consecutive failures — defends
  * customers from a misbehaving endpoint accumulating noise indefinitely.
  *
+ * Every deliver() attempt records a WebhookDelivery audit row (status
+ * one of success / failure / blocked). The summary fields on the
+ * Webhook row (`lastDeliveryAt` / `lastError` / `failureCount`) are
+ * kept for fast row-level reads in CRUD responses; the audit table is
+ * the source of truth for delivery history.
+ *
  * The webhook secret is NEVER returned from any controller-facing
  * method. Customers keep their own copy of the secret they submitted;
  * the server only stores it for signing outbound deliveries.
@@ -36,6 +45,10 @@ import {
 @Injectable()
 export class WebhooksService {
   private readonly logger = new Logger(WebhooksService.name);
+
+  // Cap on errorMessage column width — audit rows hold short error
+  // text only, never full upstream response bodies.
+  private static readonly MAX_ERROR_MSG_LENGTH = 500;
 
   // Single select shape — secret is intentionally omitted everywhere
   // except findActiveSubscribers (internal use, never returned to a
@@ -122,6 +135,41 @@ export class WebhooksService {
   }
 
   // ---------------------------------------------------------------------------
+  // Delivery audit listing
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Paginated audit log for one webhook. Cross-org guarded via findOne
+   * — NotFound for foreign-org webhook id, identical to the other
+   * per-webhook endpoints. Newest-first; optional status filter.
+   */
+  async findDeliveries(
+    organizationId: string,
+    webhookId: string,
+    query: ListDeliveriesDto,
+  ) {
+    await this.findOne(organizationId, webhookId); // cross-org guard
+
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 10;
+
+    const where: { webhookId: string; status?: string } = { webhookId };
+    if (query.status) where.status = query.status;
+
+    const [rows, total] = await Promise.all([
+      this.db.webhookDelivery.findMany({
+        where,
+        orderBy: { attemptedAt: 'desc' },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.db.webhookDelivery.count({ where }),
+    ]);
+
+    return new PaginatedResponse(rows, total, page, limit);
+  }
+
+  // ---------------------------------------------------------------------------
   // Delivery (called from the @OnEvent dispatcher)
   // ---------------------------------------------------------------------------
 
@@ -149,33 +197,38 @@ export class WebhooksService {
    * On failure: lastError set, failureCount incremented. When failureCount
    * crosses AUTO_DISABLE_THRESHOLD, isActive flips to false until an
    * operator manually re-enables (which resets the counter).
+   *
+   * Every attempt — success, HTTP failure, network error, SSRF-blocked
+   * — records a WebhookDelivery audit row.
    */
   async deliver(
-    webhook: { id: string; url: string; secret: string },
+    webhook: { id: string; organizationId: string; url: string; secret: string },
     event: WebhookEvent,
     payload: Record<string, unknown>,
   ): Promise<void> {
+    const startedAt = Date.now();
     const body = JSON.stringify({ event, payload, deliveredAt: new Date().toISOString() });
     const signature = this.signBody(body, webhook.secret);
-
-    let ok = false;
-    let errMsg: string | null = null;
 
     // PR-review fix (post-merge): re-run the SSRF guard at delivery
     // time. The URL was validated at create/update, but DNS can flip
     // between then and now (DNS-rebind, infrastructure migration, etc.)
     // — re-resolving makes a flip caught here rather than connecting to
-    // an internal address.
+    // an internal address. The audit row gets status='blocked' so the
+    // customer can see that the dispatch never went out.
     try {
       await this.assertUrlSafe(webhook.url);
     } catch (err) {
-      errMsg = err instanceof Error ? err.message : 'unknown';
-      await this.recordFailure(webhook.id, errMsg);
+      const errMsg = this.truncateError(err instanceof Error ? err.message : 'unknown');
+      await this.recordAttempt(webhook, event, 'blocked', null, errMsg, Date.now() - startedAt);
       return;
     }
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), DELIVERY_TIMEOUT_MS);
+    let status: WebhookDeliveryStatus = 'failure';
+    let statusCode: number | null = null;
+    let errMsg: string | null = null;
 
     try {
       const res = await fetch(webhook.url, {
@@ -193,18 +246,62 @@ export class WebhooksService {
         // redirect chain would also bypass the SSRF guard above.
         redirect: 'manual',
       });
+      statusCode = res.status;
       if (res.ok) {
-        ok = true;
+        status = 'success';
       } else {
         errMsg = `HTTP ${res.status}`;
       }
     } catch (err) {
-      errMsg = err instanceof Error ? err.message : 'unknown';
+      errMsg = this.truncateError(err instanceof Error ? err.message : 'unknown');
     } finally {
       clearTimeout(timeoutId);
     }
 
-    if (ok) {
+    await this.recordAttempt(webhook, event, status, statusCode, errMsg, Date.now() - startedAt);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Records an audit row + updates the summary fields on the Webhook
+   * row + auto-disables if the failure counter trips. Single write-path
+   * for all four delivery outcomes (success / failure / blocked).
+   */
+  private async recordAttempt(
+    webhook: { id: string; organizationId: string },
+    event: WebhookEvent,
+    status: WebhookDeliveryStatus,
+    statusCode: number | null,
+    errorMessage: string | null,
+    durationMs: number,
+  ): Promise<void> {
+    // Audit row first — best-effort. If audit insert fails for any
+    // reason (table missing, schema drift), we still want to update
+    // the summary row so the customer sees lastError move. Log and
+    // continue.
+    try {
+      await this.db.webhookDelivery.create({
+        data: {
+          webhookId: webhook.id,
+          organizationId: webhook.organizationId,
+          event,
+          status,
+          statusCode,
+          errorMessage,
+          durationMs,
+        },
+      });
+    } catch (err) {
+      this.logger.error(
+        `Failed to record WebhookDelivery audit row for ${webhook.id}/${event}`,
+        err instanceof Error ? err.stack : String(err),
+      );
+    }
+
+    if (status === 'success') {
       await this.db.webhook.update({
         where: { id: webhook.id },
         data: {
@@ -216,19 +313,12 @@ export class WebhooksService {
       return;
     }
 
-    await this.recordFailure(webhook.id, errMsg);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Internal helpers
-  // ---------------------------------------------------------------------------
-
-  private async recordFailure(webhookId: string, errMsg: string | null): Promise<void> {
+    // failure or blocked — increment counter, possibly auto-disable
     const updated = await this.db.webhook.update({
-      where: { id: webhookId },
+      where: { id: webhook.id },
       data: {
         lastDeliveryAt: new Date(),
-        lastError: errMsg,
+        lastError: errorMessage,
         failureCount: { increment: 1 },
       },
       select: { failureCount: true },
@@ -236,13 +326,18 @@ export class WebhooksService {
 
     if (updated.failureCount >= AUTO_DISABLE_THRESHOLD) {
       await this.db.webhook.update({
-        where: { id: webhookId },
+        where: { id: webhook.id },
         data: { isActive: false },
       });
       this.logger.warn(
-        `Webhook ${webhookId} auto-disabled after ${updated.failureCount} consecutive failures (last error: ${errMsg})`,
+        `Webhook ${webhook.id} auto-disabled after ${updated.failureCount} consecutive failures (last error: ${errorMessage})`,
       );
     }
+  }
+
+  private truncateError(msg: string): string {
+    if (msg.length <= WebhooksService.MAX_ERROR_MSG_LENGTH) return msg;
+    return msg.slice(0, WebhooksService.MAX_ERROR_MSG_LENGTH - 3) + '...';
   }
 
   private signBody(body: string, secret: string): string {

--- a/packages/database/prisma/migrations/20260519180000_add_webhook_deliveries/migration.sql
+++ b/packages/database/prisma/migrations/20260519180000_add_webhook_deliveries/migration.sql
@@ -1,0 +1,46 @@
+-- Migration: add_webhook_deliveries
+--
+-- O5 follow-up — per-delivery audit log for outbound webhook attempts.
+--
+-- Records every deliver() attempt (success / failure / SSRF-blocked) so
+-- customers can debug their endpoint via GET /webhooks/:id/deliveries.
+-- Body and HMAC signature deliberately NOT stored (size + secret-
+-- recovery surface).
+--
+-- See packages/database/prisma/schema.prisma `model WebhookDelivery`.
+
+CREATE TABLE "webhook_deliveries" (
+    "id" TEXT NOT NULL,
+    "webhookId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "event" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "statusCode" INTEGER,
+    "errorMessage" TEXT,
+    "durationMs" INTEGER NOT NULL,
+    "attemptedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "webhook_deliveries_pkey" PRIMARY KEY ("id")
+);
+
+-- Primary listing query: newest first per webhook.
+CREATE INDEX "webhook_deliveries_webhookId_attemptedAt_idx"
+    ON "webhook_deliveries"("webhookId", "attemptedAt" DESC);
+
+-- Future cross-webhook org view + reporting.
+CREATE INDEX "webhook_deliveries_organizationId_attemptedAt_idx"
+    ON "webhook_deliveries"("organizationId", "attemptedAt" DESC);
+
+-- Retention sweep (delete WHERE attemptedAt < cutoff).
+CREATE INDEX "webhook_deliveries_attemptedAt_idx"
+    ON "webhook_deliveries"("attemptedAt");
+
+ALTER TABLE "webhook_deliveries"
+    ADD CONSTRAINT "webhook_deliveries_webhookId_fkey"
+    FOREIGN KEY ("webhookId") REFERENCES "webhooks"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "webhook_deliveries"
+    ADD CONSTRAINT "webhook_deliveries_organizationId_fkey"
+    FOREIGN KEY ("organizationId") REFERENCES "organizations"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -59,6 +59,7 @@ model Organization {
   mcpTokens              McpToken[]
   agentRuns              AgentRun[]
   webhooks               Webhook[]
+  webhookDeliveries      WebhookDelivery[]
 
   @@index([slug])
   @@index([stripeCustomerId])
@@ -1013,27 +1014,61 @@ model AgentRun {
 /// webhook's secret, and POSTs to `url`. On consecutive failures the
 /// webhook auto-disables (`failureCount >= AUTO_DISABLE_THRESHOLD`).
 ///
-/// Cross-org: organizationId cascade-deletes. No per-delivery audit table
-/// in v1 — `lastDeliveryAt`/`lastError`/`failureCount` on the row cover
-/// the ops-visibility need; if customers ask for full audit, add a
-/// WebhookDelivery table in a follow-up.
+/// Per-delivery audit lives in `WebhookDelivery` — every dispatch attempt
+/// (success / failure / SSRF-blocked) records a row there. The summary
+/// fields here (`lastDeliveryAt` / `lastError` / `failureCount`) are kept
+/// for fast row-level reads in CRUD responses.
 model Webhook {
-  id              String   @id @default(cuid())
-  organizationId  String
-  name            String
-  url             String                                // HTTPS only; SSRF guard at service layer
-  secret          String                                // HMAC secret stored as plaintext at create — see service comment about hashing tradeoff
-  events          String[]                              // event names this hook subscribes to
-  isActive        Boolean  @default(true)
-  lastDeliveryAt  DateTime?
-  lastError       String?
-  failureCount    Int      @default(0)                  // consecutive failures; auto-disable threshold check at service layer
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  id             String    @id @default(cuid())
+  organizationId String
+  name           String
+  url            String // HTTPS only; SSRF guard at service layer
+  secret         String // HMAC secret stored as plaintext at create — see service comment about hashing tradeoff
+  events         String[] // event names this hook subscribes to
+  isActive       Boolean   @default(true)
+  lastDeliveryAt DateTime?
+  lastError      String?
+  failureCount   Int       @default(0) // consecutive failures; auto-disable threshold check at service layer
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
 
-  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  organization Organization      @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  deliveries   WebhookDelivery[]
 
-  @@unique([organizationId, name])                      // UI uniqueness
+  @@unique([organizationId, name]) // UI uniqueness
   @@index([organizationId, isActive])
   @@map("webhooks")
+}
+
+/// Per-delivery audit row. Recorded at every deliver() exit — success,
+/// HTTP failure, network error, or SSRF-blocked. Customers list this via
+/// `GET /webhooks/:id/deliveries` to debug their endpoint.
+///
+/// Body and HMAC signature are deliberately NOT stored:
+///   - body can be MBs and v1 doesn't need replay capability
+///   - signature + body = a secret-recovery surface (offline brute-force
+///     on a leaked audit dump would recover the HMAC secret)
+///
+/// status is a string + DTO `@IsIn` (no Prisma enums elsewhere in this
+/// schema). Closed values: `success` | `failure` | `blocked`. The
+/// `blocked` value means the SSRF guard rejected at delivery time
+/// (typically a DNS rebind) — fetch was never attempted.
+model WebhookDelivery {
+  id             String   @id @default(cuid())
+  webhookId      String
+  organizationId String // denormalized for fast org-scoped reads + future retention sweeps
+  event          String // e.g. "display.paired"
+  status         String // success | failure | blocked
+  statusCode     Int? // HTTP code if reached; null for blocked / network error
+  errorMessage   String? // truncated error text (no secret-recovery surface)
+  durationMs     Int // wall time of the deliver() call
+  attemptedAt    DateTime @default(now())
+
+  webhook      Webhook      @relation(fields: [webhookId], references: [id], onDelete: Cascade)
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  @@index([webhookId, attemptedAt(sort: Desc)]) // primary listing query (newest first)
+  @@index([organizationId, attemptedAt(sort: Desc)]) // future cross-webhook org view
+  @@index([attemptedAt]) // future retention sweep
+  @@map("webhook_deliveries")
 }


### PR DESCRIPTION
## Summary

Stacked on `feat/o5-outbound-webhooks` (#70). Adds per-delivery audit so customers can debug their endpoint via `GET /webhooks/:id/deliveries`.

**Depends on #70 merging first.** Rebases trivially onto main once that lands; expect a small conflict on `webhooks.service.ts` / `webhook.types.ts` where this PR extends the base.

## What ships

- New `WebhookDelivery` model + table `webhook_deliveries` (cuid PK, FK cascade to webhooks + organizations).
- 3 indexes: `(webhookId, attemptedAt desc)` for the listing query, `(organizationId, attemptedAt desc)` for future cross-webhook views, `(attemptedAt)` for retention sweeps.
- `deliver()` records an audit row at all 4 exit paths: `success` / `failure` / `failure` (network) / `blocked` (SSRF-rejected at delivery).
- New `GET /webhooks/:id/deliveries` — paginated newest-first, `@Roles('admin', 'manager')` (per review note — viewer excluded since delivery rows leak endpoint health + error text).
- `ListDeliveriesDto` extends `PaginationDto` (limit cap 100) with optional `@IsIn` status filter against the closed `WEBHOOK_DELIVERY_STATUSES` set.

## What's deliberately omitted

- **Body / HMAC signature storage** — body can be MBs; signature+body is a secret-recovery surface (offline brute-force on a leaked audit dump). Per Sri's review note.
- **Prisma enum for status** — repo style is `String` + DTO `@IsIn`. Closed set still enforced server-side via `WEBHOOK_DELIVERY_STATUSES`.
- **Retention sweep job** — table has the index (`attemptedAt` alone) but no cron. Defer until we know what TTL customers want.
- **Cross-webhook all-org delivery view** — defer until someone asks.

## Behaviour notes

- Audit insert is best-effort: if the audit insert fails (table missing, FK constraint drift), the Webhook summary row still updates so the customer's UI moves. Failure logged with stack.
- `errorMessage` truncated to 500 chars with `...` suffix.
- The deliver-time SSRF guard records `blocked` status — the customer can see WHY their webhook stopped firing without leaking the resolved internal IP.
- `organizationId` is denormalized on the row (per Sri's note) — fast org-scoped listing + retention sweep without a join.

## Tests

107/107 pass across webhooks + ssrf-guard + list-deliveries specs. Full middleware `tsc --noEmit` green.

- service: +10 tests (4 audit-recording paths + truncation + best-effort behavior + 4 findDeliveries tests)
- controller: +1 forwards-to-service test + RBAC assertion (admin+manager pass, viewer rejected)
- DTO: +9 tests covering closed status enum + pagination cap

## Migration

- `20260519180000_add_webhook_deliveries` — hand-written SQL (Docker was down at branch creation). Verified against the `20260519150210_add_webhooks` convention for table-naming and FK shape. `prisma generate` run locally before push.
- Re-run `prisma migrate dev` on the deployer machine after `#70` merges + this rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)