### PR TITLE
fix(notifications): broadcast device-offline in-app alert in real-time

### DIFF
--- a/middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.spec.ts
+++ b/middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.spec.ts
@@ -1,8 +1,9 @@
-import { of, throwError } from 'rxjs';
+import { of } from 'rxjs';
 import { AlertRuleEvaluator } from './alert-rule.evaluator';
 import { AlertRulesService } from './alert-rules.service';
 import { DatabaseService } from '../../database/database.service';
 import { MailService } from '../../mail/mail.service';
+import { NotificationsService } from '../notifications.service';
 import { HttpService } from '@nestjs/axios';
 
 describe('AlertRuleEvaluator', () => {
@@ -11,6 +12,11 @@ describe('AlertRuleEvaluator', () => {
   let alertRulesService: jest.Mocked<Pick<AlertRulesService, 'findActiveForEvent' | 'tryClaimDedupWindow'>>;
   let mail: jest.Mocked<Pick<MailService, 'sendDeviceOfflineAlertEmail'>>;
   let http: jest.Mocked<Pick<HttpService, 'post'>>;
+  // in_app dispatch now routes through NotificationsService.create() (not a raw
+  // db write) so the new notification is broadcast over the realtime gateway.
+  // Tests assert against this mock as the "an in_app notification was created"
+  // sentinel.
+  let notifications: jest.Mocked<Pick<NotificationsService, 'create'>>;
 
   const orgId = 'org-123';
   const deviceId = 'device-1';
@@ -32,12 +38,14 @@ describe('AlertRuleEvaluator', () => {
     } as any;
     mail = { sendDeviceOfflineAlertEmail: jest.fn() } as any;
     http = { post: jest.fn() } as any;
+    notifications = { create: jest.fn().mockResolvedValue({ id: 'notif-1' }) } as any;
 
     evaluator = new AlertRuleEvaluator(
       db as unknown as DatabaseService,
       alertRulesService as unknown as AlertRulesService,
       mail as unknown as MailService,
       http as unknown as HttpService,
+      notifications as unknown as NotificationsService,
     );
   });
 
@@ -87,7 +95,7 @@ describe('AlertRuleEvaluator', () => {
     await evaluator.handleDeviceOffline(payload);
 
     expect(alertRulesService.tryClaimDedupWindow).not.toHaveBeenCalled();
-    expect(db.notification.create).not.toHaveBeenCalled();
+    expect(notifications.create).not.toHaveBeenCalled();
   });
 
   it('top-level try/catch swallows DB failures so EventEmitter does not crash', async () => {
@@ -103,11 +111,10 @@ describe('AlertRuleEvaluator', () => {
     db.display.findUnique.mockResolvedValue(makeDevice({ lastHeartbeat: null }));
     alertRulesService.findActiveForEvent.mockResolvedValue([makeRule({ minOfflineSec: 99999 })]);
     alertRulesService.tryClaimDedupWindow.mockResolvedValue(true);
-    db.notification.create.mockResolvedValue({});
 
     await evaluator.handleDeviceOffline(payload);
 
-    expect(db.notification.create).toHaveBeenCalledTimes(1);
+    expect(notifications.create).toHaveBeenCalledTimes(1);
   });
 
   // ---------------------------------------------------------------------------
@@ -116,7 +123,6 @@ describe('AlertRuleEvaluator', () => {
   describe('scope', () => {
     beforeEach(() => {
       alertRulesService.tryClaimDedupWindow.mockResolvedValue(true);
-      db.notification.create.mockResolvedValue({});
     });
 
     it('scope=all matches every device', async () => {
@@ -125,7 +131,7 @@ describe('AlertRuleEvaluator', () => {
 
       await evaluator.handleDeviceOffline(payload);
 
-      expect(db.notification.create).toHaveBeenCalledTimes(1);
+      expect(notifications.create).toHaveBeenCalledTimes(1);
     });
 
     it('scope=tag matches when device has the tag', async () => {
@@ -138,7 +144,7 @@ describe('AlertRuleEvaluator', () => {
 
       await evaluator.handleDeviceOffline(payload);
 
-      expect(db.notification.create).toHaveBeenCalledTimes(1);
+      expect(notifications.create).toHaveBeenCalledTimes(1);
     });
 
     it('scope=tag skips when device lacks the tag', async () => {
@@ -149,7 +155,7 @@ describe('AlertRuleEvaluator', () => {
 
       await evaluator.handleDeviceOffline(payload);
 
-      expect(db.notification.create).not.toHaveBeenCalled();
+      expect(notifications.create).not.toHaveBeenCalled();
     });
 
     it('scope=tag with scopeTagId=null (Tag was deleted) skips with WARN log', async () => {
@@ -161,7 +167,7 @@ describe('AlertRuleEvaluator', () => {
 
       await evaluator.handleDeviceOffline(payload);
 
-      expect(db.notification.create).not.toHaveBeenCalled();
+      expect(notifications.create).not.toHaveBeenCalled();
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('scope=tag but scopeTagId=null'));
     });
 
@@ -175,7 +181,7 @@ describe('AlertRuleEvaluator', () => {
 
       await evaluator.handleDeviceOffline(payload);
 
-      expect(db.notification.create).toHaveBeenCalledTimes(1);
+      expect(notifications.create).toHaveBeenCalledTimes(1);
     });
 
     it('scope=group with scopeGroupId=null skips with WARN log', async () => {
@@ -187,7 +193,7 @@ describe('AlertRuleEvaluator', () => {
 
       await evaluator.handleDeviceOffline(payload);
 
-      expect(db.notification.create).not.toHaveBeenCalled();
+      expect(notifications.create).not.toHaveBeenCalled();
       expect(warnSpy).toHaveBeenCalled();
     });
 
@@ -199,7 +205,7 @@ describe('AlertRuleEvaluator', () => {
 
       await evaluator.handleDeviceOffline(payload);
 
-      expect(db.notification.create).toHaveBeenCalledTimes(1);
+      expect(notifications.create).toHaveBeenCalledTimes(1);
     });
 
     it('scope=display skips when scopeDisplayId is different', async () => {
@@ -210,7 +216,7 @@ describe('AlertRuleEvaluator', () => {
 
       await evaluator.handleDeviceOffline(payload);
 
-      expect(db.notification.create).not.toHaveBeenCalled();
+      expect(notifications.create).not.toHaveBeenCalled();
     });
 
     it('unknown scope value skips with WARN log', async () => {
@@ -220,7 +226,7 @@ describe('AlertRuleEvaluator', () => {
 
       await evaluator.handleDeviceOffline(payload);
 
-      expect(db.notification.create).not.toHaveBeenCalled();
+      expect(notifications.create).not.toHaveBeenCalled();
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown scope'));
     });
   });
@@ -256,14 +262,13 @@ describe('AlertRuleEvaluator', () => {
 
     await evaluator.handleDeviceOffline(payload);
 
-    expect(db.notification.create).not.toHaveBeenCalled();
+    expect(notifications.create).not.toHaveBeenCalled();
   });
 
   it('passes both ruleId AND deviceId to tryClaimDedupWindow (per-device dedup)', async () => {
     db.display.findUnique.mockResolvedValue(makeDevice());
     alertRulesService.findActiveForEvent.mockResolvedValue([makeRule({ id: 'rule-X' })]);
     alertRulesService.tryClaimDedupWindow.mockResolvedValue(true);
-    db.notification.create.mockResolvedValue({});
 
     await evaluator.handleDeviceOffline(payload);
 
@@ -279,7 +284,6 @@ describe('AlertRuleEvaluator', () => {
     alertRulesService.findActiveForEvent.mockResolvedValue([makeRule()]);
     // First call: claim succeeds for device-A
     alertRulesService.tryClaimDedupWindow.mockResolvedValueOnce(true);
-    db.notification.create.mockResolvedValue({});
 
     await evaluator.handleDeviceOffline({ deviceId: 'device-A', deviceName: 'A', organizationId: orgId });
 
@@ -291,7 +295,7 @@ describe('AlertRuleEvaluator', () => {
     await evaluator.handleDeviceOffline({ deviceId: 'device-B', deviceName: 'B', organizationId: orgId });
 
     // Both devices got their in_app notification
-    expect(db.notification.create).toHaveBeenCalledTimes(2);
+    expect(notifications.create).toHaveBeenCalledTimes(2);
   });
 
   // ---------------------------------------------------------------------------
@@ -308,8 +312,8 @@ describe('AlertRuleEvaluator', () => {
       }),
     ]);
     alertRulesService.tryClaimDedupWindow.mockResolvedValue(true);
-    // Make the in_app dispatch throw — emulating an FK violation on userId
-    db.notification.create.mockRejectedValueOnce(new Error('FK violation on userId'));
+    // Make the in_app dispatch throw — emulating a failure inside create()
+    notifications.create.mockRejectedValueOnce(new Error('create failed'));
     mail.sendDeviceOfflineAlertEmail.mockResolvedValue(undefined);
 
     await evaluator.handleDeviceOffline(payload);
@@ -321,22 +325,24 @@ describe('AlertRuleEvaluator', () => {
   // ---------------------------------------------------------------------------
   // Channels
   // ---------------------------------------------------------------------------
-  it('dispatches in_app via db.notification.create with scoped userId', async () => {
+  it('dispatches in_app via NotificationsService.create with scoped userId (so it broadcasts)', async () => {
     db.display.findUnique.mockResolvedValue(makeDevice());
     alertRulesService.findActiveForEvent.mockResolvedValue([makeRule()]);
     alertRulesService.tryClaimDedupWindow.mockResolvedValue(true);
-    db.notification.create.mockResolvedValue({});
 
     await evaluator.handleDeviceOffline(payload);
 
-    expect(db.notification.create).toHaveBeenCalledWith({
-      data: expect.objectContaining({
+    expect(notifications.create).toHaveBeenCalledWith(
+      expect.objectContaining({
         organizationId: orgId,
         userId: 'user-1',
         type: 'device_offline',
         severity: 'warning',
       }),
-    });
+    );
+    // The raw db write is no longer used by the in_app path — the broadcast
+    // only fires when routed through NotificationsService.create().
+    expect(db.notification.create).not.toHaveBeenCalled();
   });
 
   it('in_app dispatch skips when recipient user no longer in the rule\'s org (cross-tenant guard)', async () => {
@@ -348,7 +354,7 @@ describe('AlertRuleEvaluator', () => {
 
     await evaluator.handleDeviceOffline(payload);
 
-    expect(db.notification.create).not.toHaveBeenCalled();
+    expect(notifications.create).not.toHaveBeenCalled();
   });
 
   it('dispatches slack_webhook with maxRedirects:0 and 5s timeout', async () => {
@@ -420,7 +426,7 @@ describe('AlertRuleEvaluator', () => {
 
     await evaluator.handleDeviceOffline(payload);
 
-    expect(db.notification.create).not.toHaveBeenCalled();
+    expect(notifications.create).not.toHaveBeenCalled();
     expect(mail.sendDeviceOfflineAlertEmail).not.toHaveBeenCalled();
     expect(http.post).not.toHaveBeenCalled();
   });

--- a/middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.ts
+++ b/middleware/src/modules/notifications/alert-rules/alert-rule.evaluator.ts
@@ -2,9 +2,9 @@ import { Injectable, Logger } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { OnEvent } from '@nestjs/event-emitter';
 import { firstValueFrom } from 'rxjs';
-import { Prisma } from '@vizora/database';
 import { DatabaseService } from '../../database/database.service';
 import { MailService } from '../../mail/mail.service';
+import { NotificationsService } from '../notifications.service';
 import { AlertRulesService } from './alert-rules.service';
 import {
   Channel,
@@ -49,6 +49,7 @@ export class AlertRuleEvaluator {
     private readonly alertRulesService: AlertRulesService,
     private readonly mail: MailService,
     private readonly http: HttpService,
+    private readonly notifications: NotificationsService,
   ) {}
 
   /**
@@ -213,16 +214,19 @@ export class AlertRuleEvaluator {
       );
       return;
     }
-    await this.db.notification.create({
-      data: {
-        organizationId: payload.organizationId,
-        userId: recipient.target,
-        type: 'device_offline',
-        severity: 'warning',
-        title: 'Device offline',
-        message: `${payload.deviceName} is offline`,
-        metadata: { deviceId: payload.deviceId } as Prisma.InputJsonValue,
-      },
+    // Route through NotificationsService.create() rather than a raw
+    // db.notification.create() so the new row is broadcast over the realtime
+    // gateway (notification:new) — otherwise the dashboard bell only picks up
+    // a device-offline alert on its next 5-min poll. The org-scope re-check
+    // inside create() is harmless defense-in-depth on top of the guard above.
+    await this.notifications.create({
+      organizationId: payload.organizationId,
+      userId: recipient.target,
+      type: 'device_offline',
+      severity: 'warning',
+      title: 'Device offline',
+      message: `${payload.deviceName} is offline`,
+      metadata: { deviceId: payload.deviceId },
     });
   }
 

--- a/middleware/src/modules/notifications/notifications.service.spec.ts
+++ b/middleware/src/modules/notifications/notifications.service.spec.ts
@@ -1,5 +1,5 @@
 import { NotFoundException } from '@nestjs/common';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { NotificationsService } from './notifications.service';
 import { DatabaseService } from '../database/database.service';
 
@@ -141,6 +141,68 @@ describe('NotificationsService', () => {
           userId: 'user-123',
         }),
       });
+    });
+
+    it('broadcasts the new notification to the realtime gateway', async () => {
+      const created = { id: 'notif-1', title: 'Test', organizationId };
+      db.notification.create.mockResolvedValue(created);
+
+      const prevSecret = process.env.INTERNAL_API_SECRET;
+      process.env.INTERNAL_API_SECRET = 'test-internal-secret';
+      try {
+        await service.create({ title: 'Test', message: 'Hello', organizationId });
+      } finally {
+        if (prevSecret === undefined) {
+          delete process.env.INTERNAL_API_SECRET;
+        } else {
+          process.env.INTERNAL_API_SECRET = prevSecret;
+        }
+      }
+
+      expect(mockHttpService.post).toHaveBeenCalledWith(
+        expect.stringContaining('/api/notifications/broadcast'),
+        { organizationId, notification: created },
+        expect.objectContaining({
+          headers: { 'x-internal-api-key': 'test-internal-secret' },
+        }),
+      );
+    });
+
+    it('does not broadcast when INTERNAL_API_SECRET is unset', async () => {
+      db.notification.create.mockResolvedValue({ id: 'notif-1' });
+
+      const prevSecret = process.env.INTERNAL_API_SECRET;
+      delete process.env.INTERNAL_API_SECRET;
+      try {
+        await service.create({ title: 'Test', message: 'Hello', organizationId });
+      } finally {
+        if (prevSecret !== undefined) {
+          process.env.INTERNAL_API_SECRET = prevSecret;
+        }
+      }
+
+      expect(mockHttpService.post).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when the realtime broadcast fails (fire-and-forget)', async () => {
+      db.notification.create.mockResolvedValue({ id: 'notif-1' });
+      // The realtime call is firstValueFrom(httpService.post(...)); model the
+      // real failure mode as a rejected observable, not a synchronous throw.
+      mockHttpService.post.mockReturnValue(throwError(() => new Error('realtime down')));
+
+      const prevSecret = process.env.INTERNAL_API_SECRET;
+      process.env.INTERNAL_API_SECRET = 'test-internal-secret';
+      try {
+        await expect(
+          service.create({ title: 'Test', message: 'Hello', organizationId }),
+        ).resolves.toEqual({ id: 'notif-1' });
+      } finally {
+        if (prevSecret === undefined) {
+          delete process.env.INTERNAL_API_SECRET;
+        } else {
+          process.env.INTERNAL_API_SECRET = prevSecret;
+        }
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Closes the live remnant of backlog **L8** ("wire real-time notification emission on creation"). Drift-check confirmed L3 (custom error pages), L8 (generic notification broadcast), and L9 (polling reduction → already 5-min + WebSocket) were already shipped via the #92–#106 hardening wave — but a **§9c data-path trace** surfaced one real residual gap.

**The gap:** `AlertRuleEvaluator.dispatchInApp()` (O7) wrote device-offline notifications with a raw `db.notification.create()`, **bypassing** `NotificationsService.create()` — the only path that broadcasts `notification:new` to the realtime gateway. So device-*online* alerts (device.gateway.ts:635) and generic notifications pushed in real-time, but the most customer-important alert — **a device went offline** — only appeared on the dashboard bell's next 5-minute poll.

## Fix

Route `dispatchInApp` through `NotificationsService.create()` so the new row is broadcast over the existing realtime HTTP→gateway path (`POST /api/notifications/broadcast`). 

- **Drift tag:** `Vizora-native` — reuses the existing `broadcastNotification` substrate; no new infra, no schema, no config, no operator action.
- Evaluator keeps its own org-scope pre-check (the stale-recipient diagnostic); `create()` re-validates as defense-in-depth.
- Same NestJS module — no circular dependency, no `forwardRef` needed.

## Data path now closed
`device.offline` → `AlertRuleEvaluator.dispatchInApp` → `NotificationsService.create()` → `broadcastNotification()` → realtime `org:{id}` room → dashboard bell (real-time).

## Tests
Closes the path at both hops:
- **evaluator spec:** asserts `dispatchInApp` delegates to `NotificationsService.create()` and no longer writes the row directly.
- **service spec:** adds previously-missing coverage that `create()` broadcasts to `/api/notifications/broadcast` with the internal header, and stays fire-and-forget when the broadcast fails (rejected-observable model).

Middleware: all notifications-module specs pass (incl. 8/8 for the two changed files). `tsc --noEmit` exit 0.

## Review
Independent diff review (orthogonal vectors: structural / DI / behavior-preservation / cross-tenant / test-quality) returned clean — no critical/important findings; one minor polish (model broadcast failure as rejected observable) applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)