### PR TITLE
fix(security): cross-tenant + access-check hardening

### DIFF
--- a/middleware/src/modules/api-keys/api-keys.service.spec.ts
+++ b/middleware/src/modules/api-keys/api-keys.service.spec.ts
@@ -1,4 +1,5 @@
 import * as crypto from 'crypto';
+import { NotFoundException } from '@nestjs/common';
 import { ApiKeysService } from './api-keys.service';
 import { DatabaseService } from '../database/database.service';
 
@@ -194,6 +195,12 @@ describe('ApiKeysService', () => {
         where: { id: 'key-123', organizationId: 'org-123' },
         data: { revokedAt: expect.any(Date) },
       });
+    });
+
+    it('should throw NotFoundException when key does not exist in caller org', async () => {
+      mockDatabaseService.apiKey.updateMany.mockResolvedValue({ count: 0 });
+
+      await expect(service.revoke('org-123', 'missing-key')).rejects.toThrow(NotFoundException);
     });
   });
 

--- a/middleware/src/modules/api-keys/api-keys.service.ts
+++ b/middleware/src/modules/api-keys/api-keys.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import * as crypto from 'crypto';
 import { DatabaseService } from '../database/database.service';
 import { CreateApiKeyDto } from './dto/create-api-key.dto';
@@ -71,13 +71,20 @@ export class ApiKeysService {
   }
 
   /**
-   * Revoke an API key
+   * Revoke an API key. Throws NotFoundException if the key doesn't exist
+   * in the caller's organization — callers were previously getting a
+   * silent {count: 0} success on bad keyIds and reporting it as revoked
+   * to the user.
    */
   async revoke(organizationId: string, keyId: string) {
-    return this.db.apiKey.updateMany({
+    const result = await this.db.apiKey.updateMany({
       where: { id: keyId, organizationId },
       data: { revokedAt: new Date() },
     });
+    if (result.count === 0) {
+      throw new NotFoundException('API key not found');
+    }
+    return result;
   }
 
   /**

--- a/middleware/src/modules/content/content.service.ts
+++ b/middleware/src/modules/content/content.service.ts
@@ -195,11 +195,17 @@ export class ContentService {
   }
 
   /**
-   * Find content by ID without org filter (for device content serving)
+   * Find content for device serving. The org filter is applied in the
+   * query (not after the fetch) so an attacker who guesses a content
+   * ID from another org gets a uniform NotFoundException without the
+   * service ever having loaded that org's record into memory.
+   *
+   * Callers MUST verify the device JWT before calling this and pass
+   * the device's organizationId from the verified payload.
    */
-  async findById(id: string) {
+  async findByIdForDevice(id: string, organizationId: string) {
     const content = await this.db.content.findFirst({
-      where: { id },
+      where: { id, organizationId },
     });
     return content;
   }

--- a/middleware/src/modules/content/device-content.controller.spec.ts
+++ b/middleware/src/modules/content/device-content.controller.spec.ts
@@ -9,7 +9,6 @@ jest.mock('isomorphic-dompurify', () => ({
 import { Test, TestingModule } from '@nestjs/testing';
 import {
   NotFoundException,
-  ForbiddenException,
   UnauthorizedException,
   BadRequestException,
 } from '@nestjs/common';
@@ -47,7 +46,7 @@ describe('DeviceContentController', () => {
 
   beforeEach(async () => {
     mockContentService = {
-      findById: jest.fn(),
+      findByIdForDevice: jest.fn(),
     } as any;
 
     mockStorageService = {
@@ -103,7 +102,7 @@ describe('DeviceContentController', () => {
       const req = createMockRequest('valid-device-token');
       const res = createMockResponse();
 
-      mockContentService.findById.mockResolvedValue(mockContent as any);
+      mockContentService.findByIdForDevice.mockResolvedValue(mockContent as any);
       mockJwtService.verify.mockReturnValue(validDevicePayload);
 
       // Create an async iterable stream mock
@@ -117,7 +116,10 @@ describe('DeviceContentController', () => {
 
       await controller.serveFile(contentId, req, res);
 
-      expect(mockContentService.findById).toHaveBeenCalledWith(contentId);
+      expect(mockContentService.findByIdForDevice).toHaveBeenCalledWith(
+        contentId,
+        validDevicePayload.organizationId,
+      );
       expect(mockJwtService.verify).toHaveBeenCalledWith('valid-device-token', {
         secret: process.env.DEVICE_JWT_SECRET,
         algorithms: ['HS256'],
@@ -135,7 +137,7 @@ describe('DeviceContentController', () => {
       const req = createMockRequest(undefined, 'valid-query-token');
       const res = createMockResponse();
 
-      mockContentService.findById.mockResolvedValue(mockContent as any);
+      mockContentService.findByIdForDevice.mockResolvedValue(mockContent as any);
       mockJwtService.verify.mockReturnValue(validDevicePayload);
 
       const buffer = Buffer.from('file-content');
@@ -159,7 +161,7 @@ describe('DeviceContentController', () => {
       const req = createMockRequest();
       const res = createMockResponse();
 
-      mockContentService.findById.mockResolvedValue(mockContent as any);
+      mockContentService.findByIdForDevice.mockResolvedValue(mockContent as any);
 
       await expect(controller.serveFile(contentId, req, res)).rejects.toThrow(
         UnauthorizedException,
@@ -170,7 +172,7 @@ describe('DeviceContentController', () => {
       const req = createMockRequest('invalid-token');
       const res = createMockResponse();
 
-      mockContentService.findById.mockResolvedValue(mockContent as any);
+      mockContentService.findByIdForDevice.mockResolvedValue(mockContent as any);
       mockJwtService.verify.mockImplementation(() => {
         throw new Error('Invalid token');
       });
@@ -184,7 +186,7 @@ describe('DeviceContentController', () => {
       const req = createMockRequest('user-token');
       const res = createMockResponse();
 
-      mockContentService.findById.mockResolvedValue(mockContent as any);
+      mockContentService.findByIdForDevice.mockResolvedValue(mockContent as any);
       mockJwtService.verify.mockReturnValue({
         ...validDevicePayload,
         type: 'user',
@@ -195,19 +197,24 @@ describe('DeviceContentController', () => {
       );
     });
 
-    it('should return 403 when content belongs to different organization', async () => {
+    it('should return 404 when content belongs to a different organization', async () => {
+      // After the IDOR hardening, the org filter lives in the query
+      // (findByIdForDevice). A device with the wrong org id therefore
+      // gets a uniform NotFoundException — the service never loads
+      // the other org's row, so there is no record on which to
+      // distinguish Forbidden vs NotFound (which is intentional).
       const req = createMockRequest('valid-token');
       const res = createMockResponse();
 
-      const contentFromDifferentOrg = {
-        ...mockContent,
-        organizationId: 'other-org-999',
-      };
-      mockContentService.findById.mockResolvedValue(contentFromDifferentOrg as any);
+      mockContentService.findByIdForDevice.mockResolvedValue(null);
       mockJwtService.verify.mockReturnValue(validDevicePayload);
 
       await expect(controller.serveFile(contentId, req, res)).rejects.toThrow(
-        ForbiddenException,
+        NotFoundException,
+      );
+      expect(mockContentService.findByIdForDevice).toHaveBeenCalledWith(
+        contentId,
+        validDevicePayload.organizationId,
       );
     });
 
@@ -215,7 +222,8 @@ describe('DeviceContentController', () => {
       const req = createMockRequest('valid-token');
       const res = createMockResponse();
 
-      mockContentService.findById.mockResolvedValue(null);
+      mockJwtService.verify.mockReturnValue(validDevicePayload);
+      mockContentService.findByIdForDevice.mockResolvedValue(null);
 
       await expect(controller.serveFile(contentId, req, res)).rejects.toThrow(
         NotFoundException,
@@ -226,7 +234,8 @@ describe('DeviceContentController', () => {
       const req = createMockRequest('valid-token');
       const res = createMockResponse();
 
-      mockContentService.findById.mockResolvedValue({
+      mockJwtService.verify.mockReturnValue(validDevicePayload);
+      mockContentService.findByIdForDevice.mockResolvedValue({
         ...mockContent,
         url: null,
       } as any);
@@ -244,7 +253,7 @@ describe('DeviceContentController', () => {
         ...mockContent,
         url: 'https://cdn.example.com/image.jpg',
       };
-      mockContentService.findById.mockResolvedValue(externalContent as any);
+      mockContentService.findByIdForDevice.mockResolvedValue(externalContent as any);
       mockJwtService.verify.mockReturnValue(validDevicePayload);
 
       await controller.serveFile(contentId, req, res);
@@ -260,7 +269,7 @@ describe('DeviceContentController', () => {
       const req = createMockRequest('valid-token');
       const res = createMockResponse();
 
-      mockContentService.findById.mockResolvedValue(mockContent as any);
+      mockContentService.findByIdForDevice.mockResolvedValue(mockContent as any);
       mockJwtService.verify.mockReturnValue(validDevicePayload);
       mockStorageService.isMinioAvailable.mockReturnValue(false);
 
@@ -274,7 +283,7 @@ describe('DeviceContentController', () => {
       const res = createMockResponse();
 
       const contentNoMime = { ...mockContent, mimeType: null };
-      mockContentService.findById.mockResolvedValue(contentNoMime as any);
+      mockContentService.findByIdForDevice.mockResolvedValue(contentNoMime as any);
       mockJwtService.verify.mockReturnValue(validDevicePayload);
 
       const buffer = Buffer.from('binary-data');

--- a/middleware/src/modules/content/device-content.controller.ts
+++ b/middleware/src/modules/content/device-content.controller.ts
@@ -6,7 +6,6 @@ import {
   Res,
   NotFoundException,
   BadRequestException,
-  ForbiddenException,
   UnauthorizedException,
   Logger,
 } from '@nestjs/common';
@@ -87,16 +86,18 @@ export class DeviceContentController {
     @Req() req: Request,
     @Res() res: Response,
   ): Promise<void> {
-    const content = await this.contentService.findById(id);
+    // Device JWT is mandatory — throws UnauthorizedException if missing/invalid.
+    // Verify it BEFORE the DB query so an unauth caller can't probe content
+    // IDs for existence via timing or DB error patterns.
+    const devicePayload = this.verifyDeviceToken(req);
+
+    const content = await this.contentService.findByIdForDevice(
+      id,
+      devicePayload.organizationId,
+    );
 
     if (!content || !content.url) {
       throw new NotFoundException('Content not found');
-    }
-
-    // Device JWT is mandatory — throws UnauthorizedException if missing/invalid
-    const devicePayload = this.verifyDeviceToken(req);
-    if (content.organizationId !== devicePayload.organizationId) {
-      throw new ForbiddenException('Content not accessible to this device');
     }
 
     if (content.url.startsWith(MINIO_URL_PREFIX)) {

--- a/middleware/src/modules/playlists/playlists.service.spec.ts
+++ b/middleware/src/modules/playlists/playlists.service.spec.ts
@@ -126,6 +126,45 @@ describe('PlaylistsService', () => {
 
       expect(result.items).toHaveLength(1);
     });
+
+    it('should allow the same contentId to appear multiple times in items', async () => {
+      // Regression: previously the validation compared findMany result
+      // length against the raw contentIds length, falsely rejecting any
+      // playlist that reused the same content twice with a misleading
+      // "missing: " (empty) error message.
+      const dtoWithDuplicateContent = {
+        ...createDto,
+        items: [
+          { contentId: 'content-123', order: 0 },
+          { contentId: 'content-123', order: 1 },
+          { contentId: 'content-456', order: 2 },
+        ],
+      };
+
+      mockDatabaseService.content.findMany.mockResolvedValue([
+        { id: 'content-123' },
+        { id: 'content-456' },
+      ]);
+
+      mockDatabaseService.playlist.create.mockResolvedValue({
+        ...mockPlaylist,
+        items: [mockPlaylistItem],
+      });
+
+      await expect(
+        service.create('org-123', dtoWithDuplicateContent),
+      ).resolves.toBeDefined();
+
+      // Ensure the de-duplication happens BEFORE the DB query — content.findMany
+      // should be called with the unique set, not the raw 3-item array.
+      expect(mockDatabaseService.content.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            id: { in: ['content-123', 'content-456'] },
+          }),
+        }),
+      );
+    });
   });
 
   describe('findAll', () => {

--- a/middleware/src/modules/playlists/playlists.service.ts
+++ b/middleware/src/modules/playlists/playlists.service.ts
@@ -41,20 +41,26 @@ export class PlaylistsService {
   async create(organizationId: string, createPlaylistDto: CreatePlaylistDto) {
     const { items, ...playlistData } = createPlaylistDto;
 
-    // Validate all content items exist and belong to organization
+    // Validate all content items exist and belong to organization.
+    // Dedupe contentIds before the cardinality check — a playlist that
+    // reuses the same content multiple times is valid, but findMany
+    // returns each match once, so comparing lengths against the raw
+    // contentIds array would falsely reject legitimate playlists with
+    // a misleading "missing: " (empty) error message.
     if (items && items.length > 0) {
       const contentIds = items.map(item => item.contentId);
+      const uniqueContentIds = Array.from(new Set(contentIds));
       const contents = await this.db.content.findMany({
         where: {
-          id: { in: contentIds },
+          id: { in: uniqueContentIds },
           organizationId,
         },
         select: { id: true },
       });
 
-      if (contents.length !== contentIds.length) {
-        const foundIds = contents.map(c => c.id);
-        const missingIds = contentIds.filter(id => !foundIds.includes(id));
+      if (contents.length !== uniqueContentIds.length) {
+        const foundIds = new Set(contents.map(c => c.id));
+        const missingIds = uniqueContentIds.filter(id => !foundIds.has(id));
         throw new NotFoundException(
           `Content item(s) not found or do not belong to your organization: ${missingIds.join(', ')}`
         );

--- a/middleware/src/modules/support/support.service.ts
+++ b/middleware/src/modules/support/support.service.ts
@@ -360,9 +360,33 @@ export class SupportService {
   }
 
   /**
-   * Get a single support request with messages
+   * Get a single support request with messages.
+   *
+   * Two-step fetch: a shallow access check (id + organizationId +
+   * userId only) runs before the full include load. The unauthorized
+   * paths therefore never load other orgs' user PII, message bodies,
+   * or resolution notes — only the access fields. The Forbidden vs.
+   * NotFound signal is preserved for callers that depend on it.
    */
   async findOne(id: string, user: UserInfo) {
+    const access = await this.db.supportRequest.findUnique({
+      where: { id },
+      select: { id: true, organizationId: true, userId: true },
+    });
+
+    if (!access) {
+      throw new NotFoundException('Support request not found');
+    }
+
+    if (!user.isSuperAdmin) {
+      if (access.organizationId !== user.organizationId) {
+        throw new ForbiddenException('Access denied');
+      }
+      if (user.role !== 'admin' && access.userId !== user.id) {
+        throw new ForbiddenException('Access denied');
+      }
+    }
+
     const request = await this.db.supportRequest.findUnique({
       where: { id },
       include: {
@@ -379,17 +403,9 @@ export class SupportService {
     });
 
     if (!request) {
+      // The row existed in the access check above but got deleted before
+      // the full fetch. Race window is microseconds; surface as 404.
       throw new NotFoundException('Support request not found');
-    }
-
-    // Access control
-    if (!user.isSuperAdmin) {
-      if (request.organizationId !== user.organizationId) {
-        throw new ForbiddenException('Access denied');
-      }
-      if (user.role !== 'admin' && request.userId !== user.id) {
-        throw new ForbiddenException('Access denied');
-      }
     }
 
     return {


### PR DESCRIPTION
## Summary

Four defense-in-depth fixes across the middleware authz boundary. Each was a small footgun rather than an active exploit, but they sit on the customer-1 launch path and were cheap to close.

1. **api-keys revoke()** — \`updateMany\` returned \`{count: 0}\` on a missing keyId without throwing; callers reported success to the user. Now throws \`NotFoundException\` when no row matches. New unit test covers the missing-key branch.

2. **playlists create()** — the content-validation cardinality check compared \`findMany\` result length against the raw items length, which falsely rejected any playlist that reused the same content twice with a misleading \`missing: \` (empty) error message. Dedupe contentIds before the comparison. New regression test.

3. **support findOne()** — previously fetched the full record (messages, user PII, resolution notes) and then threw \`Forbidden\` if the caller's org didn't match. That leaked sensitive data into the error path's request log + Sentry frames. Now does a shallow access check (id + organizationId + userId only) first, throws \`Forbidden\` cleanly, then loads the full record only after access is granted.

4. **content \`findById\` → \`findByIdForDevice\` + \`device-content.serveFile\`** — collapse "fetch row, then check org" into a single \`findFirst({where: {id, organizationId}})\` query, with the device JWT verified BEFORE the DB call. The org filter now lives in the query, so a wrong-org request never loads the other org's row. Tests updated for the new method name and the Forbidden → 404 behavioral change (no longer signal existence to wrong-org callers).

## Tests

- [x] \`(api-keys|playlists|support|content|device-content)\` modules: 253/253 pass.
- [x] New tests: api-keys missing-key revoke, playlists duplicate-contentId.

🤖 Generated with [Claude Code](https://claude.com/claude-code)