### PR TITLE
fix(admin+billing+org): privilege change token revocation + onboarding age guard + quota excludes disabled

### DIFF
--- a/middleware/src/modules/admin/services/users-admin.service.spec.ts
+++ b/middleware/src/modules/admin/services/users-admin.service.spec.ts
@@ -1,10 +1,12 @@
 import { NotFoundException, BadRequestException } from '@nestjs/common';
 import { UsersAdminService, UserFiltersDto, UpdateUserAdminDto } from './users-admin.service';
 import { DatabaseService } from '../../database/database.service';
+import { RedisService } from '../../redis/redis.service';
 
 describe('UsersAdminService', () => {
   let service: UsersAdminService;
   let mockDb: any;
+  let mockRedis: any;
 
   const mockUser = {
     id: 'user-123',
@@ -41,7 +43,15 @@ describe('UsersAdminService', () => {
       },
     };
 
-    service = new UsersAdminService(mockDb as DatabaseService);
+    mockRedis = {
+      set: jest.fn().mockResolvedValue('OK'),
+      del: jest.fn().mockResolvedValue(1),
+    };
+
+    service = new UsersAdminService(
+      mockDb as DatabaseService,
+      mockRedis as RedisService,
+    );
   });
 
   it('should be defined', () => {
@@ -207,6 +217,15 @@ describe('UsersAdminService', () => {
 
       await expect(service.grantSuperAdmin('user-123')).rejects.toThrow(BadRequestException);
     });
+
+    it('should flush user_auth cache so new isSuperAdmin claim is picked up', async () => {
+      mockDb.user.findUnique.mockResolvedValue(mockUser);
+      mockDb.user.update.mockResolvedValue({ ...mockUser, isSuperAdmin: true });
+
+      await service.grantSuperAdmin('user-123');
+
+      expect(mockRedis.del).toHaveBeenCalledWith('user_auth:user-123');
+    });
   });
 
   describe('revokeSuperAdmin', () => {
@@ -231,6 +250,21 @@ describe('UsersAdminService', () => {
       mockDb.user.count.mockResolvedValue(1);
 
       await expect(service.revokeSuperAdmin('user-123')).rejects.toThrow(BadRequestException);
+    });
+
+    it('should set user_revoked: flag and flush auth cache', async () => {
+      mockDb.user.findUnique.mockResolvedValue({ ...mockUser, isSuperAdmin: true });
+      mockDb.user.count.mockResolvedValue(2);
+      mockDb.user.update.mockResolvedValue({ ...mockUser, isSuperAdmin: false });
+
+      await service.revokeSuperAdmin('user-123');
+
+      expect(mockRedis.set).toHaveBeenCalledWith(
+        'user_revoked:user-123',
+        '1',
+        expect.any(Number),
+      );
+      expect(mockRedis.del).toHaveBeenCalledWith('user_auth:user-123');
     });
   });
 

--- a/middleware/src/modules/admin/services/users-admin.service.ts
+++ b/middleware/src/modules/admin/services/users-admin.service.ts
@@ -5,6 +5,8 @@ import {
   Logger,
 } from '@nestjs/common';
 import { DatabaseService } from '../../database/database.service';
+import { RedisService } from '../../redis/redis.service';
+import { AUTH_CONSTANTS } from '../../auth/constants/auth.constants';
 import { Prisma } from '@vizora/database';
 import * as bcrypt from 'bcryptjs';
 import * as crypto from 'crypto';
@@ -33,7 +35,10 @@ export interface UpdateUserAdminDto {
 export class UsersAdminService {
   private readonly logger = new Logger(UsersAdminService.name);
 
-  constructor(private readonly db: DatabaseService) {}
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly redisService: RedisService,
+  ) {}
 
   /**
    * List all users across all organizations
@@ -283,6 +288,13 @@ export class UsersAdminService {
       },
     });
 
+    // Privilege change — flush cached AuthenticatedUser payload so the
+    // new isSuperAdmin claim is picked up on the next request rather
+    // than waiting for the 60s user_auth: TTL to elapse. R9 admin
+    // scout finding (grantSuperAdmin counterpart to PR #88's
+    // user_revoked: pattern).
+    await this.redisService.del(`user_auth:${id}`);
+
     this.logger.warn(`Granted super admin to user ${id} (${user.email})`);
     return updated;
   }
@@ -317,6 +329,18 @@ export class UsersAdminService {
         isSuperAdmin: true,
       },
     });
+
+    // Privilege REDUCTION — set user_revoked: so any outstanding JWT
+    // is rejected on its next request, not just after the cache TTL.
+    // Also flush user_auth: so the next login lookup reads from DB.
+    // R9 admin scout CRITICAL: previously a demoted super-admin kept
+    // operating with their old token until natural expiry.
+    await this.redisService.set(
+      `user_revoked:${id}`,
+      '1',
+      AUTH_CONSTANTS.TOKEN_EXPIRY_SECONDS,
+    );
+    await this.redisService.del(`user_auth:${id}`);
 
     this.logger.warn(`Revoked super admin from user ${id} (${user.email})`);
     return updated;

--- a/middleware/src/modules/billing/guards/quota.guard.spec.ts
+++ b/middleware/src/modules/billing/guards/quota.guard.spec.ts
@@ -80,6 +80,20 @@ describe('QuotaGuard', () => {
         expect(result).toBe(true);
       });
 
+      it('should exclude disabled displays from the quota count (where: isDisabled: false)', async () => {
+        mockDatabaseService.organization.findUnique.mockResolvedValue({
+          screenQuota: 25,
+          _count: { displays: 12 },
+        } as any);
+
+        await guard.canActivate(mockExecutionContext);
+
+        const findUniqueArgs = mockDatabaseService.organization.findUnique.mock.calls[0][0];
+        expect(findUniqueArgs.select._count.select.displays).toEqual({
+          where: { isDisabled: false },
+        });
+      });
+
       it('should allow when quota is unlimited (-1)', async () => {
         mockDatabaseService.organization.findUnique.mockResolvedValue({
           screenQuota: -1,
@@ -172,7 +186,7 @@ describe('QuotaGuard', () => {
           select: {
             screenQuota: true,
             _count: {
-              select: { displays: true },
+              select: { displays: { where: { isDisabled: false } } },
             },
           },
         });

--- a/middleware/src/modules/billing/guards/quota.guard.ts
+++ b/middleware/src/modules/billing/guards/quota.guard.ts
@@ -33,12 +33,17 @@ export class QuotaGuard implements CanActivate {
       throw new ForbiddenException('Organization not found');
     }
 
+    // Exclude disabled displays from the quota count — a customer who
+    // disables a screen should be able to reclaim that quota slot.
+    // R9 admin scout: previously `_count: { displays: true }` counted
+    // every row including disabled ones, so disabling didn't free up
+    // the slot and the customer remained gated until hard-delete.
     const org = await this.db.organization.findUnique({
       where: { id: organizationId },
       select: {
         screenQuota: true,
         _count: {
-          select: { displays: true },
+          select: { displays: { where: { isDisabled: false } } },
         },
       },
     });

--- a/middleware/src/modules/organizations/organizations.service.spec.ts
+++ b/middleware/src/modules/organizations/organizations.service.spec.ts
@@ -264,7 +264,12 @@ describe('OrganizationsService', () => {
   });
 
   describe('setOnboardingCompleted (customer-lifecycle write)', () => {
-    it('upserts completedAt=NOW() (idempotent)', async () => {
+    const ageMs = (days: number) => Date.now() - days * 24 * 60 * 60 * 1000;
+
+    it('upserts completedAt=NOW() (idempotent) when org is >= 30 days old', async () => {
+      mockDatabaseService.organization.findUnique.mockResolvedValue({
+        createdAt: new Date(ageMs(45)),
+      });
       mockDatabaseService.organizationOnboarding.upsert.mockResolvedValue({
         organizationId: 'org-1',
       });
@@ -273,6 +278,22 @@ describe('OrganizationsService', () => {
       const arg = mockDatabaseService.organizationOnboarding.upsert.mock.calls[0][0];
       expect(arg.create).toMatchObject({ organizationId: 'org-1', completedAt: expect.any(Date) });
       expect(arg.update).toMatchObject({ completedAt: expect.any(Date) });
+    });
+
+    it('refuses to mark complete when org is younger than 30 days', async () => {
+      mockDatabaseService.organization.findUnique.mockResolvedValue({
+        createdAt: new Date(ageMs(5)),
+      });
+      const ok = await service.setOnboardingCompleted('org-1');
+      expect(ok).toBe(false);
+      expect(mockDatabaseService.organizationOnboarding.upsert).not.toHaveBeenCalled();
+    });
+
+    it('returns false (does not throw) when org id not found', async () => {
+      mockDatabaseService.organization.findUnique.mockResolvedValue(null);
+      const ok = await service.setOnboardingCompleted('missing');
+      expect(ok).toBe(false);
+      expect(mockDatabaseService.organizationOnboarding.upsert).not.toHaveBeenCalled();
     });
   });
 

--- a/middleware/src/modules/organizations/organizations.service.ts
+++ b/middleware/src/modules/organizations/organizations.service.ts
@@ -200,8 +200,32 @@ export class OrganizationsService {
    * path for stale (>30d) signups that never finish. Idempotent —
    * re-calling on an already-completed row updates the timestamp,
    * which is fine.
+   *
+   * R7 onboarding scout: server-side enforces the ">= 30 days old"
+   * contract documented in the MCP tool description. Without this
+   * guard, a buggy or hostile agent with `customer:write` could call
+   * auto-complete on a 1-day-old signup and silently skip every
+   * lifecycle nudge they were supposed to receive — the agent's
+   * client-side check is necessary but not sufficient.
    */
   async setOnboardingCompleted(organizationId: string): Promise<boolean> {
+    const MIN_AGE_DAYS = 30;
+    const org = await this.db.organization.findUnique({
+      where: { id: organizationId },
+      select: { createdAt: true },
+    });
+    if (!org) return false;
+    const ageMs = Date.now() - org.createdAt.getTime();
+    if (ageMs < MIN_AGE_DAYS * 24 * 60 * 60 * 1000) {
+      // Refuse — caller is trying to force-skip nudges. Returning false
+      // (vs throwing) keeps idempotent semantics for the MCP tool:
+      // result.completed === false means "no change was made", same
+      // shape as a re-call on an already-completed row.
+      this.logger.warn(
+        `Refusing setOnboardingCompleted for ${organizationId}: org age ${Math.round(ageMs / 86400000)}d < ${MIN_AGE_DAYS}d`,
+      );
+      return false;
+    }
     const res = await this.db.organizationOnboarding.upsert({
       where: { organizationId },
       create: { organizationId, completedAt: new Date() },


### PR DESCRIPTION
## Summary

Four R9 admin/billing scout findings bundled.

### CRITICAL
- **`users-admin.revokeSuperAdmin`** — sets `user_revoked:` Redis flag + flushes `user_auth:` cache. Previously a demoted super-admin kept operating with their old token until natural JWT expiry (up to 7 days). Mirrors `users.service.deactivate` pattern (PR #88).

### HIGH
- **`users-admin.grantSuperAdmin`** — flushes `user_auth:` cache so the new `isSuperAdmin` claim is picked up on the next request instead of waiting for the 60s cache TTL.

- **`organizations.setOnboardingCompleted`** — refuses to mark complete when org is younger than 30 days. MCP tool description says \">= 30 days\" but server-side enforcement was missing — a buggy or hostile customer-lifecycle agent could force-skip every lifecycle nudge by calling auto-complete on a 1-day-old signup. Returns `false` (idempotent semantics) rather than throwing.

- **`billing.QuotaGuard`** — `_count.displays` now filters `where: isDisabled = false` so a customer who disables a screen reclaims their quota slot. Previously disabling was useless for freeing quota — only hard delete counted, which trapped customers at quota and pushed them toward an upgrade they didn't actually need.

## Test plan
- [x] `users-admin.service.spec` — 22/22 (added grant + revoke Redis assertions)
- [x] `quota.guard.spec` — 21/21 (added isDisabled-filter assertion + updated existing exact-shape test)
- [x] `organizations.service.spec` — 26/26 (added under-30d, missing-org tests; updated happy-path with age mock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)