### PR TITLE
fix(content,playlists): push fresh playlist to fleet on content expiration

### DIFF
--- a/middleware/src/modules/content/content.service.spec.ts
+++ b/middleware/src/modules/content/content.service.spec.ts
@@ -17,6 +17,7 @@ import { CreateTemplateDto } from './dto/create-template.dto';
 describe('ContentService', () => {
   let service: ContentService;
   let mockDatabaseService: any;
+  let mockEventEmitter: { emit: jest.Mock };
   let mockTemplateRendering: jest.Mocked<TemplateRenderingService>;
   let mockDataSourceRegistry: jest.Mocked<DataSourceRegistryService>;
   let mockStorageQuotaService: jest.Mocked<StorageQuotaService>;
@@ -77,6 +78,7 @@ describe('ContentService', () => {
       playlistItem: {
         updateMany: jest.fn(),
         deleteMany: jest.fn(),
+        findMany: jest.fn().mockResolvedValue([]),
       },
       tag: {
         count: jest.fn(),
@@ -128,7 +130,7 @@ describe('ContentService', () => {
       isMinioAvailable: jest.fn().mockReturnValue(false),
     } as any;
 
-    const mockEventEmitter = { emit: jest.fn() };
+    mockEventEmitter = { emit: jest.fn() };
     const mockNotificationsService = { create: jest.fn().mockResolvedValue({}) };
     service = new ContentService(
       mockDatabaseService as DatabaseService,
@@ -1184,6 +1186,53 @@ describe('ContentService', () => {
       const result = await service.checkExpiredContent();
 
       expect(result.processed).toBe(0);
+    });
+
+    it('emits playlist.updated for each distinct affected playlist (device fleet refresh)', async () => {
+      // Regression: when content expires, devices used to keep
+      // serving the old/expired item until they reconnected — sometimes
+      // hours later. checkExpiredContent now emits playlist.updated
+      // with action='expired_content_replaced' so PlaylistsService's
+      // @OnEvent listener can push refreshes via realtime.
+      const expiredContent = {
+        ...mockContent,
+        id: 'content-exp',
+        expiresAt: new Date('2020-01-01'),
+        replacementContentId: 'replacement-x',
+        status: 'active',
+      };
+      mockDatabaseService.content.findMany.mockResolvedValue([expiredContent]);
+      mockDatabaseService.content.findFirst.mockResolvedValue({
+        id: 'replacement-x',
+        organizationId: 'org-123',
+      });
+      // Two distinct playlists contain this content (e.g. content
+      // shared across playlists). De-dup should collapse them.
+      mockDatabaseService.playlistItem.findMany.mockResolvedValue([
+        { playlistId: 'pl-a' },
+        { playlistId: 'pl-b' },
+        { playlistId: 'pl-a' }, // duplicate of pl-a — only one event expected
+      ]);
+      mockDatabaseService.playlistItem.updateMany.mockResolvedValue({ count: 3 });
+      mockDatabaseService.content.update.mockResolvedValue({
+        ...expiredContent,
+        status: 'expired',
+      });
+
+      const result = await service.checkExpiredContent();
+
+      expect(result.processed).toBe(1);
+      expect(result.playlistsRefreshed).toBe(2);
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith('playlist.updated', {
+        entityId: 'pl-a',
+        organizationId: 'org-123',
+        action: 'expired_content_replaced',
+      });
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith('playlist.updated', {
+        entityId: 'pl-b',
+        organizationId: 'org-123',
+        action: 'expired_content_replaced',
+      });
     });
 
     it('should only find active expired content', async () => {

--- a/middleware/src/modules/content/content.service.ts
+++ b/middleware/src/modules/content/content.service.ts
@@ -422,8 +422,22 @@ export class ContentService {
       },
     });
 
+    // Collect (playlistId, organizationId) pairs that need a device-fleet
+    // push after the transaction commits — without this, device clients
+    // continue serving the expired content (or the now-deleted playlist
+    // slot) until they reconnect, sometimes hours later.
+    const affectedPlaylists: Array<{ playlistId: string; organizationId: string }> = [];
+
     for (const content of expiredContent) {
       await this.db.$transaction(async (tx) => {
+        // Snapshot playlistIds BEFORE the updateMany / deleteMany — we
+        // can't read them after the contentId rewrite or row deletion.
+        const items = await tx.playlistItem.findMany({
+          where: { contentId: content.id },
+          select: { playlistId: true },
+        });
+        const distinctPlaylistIds = Array.from(new Set(items.map((i) => i.playlistId)));
+
         if (content.replacementContentId) {
           // Validate replacement content belongs to same organization
           const replacement = await tx.content.findFirst({
@@ -457,10 +471,40 @@ export class ContentService {
           where: { id: content.id },
           data: { status: 'expired' },
         });
+
+        for (const playlistId of distinctPlaylistIds) {
+          affectedPlaylists.push({
+            playlistId,
+            organizationId: content.organizationId,
+          });
+        }
       });
     }
 
-    return { processed: expiredContent.length };
+    // Notify device fleet AFTER the transactions commit so the realtime
+    // gateway pushes the up-to-date playlist (with replacement content
+    // swapped in OR with the expired slot removed). De-dup by playlistId
+    // — a single playlist with N expired items only needs one push.
+    const distinctAffected = new Map<string, string>();
+    for (const a of affectedPlaylists) {
+      distinctAffected.set(a.playlistId, a.organizationId);
+    }
+    for (const [playlistId, organizationId] of distinctAffected) {
+      // playlist.updated is already listened-to by PlaylistsService's
+      // notifyDisplaysOfPlaylistUpdate plumbing (via the @OnEvent
+      // handler that triggers off this event), so the device push
+      // pipeline is reused exactly. action='expired_content_replaced'
+      // tags the event so downstream consumers (audit log, ops
+      // dashboards) can distinguish a system-driven push from an
+      // operator-driven edit.
+      this.eventEmitter.emit('playlist.updated', {
+        entityId: playlistId,
+        organizationId,
+        action: 'expired_content_replaced',
+      });
+    }
+
+    return { processed: expiredContent.length, playlistsRefreshed: distinctAffected.size };
   }
 
 

--- a/middleware/src/modules/playlists/playlists.service.ts
+++ b/middleware/src/modules/playlists/playlists.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException, ConflictException, Logger } from '@nestjs/common';
-import { EventEmitter2 } from '@nestjs/event-emitter';
+import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
 import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
 import { DatabaseService } from '../database/database.service';
@@ -449,6 +449,57 @@ export class PlaylistsService {
     });
     this.eventEmitter.emit('playlist.deleted', { entityId: id, organizationId });
     return result;
+  }
+
+  /**
+   * @OnEvent listener: any time a `playlist.updated` event is emitted
+   * (CRUD edit, addItem, removeItem, OR content-expiration-driven swap
+   * from ContentService.checkExpiredContent), refresh the affected
+   * device fleet.
+   *
+   * The CRUD methods on this service already call
+   * notifyDisplaysOfPlaylistUpdate directly with the freshly-loaded
+   * playlist, so this listener only acts on events from OTHER services
+   * (where the emitter doesn't have the playlist in hand). It re-loads
+   * the playlist by id from the DB to make sure the realtime push
+   * carries the latest item set, not stale in-memory state.
+   *
+   * Filtering: only handle events with `action='expired_content_replaced'`
+   * to avoid double-pushing CRUD edits (where the direct call already
+   * fired). The action tag was introduced in the content-expiration
+   * PR specifically to make this discrimination cheap.
+   */
+  @OnEvent('playlist.updated', { async: true })
+  async handlePlaylistUpdatedEvent(payload: {
+    entityId: string;
+    organizationId: string;
+    action?: string;
+  }): Promise<void> {
+    if (payload.action !== 'expired_content_replaced') return;
+    try {
+      const playlist = await this.db.playlist.findFirst({
+        where: { id: payload.entityId, organizationId: payload.organizationId },
+        include: {
+          items: {
+            include: { content: true },
+            orderBy: { order: 'asc' },
+          },
+        },
+      });
+      if (!playlist) {
+        this.logger.warn(
+          `playlist.updated event for missing playlist ${payload.entityId} (org ${payload.organizationId}) — skipping push`,
+        );
+        return;
+      }
+      await this.notifyDisplaysOfPlaylistUpdate(payload.entityId, playlist);
+    } catch (err) {
+      this.logger.error(
+        `Failed to notify displays of expired-content playlist refresh for ${payload.entityId}: ${
+          err instanceof Error ? err.message : err
+        }`,
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes the largest scout-2 finding: when content expires, the hourly \`checkExpiredContent\` cron rewrote playlist items (swap to replacement OR delete) but never told the device fleet. Devices kept serving the old item — sometimes the now-expired URL returning 404 — for hours until the next reconnect or manual refresh.

The fix is end-to-end:

1. **\`content.service.checkExpiredContent\`** now snapshots the affected playlistIds INSIDE the transaction (before the updateMany / deleteMany rewrite, so we can still read them) and, after each transaction commits, emits one \`playlist.updated\` event per distinct affected playlist with \`action='expired_content_replaced'\`. The action tag distinguishes system-driven refreshes from operator-driven CRUD edits.

2. **\`playlists.service.handlePlaylistUpdatedEvent\`** — new \`@OnEvent\` listener that filters on \`action='expired_content_replaced'\`. When it fires, it re-loads the playlist (with items + content) and calls the existing \`notifyDisplaysOfPlaylistUpdate\` helper, which already POSTs \`/api/push/playlist\` to the realtime gateway for each display currently using that playlist. The filter prevents double-pushing on CRUD edits (where the direct call already fired). Re-load happens server-side so the push carries the latest item set, not stale in-memory state.

3. Return shape extended with \`playlistsRefreshed\` for observability.

The path now: cron fires → tx commits new contentId → event emits → listener loads fresh playlist → realtime push → device receives updated playlist in seconds (not hours).

## Tests

- [x] \`content.service\`: 86/86 (was 85 + 1 new — distinct-playlist de-dup + emit shape).
- [x] \`playlists.service\`: 28/28 still pass (the new \`@OnEvent\` listener is additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)