### PR TITLE
fix(api-keys+alert-rules): scope allowlist + paginated heal cron

### DIFF
--- a/middleware/src/modules/api-keys/dto/create-api-key.dto.ts
+++ b/middleware/src/modules/api-keys/dto/create-api-key.dto.ts
@@ -1,4 +1,28 @@
-import { IsString, IsNotEmpty, IsArray, IsOptional, IsDateString } from 'class-validator';
+import { IsString, IsNotEmpty, IsArray, IsOptional, IsDateString, IsIn } from 'class-validator';
+
+/**
+ * Allowlist of valid API-key scopes. Used by `@IsIn(VALID_SCOPES, ...)` on
+ * the DTO so a caller can never invent privileged scopes like `admin:*`
+ * or `delete:all` and get them stored on the key record. R10 api-keys
+ * scout: previously `@IsString({ each: true })` accepted any string,
+ * and downstream consumers would happily match the made-up scope.
+ *
+ * When adding a new scope: extend this list AND wire the corresponding
+ * check in the relevant guard / controller. Don't ship scope strings
+ * that no consumer checks.
+ */
+export const VALID_API_KEY_SCOPES = [
+  'read:all',
+  'read:content',
+  'read:displays',
+  'read:analytics',
+  'write:content',
+  'write:displays',
+  'write:playlists',
+  'write:schedules',
+] as const;
+
+export type ApiKeyScope = (typeof VALID_API_KEY_SCOPES)[number];
 
 export class CreateApiKeyDto {
   @IsString()
@@ -6,9 +30,9 @@ export class CreateApiKeyDto {
   name!: string;
 
   @IsArray()
-  @IsString({ each: true })
+  @IsIn(VALID_API_KEY_SCOPES as unknown as string[], { each: true })
   @IsOptional()
-  scopes?: string[];
+  scopes?: ApiKeyScope[];
 
   @IsDateString()
   @IsOptional()

--- a/middleware/src/modules/notifications/alert-rules/alert-rules.service.spec.ts
+++ b/middleware/src/modules/notifications/alert-rules/alert-rules.service.spec.ts
@@ -360,14 +360,20 @@ describe('AlertRulesService', () => {
 
       await service.healMissingDefaultRules();
 
-      expect(db.organization.findMany).toHaveBeenCalledWith({
-        where: {
-          alertRules: {
-            none: { name: 'Default offline alert (auto-migrated)' },
+      // Pagination cursor + take added — query now includes orderBy/take but the
+      // where + select shape is preserved.
+      expect(db.organization.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            alertRules: {
+              none: { name: 'Default offline alert (auto-migrated)' },
+            },
           },
-        },
-        select: { id: true, name: true },
-      });
+          select: { id: true, name: true },
+          orderBy: { id: 'asc' },
+          take: 100,
+        }),
+      );
       expect(db.alertRule.create).not.toHaveBeenCalled();
     });
 

--- a/middleware/src/modules/notifications/alert-rules/alert-rules.service.ts
+++ b/middleware/src/modules/notifications/alert-rules/alert-rules.service.ts
@@ -310,43 +310,65 @@ export class AlertRulesService {
    */
   @Cron(CronExpression.EVERY_HOUR)
   async healMissingDefaultRules(): Promise<void> {
-    const orgsNeedingRule = await this.db.organization.findMany({
-      where: {
-        alertRules: {
-          none: { name: 'Default offline alert (auto-migrated)' },
-        },
-      },
-      select: { id: true, name: true },
-    });
+    // R10 alert-rules scout: page through orgs in batches instead of
+    // loading the entire set into memory. At a few thousand orgs the
+    // unpaginated findMany would spike memory + force a long-running
+    // transaction; at tens of thousands it's an OOM risk every hour.
+    // Per-batch processing also lets us interleave Prisma + heal work
+    // so a single bad org doesn't gate the rest.
+    const PAGE_SIZE = 100;
+    let cursor: string | undefined;
+    let healed = 0;
+    let failed = 0;
+    let totalSeen = 0;
 
-    if (orgsNeedingRule.length === 0) {
+    /* eslint-disable no-constant-condition */
+    while (true) {
+      const orgsNeedingRule = await this.db.organization.findMany({
+        where: {
+          alertRules: {
+            none: { name: 'Default offline alert (auto-migrated)' },
+          },
+        },
+        select: { id: true, name: true },
+        orderBy: { id: 'asc' },
+        take: PAGE_SIZE,
+        ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+      });
+
+      if (orgsNeedingRule.length === 0) break;
+      totalSeen += orgsNeedingRule.length;
+
+      for (const org of orgsNeedingRule) {
+        try {
+          const admins = await this.db.user.findMany({
+            where: { organizationId: org.id, role: 'admin' },
+            select: { id: true },
+          });
+          await this.seedDefaultRuleForOrg(
+            org.id,
+            admins.map((a) => a.id),
+          );
+          healed++;
+        } catch (err) {
+          failed++;
+          this.logger.error(
+            `Heal cron: failed to seed default alert rule for org ${org.id}: ${err instanceof Error ? err.message : err}`,
+          );
+        }
+      }
+
+      cursor = orgsNeedingRule[orgsNeedingRule.length - 1].id;
+      if (orgsNeedingRule.length < PAGE_SIZE) break;
+    }
+    /* eslint-enable no-constant-condition */
+
+    if (totalSeen === 0) {
       this.logger.debug('Heal cron: all orgs have the default downtime alert rule');
       return;
     }
-
-    let healed = 0;
-    let failed = 0;
-    for (const org of orgsNeedingRule) {
-      try {
-        const admins = await this.db.user.findMany({
-          where: { organizationId: org.id, role: 'admin' },
-          select: { id: true },
-        });
-        await this.seedDefaultRuleForOrg(
-          org.id,
-          admins.map((a) => a.id),
-        );
-        healed++;
-      } catch (err) {
-        failed++;
-        this.logger.error(
-          `Heal cron: failed to seed default alert rule for org ${org.id}: ${err instanceof Error ? err.message : err}`,
-        );
-      }
-    }
-
     this.logger.log(
-      `Heal cron: healed ${healed}, failed ${failed} of ${orgsNeedingRule.length} orgs needing default downtime alert rule`,
+      `Heal cron: healed ${healed}, failed ${failed} of ${totalSeen} orgs needing default downtime alert rule`,
     );
   }
 


### PR DESCRIPTION
## Summary

Two R10 scout findings.

- **`api-keys.dto.CreateApiKeyDto`** — `scopes` now `@IsIn(VALID_API_KEY_SCOPES, { each: true })` with an explicit allowlist. Previously a caller could create a key claiming \`admin:*\` or \`delete:all\` and downstream consumers would happily match the made-up scope.

- **`alert-rules.healMissingDefaultRules`** — paginated 100-org id-cursor batches instead of one unpaginated `findMany`. At thousands of orgs the original was a memory spike every hour; at tens of thousands it was an OOM risk.

## Test plan
- [x] `api-keys.service.spec` — 29/29 (DTO is request-time validated; unit tests unaffected)
- [x] `alert-rules.service.spec` — 79/79 (updated heal-cron no-op test for new query shape; multi-org test still passes since first page returns all orgs and second page returns empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)