### PR TITLE
fix(billing+admin): startup price-ID validation + trial extension cap

### DIFF
--- a/middleware/src/modules/admin/services/organizations-admin.service.spec.ts
+++ b/middleware/src/modules/admin/services/organizations-admin.service.spec.ts
@@ -161,7 +161,7 @@ describe('OrganizationsAdminService', () => {
 
   describe('extendTrial', () => {
     it('should extend trial by specified days', async () => {
-      const orgWithTrial = { ...mockOrganization, trialEndsAt: new Date() };
+      const orgWithTrial = { ...mockOrganization, trialEndsAt: new Date(), createdAt: new Date() };
       mockDb.organization.findUnique.mockResolvedValue(orgWithTrial);
       mockDb.organization.update.mockResolvedValue({ ...orgWithTrial, subscriptionStatus: 'trial' });
 
@@ -180,6 +180,32 @@ describe('OrganizationsAdminService', () => {
     it('should throw BadRequestException for non-positive days', async () => {
       await expect(service.extendTrial('org-123', 0)).rejects.toThrow(BadRequestException);
       await expect(service.extendTrial('org-123', -5)).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw if extension would exceed 90 days from signup', async () => {
+      const ageMs = (days: number) => Date.now() - days * 24 * 60 * 60 * 1000;
+      // Org is 80 days old, already in trial; another 30 days would push past 90.
+      const orgStaleTrial = {
+        ...mockOrganization,
+        createdAt: new Date(ageMs(80)),
+        trialEndsAt: new Date(ageMs(-10)), // trial ends 10d from now (~90d total)
+      };
+      mockDb.organization.findUnique.mockResolvedValue(orgStaleTrial);
+
+      await expect(service.extendTrial('org-123', 30)).rejects.toThrow(/cannot exceed 90 days/);
+    });
+
+    it('should allow extension that stays within 90 days from signup', async () => {
+      const ageMs = (days: number) => Date.now() - days * 24 * 60 * 60 * 1000;
+      const orgYoung = {
+        ...mockOrganization,
+        createdAt: new Date(ageMs(15)),
+        trialEndsAt: new Date(ageMs(-15)), // trial ends 15d from now (~30d total)
+      };
+      mockDb.organization.findUnique.mockResolvedValue(orgYoung);
+      mockDb.organization.update.mockResolvedValue({ ...orgYoung, subscriptionStatus: 'trial' });
+
+      await expect(service.extendTrial('org-123', 30)).resolves.toBeDefined();
     });
   });
 

--- a/middleware/src/modules/admin/services/organizations-admin.service.ts
+++ b/middleware/src/modules/admin/services/organizations-admin.service.ts
@@ -142,19 +142,34 @@ export class OrganizationsAdminService {
   }
 
   /**
-   * Extend trial period by specified number of days
+   * Extend trial period by specified number of days.
+   *
+   * R9 admin scout: caps total trial duration at MAX_TRIAL_DAYS days
+   * from the org's creation date. Without this cap an admin could
+   * repeatedly call extendTrial and push trialEndsAt arbitrarily far
+   * into the future — turning a "trial" customer into a perpetual
+   * free-of-charge enterprise user with no audit-visible threshold
+   * for what crossed the line into abuse.
    */
   async extendTrial(id: string, days: number) {
     if (days <= 0) {
       throw new BadRequestException('Days must be positive');
     }
+    const MAX_TRIAL_DAYS = 90;
 
     const org = await this.findOne(id);
 
-    // Calculate new trial end date
     const currentEnd = org.trialEndsAt ? new Date(org.trialEndsAt) : new Date();
     const newEnd = new Date(currentEnd);
     newEnd.setDate(newEnd.getDate() + days);
+
+    const totalTrialMs = newEnd.getTime() - org.createdAt.getTime();
+    const totalTrialDays = totalTrialMs / (24 * 60 * 60 * 1000);
+    if (totalTrialDays > MAX_TRIAL_DAYS) {
+      throw new BadRequestException(
+        `Trial cannot exceed ${MAX_TRIAL_DAYS} days from signup (would be ${Math.round(totalTrialDays)}). Convert to paid plan or extend a shorter window.`,
+      );
+    }
 
     const updated = await this.db.organization.update({
       where: { id },

--- a/middleware/src/modules/billing/billing.service.spec.ts
+++ b/middleware/src/modules/billing/billing.service.spec.ts
@@ -160,6 +160,67 @@ describe('BillingService', () => {
     expect(service).toBeDefined();
   });
 
+  describe('onModuleInit (price-ID startup validation)', () => {
+    const KEYS = [
+      'STRIPE_BASIC_MONTHLY_PRICE_ID',
+      'STRIPE_BASIC_YEARLY_PRICE_ID',
+      'RAZORPAY_BASIC_PLAN_ID',
+      'STRIPE_PRO_MONTHLY_PRICE_ID',
+      'STRIPE_PRO_YEARLY_PRICE_ID',
+      'RAZORPAY_PRO_PLAN_ID',
+      'STRIPE_ENTERPRISE_MONTHLY_PRICE_ID',
+      'STRIPE_ENTERPRISE_YEARLY_PRICE_ID',
+      'RAZORPAY_ENTERPRISE_PLAN_ID',
+    ];
+    let savedEnv: Record<string, string | undefined>;
+    let savedNodeEnv: string | undefined;
+
+    beforeEach(() => {
+      savedEnv = {};
+      KEYS.forEach((k) => {
+        savedEnv[k] = process.env[k];
+        delete process.env[k];
+      });
+      savedNodeEnv = process.env.NODE_ENV;
+    });
+
+    afterEach(() => {
+      KEYS.forEach((k) => {
+        if (savedEnv[k] === undefined) delete process.env[k];
+        else process.env[k] = savedEnv[k];
+      });
+      if (savedNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = savedNodeEnv;
+    });
+
+    it('throws when production and a paid-tier env var is missing', () => {
+      process.env.NODE_ENV = 'production';
+      expect(() => service.onModuleInit()).toThrow(/Missing billing price/);
+    });
+
+    it('does NOT throw in non-production (warns instead)', () => {
+      process.env.NODE_ENV = 'development';
+      expect(() => service.onModuleInit()).not.toThrow();
+    });
+
+    it('does NOT throw when all paid-tier env vars are set', () => {
+      process.env.NODE_ENV = 'production';
+      KEYS.forEach((k) => {
+        process.env[k] = `${k}_VALUE`;
+      });
+      expect(() => service.onModuleInit()).not.toThrow();
+    });
+
+    it('does not require env vars for the free tier', () => {
+      process.env.NODE_ENV = 'production';
+      KEYS.forEach((k) => {
+        process.env[k] = `${k}_VALUE`;
+      });
+      // Free tier env vars NOT set, but validation should pass — free has no price.
+      expect(() => service.onModuleInit()).not.toThrow();
+    });
+  });
+
   describe('getSubscriptionStatus', () => {
     it('should return subscription status for an organization', async () => {
       mockDatabaseService.organization.findUnique.mockResolvedValue(mockOrganization);

--- a/middleware/src/modules/billing/billing.service.ts
+++ b/middleware/src/modules/billing/billing.service.ts
@@ -3,6 +3,7 @@ import {
   Logger,
   BadRequestException,
   NotFoundException,
+  OnModuleInit,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { DatabaseService } from '../database/database.service';
@@ -38,7 +39,7 @@ interface WebhookData {
 }
 
 @Injectable()
-export class BillingService {
+export class BillingService implements OnModuleInit {
   private readonly logger = new Logger(BillingService.name);
 
   constructor(
@@ -49,6 +50,48 @@ export class BillingService {
     private readonly mailService: MailService,
     private readonly redisService: RedisService,
   ) {}
+
+  /**
+   * Validate at startup that price/plan IDs are configured for every
+   * paid tier in PLAN_TIERS. Production: throw and refuse to boot if a
+   * required env var is missing. Non-production: warn loudly so the
+   * dev sees the gap without blocking local work.
+   *
+   * R9 billing scout finding (CRITICAL): previously
+   * `getStripePriceId`/`getRazorpayPlanId` returned `undefined` on
+   * every call when the env var was missing — checkout would 400 at
+   * the moment the customer clicked Buy, not at deploy time. Catching
+   * this at boot means a misconfigured deploy never reaches a real
+   * customer.
+   */
+  onModuleInit(): void {
+    const missing: string[] = [];
+    for (const [tierId, tier] of Object.entries(PLAN_TIERS)) {
+      const isPaidTier =
+        tier.prices.usd.monthly > 0 || tier.prices.inr.monthly > 0;
+      if (!isPaidTier) continue;
+      for (const interval of ['monthly', 'yearly'] as const) {
+        const stripeKey = `STRIPE_${tierId.toUpperCase()}_${interval.toUpperCase()}_PRICE_ID`;
+        if (!process.env[stripeKey]) missing.push(stripeKey);
+      }
+      const razorpayKey = `RAZORPAY_${tierId.toUpperCase()}_PLAN_ID`;
+      if (!process.env[razorpayKey]) missing.push(razorpayKey);
+    }
+
+    if (missing.length === 0) {
+      this.logger.log(
+        `Billing price IDs validated for ${Object.keys(PLAN_TIERS).length} tier(s)`,
+      );
+      return;
+    }
+
+    const summary = `Missing billing price/plan env vars: ${missing.join(', ')}`;
+    if (process.env.NODE_ENV === 'production') {
+      this.logger.error(summary);
+      throw new Error(summary);
+    }
+    this.logger.warn(`${summary} (allowed in non-production)`);
+  }
 
   /**
    * Get the appropriate payment provider for an organization


### PR DESCRIPTION
## Summary

Two R9 billing/admin scout findings bundled.

### CRITICAL
- **`billing.service.onModuleInit`** — validates that `STRIPE_{TIER}_{INTERVAL}_PRICE_ID` and `RAZORPAY_{TIER}_PLAN_ID` env vars are set for every paid tier in `PLAN_TIERS`. In production: throws + refuses to boot if a required var is missing. In dev/test: warns. Previously a missing env var only surfaced when a customer clicked Buy — silently 400-ing at the worst possible moment.

### HIGH
- **`organizations-admin.extendTrial`** — caps total trial duration at 90 days from `org.createdAt`. Without this an admin could repeatedly extend a trial and turn it into a perpetual free-of-charge enterprise customer with no audit-visible line for what crossed into abuse.

## Test plan
- [x] `billing.service.spec` — 32/32 (added 4 startup-validation tests: prod-missing throws, dev warns, all-set passes, free-tier exempt)
- [x] `organizations-admin.service.spec` — 21/21 (added 2 extend-trial tests: >90d throws, <90d allowed; updated happy-path to include createdAt mock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)