### PR TITLE
fix(realtime): hardening on screenshot guard + dashboard catch-up cap

### DIFF
--- a/realtime/src/gateways/device.gateway.spec.ts
+++ b/realtime/src/gateways/device.gateway.spec.ts
@@ -68,6 +68,7 @@ describe('DeviceGateway', () => {
     display: {
       update: jest.fn().mockResolvedValue({ nickname: 'Test Device', deviceIdentifier: 'test-id' }),
       findUnique: jest.fn().mockResolvedValue(null),
+      findMany: jest.fn().mockResolvedValue([]),
     },
     playlist: {
       findUnique: jest.fn().mockResolvedValue(null),
@@ -755,6 +756,48 @@ describe('DeviceGateway', () => {
       await gateway.handleJoinOrganization(client as any, data as any);
 
       expect(client.data.isDashboard).toBe(true);
+    });
+  });
+
+  describe('sendDeviceStatusCatchUp (catch-up cap)', () => {
+    it('should cap a large fleet at 500 devices and warn about truncation', async () => {
+      const client = createMockSocket();
+      // Simulate 501 devices for one org — the cap is 500, so the
+      // query should request take=501 (cap + 1 peek) and the function
+      // should emit only the first 500 + a warning.
+      const fleet = Array.from({ length: 501 }, (_, i) => ({
+        id: `dev-${i}`,
+        status: 'offline',
+        lastHeartbeat: new Date(Date.now() - i * 1000),
+      }));
+      databaseService.display.findMany.mockResolvedValue(fleet as any);
+
+      const warnSpy = jest.spyOn((gateway as any).logger, 'warn');
+
+      await (gateway as any).sendDeviceStatusCatchUp(client, 'org-big');
+
+      expect(databaseService.display.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { organizationId: 'org-big' },
+          take: 501,
+        }),
+      );
+      expect(client.emit).toHaveBeenCalledTimes(500);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('truncated at 500'));
+    });
+
+    it('should send all devices when fleet is under the cap', async () => {
+      const client = createMockSocket();
+      const fleet = Array.from({ length: 7 }, (_, i) => ({
+        id: `dev-${i}`,
+        status: 'offline',
+        lastHeartbeat: new Date(),
+      }));
+      databaseService.display.findMany.mockResolvedValue(fleet as any);
+
+      await (gateway as any).sendDeviceStatusCatchUp(client, 'org-small');
+
+      expect(client.emit).toHaveBeenCalledTimes(7);
     });
   });
 

--- a/realtime/src/gateways/device.gateway.ts
+++ b/realtime/src/gateways/device.gateway.ts
@@ -661,16 +661,31 @@ export class DeviceGateway
    * Send current device statuses to a newly connected dashboard client.
    * This ensures the dashboard has accurate online/offline state immediately,
    * even if the devices connected before the dashboard did.
+   *
+   * Capped at CATCH_UP_DEVICE_CAP devices per call. For larger fleets the
+   * dashboard can paginate via REST and rely on incremental status updates
+   * from then on. Without this cap, a single dashboard reconnect for a
+   * 10k-device org would load the entire fleet into memory and emit 10k
+   * events to one socket on the connection-handling path — which is what
+   * the "stale-org outage" follow-up was about.
    */
+  private static readonly CATCH_UP_DEVICE_CAP = 500;
+
   private async sendDeviceStatusCatchUp(client: Socket, orgId: string): Promise<void> {
     try {
+      const cap = DeviceGateway.CATCH_UP_DEVICE_CAP;
       const devices = await this.databaseService.display.findMany({
         where: { organizationId: orgId },
         select: { id: true, status: true, lastHeartbeat: true },
+        orderBy: { lastHeartbeat: 'desc' },
+        take: cap + 1, // peek one past the cap so we know if more exist
       });
 
+      const truncated = devices.length > cap;
+      const toSend = truncated ? devices.slice(0, cap) : devices;
+
       const now = new Date().toISOString();
-      for (const device of devices) {
+      for (const device of toSend) {
         // Check in-memory cache first (most accurate for connected devices)
         const cachedStatus = this.deviceStatusCache.get(device.id);
         const status = cachedStatus || device.status || 'offline';
@@ -682,7 +697,13 @@ export class DeviceGateway
         });
       }
 
-      this.logger.debug(`Sent status catch-up for ${devices.length} devices to dashboard (org: ${orgId})`);
+      if (truncated) {
+        this.logger.warn(
+          `Device catch-up truncated at ${cap} for org ${orgId}; dashboard should paginate the remainder via REST and rely on incremental events afterwards`,
+        );
+      } else {
+        this.logger.debug(`Sent status catch-up for ${toSend.length} devices to dashboard (org: ${orgId})`);
+      }
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       this.logger.warn(`Failed to send device status catch-up: ${errorMessage}`);
@@ -1239,6 +1260,7 @@ export class DeviceGateway
    * Device sends base64-encoded image data which we upload to MinIO
    */
   @SubscribeMessage('screenshot:response')
+  @UseGuards(WsDeviceGuard)
   @UsePipes(new WsValidationPipe())
   async handleScreenshotResponse(
     @ConnectedSocket() client: Socket,


### PR DESCRIPTION
## Summary

Two production-readiness fixes in the realtime gateway:

1. **screenshot:response was missing \`@UseGuards(WsDeviceGuard)\`.** Every other device-only handler (heartbeat, content:impression, content:error, playlist:request) has it; this one slipped. Without the guard a dashboard-authenticated client could fire screenshot uploads, which would attempt a MinIO write + a broken DB update (\`where id=undefined\`). The handler already uses \`client.data.deviceId\` for the update, so there was no IDOR escape — just a wasted MinIO round-trip and a noisy 500.

2. **sendDeviceStatusCatchUp was unbounded.** On a 10k-device fleet, a single dashboard reconnect loaded the entire fleet into memory and fired 10k emits to one socket on the connection-handling path. This is the "stale-org outage" follow-up: capped at 500 devices (most-recent-heartbeat ordering), with a warn log when truncation kicks in so the dashboard team sees the cap getting hit and can move to REST-paginated catch-up + incremental events.

## Tests

- [x] \`device.gateway\` spec: 64/64 (was 62 + 2 new for the catch-up cap behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)