### PR TITLE
fix(ops): §12b write-site alerts for schedule-doctor + content-lifecycle

### DIFF
--- a/scripts/ops/content-lifecycle.ts
+++ b/scripts/ops/content-lifecycle.ts
@@ -27,7 +27,7 @@ import {
   makeIncidentId,
 } from './lib/state.js';
 import { login, OpsApiClient } from './lib/api-client.js';
-import { log } from './lib/alerting.js';
+import { log, sendInlineAlert } from './lib/alerting.js';
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -117,6 +117,15 @@ async function checkExpiredContent(
 
       state.issuesFixed++;
       log(AGENT, `Archived expired content: ${label}`);
+      // §12b: write-site alert. The operator uploaded this content and
+      // set an expiry; we just flipped its status to archived. Tell
+      // them within seconds, not at the next ops-reporter cycle.
+      await sendInlineAlert(
+        AGENT,
+        'warning',
+        `Auto-archived expired content "${label}"`,
+        `Content id ${item.id} reached its expiresAt (${item.expiresAt}) and was archived. If still needed, restore via the content library and update the expiry date.`,
+      );
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
       log(AGENT, `Failed to archive expired content ${label}: ${errorMsg}`);
@@ -219,6 +228,16 @@ async function checkOrphanedContent(
 
       state.issuesFixed++;
       log(AGENT, `Archived orphaned content: ${label}`);
+      // §12b: write-site alert. Orphan archive is gentler than expiry —
+      // the operator never picked an expiry, the cron is just garbage-
+      // collecting unused content after ORPHAN_AGE_DAYS. Still surfaces
+      // so an operator can restore if they were saving it for later.
+      await sendInlineAlert(
+        AGENT,
+        'warning',
+        `Auto-archived orphaned content "${label}"`,
+        `Content id ${item.id} was not referenced by any playlist and was older than ${ORPHAN_AGE_DAYS} days. Archived automatically. Restore via the content library if you still need it.`,
+      );
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
       log(AGENT, `Failed to archive orphaned content ${label}: ${errorMsg}`);

--- a/scripts/ops/lib/alerting.ts
+++ b/scripts/ops/lib/alerting.ts
@@ -352,6 +352,78 @@ export async function updateDashboard(
   }
 }
 
+// ─── Per-event inline alert (§12b) ──────────────────────────────────────────
+
+/**
+ * Fire an immediate Slack alert for a single automated state-reversal
+ * event. Use this from ops agents at the WRITE site (right next to
+ * the auto-disable / auto-archive / kill-switch flip) so the operator
+ * sees "we just turned off the thing you set up, here's why"
+ * within seconds instead of waiting for the next 30-min ops-reporter
+ * cycle.
+ *
+ * Implements the global CLAUDE.md §12b silent-failure prevention rule
+ * for the schedule-doctor + content-lifecycle auto-remediation paths.
+ * Each fire is independent of the aggregate sendSlackAlert flow.
+ *
+ * @param agent      Agent name for log attribution (e.g. "schedule-doctor")
+ * @param severity   "critical" | "warning" — drives the emoji + section header
+ * @param summary    One-line headline, will be bolded
+ * @param details    Optional multi-line body shown below the summary
+ *
+ * No-op if SLACK_WEBHOOK_URL is unset. Errors are logged but never thrown.
+ */
+export async function sendInlineAlert(
+  agent: string,
+  severity: 'critical' | 'warning',
+  summary: string,
+  details?: string,
+): Promise<void> {
+  const webhookUrl = process.env.SLACK_WEBHOOK_URL || '';
+  if (!webhookUrl) return;
+
+  const emoji = severity === 'critical' ? ':red_circle:' : ':large_yellow_circle:';
+  const headerText = severity === 'critical' ? 'CRITICAL' : 'WARNING';
+
+  const blocks: Record<string, unknown>[] = [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: `${emoji} Vizora Ops: ${headerText} (${agent})` },
+    },
+    {
+      type: 'section',
+      text: { type: 'mrkdwn', text: `*${escapeMrkdwn(summary)}*` },
+    },
+  ];
+
+  if (details) {
+    blocks.push({
+      type: 'section',
+      text: { type: 'mrkdwn', text: escapeMrkdwn(details) },
+    });
+  }
+
+  blocks.push({
+    type: 'context',
+    elements: [
+      { type: 'mrkdwn', text: `Vizora Ops | ${agent} | ${new Date().toISOString()}` },
+    ],
+  });
+
+  try {
+    const res = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ blocks }),
+    });
+    if (!res.ok) {
+      log(agent, `Inline Slack alert returned ${res.status}`);
+    }
+  } catch (err) {
+    log(agent, `Inline Slack alert failed: ${err instanceof Error ? err.message : err}`);
+  }
+}
+
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 function escapeHtml(text: string): string {

--- a/scripts/ops/schedule-doctor.ts
+++ b/scripts/ops/schedule-doctor.ts
@@ -28,7 +28,7 @@ import {
   addRemediation,
   makeIncidentId,
 } from './lib/state.js';
-import { log } from './lib/alerting.js';
+import { log, sendInlineAlert } from './lib/alerting.js';
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -151,6 +151,15 @@ async function main(): Promise<void> {
       fixed = true;
       issuesFixed++;
       log(AGENT, `  -> Deactivated "${label}"`);
+      // §12b: write-site alert. The operator set isActive=true; we just
+      // flipped it to false. Tell them immediately rather than waiting
+      // for the next ops-reporter aggregate cycle.
+      await sendInlineAlert(
+        AGENT,
+        'warning',
+        `Auto-deactivated past-end schedule "${label}"`,
+        `Schedule id ${sched.id} had endDate=${sched.endDate} (in the past) but isActive=true. Deactivated automatically. If the endDate was meant to be in the future, re-activate and correct the date.`,
+      );
     } catch (err) {
       log(AGENT, `  -> Failed to deactivate "${label}": ${err instanceof Error ? err.message : err}`);
     }
@@ -197,6 +206,16 @@ async function main(): Promise<void> {
       fixed = true;
       issuesFixed++;
       log(AGENT, `  -> Deactivated "${label}"`);
+      // §12b: write-site alert. Orphan deactivation is more severe than
+      // past-end because it indicates the operator deleted a device but
+      // left a schedule pointing at it — likely a config inconsistency
+      // they should know about right now, not in 30 min.
+      await sendInlineAlert(
+        AGENT,
+        'critical',
+        `Auto-deactivated orphan schedule "${label}"`,
+        `Schedule id ${sched.id} referenced display ${sched.displayId}, which no longer exists. Deactivated automatically. Investigate whether the schedule should be reassigned or deleted.`,
+      );
     } catch (err) {
       log(AGENT, `  -> Failed to deactivate "${label}": ${err instanceof Error ? err.message : err}`);
     }


### PR DESCRIPTION
## Summary

Round-2 follow-up to the OPS-reporter "stale-org outage" cluster.

**Background — global CLAUDE.md §12b**: "Every automated state change that reverses or overrides an operator-applied state MUST fire an operator alert at the write site." Until now, \`schedule-doctor\` and \`content-lifecycle\` agents deactivated/archived rows the operator created (past-end schedules, orphan schedules, expired content, orphaned content) and only surfaced the change via the ops-reporter aggregate cycle 30 minutes later. The operator's mental model of "my schedule is on / my content is live" stayed wrong for that window — exactly the silent-failure shape §12b is meant to prevent.

## Changes

1. **\`scripts/ops/lib/alerting.ts\`** — new \`sendInlineAlert(agent, severity, summary, details)\` helper. Single-event Slack post with header + summary block + optional details + context line. No-op when \`SLACK_WEBHOOK_URL\` is unset, errors logged-not-thrown. Reuses \`escapeMrkdwn\` so incident type/message text doesn't silently mangle on Slack.

2. **\`scripts/ops/schedule-doctor.ts\`** — two call sites added at the write boundary: past-end deactivation (warning severity) and orphan deactivation (critical, since it signals operator config drift, not lifecycle).

3. **\`scripts/ops/content-lifecycle.ts\`** — two call sites added at the write boundary: expired-content archive (warning) and orphaned-content archive (warning — gentler since the operator never explicitly chose an expiry).

## Tests

- [x] No test infra for \`scripts/ops/\`; verified via \`tsx -e\` import smoke against \`alerting.ts\`.
- [x] Cron aggregation (\`sendSlackAlert\` from ops-reporter) continues to work as before — these inline alerts are **additive, not replacement**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)