### PR TITLE
fix(ops): known follow-ups — alert recipient, Slack mrkdwn, state lock contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,7 @@ ANTHROPIC_API_KEY       # Required when AGENT_AI_PROVIDER=anthropic
 
 ```
 OPS_EMAIL, OPS_PASSWORD # Service-account credentials used by ops scripts
-OPS_ALERT_EMAIL         # Alert recipient email (optional; SMTP_TO is the actual envelope target)
+OPS_ALERT_EMAIL         # Preferred ops alert recipient. When set, ops alerts go here; otherwise falls back to SMTP_TO. Use to send ops alerts to a different mailbox than transactional mail.
 REALTIME_URL            # Realtime gateway base URL (default http://localhost:3002)
 WEB_URL                 # Web frontend base URL (default http://localhost:3001)
 VALIDATOR_BASE_URL      # Middleware base URL for ops scripts (default http://localhost:3000)

--- a/scripts/ops/lib/alerting.ts
+++ b/scripts/ops/lib/alerting.ts
@@ -13,7 +13,15 @@
  *   SMTP_USER                          — SMTP username
  *   SMTP_PASS                          — SMTP password
  *   SMTP_FROM                          — Sender email address
- *   SMTP_TO                            — Recipient email address(es), comma-separated
+ *   SMTP_TO                            — Generic SMTP envelope recipient,
+ *                                        comma-separated. Used as the
+ *                                        fallback for ops alerts when
+ *                                        OPS_ALERT_EMAIL is not set.
+ *   OPS_ALERT_EMAIL                    — Preferred ops alert recipient(s),
+ *                                        comma-separated. Distinct from
+ *                                        SMTP_TO so transactional mail
+ *                                        and ops alerts can target
+ *                                        different mailboxes.
  *   HEALTHCHECKS_HEALTH_GUARDIAN_URL   — healthchecks.io ping URL for the
  *                                        health-guardian heartbeat. When set,
  *                                        a successful health-guardian run POSTs
@@ -137,7 +145,7 @@ export async function sendSlackAlert(
   if (criticals.length > 0) {
     const list = criticals
       .slice(0, 5)
-      .map(i => `* *${i.type}*: ${i.message}`)
+      .map(i => `* *${escapeMrkdwn(i.type)}*: ${escapeMrkdwn(i.message)}`)
       .join('\n');
     blocks.push({
       type: 'section',
@@ -153,7 +161,7 @@ export async function sendSlackAlert(
   if (warnings.length > 0 && criticals.length === 0) {
     const list = warnings
       .slice(0, 3)
-      .map(i => `* *${i.type}*: ${i.message}`)
+      .map(i => `* *${escapeMrkdwn(i.type)}*: ${escapeMrkdwn(i.message)}`)
       .join('\n');
     blocks.push({
       type: 'section',
@@ -218,10 +226,14 @@ export async function sendEmailAlert(
   const user = process.env.SMTP_USER || '';
   const pass = process.env.SMTP_PASS || '';
   const from = process.env.SMTP_FROM || 'vizora-ops@vizora.cloud';
-  const to = process.env.SMTP_TO || '';
+  // Prefer the ops-specific recipient if configured. Falls back to SMTP_TO
+  // so existing deployments without OPS_ALERT_EMAIL continue to work, but
+  // operators who want ops alerts going to a different mailbox than
+  // transactional mail can now configure that without touching SMTP_TO.
+  const to = process.env.OPS_ALERT_EMAIL || process.env.SMTP_TO || '';
 
   if (!to) {
-    log('alerting', 'SMTP_TO not set — skipping email alert');
+    log('alerting', 'OPS_ALERT_EMAIL and SMTP_TO are both unset — skipping email alert');
     return;
   }
 
@@ -349,4 +361,24 @@ function escapeHtml(text: string): string {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
+}
+
+/**
+ * Escape characters that Slack mrkdwn treats as formatting markers.
+ * Without this, an incident type like `device_offline_long` renders as
+ * `device` italic `offline` italic `long` — operators see a mangled
+ * message and don't recognise it as a real alert. Per the §12b
+ * silent-failure rule (global CLAUDE.md), automated alerts that
+ * silently mis-format are as bad as alerts that don't fire.
+ *
+ * Escapes: _ * ` ~  (the four mrkdwn formatting characters that occur
+ * naturally in our incident type names and free-form messages).
+ */
+function escapeMrkdwn(text: string): string {
+  return text
+    .replace(/\\/g, '\\\\')
+    .replace(/_/g, '\\_')
+    .replace(/\*/g, '\\*')
+    .replace(/`/g, '\\`')
+    .replace(/~/g, '\\~');
 }

--- a/scripts/ops/lib/state.ts
+++ b/scripts/ops/lib/state.ts
@@ -92,8 +92,28 @@ function emptyState(): OpsState {
 
 /**
  * Read the ops state file. Returns an empty state if the file does not
- * exist or cannot be parsed. Acquires file lock to prevent concurrent
- * read-modify-write races between agents.
+ * exist or cannot be parsed.
+ *
+ * **LOCK CONTRACT (must read before calling):** This function acquires
+ * an exclusive file lock and DOES NOT RELEASE IT. Every caller MUST
+ * pair the read with a writeOpsState() to release the lock. The
+ * canonical shape is:
+ *
+ * ```ts
+ * const state = readOpsState();
+ * try {
+ *   // mutate state ...
+ * } finally {
+ *   writeOpsState(state);  // releases lock, even on throw above
+ * }
+ * ```
+ *
+ * Calling readOpsState() twice without a writeOpsState() between them
+ * will deadlock on LOCK_TIMEOUT_MS (5s) and the second read will then
+ * proceed without a lock — silently breaking the atomicity guarantee
+ * for any concurrent agent. If you only need a snapshot for reporting,
+ * call readOpsState() then immediately call writeOpsState(state)
+ * unchanged to release the lock cleanly.
  */
 export function readOpsState(): OpsState {
   acquireLock();
@@ -120,7 +140,12 @@ export function readOpsState(): OpsState {
 /**
  * Write ops state to disk and release the file lock. Trims incidents
  * to MAX_INCIDENTS and remediations to MAX_REMEDIATIONS (keeping most recent).
- * Must be called after readOpsState() to release the lock.
+ *
+ * **Must be called after every readOpsState()**, including on the error
+ * path, otherwise the lock leaks until the OS releases the .lock file's
+ * mtime past LOCK_STALE_MS (30s) — during which window every other
+ * agent's read silently degrades to a busy-wait. Pair the two calls
+ * in a try/finally per the readOpsState() JSDoc example.
  */
 export function writeOpsState(state: OpsState): void {
   try {

--- a/scripts/ops/ops-reporter.ts
+++ b/scripts/ops/ops-reporter.ts
@@ -276,7 +276,15 @@ async function main(): Promise<void> {
       log(AGENT, `Dashboard update failed: ${err instanceof Error ? err.message : err}`);
     }
   } else {
-    log(AGENT, 'Dashboard update skipped (OPS_EMAIL/VALIDATOR_EMAIL not set)');
+    // This is a misconfiguration the operator should fix — without ops
+    // credentials, ops-state.json never syncs to the dashboard's Redis
+    // cache and the /dashboard/ops view shows stale data forever. Log
+    // it as a WARNING (not the previous info-level message) so it
+    // surfaces in alerting/log scrapers.
+    log(
+      AGENT,
+      'WARNING: dashboard update skipped — set OPS_EMAIL (or VALIDATOR_EMAIL) + OPS_PASSWORD to enable dashboard sync',
+    );
   }
 
   // ─── 7. Prune Old Data ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Four ops follow-ups tracked since the 2026-05-19 OptiSigns deploy:

1. **Vizora System/Ops admin recipients** — \`alerting.ts\`'s \`sendEmailAlert\` hard-coded \`process.env.SMTP_TO\` as the only recipient, even though CLAUDE.md already documented an \`OPS_ALERT_EMAIL\` env var with intent for it to be the preferred ops mailbox. Plumbed: \`OPS_ALERT_EMAIL || SMTP_TO\`. SMTP_TO stays as the fallback so existing deployments don't break. Doc strings updated to reflect the new precedence.

2. **Slack mrkdwn underscore mangling** (§12b silent-failure pattern). Incident messages like \`device_offline_long\` rendered as \`device\` italic \`offline\` italic \`long\` — operators saw a mangled string and didn't recognise the alert. Added \`escapeMrkdwn()\` helper, applied to both type + message fields in the critical/warning incident lists. Escapes \`_ * \` ~\` (the four mrkdwn formatting chars that occur naturally in our incident names and free-form messages).

3. **state.ts lock contract** was inline-commented but not in the JSDoc. New devs adding ops agents could easily miss that \`readOpsState()\` acquires a file lock that ONLY \`writeOpsState()\` releases — and double-reads deadlock at \`LOCK_TIMEOUT_MS\`, then silently degrade to lockless reads. JSDoc now spells out the try/finally pairing contract with an example.

4. **ops-reporter logged "Dashboard update skipped" at info level** when OPS_EMAIL was unset. This is an operator misconfiguration that should be loud: the dashboard never receives state and the /dashboard/ops view shows stale data forever. Bumped to a WARNING-level log line that surfaces in log scrapers.

Bonus: CLAUDE.md \`OPS_ALERT_EMAIL\` row updated to reflect the new precedence and explain when an operator would set it differently from SMTP_TO.

## Tests

- [x] No test infrastructure exists for \`scripts/ops/\` — verified syntax via \`tsx -e\` import smoke tests against each touched module.
- [ ] Reviewer can verify the escapeMrkdwn() output by feeding any of our existing incident types (e.g. \`device_offline_long\`) through it: \`device\\_offline\\_long\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)