### PR TITLE
fix(content): bulkDelete retains DB row when MinIO delete fails

### DIFF
--- a/middleware/src/modules/content/content.service.spec.ts
+++ b/middleware/src/modules/content/content.service.spec.ts
@@ -21,6 +21,7 @@ describe('ContentService', () => {
   let mockTemplateRendering: jest.Mocked<TemplateRenderingService>;
   let mockDataSourceRegistry: jest.Mocked<DataSourceRegistryService>;
   let mockStorageQuotaService: jest.Mocked<StorageQuotaService>;
+  let mockStorageService: { deleteFile: jest.Mock; isMinioAvailable: jest.Mock };
 
   const mockContent = {
     id: 'content-123',
@@ -125,10 +126,10 @@ describe('ContentService', () => {
       recalculateUsage: jest.fn(),
     } as any;
 
-    const mockStorageService = {
+    mockStorageService = {
       deleteFile: jest.fn().mockResolvedValue(undefined),
       isMinioAvailable: jest.fn().mockReturnValue(false),
-    } as any;
+    };
 
     mockEventEmitter = { emit: jest.fn() };
     const mockNotificationsService = { create: jest.fn().mockResolvedValue({}) };
@@ -1403,6 +1404,34 @@ describe('ContentService', () => {
       await expect(
         service.bulkDelete('org-123', { ids: ['id-1', 'id-2', 'id-3'] }),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it('retains the DB row when MinIO delete fails so the file is not orphaned', async () => {
+      // Regression: previously the function logged storage-delete
+      // failures, then ran deleteMany on EVERY id. The MinIO file
+      // remained, the DB row was gone — quota counted, no operator
+      // visibility. Now only successful-MinIO ids get DB-deleted.
+      mockDatabaseService.content.findMany.mockResolvedValue([
+        { id: 'good-1', fileSize: 1000, url: 'minio://o/good-1.png' },
+        { id: 'bad-1', fileSize: 2000, url: 'minio://o/bad-1.png' },
+      ]);
+      mockStorageService.deleteFile.mockImplementation(async (key: string) => {
+        if (key === 'o/bad-1.png') throw new Error('connection refused');
+      });
+      mockDatabaseService.content.deleteMany.mockResolvedValue({ count: 1 });
+
+      const result = await service.bulkDelete('org-123', { ids: ['good-1', 'bad-1'] });
+
+      // Only the successful id is in the deleteMany WHERE.
+      expect(mockDatabaseService.content.deleteMany).toHaveBeenCalledWith({
+        where: { id: { in: ['good-1'] }, organizationId: 'org-123' },
+      });
+      // Result surfaces both counts so the caller can act on failures.
+      expect(result.deleted).toBe(1);
+      expect(result.failed).toBe(1);
+      expect(result.failedIds).toEqual(['bad-1']);
+      // Quota decrement is for the SUCCESSFUL bytes only (1000), not 3000.
+      expect(mockStorageQuotaService.decrementUsage).toHaveBeenCalledWith('org-123', 1000);
     });
   });
 

--- a/middleware/src/modules/content/content.service.ts
+++ b/middleware/src/modules/content/content.service.ts
@@ -637,42 +637,69 @@ export class ContentService {
 
   async bulkDelete(organizationId: string, dto: BulkDeleteDto) {
     const { ids } = dto;
+    const uniqueIds = Array.from(new Set(ids));
 
     // Fetch items with file info for storage cleanup
     const items = await this.db.content.findMany({
-      where: { id: { in: ids }, organizationId },
+      where: { id: { in: uniqueIds }, organizationId },
       select: { id: true, fileSize: true, url: true },
     });
 
-    if (items.length !== ids.length) {
+    if (items.length !== uniqueIds.length) {
       throw new BadRequestException('Some content items not found or not accessible');
     }
 
-    // Delete files from storage with error collection
-    const deletionResults = await Promise.allSettled(
+    // Delete files from storage, tracking which items succeeded.
+    //
+    // Previously the function ran Promise.allSettled, logged failures,
+    // then deleteMany'd ALL DB rows — leaving the failed-MinIO files
+    // ORPHANED forever (consuming quota with no DB row pointing to
+    // them, no operator visibility). The new shape only deletes the DB
+    // rows whose storage file actually went away; failures stay in the
+    // DB so the operator (or a retry cron) can re-attempt the delete
+    // later. Quota decrement matches the same successful-only set.
+    const deletableIds: string[] = [];
+    const failedIds: string[] = [];
+    await Promise.all(
       items.map(async (item) => {
-        const objectKey = item.url?.startsWith('minio://') ? item.url.substring('minio://'.length) : null;
-        if (objectKey) {
+        const objectKey = item.url?.startsWith('minio://')
+          ? item.url.substring('minio://'.length)
+          : null;
+        if (!objectKey) {
+          // No file to delete (e.g., url-type content) — safe to drop DB row.
+          deletableIds.push(item.id);
+          return;
+        }
+        try {
           await this.storageService.deleteFile(objectKey);
+          deletableIds.push(item.id);
+        } catch (err) {
+          failedIds.push(item.id);
+          this.logger.warn(
+            `Bulk delete: storage delete failed for content ${item.id} (key=${objectKey}): ${
+              err instanceof Error ? err.message : err
+            }. DB row retained for retry.`,
+          );
         }
       }),
     );
-    const failures = deletionResults.filter(r => r.status === 'rejected');
-    if (failures.length > 0) {
-      this.logger.warn(`Bulk delete: ${failures.length}/${items.length} storage file(s) failed to delete`);
+
+    let deleted = 0;
+    if (deletableIds.length > 0) {
+      const result = await this.db.content.deleteMany({
+        where: { id: { in: deletableIds }, organizationId },
+      });
+      deleted = result.count;
+
+      const successfulBytes = items
+        .filter((i) => deletableIds.includes(i.id))
+        .reduce((sum, i) => sum + (i.fileSize || 0), 0);
+      if (successfulBytes > 0) {
+        await this.storageQuotaService.decrementUsage(organizationId, successfulBytes);
+      }
     }
 
-    const result = await this.db.content.deleteMany({
-      where: { id: { in: ids }, organizationId },
-    });
-
-    // Decrement storage quota for total file sizes
-    const totalBytes = items.reduce((sum, item) => sum + (item.fileSize || 0), 0);
-    if (totalBytes > 0) {
-      await this.storageQuotaService.decrementUsage(organizationId, totalBytes);
-    }
-
-    return { deleted: result.count };
+    return { deleted, failed: failedIds.length, failedIds };
   }
 
   async bulkAddTags(organizationId: string, dto: BulkTagDto) {


### PR DESCRIPTION
## Summary

R4 storage scout finding #10. The previous shape was a silent orphan factory:

1. \`Promise.allSettled\` the storage deletes
2. Log failures but ignore them
3. \`deleteMany\` ALL N DB rows regardless

Result: a connection blip during a bulk-delete of 100 items would delete all 100 DB rows but leave the failed-storage files in MinIO indefinitely — counted against quota, no DB pointer, no operator visibility.

New shape:
- **Per-item tracking** — successful MinIO delete IDs go into \`deletableIds\`; failures into \`failedIds\` with a warn log carrying the specific id + key + error.
- Only \`deletableIds\` are passed to \`deleteMany\`. The failed rows stay in the DB so a retry (operator-driven or a future cleanup cron) can re-attempt the delete.
- Quota decrement is for the **SUCCESSFUL** bytes only — the failed files still occupy storage, so the quota should reflect that.
- Return shape extended with \`{deleted, failed, failedIds}\` so the caller (UI) can surface partial-failure feedback.
- Bonus: dedupe input ids (defensive — matches PR #89 pattern).

## Tests

- [x] content.service: 88/88 (was 87 + 1 new — explicit partial-failure regression asserting deletableIds-only deleteMany + quota-on-successful-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)