### PR TITLE
fix(support,admin,organizations): rate-limit + self-elevation + SMTP shutdown

### DIFF
--- a/middleware/src/modules/admin/admin.controller.spec.ts
+++ b/middleware/src/modules/admin/admin.controller.spec.ts
@@ -442,6 +442,19 @@ describe('AdminController', () => {
       );
     });
 
+    it('REJECTS self-grant of super-admin (peer-witness requirement)', async () => {
+      // Regression: super-admin elevation must flow through a second
+      // super-admin so every privilege escalation has a human peer in
+      // the audit chain. Self-elevation would log "I granted myself"
+      // and bypass that control.
+      await expect(
+        controller.grantSuperAdmin(adminId, adminId, mockRequest),
+      ).rejects.toThrow(/Cannot grant super-admin to yourself/);
+
+      expect(mockUsersAdminService.grantSuperAdmin).not.toHaveBeenCalled();
+      expect(mockAdminAuditService.log).not.toHaveBeenCalled();
+    });
+
     it('should revoke super admin privileges', async () => {
       mockUsersAdminService.revokeSuperAdmin.mockResolvedValue({ ...mockUser, isSuperAdmin: false } as any);
 

--- a/middleware/src/modules/admin/admin.controller.ts
+++ b/middleware/src/modules/admin/admin.controller.ts
@@ -11,6 +11,7 @@ import {
   HttpCode,
   HttpStatus,
   UseGuards,
+  ForbiddenException,
 } from '@nestjs/common';
 import { ParseIdPipe } from '../common/pipes/parse-id.pipe';
 import { Request } from 'express';
@@ -579,6 +580,18 @@ export class AdminController {
     @CurrentUser('userId') adminId: string,
     @Req() req: Request,
   ) {
+    // Block self-elevation. SuperAdminGuard guarantees the caller is
+    // already a super-admin (so grant-on-self is technically a no-op),
+    // but the audit row would then show "I granted myself" with no
+    // human in the loop — and downstream privilege-escalation reviews
+    // get harder. Force the grant to flow through a SECOND super-admin
+    // so every elevation has a peer witness.
+    if (id === adminId) {
+      throw new ForbiddenException(
+        'Cannot grant super-admin to yourself — ask another super-admin to perform the elevation',
+      );
+    }
+
     const user = await this.usersAdminService.grantSuperAdmin(id);
 
     await this.adminAuditService.log({

--- a/middleware/src/modules/organizations/organizations.service.ts
+++ b/middleware/src/modules/organizations/organizations.service.ts
@@ -424,7 +424,10 @@ export class OrganizationsService {
    * Returns null if SMTP isn't configured (dev environments).
    */
   private lifecycleTransporter:
-    | { sendMail: (opts: Record<string, unknown>) => Promise<unknown> }
+    | {
+        sendMail: (opts: Record<string, unknown>) => Promise<unknown>;
+        close?: () => void;
+      }
     | null
     | undefined = undefined;
 
@@ -445,6 +448,33 @@ export class OrganizationsService {
       auth: smtpUser && smtpPass ? { user: smtpUser, pass: smtpPass } : undefined,
     });
     return this.lifecycleTransporter;
+  }
+
+  /**
+   * NestJS lifecycle hook — close the cached nodemailer transporter
+   * pool when the app shuts down (SIGTERM from PM2 reload or upgrade).
+   * Without this, the pool's TCP keep-alives leak into the OS until
+   * the process is killed, and rapid PM2 reloads can exhaust file
+   * descriptors on the SMTP host. R7 support+onboarding scout
+   * finding #11.
+   *
+   * enableShutdownHooks() in main.ts is what wires this method to
+   * SIGTERM / SIGINT — no extra setup needed here.
+   */
+  async onApplicationShutdown(): Promise<void> {
+    if (this.lifecycleTransporter && typeof this.lifecycleTransporter.close === 'function') {
+      try {
+        this.lifecycleTransporter.close();
+        this.logger.log('lifecycle SMTP transporter pool closed on shutdown');
+      } catch (err) {
+        this.logger.warn(
+          `lifecycle SMTP transporter close failed on shutdown: ${
+            err instanceof Error ? err.message : err
+          }`,
+        );
+      }
+    }
+    this.lifecycleTransporter = undefined;
   }
 
   /**

--- a/middleware/src/modules/support/support.controller.ts
+++ b/middleware/src/modules/support/support.controller.ts
@@ -9,6 +9,7 @@ import {
   UseGuards,
   ParseUUIDPipe,
 } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
@@ -27,10 +28,21 @@ export class SupportController {
   constructor(private readonly supportService: SupportService) {}
 
   /**
-   * Create a new support request
-   * Any authenticated user can create a request
+   * Create a new support request.
+   * Any authenticated user can create a request. Throttled to prevent
+   * a single user from spamming the admin queue: 5 per minute in
+   * production, 1000/min in dev/test. R7 support scout flagged the
+   * absence of this throttle — without it, a hostile user (or a
+   * buggy client retry loop) could flood the admin's queue and
+   * gate-keep tickets behind hours of triage noise.
    */
   @Post('requests')
+  @Throttle({
+    default: {
+      limit: process.env.NODE_ENV === 'production' ? 5 : 1000,
+      ttl: 60_000,
+    },
+  })
   @ApiOperation({ summary: 'Create a new support request' })
   async createRequest(
     @CurrentUser('id') userId: string,


### PR DESCRIPTION
## Summary

Three R7 scout findings:

1. **\`support.controller POST /requests\`** now \`@Throttle\`'d at 5/min in prod (1000/min in dev/test). Without this a single hostile user (or buggy client retry loop) could flood the admin's triage queue. R7 support scout finding #3.

2. **\`admin.grantSuperAdmin\` rejects self-elevation.** \`SuperAdminGuard\` guarantees the caller IS a super-admin (so grant-on-self is technically a no-op), but the audit row would then read "I granted myself" with no human in the loop — privilege-escalation reviews then get harder. Force every elevation through a SECOND super-admin so each one has a peer witness. R7 support scout #9.

3. **\`organizations.service\` implements \`onApplicationShutdown\`** to close the nodemailer lifecycle transporter pool on SIGTERM. Without this, the pool's TCP keep-alives leak into the OS until process kill, and rapid PM2 reloads can exhaust file descriptors on the SMTP host. \`enableShutdownHooks()\` in main.ts is what wires this to SIGTERM/SIGINT (already present, no extra config needed). R7 support scout #11.

## Tests

- [x] support + admin + organizations: 68/68 (was 67 + 1 new — self-elevation rejection + no audit-log side effect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)