### PR TITLE
fix(web): content table a11y + template modal Escape key

### DIFF
--- a/web/src/app/dashboard/content/page-client.tsx
+++ b/web/src/app/dashboard/content/page-client.tsx
@@ -1030,6 +1030,7 @@ export default function ContentClient() {
  <th className="eh-th">
  <input
  type="checkbox"
+ aria-label="Select all content items"
  checked={selectedItems.size === filteredContent.length && filteredContent.length > 0}
  onChange={toggleSelectAll}
  className="rounded border-[var(--border)] text-[var(--primary)] focus:ring-[var(--primary)]"
@@ -1048,6 +1049,7 @@ export default function ContentClient() {
  <td className="eh-td">
  <input
  type="checkbox"
+ aria-label={`Select ${item.title}`}
  checked={selectedItems.has(item.id)}
  onChange={() => toggleSelectItem(item.id)}
  className="rounded border-[var(--border)] text-[var(--primary)] focus:ring-[var(--primary)]"
@@ -1055,7 +1057,19 @@ export default function ContentClient() {
  />
  </td>
  <td className="eh-td">
- <div className="flex items-center gap-3 cursor-pointer" onClick={() => handlePreview(item)}>
+ <div
+ role="button"
+ tabIndex={0}
+ aria-label={`Preview ${item.title}`}
+ className="flex items-center gap-3 cursor-pointer focus:outline-none focus:ring-2 focus:ring-[var(--primary)] rounded"
+ onClick={() => handlePreview(item)}
+ onKeyDown={(e) => {
+ if (e.key === 'Enter' || e.key === ' ') {
+ e.preventDefault();
+ handlePreview(item);
+ }
+ }}
+ >
  <div className="w-12 h-12 bg-gradient-to-br from-[#00E5A0] to-[#00B4D8] rounded flex items-center justify-center flex-shrink-0 overflow-hidden">
  {item.thumbnailUrl ? (
  <img src={item.thumbnailUrl} alt={item.title} className="w-full h-full object-cover" />

--- a/web/src/app/dashboard/templates/page.tsx
+++ b/web/src/app/dashboard/templates/page.tsx
@@ -86,6 +86,20 @@ export default function TemplateLibraryPage() {
     return () => clearTimeout(timer);
   }, [searchQuery]);
 
+  // Close clone/delete confirmation modals on Escape — backdrop click
+  // already works but keyboard users had no way to dismiss them other
+  // than tabbing into the Cancel button.
+  useEffect(() => {
+    if (!cloneModalId && !deleteModalId) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      if (cloneModalId && !cloning) setCloneModalId(null);
+      if (deleteModalId && !deleting) setDeleteModalId(null);
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [cloneModalId, deleteModalId, cloning, deleting]);
+
   // Load initial data
   useEffect(() => {
     Promise.all([


### PR DESCRIPTION
## Summary

Three accessibility fixes in the dashboard:

1. **Content table row "preview" target was a plain \`<div onClick>\`** with no keyboard support — keyboard-only users couldn't open the preview, and screen readers got no semantic hint. Converted to \`role=\"button\"\` + \`tabIndex=0\` + \`onKeyDown\` (Enter/Space) + aria-label, with a focus ring so the focused row is visible.

2. **Content table checkboxes** (header "select all" + per-row select) had no accessible name — screen readers announced "checkbox, unchecked" with no context. Added \`aria-label=\"Select all content items\"\` + \`aria-label={\`Select \${item.title}\`}\` for the row-level ones. The per-row variant uses the content title so the announcement names what's being selected.

3. **Templates clone + delete confirmation modals** could be dismissed by clicking the backdrop or the Cancel button, but had no Escape-key handler — keyboard-only users had to tab into the Cancel button. Added a useEffect that listens for Escape while either modal is open and dismisses the appropriate one, honoring the "in-flight clone/delete" guard so a network-pending action doesn't get half-cancelled.

## Tests

- [x] \`content-page\` + \`templates-page\` suites: 20/20 still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)