### PR TITLE
fix(common): circuit-breaker OPEN alert + tighten error-message disclosure

### DIFF
--- a/middleware/src/modules/common/filters/all-exceptions.filter.spec.ts
+++ b/middleware/src/modules/common/filters/all-exceptions.filter.spec.ts
@@ -309,15 +309,34 @@ describe('AllExceptionsFilter', () => {
       process.env.NODE_ENV = originalEnv;
     });
 
-    it('should include error property in non-production response', () => {
+    it('should include error property + raw message ONLY in development', () => {
       const originalEnv = process.env.NODE_ENV;
-      process.env.NODE_ENV = 'test';
+      process.env.NODE_ENV = 'development';
 
       filter.catch(new Error('test error'), mockHost);
 
       const jsonCall = mockResponse.json.mock.calls[0][0];
       expect(jsonCall).toHaveProperty('error', 'Internal Server Error');
+      expect(jsonCall).toHaveProperty('message', 'test error');
 
+      process.env.NODE_ENV = originalEnv;
+    });
+
+    it('should NOT expose internals in test/staging/production envs', () => {
+      // Previously the filter checked `NODE_ENV !== 'production'` which
+      // let staging through as if it were dev — a leaked exception
+      // message in staging can carry DB connection strings or file
+      // paths. Now only `development` exposes.
+      const originalEnv = process.env.NODE_ENV;
+      for (const env of ['test', 'staging', 'production']) {
+        process.env.NODE_ENV = env;
+        mockResponse.json.mockClear();
+        filter.catch(new Error('leaked internal detail'), mockHost);
+        const jsonCall = mockResponse.json.mock.calls[0][0];
+        expect(jsonCall.message).toBe('Internal server error');
+        expect(jsonCall.message).not.toContain('leaked internal detail');
+        expect(jsonCall).not.toHaveProperty('error');
+      }
       process.env.NODE_ENV = originalEnv;
     });
   });

--- a/middleware/src/modules/common/filters/all-exceptions.filter.ts
+++ b/middleware/src/modules/common/filters/all-exceptions.filter.ts
@@ -21,7 +21,12 @@ export class AllExceptionsFilter implements ExceptionFilter {
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest<Request>();
 
-    const isProduction = process.env.NODE_ENV === 'production';
+    // Only expose internal error messages in LOCAL development. Staging
+    // and any other non-production env share a production-like blast
+    // radius — a leaked exception message can contain DB connection
+    // strings, file paths, or other internal-only data. The previous
+    // `isProduction` check let staging through as if it were dev.
+    const exposeInternals = process.env.NODE_ENV === 'development';
 
     if (exception instanceof HttpException) {
       const status = exception.getStatus();
@@ -57,10 +62,8 @@ export class AllExceptionsFilter implements ExceptionFilter {
 
     response.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
       statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
-      message: isProduction
-        ? 'Internal server error'
-        : errorMessage,
-      ...(isProduction ? {} : { error: 'Internal Server Error' }),
+      message: exposeInternals ? errorMessage : 'Internal server error',
+      ...(exposeInternals ? { error: 'Internal Server Error' } : {}),
     });
   }
 }

--- a/middleware/src/modules/common/services/circuit-breaker.service.ts
+++ b/middleware/src/modules/common/services/circuit-breaker.service.ts
@@ -291,6 +291,27 @@ export class CircuitBreakerService {
     this.logger.warn(
       `Circuit ${circuitName} transitioned to OPEN. Will retry in ${config.resetTimeout / 1000}s`,
     );
+    // §12b write-site alert. A circuit going OPEN means a downstream
+    // dependency just failed N times in a row — operators should know
+    // immediately, not via the next ops-reporter aggregate cycle. Use
+    // Sentry's captureMessage (already wired in middleware) so the
+    // alert routes through whichever channels ops has configured on
+    // the Sentry project (Slack, PagerDuty, email).
+    //
+    // Lazy-require Sentry so the test boot path doesn't need the
+    // module mocked — the service is constructed before Sentry is
+    // available in test environments.
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const Sentry = require('@sentry/nestjs');
+      Sentry.captureMessage(`Circuit '${circuitName}' OPEN`, {
+        level: 'warning',
+        tags: { circuit: circuitName, event: 'circuit_open' },
+        extra: { resetTimeoutMs: config.resetTimeout },
+      });
+    } catch {
+      /* Sentry not loaded in this context (e.g., unit tests) — drop the alert */
+    }
   }
 
   private cleanupFailures(circuitName: string, windowMs: number): void {


### PR DESCRIPTION
## Summary

Two findings from the R6 webhooks+common scout:

1. **\`CircuitBreakerService.openCircuit\`** logged at WARN level only — when a circuit transitions to OPEN (downstream service just failed N times in a row), the operator only learned about it via the next ops-reporter aggregate cycle (~30 min lag). §12b says write-site alert. Now also fires \`Sentry.captureMessage\` at warning level with circuit name + tags so the alert routes through whichever channels ops has configured on the Sentry project (Slack, PagerDuty, email). Lazy-required so the test boot path doesn't need Sentry mocked.

2. **\`AllExceptionsFilter\` exposed \`errorMessage\` in non-production envs.** Previous shape: \`isProduction = NODE_ENV === 'production'\`, non-prod (including **STAGING**) returned the raw exception message. Staging shares production's blast radius — a leaked error message can carry DB connection strings or file paths. Renamed to \`exposeInternals\` and tightened to \`NODE_ENV === 'development'\`. Test, staging, and production all now return the generic 'Internal server error' message without the \`error\` property.

## Tests

- [x] circuit-breaker + all-exceptions: 49/49 (was 47 + 1 pre-existing test rewritten to assert the new dev-only behavior, plus 1 new test confirming test/staging/production all hide internals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)