### PR TITLE
hotfix(billing): make price-ID validation warn-only by default — PROD-DOWN FIX

### DIFF
--- a/middleware/src/modules/billing/billing.service.spec.ts
+++ b/middleware/src/modules/billing/billing.service.spec.ts
@@ -173,7 +173,7 @@ describe('BillingService', () => {
       'RAZORPAY_ENTERPRISE_PLAN_ID',
     ];
     let savedEnv: Record<string, string | undefined>;
-    let savedNodeEnv: string | undefined;
+    let savedStrict: string | undefined;
 
     beforeEach(() => {
       savedEnv = {};
@@ -181,7 +181,8 @@ describe('BillingService', () => {
         savedEnv[k] = process.env[k];
         delete process.env[k];
       });
-      savedNodeEnv = process.env.NODE_ENV;
+      savedStrict = process.env.BILLING_VALIDATION_STRICT;
+      delete process.env.BILLING_VALIDATION_STRICT;
     });
 
     afterEach(() => {
@@ -189,22 +190,21 @@ describe('BillingService', () => {
         if (savedEnv[k] === undefined) delete process.env[k];
         else process.env[k] = savedEnv[k];
       });
-      if (savedNodeEnv === undefined) delete process.env.NODE_ENV;
-      else process.env.NODE_ENV = savedNodeEnv;
+      if (savedStrict === undefined) delete process.env.BILLING_VALIDATION_STRICT;
+      else process.env.BILLING_VALIDATION_STRICT = savedStrict;
     });
 
-    it('throws when production and a paid-tier env var is missing', () => {
-      process.env.NODE_ENV = 'production';
+    it('throws when STRICT mode is on and a paid-tier env var is missing', () => {
+      process.env.BILLING_VALIDATION_STRICT = 'true';
       expect(() => service.onModuleInit()).toThrow(/Missing billing price/);
     });
 
-    it('does NOT throw in non-production (warns instead)', () => {
-      process.env.NODE_ENV = 'development';
+    it('does NOT throw when STRICT is unset (default warn-only behavior)', () => {
       expect(() => service.onModuleInit()).not.toThrow();
     });
 
-    it('does NOT throw when all paid-tier env vars are set', () => {
-      process.env.NODE_ENV = 'production';
+    it('does NOT throw when STRICT mode is on AND all paid-tier env vars are set', () => {
+      process.env.BILLING_VALIDATION_STRICT = 'true';
       KEYS.forEach((k) => {
         process.env[k] = `${k}_VALUE`;
       });
@@ -212,7 +212,7 @@ describe('BillingService', () => {
     });
 
     it('does not require env vars for the free tier', () => {
-      process.env.NODE_ENV = 'production';
+      process.env.BILLING_VALIDATION_STRICT = 'true';
       KEYS.forEach((k) => {
         process.env[k] = `${k}_VALUE`;
       });

--- a/middleware/src/modules/billing/billing.service.ts
+++ b/middleware/src/modules/billing/billing.service.ts
@@ -53,16 +53,18 @@ export class BillingService implements OnModuleInit {
 
   /**
    * Validate at startup that price/plan IDs are configured for every
-   * paid tier in PLAN_TIERS. Production: throw and refuse to boot if a
-   * required env var is missing. Non-production: warn loudly so the
-   * dev sees the gap without blocking local work.
+   * paid tier in PLAN_TIERS. Default behavior: warn. Hard-fail only
+   * when `BILLING_VALIDATION_STRICT=true` — that's a deliberate opt-in
+   * for environments that actually have paid plans wired up (Stripe/
+   * Razorpay products created, customers actively subscribing).
    *
-   * R9 billing scout finding (CRITICAL): previously
-   * `getStripePriceId`/`getRazorpayPlanId` returned `undefined` on
-   * every call when the env var was missing — checkout would 400 at
-   * the moment the customer clicked Buy, not at deploy time. Catching
-   * this at boot means a misconfigured deploy never reaches a real
-   * customer.
+   * Hotfix rationale: an earlier version of this method threw in any
+   * `NODE_ENV=production` boot, which crashed prod the moment the
+   * commit landed — prod was running free-tier-only at the time and
+   * had never needed the env vars. The validation is still useful
+   * (catches misconfig before a customer hits checkout), but the
+   * blast radius of forced-fail-at-boot is too large to default to.
+   * Opt in once the org's billing path is live.
    */
   onModuleInit(): void {
     const missing: string[] = [];
@@ -86,11 +88,13 @@ export class BillingService implements OnModuleInit {
     }
 
     const summary = `Missing billing price/plan env vars: ${missing.join(', ')}`;
-    if (process.env.NODE_ENV === 'production') {
+    if (process.env.BILLING_VALIDATION_STRICT === 'true') {
       this.logger.error(summary);
       throw new Error(summary);
     }
-    this.logger.warn(`${summary} (allowed in non-production)`);
+    this.logger.warn(
+      `${summary} (warn-only; set BILLING_VALIDATION_STRICT=true to fail boot)`,
+    );
   }
 
   /**


### PR DESCRIPTION
## PROD DOWN — emergency fix

PR #101 introduced `BillingService.onModuleInit` that throws in `NODE_ENV=production` when paid-tier env vars are missing. Prod is currently free-tier-only and has never had those env vars set — boot crashed, PM2 thrashed at 999 restarts, nginx returns 502.

## Fix

- Validation now WARNS by default (logs missing keys + how to opt in)
- Hard-fail gated behind explicit `BILLING_VALIDATION_STRICT=true`
- Set STRICT=true once paid plans are wired up — preserves the original safety value, doesn't blast-radius the default

## Test plan
- [x] `billing.service.spec` — 32/32 (updated 4 startup-validation tests for new STRICT gating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)