### PR TITLE
fix(security): close cross-tenant gaps in display-groups + notifications cleanup + alert-rule dispatch + config allowlist + trial pricing + api-key audit

### DIFF
--- a/middleware/src/modules/admin/services/system-config.service.spec.ts
+++ b/middleware/src/modules/admin/services/system-config.service.spec.ts
@@ -153,6 +153,23 @@ describe('SystemConfigService', () => {
         })
       );
     });
+
+    it('rejects keys outside the namespace allowlist', async () => {
+      await expect(
+        service.set('arbitrary_key', true, 'admin-123'),
+      ).rejects.toThrow(/not in the allowlist/);
+      await expect(
+        service.set('DISABLE_RATE_LIMITS', true, 'admin-123'),
+      ).rejects.toThrow(/not in the allowlist/);
+      expect(mockDb.systemConfig.upsert).not.toHaveBeenCalled();
+    });
+
+    it('accepts namespaced keys (feature.*, announcement.*, etc.)', async () => {
+      mockDb.systemConfig.upsert.mockResolvedValue(mockConfig);
+      await expect(service.set('feature.new_dashboard', true, 'admin-123')).resolves.toBeDefined();
+      await expect(service.set('announcement.maintenance', 'down 2h', 'admin-123')).resolves.toBeDefined();
+      await expect(service.set('limit.daily_uploads', 100, 'admin-123')).resolves.toBeDefined();
+    });
   });
 
   describe('delete', () => {

--- a/middleware/src/modules/admin/services/system-config.service.ts
+++ b/middleware/src/modules/admin/services/system-config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException, Logger } from '@nestjs/common';
+import { Injectable, NotFoundException, BadRequestException, Logger } from '@nestjs/common';
 import { DatabaseService } from '../../database/database.service';
 
 export interface SetConfigDto {
@@ -14,11 +14,44 @@ export interface BulkConfigUpdate {
   value: unknown;
 }
 
+/**
+ * Allowlist of admin-settable config-key patterns. Each entry is a regex
+ * tested against the incoming key. Anything outside this list is rejected
+ * with a BadRequestException.
+ *
+ * R9 admin scout: previously `set()` accepted any string key with no
+ * gating. A typo (e.g. `disable_rate_limit` vs `disable_rate_limits`)
+ * silently saved as a new row that no consumer reads — looking like a
+ * working toggle but doing nothing. Worse, future developers could add
+ * a runtime-toggleable flag like `disable_rate_limits` and the admin UI
+ * would then expose that toggle without any explicit gating step.
+ *
+ * Adding a new admin-settable key requires adding its pattern here.
+ */
+const KEY_ALLOWLIST_PATTERNS: readonly RegExp[] = [
+  /^app\.[a-z0-9_.-]+$/, // legacy + general app-level settings
+  /^feature\.[a-z0-9_-]+$/, // feature flags
+  /^announcement\.[a-z0-9_-]+$/, // announcement banners
+  /^maintenance\.[a-z0-9_-]+$/, // maintenance-mode toggles
+  /^branding\.[a-z0-9_-]+$/, // platform-wide branding overrides
+  /^email\.[a-z0-9_-]+$/, // operator-controlled email settings (not secrets)
+  /^onboarding\.[a-z0-9_-]+$/, // onboarding tuning knobs
+  /^limit\.[a-z0-9_-]+$/, // adjustable usage limits
+];
+
 @Injectable()
 export class SystemConfigService {
   private readonly logger = new Logger(SystemConfigService.name);
 
   constructor(private readonly db: DatabaseService) {}
+
+  private assertKeyAllowed(key: string): void {
+    if (!KEY_ALLOWLIST_PATTERNS.some((re) => re.test(key))) {
+      throw new BadRequestException(
+        `Config key '${key}' is not in the allowlist. Allowed namespaces: feature.*, announcement.*, maintenance.*, branding.*, email.*, onboarding.*, limit.*`,
+      );
+    }
+  }
 
   /**
    * Get all system configurations
@@ -87,6 +120,7 @@ export class SystemConfigService {
    * Set a configuration value
    */
   async set(key: string, value: unknown, adminUserId: string, options?: Omit<SetConfigDto, 'value'>) {
+    this.assertKeyAllowed(key);
     const dataType = options?.dataType ?? this.inferDataType(value);
     const jsonValue = this.serializeValue(value, dataType);
 
@@ -139,6 +173,9 @@ export class SystemConfigService {
    * Bulk update multiple configurations
    */
   async bulkUpdate(configs: BulkConfigUpdate[], adminUserId: string) {
+    for (const { key } of configs) {
+      this.assertKeyAllowed(key);
+    }
     const results = await this.db.$transaction(
       configs.map(({ key, value }) => {
         const dataType = this.inferDataType(value);

--- a/middleware/src/modules/api-keys/guards/api-key.guard.ts
+++ b/middleware/src/modules/api-keys/guards/api-key.guard.ts
@@ -1,8 +1,10 @@
-import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Injectable, CanActivate, ExecutionContext, Logger } from '@nestjs/common';
 import { ApiKeysService } from '../api-keys.service';
 
 @Injectable()
 export class ApiKeyGuard implements CanActivate {
+  private readonly logger = new Logger(ApiKeyGuard.name);
+
   constructor(private readonly apiKeysService: ApiKeysService) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -19,9 +21,16 @@ export class ApiKeyGuard implements CanActivate {
     request.apiKeyScopes = keyRecord.scopes;
     request.apiKeyId = keyRecord.id;
 
-    // Update last used timestamp (fire and forget)
-    this.apiKeysService.updateLastUsed(keyRecord.id).catch(() => {
-      // Silently ignore errors updating lastUsedAt
+    // Update last used timestamp — intentionally fire-and-forget so a
+    // transient DB blip doesn't fail an otherwise-valid auth, but logged
+    // at warn so the failure is visible. R10 api-keys scout: previous
+    // empty .catch() hid DB degradation and left the audit trail with
+    // silent gaps. The request still succeeds (key was valid); ops sees
+    // the warn and knows the timestamp didn't update.
+    this.apiKeysService.updateLastUsed(keyRecord.id).catch((err) => {
+      this.logger.warn(
+        `Failed to update lastUsedAt for api-key ${keyRecord.id}: ${err instanceof Error ? err.message : 'unknown error'}`,
+      );
     });
 
     return true;

--- a/middleware/src/modules/billing/billing-lifecycle.service.ts
+++ b/middleware/src/modules/billing/billing-lifecycle.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { DatabaseService } from '../database/database.service';
 import { MailService } from '../mail/mail.service';
+import { PLAN_TIERS } from './constants/plans';
 
 @Injectable()
 export class BillingLifecycleService {
@@ -11,6 +12,23 @@ export class BillingLifecycleService {
     private readonly db: DatabaseService,
     private readonly mailService: MailService,
   ) {}
+
+  /**
+   * Derive entry-tier display pricing from PLAN_TIERS instead of
+   * hardcoding "$6 / ₹399" in email templates. Previously prices
+   * here drifted from the actual paid-tier pricing whenever the
+   * basic tier changed — customers got a reminder email quoting
+   * the wrong number. R9 billing scout.
+   */
+  private getDisplayPricing(country: string | null): { amount: string; currency: string } {
+    const basic = PLAN_TIERS.basic;
+    if (country === 'IN') {
+      const rupees = Math.round(basic.prices.inr.monthly / 100);
+      return { amount: `₹${rupees}`, currency: 'INR' };
+    }
+    const dollars = Math.round(basic.prices.usd.monthly / 100);
+    return { amount: `$${dollars}`, currency: 'USD' };
+  }
 
   /**
    * Daily job: expire trials and send reminders
@@ -67,9 +85,7 @@ export class BillingLifecycleService {
         // Send trial expired email
         const admin = org.users[0];
         if (admin?.email) {
-          const pricing = org.country === 'IN'
-            ? { amount: '\u20B9399', currency: 'INR' }
-            : { amount: '$6', currency: 'USD' };
+          const pricing = this.getDisplayPricing(org.country);
           await this.mailService.sendTrialExpiredEmail(
             admin.email,
             admin.firstName || admin.email.split('@')[0],
@@ -125,9 +141,7 @@ export class BillingLifecycleService {
       try {
         const admin = org.users[0];
         if (admin?.email) {
-          const pricing = org.country === 'IN'
-            ? { amount: '\u20B9399', currency: 'INR' }
-            : { amount: '$6', currency: 'USD' };
+          const pricing = this.getDisplayPricing(org.country);
           await this.mailService.sendTrialReminderEmail(
             admin.email,
             admin.firstName || admin.email.split('@')[0],

--- a/middleware/src/modules/display-groups/display-groups.service.spec.ts
+++ b/middleware/src/modules/display-groups/display-groups.service.spec.ts
@@ -30,7 +30,9 @@ describe('DisplayGroupsService', () => {
         findMany: jest.fn(),
         findFirst: jest.fn(),
         update: jest.fn(),
+        updateMany: jest.fn(),
         delete: jest.fn(),
+        deleteMany: jest.fn(),
         count: jest.fn(),
       },
       displayGroupMember: {
@@ -210,8 +212,8 @@ describe('DisplayGroupsService', () => {
     const updateDto = { name: 'Updated Group' };
 
     it('should update a display group', async () => {
-      mockDatabaseService.displayGroup.findFirst.mockResolvedValue(mockDisplayGroup);
-      mockDatabaseService.displayGroup.update.mockResolvedValue({
+      mockDatabaseService.displayGroup.updateMany.mockResolvedValue({ count: 1 });
+      mockDatabaseService.displayGroup.findFirst.mockResolvedValue({
         ...mockDisplayGroup,
         ...updateDto,
       });
@@ -219,10 +221,14 @@ describe('DisplayGroupsService', () => {
       const result = await service.update('org-123', 'group-123', updateDto);
 
       expect(result.name).toBe('Updated Group');
+      expect(mockDatabaseService.displayGroup.updateMany).toHaveBeenCalledWith({
+        where: { id: 'group-123', organizationId: 'org-123' },
+        data: updateDto,
+      });
     });
 
     it('should throw NotFoundException if display group not found', async () => {
-      mockDatabaseService.displayGroup.findFirst.mockResolvedValue(null);
+      mockDatabaseService.displayGroup.updateMany.mockResolvedValue({ count: 0 });
 
       await expect(service.update('org-123', 'invalid-id', updateDto)).rejects.toThrow(
         NotFoundException,
@@ -231,8 +237,8 @@ describe('DisplayGroupsService', () => {
 
     it('should update description only', async () => {
       const descDto = { description: 'Updated description' };
-      mockDatabaseService.displayGroup.findFirst.mockResolvedValue(mockDisplayGroup);
-      mockDatabaseService.displayGroup.update.mockResolvedValue({
+      mockDatabaseService.displayGroup.updateMany.mockResolvedValue({ count: 1 });
+      mockDatabaseService.displayGroup.findFirst.mockResolvedValue({
         ...mockDisplayGroup,
         ...descDto,
       });
@@ -242,39 +248,48 @@ describe('DisplayGroupsService', () => {
       expect(result.description).toBe('Updated description');
     });
 
-    it('should enforce organization isolation in update', async () => {
-      mockDatabaseService.displayGroup.findFirst.mockResolvedValue(null);
+    it('should enforce organization isolation in update (compound WHERE)', async () => {
+      mockDatabaseService.displayGroup.updateMany.mockResolvedValue({ count: 0 });
 
       await expect(
         service.update('org-different', 'group-123', { name: 'Hacked' }),
       ).rejects.toThrow(NotFoundException);
 
-      expect(mockDatabaseService.displayGroup.update).not.toHaveBeenCalled();
+      // The compound where binds the write to the verified org — the
+      // updateMany itself returns count=0 for a foreign-org id.
+      expect(mockDatabaseService.displayGroup.updateMany).toHaveBeenCalledWith({
+        where: { id: 'group-123', organizationId: 'org-different' },
+        data: { name: 'Hacked' },
+      });
     });
   });
 
   describe('remove', () => {
     it('should delete a display group', async () => {
-      mockDatabaseService.displayGroup.findFirst.mockResolvedValue(mockDisplayGroup);
-      mockDatabaseService.displayGroup.delete.mockResolvedValue(mockDisplayGroup);
+      mockDatabaseService.displayGroup.deleteMany.mockResolvedValue({ count: 1 });
 
       const result = await service.remove('org-123', 'group-123');
 
-      expect(result).toEqual(mockDisplayGroup);
+      expect(result).toEqual({ deleted: true, id: 'group-123' });
+      expect(mockDatabaseService.displayGroup.deleteMany).toHaveBeenCalledWith({
+        where: { id: 'group-123', organizationId: 'org-123' },
+      });
     });
 
     it('should throw NotFoundException if display group not found', async () => {
-      mockDatabaseService.displayGroup.findFirst.mockResolvedValue(null);
+      mockDatabaseService.displayGroup.deleteMany.mockResolvedValue({ count: 0 });
 
       await expect(service.remove('org-123', 'invalid-id')).rejects.toThrow(NotFoundException);
     });
 
-    it('should enforce organization isolation in remove', async () => {
-      mockDatabaseService.displayGroup.findFirst.mockResolvedValue(null);
+    it('should enforce organization isolation in remove (compound WHERE)', async () => {
+      mockDatabaseService.displayGroup.deleteMany.mockResolvedValue({ count: 0 });
 
       await expect(service.remove('org-different', 'group-123')).rejects.toThrow(NotFoundException);
 
-      expect(mockDatabaseService.displayGroup.delete).not.toHaveBeenCalled();
+      expect(mockDatabaseService.displayGroup.deleteMany).toHaveBeenCalledWith({
+        where: { id: 'group-123', organizationId: 'org-different' },
+      });
     });
   });
 

--- a/middleware/src/modules/display-groups/display-groups.service.ts
+++ b/middleware/src/modules/display-groups/display-groups.service.ts
@@ -69,27 +69,30 @@ export class DisplayGroupsService {
   }
 
   async update(organizationId: string, id: string, dto: UpdateDisplayGroupDto) {
-    await this.findOne(organizationId, id);
-
-    return this.db.displayGroup.update({
-      where: { id },
+    // Compound WHERE to close the TOCTOU race — previously findOne()
+    // verified the org but update() used only `{id}`, so a parallel
+    // request from another tenant during the gap between read and
+    // write could mutate this row. R10 display-groups scout.
+    const result = await this.db.displayGroup.updateMany({
+      where: { id, organizationId },
       data: dto,
-      include: {
-        displays: {
-          include: {
-            display: true,
-          },
-        },
-      },
     });
+    if (result.count === 0) {
+      throw new NotFoundException('Display group not found');
+    }
+    return this.findOne(organizationId, id);
   }
 
   async remove(organizationId: string, id: string) {
-    await this.findOne(organizationId, id);
-
-    return this.db.displayGroup.delete({
-      where: { id },
+    // Same TOCTOU close as update() — compound WHERE binds the delete
+    // to the verified org.
+    const result = await this.db.displayGroup.deleteMany({
+      where: { id, organizationId },
     });
+    if (result.count === 0) {
+      throw new NotFoundException('Display group not found');
+    }
+    return { deleted: true, id };
   }
 
   async addDisplays(organizationId: string, groupId: string, dto: ManageDisplaysDto) {

--- a/middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.spec.ts
+++ b/middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.spec.ts
@@ -22,6 +22,9 @@ describe('AlertRuleEvaluator', () => {
     db = {
       display: { findUnique: jest.fn() },
       notification: { create: jest.fn() },
+      // Default: the recipient user exists in the rule's org. Override
+      // per-test for cross-tenant guard checks.
+      user: { findFirst: jest.fn().mockResolvedValue({ id: 'user-1' }) },
     };
     alertRulesService = {
       findActiveForEvent: jest.fn(),
@@ -334,6 +337,18 @@ describe('AlertRuleEvaluator', () => {
         severity: 'warning',
       }),
     });
+  });
+
+  it('in_app dispatch skips when recipient user no longer in the rule\'s org (cross-tenant guard)', async () => {
+    db.display.findUnique.mockResolvedValue(makeDevice());
+    alertRulesService.findActiveForEvent.mockResolvedValue([makeRule()]);
+    alertRulesService.tryClaimDedupWindow.mockResolvedValue(true);
+    // User was moved to another org since the recipient row was created.
+    db.user.findFirst.mockResolvedValue(null);
+
+    await evaluator.handleDeviceOffline(payload);
+
+    expect(db.notification.create).not.toHaveBeenCalled();
   });
 
   it('dispatches slack_webhook with maxRedirects:0 and 5s timeout', async () => {

--- a/middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.ts
+++ b/middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.ts
@@ -197,6 +197,22 @@ export class AlertRuleEvaluator {
     recipient: { target: string },
     payload: DeviceOfflinePayload,
   ): Promise<void> {
+    // Re-verify the recipient user belongs to the rule's org before
+    // creating the notification. The rule's recipients are validated at
+    // create-time by the IsValidRecipientTarget validator, but a
+    // direct DB edit OR a user-org reassignment after the rule was
+    // created could end up writing a notification to a user from
+    // another org — silent cross-tenant leak. R10 alert-rules scout.
+    const user = await this.db.user.findFirst({
+      where: { id: recipient.target, organizationId: payload.organizationId },
+      select: { id: true },
+    });
+    if (!user) {
+      this.logger.warn(
+        `In-app dispatch skipped: user ${recipient.target} not in org ${payload.organizationId} (recipient row likely stale)`,
+      );
+      return;
+    }
     await this.db.notification.create({
       data: {
         organizationId: payload.organizationId,

--- a/middleware/src/modules/notifications/notifications.service.spec.ts
+++ b/middleware/src/modules/notifications/notifications.service.spec.ts
@@ -468,25 +468,33 @@ describe('NotificationsService', () => {
   });
 
   describe('cleanupOldNotifications', () => {
-    it('should delete old dismissed notifications', async () => {
+    it('should delete old dismissed notifications scoped to one org', async () => {
       db.notification.deleteMany.mockResolvedValue({ count: 50 });
 
-      const result = await service.cleanupOldNotifications(30);
+      const result = await service.cleanupOldNotifications('org-123', 30);
 
       expect(result.deleted).toBe(50);
       expect(db.notification.deleteMany).toHaveBeenCalledWith({
         where: {
+          organizationId: 'org-123',
           dismissedAt: { not: null, lt: expect.any(Date) },
         },
       });
     });
 
-    it('should use default days parameter', async () => {
+    it('should use default days parameter when only orgId provided', async () => {
       db.notification.deleteMany.mockResolvedValue({ count: 0 });
 
-      await service.cleanupOldNotifications();
+      await service.cleanupOldNotifications('org-123');
 
       expect(db.notification.deleteMany).toHaveBeenCalled();
+    });
+
+    it('throws when organizationId is missing — prevents cross-tenant wipe', async () => {
+      await expect(
+        service.cleanupOldNotifications('' as string, 30),
+      ).rejects.toThrow(/requires an organizationId/);
+      expect(db.notification.deleteMany).not.toHaveBeenCalled();
     });
   });
 });

--- a/middleware/src/modules/notifications/notifications.service.ts
+++ b/middleware/src/modules/notifications/notifications.service.ts
@@ -264,19 +264,35 @@ export class NotificationsService {
   // inlines the notification creation per matched recipient.
 
   /**
-   * Delete old dismissed notifications (cleanup job)
+   * Delete old dismissed notifications for a SINGLE org. The orgId
+   * parameter is required and the deleteMany is compound-WHERE-scoped
+   * so the cleanup can NEVER cross tenants.
+   *
+   * R10 notifications scout (CRITICAL): the previous signature accepted
+   * only `daysOld` and deleted across all orgs in one call — a single
+   * stray invocation from a cron, ops script, or admin UI would wipe
+   * dismissed notifications for every customer in one statement. Making
+   * `organizationId` a required argument makes that misuse impossible
+   * to express. The platform-wide cleanup cron (if it exists) should
+   * iterate orgs and call this per-org.
    */
-  async cleanupOldNotifications(daysOld: number = 30) {
+  async cleanupOldNotifications(organizationId: string, daysOld: number = 30) {
+    if (!organizationId) {
+      throw new Error('cleanupOldNotifications requires an organizationId');
+    }
     const cutoffDate = new Date();
     cutoffDate.setDate(cutoffDate.getDate() - daysOld);
 
     const result = await this.db.notification.deleteMany({
       where: {
+        organizationId,
         dismissedAt: { not: null, lt: cutoffDate },
       },
     });
 
-    this.logger.log(`Cleaned up ${result.count} old dismissed notifications`);
+    this.logger.log(
+      `Cleaned up ${result.count} old dismissed notifications for org ${organizationId}`,
+    );
     return { deleted: result.count };
   }
 }


### PR DESCRIPTION
## Summary

Six findings bundled — two from R9 scout (admin/billing) + four from R10 scout (display-groups/notifications/api-keys).

### CRITICAL (cross-tenant)
- **`display-groups.update/remove`** — replaced TOCTOU pattern (findOne org-check → unscoped update) with compound-WHERE updateMany/deleteMany. Prevents a parallel request from another tenant from race-mutating the row.

- **`notifications.cleanupOldNotifications`** — requires organizationId arg; deleteMany WHERE scopes to that org. Previously a single call deleted dismissed notifications across ALL tenants in one statement.

- **`alert-rule.evaluator.dispatchInApp`** — re-verifies recipient user still belongs to the rule's org before creating the notification. Closes a leak when a user is moved to another org after an alert rule was created.

- **`api-key.guard.updateLastUsed`** — silent `.catch()` replaced with warn-level log so transient DB failures don't disappear.

### HIGH
- **`system-config.set / bulkUpdate`** — rejects keys outside an explicit allowlist (`app.*`, `feature.*`, `announcement.*`, `maintenance.*`, `branding.*`, `email.*`, `onboarding.*`, `limit.*`). Adding a new admin-settable key now requires explicitly extending the allowlist.

- **`billing-lifecycle`** — trial emails derive display pricing from `PLAN_TIERS.basic` instead of hardcoded \"\$6 / ₹399\". Reminder emails no longer drift from real prices.

## Test plan
- [x] `display-groups.service.spec` — 46/46 (updated update/remove tests for new compound-WHERE shape)
- [x] `notifications.service.spec` — 125/125 (added cross-tenant guard tests)
- [x] `alert-rule.evaluator.spec` — 24/24 (added user-moved-to-other-org skip test)
- [x] `api-keys.service.spec` — 29/29 (no test changes needed; behavior identical from caller POV)
- [x] `system-config.service.spec` — 15/15 (added 2 allowlist tests)
- [x] `billing.service.spec` — 142/142

🤖 Generated with [Claude Code](https://claude.com/claude-code)