### PR TITLE
fix(support+agents): KB word-boundary match + onboarding handler escalation

### DIFF
--- a/middleware/src/modules/agents/onboarding.service.ts
+++ b/middleware/src/modules/agents/onboarding.service.ts
@@ -72,6 +72,26 @@ export class OnboardingService {
         `onboarding handler failed (field=${field})`,
         err instanceof Error ? err.stack : String(err),
       );
+      // R7-HIGH: also surface to Sentry so repeated handler failures
+      // group as an issue and page on-call instead of hiding inside
+      // server logs nobody reads. Sentry's default integration only
+      // captures UNCAUGHT exceptions; we explicitly capture here
+      // because the catch is intentional fire-and-forget.
+      OnboardingService.captureSentry(err, { field, orgId: evt.organizationId });
+    }
+  }
+
+  /**
+   * Lazy Sentry capture — middleware boot wires Sentry but tests don't
+   * load it, so import-failure shouldn't poison the milestone path.
+   */
+  private static captureSentry(err: unknown, tags: Record<string, unknown>): void {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const Sentry = require('@sentry/nestjs');
+      Sentry.captureException(err, { tags: { event: 'onboarding_handler_failed', ...tags } });
+    } catch {
+      /* Sentry not loaded — silent drop, log.error already fired */
     }
   }
 

--- a/middleware/src/modules/support/support-knowledge.service.ts
+++ b/middleware/src/modules/support/support-knowledge.service.ts
@@ -92,8 +92,21 @@ export class SupportKnowledgeService {
     for (const entry of this.entries) {
       let score = 0;
       for (const keyword of entry.keywords) {
-        if (lower.includes(keyword)) {
-          score += keyword.length; // Longer keyword matches score higher
+        // Short keywords (< 4 chars) like "ai", "tv", "use" use word-
+        // boundary matching so they don't match inside longer words
+        // ("ai" inside "again", "use" inside "abuse"/"useful"). Longer
+        // keywords keep substring matching so "price" still matches
+        // "pricing", "plan" matches "plans", "template" matches
+        // "templates" — the natural English-plural/gerund forms that
+        // customers type. R7 support scout finding #12.
+        const matches = keyword.length < 4
+          ? new RegExp(
+              `\\b${keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`,
+              'i',
+            ).test(lower)
+          : lower.includes(keyword);
+        if (matches) {
+          score += keyword.length;
         }
       }
       if (score > bestScore) {
@@ -102,7 +115,6 @@ export class SupportKnowledgeService {
       }
     }
 
-    // Require minimum threshold (at least one keyword match with length >= 3)
     return bestScore >= 3 ? bestMatch : null;
   }
 }


### PR DESCRIPTION
## Summary

Two R7 scout findings bundled in one PR.

- **KB word-boundary match** (`support-knowledge.service.ts`)
  Short keywords (`< 4` chars: `ai`, `tv`, `use`) now match only at word boundaries — previously `lower.includes('ai')` matched inside `again`, `use` matched inside `abuse`/`useful`, serving wrong KB answers and degrading trust in auto-responses. Longer keywords keep substring matching so `price` still matches `pricing` and `plan` matches `plans`. R7 finding #12.

- **Onboarding handler escalation** (`onboarding.service.ts`)
  The `handle()` catch block now escalates to Sentry via a lazy-required static helper. Previously a failed milestone marker only logged to stderr and could rot silently — operator wouldn't know the onboarding nudge pipeline was broken until customers complained. R7 finding #8.

## Test plan
- [x] `pnpm --filter @vizora/middleware test -- --testPathPattern=\"(onboarding|support-knowledge)\"` — 17/17 pass
- [x] Existing test `should return null for unrelated queries like \"quantum physics\"` still null
- [x] Existing test `should find pricing entry for what are the plans and pricing` now passes (via substring path on 5-char `price`)
- [x] Existing test `should find offline entry for my screen is offline` still passes (via substring path on 7-char `offline`)
- [x] Sentry helper falls through silently if `@sentry/nestjs` not loaded (lazy require with try/catch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)