### PR TITLE
fix(config): require INTERNAL_API_SECRET in prod + tighten ops gaps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -214,6 +214,7 @@ VALIDATOR_BASE_URL=http://localhost:3000
 # GIT_REPO_URL=git@github.com:your-org/vizora.git
 
 # =============================================================================
-# Error tracking (required for production monitoring)
+# Error tracking (optional — Sentry gracefully no-ops when unset; the
+# duplicate entry up top is the canonical one. Uncomment + set to enable.)
 # =============================================================================
-SENTRY_DSN=https://your-dsn@sentry.io/project-id
+# SENTRY_DSN=https://your-dsn@sentry.io/project-id

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -109,8 +109,10 @@ module.exports = {
           } catch { return {}; }
         })(),
       },
-      // Graceful shutdown
-      kill_timeout: 10000,
+      // Graceful shutdown — Next.js needs more time than the API services
+      // to drain in-flight SSR + RSC streams cleanly; 10s was occasionally
+      // truncating responses on PM2 reload. Match the middleware budget.
+      kill_timeout: 30000,
       // Logging
       log_date_format: 'YYYY-MM-DD HH:mm:ss Z',
       max_size: '50M',

--- a/middleware/src/modules/config/env.validation.spec.ts
+++ b/middleware/src/modules/config/env.validation.spec.ts
@@ -146,6 +146,7 @@ describe('envSchema', () => {
         NODE_ENV: 'production',
         MINIO_ACCESS_KEY: 'prod-key',
         MINIO_SECRET_KEY: 'prod-secret',
+        INTERNAL_API_SECRET: 'x'.repeat(32),
       });
       expect(result.success).toBe(true);
     });
@@ -399,6 +400,34 @@ describe('envSchema', () => {
         NODE_ENV: 'production',
         MINIO_ACCESS_KEY: 'prod-key',
         MINIO_SECRET_KEY: 'prod-secret',
+        INTERNAL_API_SECRET: 'x'.repeat(32),
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject missing INTERNAL_API_SECRET in production', () => {
+      // Regression: previously INTERNAL_API_SECRET was simply optional, so
+      // a prod deploy without it silently broke every internal service-
+      // to-service call (ops scripts, realtime push, MCP audit hooks)
+      // with 401s that nothing surfaced. Now enforced at startup.
+      const result = envSchema.safeParse({
+        ...validEnv,
+        NODE_ENV: 'production',
+        MINIO_ACCESS_KEY: 'prod-key',
+        MINIO_SECRET_KEY: 'prod-secret',
+        // INTERNAL_API_SECRET intentionally omitted
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues.some(i => i.path[0] === 'INTERNAL_API_SECRET')).toBe(true);
+      }
+    });
+
+    it('should not enforce INTERNAL_API_SECRET in development', () => {
+      const result = envSchema.safeParse({
+        ...validEnv,
+        NODE_ENV: 'development',
+        // INTERNAL_API_SECRET intentionally omitted
       });
       expect(result.success).toBe(true);
     });

--- a/middleware/src/modules/config/env.validation.ts
+++ b/middleware/src/modules/config/env.validation.ts
@@ -80,6 +80,22 @@ export const envSchema = z.object({
         path: ['MINIO_SECRET_KEY'],
       });
     }
+    // INTERNAL_API_SECRET is optional in the base schema (dev + test
+    // don't require it for the ops scripts to spin up against an empty
+    // env), but it is REQUIRED in production. Without it, every call
+    // to /api/v1/internal/* — ops agents writing back state, the
+    // realtime gateway pushing content, the in-process MCP audit
+    // hooks — returns 401, and the failure mode is silent because
+    // those calls fire-and-forget.
+    if (!data.INTERNAL_API_SECRET) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'INTERNAL_API_SECRET must be set in production (min 32 chars). ' +
+          'Used for service-to-service auth between middleware, realtime, and ops scripts.',
+        path: ['INTERNAL_API_SECRET'],
+      });
+    }
   }
 });
 


### PR DESCRIPTION
## Summary

Three prod-readiness fixes that surfaced from the readiness audit:

1. **INTERNAL_API_SECRET was \`.optional()\` in the Zod schema**, with a comment explaining it's "required in production." But the schema never actually enforced that — a prod deploy without the secret booted cleanly and then silently broke every internal call (ops agents writing state back, realtime gateway pushing content, MCP audit hooks). Moved to the production \`superRefine\` block alongside the MinIO credential checks. Two new regression tests: prod-without-it fails fast, dev-without-it still works.

2. **vizora-web's PM2 \`kill_timeout\` was 10s** — middleware + realtime are 30s + 15s respectively. Next.js needs the most time of the three to drain in-flight SSR + RSC streams cleanly on reload; 10s was occasionally truncating responses. Bumped to 30s to match middleware.

3. **\`.env.example\` had SENTRY_DSN listed twice** — once commented out under "(optional, skip if not set)" near the top, then again un-commented near the bottom under a "(required for production monitoring)" header. The truth (per \`env.validation.ts\`) is that Sentry is optional; the second entry's header was confusing operators into thinking they had to set it. Re-commented the second entry and corrected its header to match the schema.

## Tests

- [x] \`env.validation\` spec: 56/56 (was 54 + 2 new for the prod gate).
- [x] \`node -e \"require('./ecosystem.config.js')\"\` parses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)