### PR TITLE
fix(middleware,webhooks): trust proxy + webhook secret entropy

### DIFF
--- a/middleware/src/main.ts
+++ b/middleware/src/main.ts
@@ -45,6 +45,29 @@ async function bootstrap() {
 
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
 
+  // Trust proxy — sets req.ip from X-Forwarded-For according to the
+  // configured hop count. Without this, GeoService and the rate-
+  // limiter key on the upstream proxy's IP (loopback in our prod
+  // nginx setup) instead of the real client IP. The R6 webhooks+
+  // common scout flagged this as a CRITICAL gap because country-
+  // based provider routing (Stripe vs Razorpay) and per-IP throttles
+  // were both running on the wrong key.
+  //
+  // TRUST_PROXY_HOPS defaults to 1 (single nginx in front). Bump if
+  // additional reverse proxies (CDN, ALB) sit between nginx and
+  // Node — setting it too high lets a malicious client spoof IPs
+  // via X-Forwarded-For, so keep it tight to the actual topology.
+  const trustProxyHops = parseInt(process.env.TRUST_PROXY_HOPS || '1', 10);
+  if (Number.isFinite(trustProxyHops) && trustProxyHops >= 0) {
+    app.set('trust proxy', trustProxyHops);
+    Logger.log(`Express trust proxy configured at ${trustProxyHops} hop(s)`);
+  } else {
+    Logger.warn(
+      `TRUST_PROXY_HOPS="${process.env.TRUST_PROXY_HOPS}" invalid; defaulting to 1 hop`,
+    );
+    app.set('trust proxy', 1);
+  }
+
   // Serve static files (thumbnails) with cache headers
   app.useStaticAssets(join(process.cwd(), 'static'), {
     prefix: '/static/',

--- a/middleware/src/modules/webhooks/dto/create-webhook.dto.spec.ts
+++ b/middleware/src/modules/webhooks/dto/create-webhook.dto.spec.ts
@@ -1,0 +1,57 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { CreateWebhookDto } from './create-webhook.dto';
+
+/**
+ * DTO-level validation tests. These exercise the class-validator
+ * decorators directly so the regression coverage doesn't depend on
+ * the full controller test path running ValidationPipe.
+ */
+describe('CreateWebhookDto secret entropy', () => {
+  const baseValid = {
+    name: 'Test webhook',
+    url: 'https://hooks.example.com/incoming',
+    events: ['content.created'],
+  };
+
+  async function expectSecretAccepted(secret: string) {
+    const dto = plainToInstance(CreateWebhookDto, { ...baseValid, secret });
+    const errors = await validate(dto);
+    expect(errors.filter((e) => e.property === 'secret')).toHaveLength(0);
+  }
+
+  async function expectSecretRejected(secret: string, reasonHint: RegExp) {
+    const dto = plainToInstance(CreateWebhookDto, { ...baseValid, secret });
+    const errors = await validate(dto);
+    const secretErrors = errors.filter((e) => e.property === 'secret');
+    expect(secretErrors.length).toBeGreaterThan(0);
+    const messages = Object.values(secretErrors[0].constraints ?? {}).join(' ');
+    expect(messages).toMatch(reasonHint);
+  }
+
+  it('accepts a mixed-case secret with at least one digit (16+ chars)', async () => {
+    await expectSecretAccepted('Abcdefgh12345678');
+  });
+
+  it('accepts a mixed-case secret with a special character', async () => {
+    await expectSecretAccepted('Abcdefghijklmnop!');
+  });
+
+  it('REJECTS a 32-char all-lowercase secret (defends against dictionary phrases)', async () => {
+    // Regression: the previous shape accepted this because it passed
+    // the 16-char length gate alone. New regex requires entropy.
+    await expectSecretRejected('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', /lowercase|uppercase|digit|special/i);
+  });
+
+  it('REJECTS the common "passwordpasswordpass" dictionary phrase', async () => {
+    await expectSecretRejected('passwordpasswordpass', /lowercase|uppercase|digit|special/i);
+  });
+
+  it('REJECTS a secret with mixed case but no digit and no special', async () => {
+    await expectSecretRejected('AbcdefghIjklmnop', /digit|special/i);
+  });
+
+  it('REJECTS a secret shorter than 16 characters even if entropy is high', async () => {
+    await expectSecretRejected('Abc1!', /16/);
+  });
+});

--- a/middleware/src/modules/webhooks/dto/create-webhook.dto.ts
+++ b/middleware/src/modules/webhooks/dto/create-webhook.dto.ts
@@ -30,12 +30,26 @@ export class CreateWebhookDto {
 
   /**
    * Customer-supplied HMAC secret. Must be at least 16 chars (so dictionary
-   * attack on a stolen payload+signature pair is impractical). The DTO
-   * caps at 256 — sufficient for any sane keying material.
+   * attack on a stolen payload+signature pair is impractical) and must
+   * contain at least 3 of {lowercase, uppercase, digit, special} so a
+   * common dictionary phrase like `passwordpassword` doesn't slip past
+   * the length gate. The DTO caps at 256 — sufficient for any sane
+   * keying material.
+   *
+   * Regex composition (positive lookahead per character class) chosen
+   * over a separate validator to keep the DTO declarative — the
+   * @Matches message lists the requirement explicitly.
    */
   @IsString()
   @MinLength(16, { message: 'secret must be at least 16 characters' })
   @MaxLength(256)
+  @Matches(
+    /^(?=(?:[^a-z]*[a-z]){1})(?=(?:[^A-Z]*[A-Z]){1})(?:(?=(?:\D*\d){1})|(?=(?:[A-Za-z0-9]*[^A-Za-z0-9]){1})).{16,}$/,
+    {
+      message:
+        'secret must include at least one lowercase letter, one uppercase letter, AND either a digit or a special character (defends against dictionary phrases)',
+    },
+  )
   secret!: string;
 
   @IsArray()


### PR DESCRIPTION
## Summary

Two R6 webhooks+common scout findings:

1. **\`main.ts\` now configures Express trust proxy** from \`TRUST_PROXY_HOPS\` env var (default 1 hop). Without this, \`req.ip\` resolved to the upstream proxy's address (loopback in our nginx setup) instead of the real client IP — GeoService got the wrong country and per-IP throttles keyed on the proxy. The R6 scout flagged this as CRITICAL because country-based provider routing (Stripe vs Razorpay) was running on the wrong key. Default 1 matches the production topology (single nginx in front); bump only if additional reverse proxies sit between nginx and Node.

2. **\`CreateWebhookDto.secret\` now enforces character-class entropy** in addition to the 16-char minimum length. Previous shape accepted dictionary phrases like \`passwordpasswordpass\` because they passed the length gate alone. New \`@Matches\` regex requires at least one lowercase + one uppercase + (digit OR special). Existing service-layer tests use \`'a'.repeat(32)\` which bypasses DTO validation, so no breakage there. New DTO-level spec file covers 6 paths: 2 accepted + 4 rejected variants.

## Tests

- [x] create-webhook dto: 6/6 (new file).
- [x] webhooks suite: 21/21 (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)