### PR TITLE
fix(notifications,ops): heal-cron for default alert rule + Slack < > escape

### DIFF
--- a/middleware/src/modules/notifications/alert-rules/alert-rules.service.spec.ts
+++ b/middleware/src/modules/notifications/alert-rules/alert-rules.service.spec.ts
@@ -347,6 +347,73 @@ describe('AlertRulesService', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // Heal cron — backfills the default rule for orgs that missed the seed
+  // ---------------------------------------------------------------------------
+  describe('healMissingDefaultRules', () => {
+    beforeEach(() => {
+      db.organization = { findMany: jest.fn() };
+      db.user.findMany = jest.fn();
+    });
+
+    it('no-ops when all orgs already have the default rule', async () => {
+      db.organization.findMany.mockResolvedValue([]);
+
+      await service.healMissingDefaultRules();
+
+      expect(db.organization.findMany).toHaveBeenCalledWith({
+        where: {
+          alertRules: {
+            none: { name: 'Default offline alert (auto-migrated)' },
+          },
+        },
+        select: { id: true, name: true },
+      });
+      expect(db.alertRule.create).not.toHaveBeenCalled();
+    });
+
+    it('seeds the default rule for every org that is missing it', async () => {
+      db.organization.findMany.mockResolvedValue([
+        { id: 'org-a', name: 'Org A' },
+        { id: 'org-b', name: 'Org B' },
+      ]);
+      db.user.findMany
+        .mockResolvedValueOnce([{ id: 'admin-a1' }, { id: 'admin-a2' }])
+        .mockResolvedValueOnce([{ id: 'admin-b1' }]);
+      db.alertRule.create.mockResolvedValue({});
+
+      await service.healMissingDefaultRules();
+
+      expect(db.alertRule.create).toHaveBeenCalledTimes(2);
+      // Per-org admin lookup is scoped to the org and to role='admin'.
+      expect(db.user.findMany).toHaveBeenNthCalledWith(1, {
+        where: { organizationId: 'org-a', role: 'admin' },
+        select: { id: true },
+      });
+      expect(db.user.findMany).toHaveBeenNthCalledWith(2, {
+        where: { organizationId: 'org-b', role: 'admin' },
+        select: { id: true },
+      });
+    });
+
+    it('continues healing remaining orgs when one seed fails', async () => {
+      db.organization.findMany.mockResolvedValue([
+        { id: 'org-fails', name: 'Org Fails' },
+        { id: 'org-ok', name: 'Org OK' },
+      ]);
+      db.user.findMany.mockResolvedValue([{ id: 'admin' }]);
+      // First create rejects with a non-idempotent error; second succeeds.
+      db.alertRule.create
+        .mockRejectedValueOnce(new Error('transient DB blip'))
+        .mockResolvedValueOnce({});
+
+      await service.healMissingDefaultRules();
+
+      // Both orgs attempted — failure in the first did not abort the second.
+      expect(db.alertRule.create).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // Constants regression
   // ---------------------------------------------------------------------------
   describe('constants', () => {

--- a/middleware/src/modules/notifications/alert-rules/alert-rules.service.ts
+++ b/middleware/src/modules/notifications/alert-rules/alert-rules.service.ts
@@ -4,6 +4,7 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
 import { DatabaseService } from '../../database/database.service';
 import { CreateAlertRuleDto } from './dto/create-alert-rule.dto';
 import { UpdateAlertRuleDto } from './dto/update-alert-rule.dto';
@@ -287,6 +288,66 @@ export class AlertRulesService {
       if (this.isUniqueConstraintError(err)) return;
       throw err;
     }
+  }
+
+  /**
+   * Hourly heal: backfill the default downtime alert rule for any org
+   * that is missing it.
+   *
+   * Why this exists: `seedDefaultRuleForOrg` is called fire-and-forget
+   * from `AuthService.register` (the seed must not block registration).
+   * If the seed fails — DB transient error, Prisma client mid-restart,
+   * Redis/connection blip — the new org silently loses offline alerts.
+   * This cron is the safety-net: every hour, find orgs that have zero
+   * rows in alert_rules matching the seeded name and re-attempt the
+   * seed for each.
+   *
+   * The query uses Prisma's `none:` predicate on the back-relation,
+   * which compiles to a single LEFT JOIN with WHERE NULL — O(orgs)
+   * not O(orgs × rules). Per-org work is bounded by the admin-user
+   * lookup + one INSERT (or a no-op P2002 if the rule appeared in
+   * the meantime).
+   */
+  @Cron(CronExpression.EVERY_HOUR)
+  async healMissingDefaultRules(): Promise<void> {
+    const orgsNeedingRule = await this.db.organization.findMany({
+      where: {
+        alertRules: {
+          none: { name: 'Default offline alert (auto-migrated)' },
+        },
+      },
+      select: { id: true, name: true },
+    });
+
+    if (orgsNeedingRule.length === 0) {
+      this.logger.debug('Heal cron: all orgs have the default downtime alert rule');
+      return;
+    }
+
+    let healed = 0;
+    let failed = 0;
+    for (const org of orgsNeedingRule) {
+      try {
+        const admins = await this.db.user.findMany({
+          where: { organizationId: org.id, role: 'admin' },
+          select: { id: true },
+        });
+        await this.seedDefaultRuleForOrg(
+          org.id,
+          admins.map((a) => a.id),
+        );
+        healed++;
+      } catch (err) {
+        failed++;
+        this.logger.error(
+          `Heal cron: failed to seed default alert rule for org ${org.id}: ${err instanceof Error ? err.message : err}`,
+        );
+      }
+    }
+
+    this.logger.log(
+      `Heal cron: healed ${healed}, failed ${failed} of ${orgsNeedingRule.length} orgs needing default downtime alert rule`,
+    );
   }
 
   // ---------------------------------------------------------------------------

--- a/scripts/ops/lib/alerting.ts
+++ b/scripts/ops/lib/alerting.ts
@@ -371,8 +371,15 @@ function escapeHtml(text: string): string {
  * silent-failure rule (global CLAUDE.md), automated alerts that
  * silently mis-format are as bad as alerts that don't fire.
  *
- * Escapes: _ * ` ~  (the four mrkdwn formatting characters that occur
- * naturally in our incident type names and free-form messages).
+ * Escapes: _ * ` ~ < >
+ *
+ * The angle-bracket pair is Slack mrkdwn's auto-link trigger: a
+ * free-form incident `message` containing `<http://x>` (or even
+ * `<...>` around a hostname) renders as a clickable link. That's
+ * a click-bait surface in operator inboxes that we should not
+ * delegate to whatever string an automated ops agent generates.
+ * Escaping to `\<http://x\>` makes the angle brackets render as
+ * plain text.
  */
 function escapeMrkdwn(text: string): string {
   return text
@@ -380,5 +387,7 @@ function escapeMrkdwn(text: string): string {
     .replace(/_/g, '\\_')
     .replace(/\*/g, '\\*')
     .replace(/`/g, '\\`')
-    .replace(/~/g, '\\~');
+    .replace(/~/g, '\\~')
+    .replace(/</g, '\\<')
+    .replace(/>/g, '\\>');
 }


### PR DESCRIPTION
## Summary

Two round-2 cleanups against the round-1 follow-up list:

1. **\`AlertRulesService.healMissingDefaultRules\`** — hourly \`@Cron\` that backfills the default downtime alert rule for any org that's missing it. \`AuthService.register\` calls \`seedDefaultRuleForOrg\` fire-and-forget; if the seed fails (DB transient blip, Prisma mid-restart, Redis hiccup) the new org silently loses offline alerts. The round-1 review flagged this as "non-blocking, fix via separate heal-cron." This is the heal-cron.

   Query uses Prisma's \`none:\` back-relation predicate so the scan is O(orgs) on a single LEFT JOIN — bounded per-org work is one admin-user lookup + one INSERT (or a P2002 no-op if the rule appeared in the meantime). Per-org failures don't abort the loop; each is logged with the org id.

   Tests: +3 covering the all-orgs-healthy no-op, the multi-org success path, and the continue-on-error path.

2. **\`escapeMrkdwn()\`** in \`scripts/ops/lib/alerting.ts\` — extended to also escape \`<\` and \`>\`. The round-1 reviewer flagged that a free-form incident message containing \`<http://x>\` would render as an auto-link in Slack — that's a click-bait surface in operator inboxes we should not delegate to whatever string an automated ops agent generates. Now covers \`_ * \` ~ < >\`. No test infra for \`scripts/ops/\`; the shape is a 2-line addition to a pure-function helper.

## Tests

- [x] \`alert-rules\` service: 30/30 (was 27 + 3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)