### PR TITLE
fix(displays,db-maintainer): pairing-orphan reset cron + impressions VACUUM

### DIFF
--- a/middleware/src/modules/displays/displays.service.spec.ts
+++ b/middleware/src/modules/displays/displays.service.spec.ts
@@ -693,4 +693,43 @@ describe('DisplaysService', () => {
       expect(databaseService.display.updateMany).not.toHaveBeenCalled();
     });
   });
+
+  describe('resetStalePairingDevices', () => {
+    it('resets displays stuck in status=pairing for >30 min back to offline', async () => {
+      // Devices that were paired but never made first WebSocket connection
+      // (device lost power / network / QR code never scanned). Stay in
+      // 'pairing' forever and block re-pairing of the same deviceIdentifier
+      // until the operator manually intervenes.
+      const stalePairing = [
+        { id: 'dev-stale-1', nickname: 'Foyer', deviceIdentifier: 'mac-1', organizationId: 'org-1' },
+        { id: 'dev-stale-2', nickname: null, deviceIdentifier: 'mac-2', organizationId: 'org-1' },
+      ];
+      databaseService.display.findMany.mockResolvedValue(stalePairing as any);
+      databaseService.display.updateMany.mockResolvedValue({ count: 2 });
+
+      await service.resetStalePairingDevices();
+
+      // Query uses updatedAt (not lastHeartbeat — pairing devices haven't
+      // heartbeated yet by definition).
+      expect(databaseService.display.findMany).toHaveBeenCalledWith({
+        where: {
+          status: 'pairing',
+          updatedAt: { lt: expect.any(Date) },
+        },
+        select: { id: true, nickname: true, deviceIdentifier: true, organizationId: true },
+      });
+      expect(databaseService.display.updateMany).toHaveBeenCalledWith({
+        where: { id: { in: ['dev-stale-1', 'dev-stale-2'] } },
+        data: { status: 'offline' },
+      });
+    });
+
+    it('no-ops when no stale pairing devices found', async () => {
+      databaseService.display.findMany.mockResolvedValue([]);
+
+      await service.resetStalePairingDevices();
+
+      expect(databaseService.display.updateMany).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/middleware/src/modules/displays/displays.service.ts
+++ b/middleware/src/modules/displays/displays.service.ts
@@ -338,6 +338,50 @@ export class DisplaysService {
     this.logger.log(`Marked ${staleDevices.length} device(s) as offline (stale heartbeat)`);
   }
 
+  /**
+   * Reset displays stuck in 'pairing' state. A device gets status='pairing'
+   * when generatePairingToken() fires (operator started pairing) but
+   * transitions to 'online' only when the device makes its first WebSocket
+   * connection. If the device loses power or network in between — or the
+   * QR code never gets scanned — the row stays 'pairing' forever, which
+   * confuses dashboards and prevents the operator from re-pairing the same
+   * deviceIdentifier (the existing-display check throws "already paired").
+   *
+   * Threshold is 30 minutes — generous compared to the 5-min pairing-token
+   * TTL but tolerant of legitimate slow first-connect (cold cache, slow
+   * 3G, captive portal handshake). Past the threshold we drop status back
+   * to 'offline' so the device can be re-paired without operator action.
+   *
+   * Runs hourly — not every minute, because pairing is a low-frequency
+   * operator action and the cost of a 30-60min delay on cleanup is
+   * trivial.
+   */
+  @Cron(CronExpression.EVERY_HOUR)
+  async resetStalePairingDevices(): Promise<void> {
+    const threshold = new Date(Date.now() - 30 * 60 * 1000); // 30 minutes ago
+    const stale = await this.db.display.findMany({
+      where: {
+        status: 'pairing',
+        // Use updatedAt — that's when generatePairingToken touched the row.
+        // lastHeartbeat is the wrong field here because a pairing-state
+        // device by definition has never heartbeated.
+        updatedAt: { lt: threshold },
+      },
+      select: { id: true, nickname: true, deviceIdentifier: true, organizationId: true },
+    });
+
+    if (stale.length === 0) return;
+
+    await this.db.display.updateMany({
+      where: { id: { in: stale.map((d) => d.id) } },
+      data: { status: 'offline' },
+    });
+
+    this.logger.log(
+      `Reset ${stale.length} stale 'pairing'-state device(s) to 'offline' (>30min in pairing)`,
+    );
+  }
+
   async generatePairingToken(organizationId: string, id: string) {
     const display = await this.findOne(organizationId, id);
 

--- a/scripts/ops/db-maintainer.ts
+++ b/scripts/ops/db-maintainer.ts
@@ -33,7 +33,15 @@ import { log } from './lib/alerting.js';
 
 const AGENT = 'db-maintainer';
 
-/** High-churn PostgreSQL tables to VACUUM ANALYZE */
+/**
+ * High-churn PostgreSQL tables to VACUUM ANALYZE.
+ *
+ * `content_impressions` is the proof-of-play table — at ~12k rows/day/org
+ * it bloats fast and was the top finding in the R6 analytics scout (table
+ * was previously absent from this list, so weekly bloat went unmanaged).
+ * Lower-case + underscores because the impressions model uses @@map for
+ * its physical table name, unlike the PascalCase Prisma defaults.
+ */
 const VACUUM_TABLES = [
   'Content',
   'Display',
@@ -41,6 +49,7 @@ const VACUUM_TABLES = [
   'Playlist',
   'AuditLog',
   'User',
+  'content_impressions',
 ];
 
 const VACUUM_TIMEOUT_MS = 120_000; // 2 minutes per table


### PR DESCRIPTION
## Summary

Two unrelated cleanups bundled because both are small + the displays test infra was already loaded:

1. **\`resetStalePairingDevices\` @Cron(EVERY_HOUR)** in \`displays.service\`. A device gets \`status='pairing'\` when \`generatePairingToken\` fires and transitions to \`'online'\` only on first WebSocket connection. If the device loses power / network in between, or the QR code never gets scanned, the row stays \`'pairing'\` FOREVER — dashboards show a phantom device and the operator can't re-pair the same \`deviceIdentifier\` (existing-display check throws "already paired"). Threshold is 30 min — generous vs the 5-min pairing-token TTL but tolerant of legitimate slow first-connects. Past the threshold, drop status to \`'offline'\` so the device can be re-paired without operator action.

2. **db-maintainer VACUUM_TABLES adds \`content_impressions\`** — the proof-of-play table. R6 analytics scout flagged it: at ~12k rows/day/org the table bloats fast and was absent from the weekly maintenance cron entirely.

## Tests

- [x] displays.service: 42/42 (was 40 + 2 new — happy-path and no-op for \`resetStalePairingDevices\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)