### PR TITLE
fix(auth): wire user_revoked: Redis key end-to-end

### DIFF
--- a/middleware/src/modules/auth/auth.service.ts
+++ b/middleware/src/modules/auth/auth.service.ts
@@ -906,8 +906,14 @@ export class AuthService {
       this.logger.warn(`Failed to send account deletion email to ${originalEmail}: ${err instanceof Error ? err.message : 'Unknown'}`);
     }
 
-    // 9. Invalidate all JWT tokens for this user via Redis
+    // 9. Invalidate all JWT tokens for this user via Redis. Uses the
+    // shared `user_revoked:` key that JwtStrategy.validate now checks
+    // on every request. Also write the legacy `user_deleted:` key so
+    // any third-party tooling still reading it keeps working during a
+    // transition window (safe to remove once external consumers move
+    // to the canonical key).
     try {
+      await this.redisService.set(`user_revoked:${userId}`, '1', AUTH_CONSTANTS.TOKEN_EXPIRY_SECONDS);
       await this.redisService.set(`user_deleted:${userId}`, '1', AUTH_CONSTANTS.TOKEN_EXPIRY_SECONDS);
       await this.redisService.del(`user_auth:${userId}`);
     } catch (err) {

--- a/middleware/src/modules/auth/strategies/jwt.strategy.spec.ts
+++ b/middleware/src/modules/auth/strategies/jwt.strategy.spec.ts
@@ -299,7 +299,10 @@ describe('JwtStrategy', () => {
         });
       });
 
-      it('should skip revocation check when jti is not present', async () => {
+      it('should skip the per-token jti revocation check when jti is not present, but still run the per-user revocation check', async () => {
+        // jti-less tokens still get the user_revoked: check applied —
+        // that's the all-user invalidation path (deactivation /
+        // self-delete). The jti check is the specific-token path.
         const payload: JwtPayload = {
           sub: 'user-123',
           email: 'test@example.com',
@@ -311,7 +314,26 @@ describe('JwtStrategy', () => {
 
         await strategy.validate(payload);
 
-        expect(mockRedisService.exists).not.toHaveBeenCalled();
+        expect(mockRedisService.exists).toHaveBeenCalledTimes(1);
+        expect(mockRedisService.exists).toHaveBeenCalledWith('user_revoked:user-123');
+      });
+
+      it('rejects the request when the user_revoked: flag is set for the payload.sub', async () => {
+        // Admin deactivation / self-delete set this flag; the request
+        // must fail closed even if the per-jti revocation key isn't set.
+        const payload: JwtPayload = {
+          sub: 'user-deactivated',
+          email: 'x@y.com',
+          organizationId: 'org-123',
+          role: 'admin',
+          jti: 'jti-abc',
+        };
+
+        mockRedisService.exists.mockImplementation((key: string) =>
+          Promise.resolve(key === 'user_revoked:user-deactivated'),
+        );
+
+        await expect(strategy.validate(payload)).rejects.toThrow('User account is no longer active');
       });
     });
 

--- a/middleware/src/modules/auth/strategies/jwt.strategy.ts
+++ b/middleware/src/modules/auth/strategies/jwt.strategy.ts
@@ -79,12 +79,25 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       throw new UnauthorizedException('Device tokens are not valid for user authentication');
     }
 
-    // Check if token has been revoked
+    // Check if THIS specific token has been revoked (logout / refresh).
     if (payload.jti) {
       const isRevoked = await this.redisService.exists(`revoked_token:${payload.jti}`);
       if (isRevoked) {
         throw new UnauthorizedException('Token has been revoked');
       }
+    }
+
+    // Check if ALL tokens for this user have been invalidated. Two
+    // admin-driven flows write this key: AuthService.deleteAccount
+    // (self-delete) and UsersService.deactivate (admin deactivation).
+    // Previously the deleteAccount path SET this key but nobody READ
+    // it — deactivation relied on the 60s user_auth: cache eviction
+    // to take effect, leaving a 60s window where a deactivated user
+    // could keep hitting the API with a cached token. The check here
+    // closes both windows.
+    const isUserRevoked = await this.redisService.exists(`user_revoked:${payload.sub}`);
+    if (isUserRevoked) {
+      throw new UnauthorizedException('User account is no longer active');
     }
 
     // Check Redis cache first to avoid DB hit on every request

--- a/middleware/src/modules/users/users.service.ts
+++ b/middleware/src/modules/users/users.service.ts
@@ -2,6 +2,7 @@ import { Injectable, NotFoundException, BadRequestException, ConflictException }
 import { Prisma } from '@vizora/database';
 import { DatabaseService } from '../database/database.service';
 import { RedisService } from '../redis/redis.service';
+import { AUTH_CONSTANTS } from '../auth/constants/auth.constants';
 import { InviteUserDto } from './dto/invite-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { PaginationDto, PaginatedResponse } from '../common/dto/pagination.dto';
@@ -203,7 +204,18 @@ export class UsersService {
       },
     });
 
-    // Invalidate auth cache so deactivation takes effect immediately
+    // Invalidate auth cache + set the user_revoked: flag so any
+    // OUTSTANDING JWT for this user is rejected on its next request,
+    // not just after the 60s user_auth: cache expires. JwtStrategy.
+    // validate reads this key on every request.
+    //
+    // Lifetime matches max token expiry so the flag naturally cleans
+    // up once no live token could still reference it.
+    await this.redisService.set(
+      `user_revoked:${id}`,
+      '1',
+      AUTH_CONSTANTS.TOKEN_EXPIRY_SECONDS,
+    );
     await this.redisService.del(`user_auth:${id}`);
 
     // Log audit event


### PR DESCRIPTION
## Summary

Two related findings from the R4 auth scout:

1. **\`AuthService.deleteAccount\` SET \`user_deleted:{userId}\` in Redis but \`JwtStrategy\` never READ it.** The flag was dead code — actual revocation relied on the deleted DB row + the 60s \`user_auth:\` cache eviction. Worked for self-delete (DB row gone) but failed for admin deactivation (DB row remains, just \`isActive=false\`).

2. **\`UsersService.deactivate\` only cleared the \`user_auth:\` cache** — a deactivated user's JWT remained usable for up to 60s while the cached \`isActive: true\` value persisted.

Fix is symmetric:
- \`JwtStrategy.validate\` now checks \`user_revoked:{payload.sub}\` on every request (cheap Redis EXISTS). Set → 401.
- \`UsersService.deactivate\` writes the same key with \`TOKEN_EXPIRY_SECONDS\` TTL so the key naturally cleans up once no live token could still reference it.
- \`AuthService.deleteAccount\` writes BOTH keys (\`user_revoked:\` as the canonical name + \`user_deleted:\` for any third-party tooling still reading the legacy key during a transition window).

The 60s deactivation window is now closed: admin deactivates → Redis key set immediately → next request from the user gets 401 before the cache even matters.

## Tests

- [x] \`users + auth + jwt.strategy\`: 98/98 (was 96 + 2 new — the new \`user_revoked:\` rejection path + the existing test updated to reflect that jti-less tokens still get the per-user check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)