### PR TITLE
fix(schedules,editor): date-range conflict filter + srcDoc-origin docs

### DIFF
--- a/middleware/src/modules/schedules/dto/check-conflicts.dto.ts
+++ b/middleware/src/modules/schedules/dto/check-conflicts.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsArray, IsInt, Min, Max } from 'class-validator';
+import { IsString, IsOptional, IsArray, IsInt, IsDateString, Min, Max } from 'class-validator';
 import { Type, Transform } from 'class-transformer';
 
 export class CheckConflictsDto {
@@ -30,6 +30,23 @@ export class CheckConflictsDto {
   @Min(0)
   @Max(1439)
   endTime?: number; // Minutes from midnight (0-1439)
+
+  /**
+   * Date-range filters for the candidate schedule. Without these,
+   * checkConflicts was matching schedules that share daysOfWeek +
+   * display but run in completely disjoint date ranges (e.g., a
+   * 2025 Christmas-week schedule reported as conflicting with a
+   * proposed 2026 Diwali-week schedule). Both are optional —
+   * absence means "no upper/lower bound" — to preserve the
+   * existing "open-ended schedule" shape.
+   */
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
 
   @IsOptional()
   @IsString()

--- a/middleware/src/modules/schedules/schedules.service.spec.ts
+++ b/middleware/src/modules/schedules/schedules.service.spec.ts
@@ -704,6 +704,49 @@ describe('SchedulesService', () => {
       expect(result.hasConflicts).toBe(true);
       expect(result.conflicts).toHaveLength(1);
     });
+
+    it('should apply date-range filters to the conflict query', async () => {
+      // Regression: previously the WHERE clause had no date-range
+      // predicates, so two schedules in disjoint date windows (e.g.
+      // a 2025 Christmas slot vs a 2026 Diwali slot) were flagged as
+      // conflicting solely because they shared display + daysOfWeek.
+      databaseService.schedule.findMany.mockResolvedValue([]);
+
+      await service.checkConflicts('org-123', {
+        displayId: 'display-1',
+        daysOfWeek: [1],
+        startTime: 540,
+        endTime: 600,
+        startDate: '2026-11-01',
+        endDate: '2026-11-07',
+      });
+
+      // Both bounds should appear in the AND[] predicate. The
+      // endDate-filter excludes schedules that start AFTER the
+      // candidate ends; the startDate-filter excludes those that
+      // ended BEFORE the candidate starts. Open-ended schedules
+      // (startDate / endDate null) survive both filters.
+      expect(databaseService.schedule.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            AND: expect.arrayContaining([
+              expect.objectContaining({
+                OR: [
+                  { startDate: null },
+                  { startDate: { lte: new Date('2026-11-07') } },
+                ],
+              }),
+              expect.objectContaining({
+                OR: [
+                  { endDate: null },
+                  { endDate: { gte: new Date('2026-11-01') } },
+                ],
+              }),
+            ]),
+          }),
+        }),
+      );
+    });
   });
 
   describe('remove', () => {

--- a/middleware/src/modules/schedules/schedules.service.ts
+++ b/middleware/src/modules/schedules/schedules.service.ts
@@ -300,6 +300,37 @@ export class SchedulesService {
       where.daysOfWeek = { hasSome: dto.daysOfWeek };
     }
 
+    // Date-range overlap filter — without this, schedules in non-
+    // overlapping date windows (e.g. one ending in 2025, the other
+    // starting in 2026) were flagged as conflicting solely because
+    // they shared daysOfWeek + display. Both bounds are optional;
+    // an open-ended schedule (no startDate / endDate) on either
+    // side falls back to "always-overlapping in time" for that side.
+    const dateConditions: Prisma.ScheduleWhereInput[] = [];
+    if (dto.endDate) {
+      // Candidate ends BEFORE existing starts → no overlap; exclude
+      // anything whose startDate is strictly after the candidate's end.
+      dateConditions.push({
+        OR: [
+          { startDate: null },
+          { startDate: { lte: new Date(dto.endDate) } },
+        ],
+      });
+    }
+    if (dto.startDate) {
+      // Existing ended BEFORE candidate starts → no overlap; exclude
+      // anything whose endDate is strictly before the candidate's start.
+      dateConditions.push({
+        OR: [
+          { endDate: null },
+          { endDate: { gte: new Date(dto.startDate) } },
+        ],
+      });
+    }
+    if (dateConditions.length > 0) {
+      where.AND = dateConditions;
+    }
+
     // Exclude specific schedule (useful when editing)
     if (dto.excludeScheduleId) {
       where.id = { not: dto.excludeScheduleId };

--- a/web/src/components/template-editor/TemplateEditorCanvas.tsx
+++ b/web/src/components/template-editor/TemplateEditorCanvas.tsx
@@ -418,7 +418,18 @@ const TemplateEditorCanvas = forwardRef<CanvasHandle, TemplateEditorCanvasProps>
 
     const handleMessage = useCallback(
       (event: MessageEvent) => {
-        // Only accept messages from our iframe
+        // Only accept messages from our iframe.
+        //
+        // We compare `event.source` to the iframe's contentWindow rather
+        // than checking `event.origin === window.location.origin` because
+        // the iframe is loaded via `srcDoc` (inline HTML), which gives it
+        // an opaque "null" origin in modern browsers — an origin check
+        // would reject every legitimate message.
+        //
+        // The source check is the stronger guarantee: only THIS specific
+        // iframe's window object can be the event.source for a message
+        // we trust, so a malicious tab embedding our origin can't spoof
+        // editor events even if it knows the message shape.
         const iframe = iframeRef.current;
         if (!iframe || event.source !== iframe.contentWindow) return;
 


### PR DESCRIPTION
## Summary

Two round-3 fixes from the R2 scout findings:

1. **\`checkConflicts\` ignored date ranges.** The WHERE clause filtered by display + daysOfWeek + (optionally) startTime/endTime but never compared the candidate's startDate/endDate against existing schedules' date windows. Result: a proposed 2026 Diwali slot was reported as conflicting with last year's Christmas-week schedule on the same display, even though their date ranges were disjoint by a year.
   - DTO: added optional \`startDate\` / \`endDate\` fields (\`IsDateString\`).
   - Service: built an \`AND[]\` of date-range OR-overlap clauses (open-ended schedules with NULL bounds still survive both filters, preserving the existing semantic).
   - Test: regression case confirms the AND[] predicates appear with the correct shape.

2. **\`TemplateEditorCanvas.handleMessage\`** — documented WHY the existing \`event.source === iframe.contentWindow\` check is used in place of \`event.origin === window.location.origin\`. The iframe is loaded via \`srcDoc\`, which gives it an opaque \`null\` origin in modern browsers — an origin equality check would reject every legitimate message. The source check is the stronger guarantee (only THIS specific iframe's window can be source), and the comment heads off future "missing origin check" reviewer complaints.

## Tests

- [x] \`schedules\`: 46/46 (was 45 + 1 new).
- [x] Editor change is comment-only — no behavioral change to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)