### PR TITLE
feat(web): device remote control panel (reload/restart/clear cache)

### DIFF
--- a/web/src/app/dashboard/devices/[id]/page.tsx
+++ b/web/src/app/dashboard/devices/[id]/page.tsx
@@ -7,6 +7,7 @@ import { apiClient } from '@/lib/api';
 import { Display } from '@/lib/types';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import DeviceStatusIndicator from '@/components/DeviceStatusIndicator';
+import { DeviceControls } from '@/components/devices/DeviceControls';
 import { Icon } from '@/theme/icons';
 
 // Extended display type for fields the backend returns but the base type doesn't include
@@ -217,6 +218,9 @@ export default function DeviceDetailPage() {
           </div>
         </div>
       )}
+
+      {/* Device Controls */}
+      <DeviceControls deviceId={device.id} />
 
       {/* Current Playlist */}
       {device.currentPlaylistId && (

--- a/web/src/components/devices/DeviceControls.test.tsx
+++ b/web/src/components/devices/DeviceControls.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { DeviceControls } from './DeviceControls';
+import { apiClient } from '@/lib/api';
+
+jest.mock('@/lib/api', () => ({
+  apiClient: {
+    sendFleetCommand: jest.fn(),
+  },
+}));
+
+const mockSuccess = jest.fn();
+const mockError = jest.fn();
+jest.mock('@/lib/hooks/useToast', () => ({
+  useToast: () => ({ success: mockSuccess, error: mockError }),
+}));
+
+jest.mock('@/theme/icons', () => ({
+  Icon: () => <span data-testid="icon" />,
+}));
+
+const sendFleetCommand = apiClient.sendFleetCommand as jest.Mock;
+
+const onlineResult = {
+  commandId: 'cmd-1',
+  command: 'reload',
+  target: { type: 'device', id: 'dev-1' },
+  devicesTargeted: 1,
+  devicesOnline: 1,
+  devicesQueued: 0,
+};
+
+describe('DeviceControls', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sendFleetCommand.mockResolvedValue(onlineResult);
+  });
+
+  it('renders the three control buttons', () => {
+    render(<DeviceControls deviceId="dev-1" />);
+    expect(screen.getByRole('button', { name: 'Reload Screen' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Restart App' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Clear Cache' })).toBeInTheDocument();
+  });
+
+  it('sends reload immediately to the single-device target without a dialog', async () => {
+    render(<DeviceControls deviceId="dev-1" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reload Screen' }));
+
+    await waitFor(() =>
+      expect(sendFleetCommand).toHaveBeenCalledWith({
+        command: 'reload',
+        target: { type: 'device', id: 'dev-1' },
+      }),
+    );
+    expect(mockSuccess).toHaveBeenCalledWith('Reload Screen sent');
+  });
+
+  it('requires confirmation before restarting', async () => {
+    render(<DeviceControls deviceId="dev-1" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restart App' }));
+
+    // Dialog shown, command not yet sent
+    expect(screen.getByText('Restart device app?')).toBeInTheDocument();
+    expect(sendFleetCommand).not.toHaveBeenCalled();
+
+    // Confirm via the dialog's action button
+    fireEvent.click(screen.getByRole('button', { name: 'Send Command' }));
+
+    await waitFor(() =>
+      expect(sendFleetCommand).toHaveBeenCalledWith({
+        command: 'restart',
+        target: { type: 'device', id: 'dev-1' },
+      }),
+    );
+  });
+
+  it('reports a queued message when the device is offline', async () => {
+    sendFleetCommand.mockResolvedValueOnce({
+      ...onlineResult,
+      devicesOnline: 0,
+      devicesQueued: 1,
+    });
+    render(<DeviceControls deviceId="dev-1" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reload Screen' }));
+
+    await waitFor(() =>
+      expect(mockSuccess).toHaveBeenCalledWith(
+        expect.stringContaining('queued'),
+      ),
+    );
+  });
+
+  it('shows an error toast when the command fails', async () => {
+    sendFleetCommand.mockRejectedValueOnce(new Error('network down'));
+    render(<DeviceControls deviceId="dev-1" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reload Screen' }));
+
+    await waitFor(() =>
+      expect(mockError).toHaveBeenCalledWith('network down'),
+    );
+  });
+});

--- a/web/src/components/devices/DeviceControls.tsx
+++ b/web/src/components/devices/DeviceControls.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useState } from 'react';
+import { apiClient } from '@/lib/api';
+import { useToast } from '@/lib/hooks/useToast';
+import ConfirmDialog from '@/components/ConfirmDialog';
+
+type DeviceControlCommand = 'reload' | 'restart' | 'clear_cache';
+
+interface DeviceControlsProps {
+  deviceId: string;
+}
+
+interface CommandMeta {
+  command: DeviceControlCommand;
+  label: string;
+  description: string;
+  /** Present for disruptive commands that require a confirmation step. */
+  confirm?: { title: string; message: string };
+}
+
+// Intentionally a safe subset of the gateway's DeviceCommandType — only the
+// reversible screen controls are exposed here (no disable/enable, no push).
+const COMMANDS: CommandMeta[] = [
+  {
+    command: 'reload',
+    label: 'Reload Screen',
+    description: 'Refresh the current content without restarting the app.',
+  },
+  {
+    command: 'restart',
+    label: 'Restart App',
+    description: 'Relaunch the player application on the device.',
+    confirm: {
+      title: 'Restart device app?',
+      message:
+        'The player application will relaunch. The screen will be briefly blank while it restarts.',
+    },
+  },
+  {
+    command: 'clear_cache',
+    label: 'Clear Cache',
+    description:
+      'Clear cached content and reload. Use if the screen shows stale content.',
+    confirm: {
+      title: 'Clear cache?',
+      message:
+        'Cached content will be cleared and the screen reloaded. The next load may be slower than usual.',
+    },
+  },
+];
+
+/**
+ * Remote control panel for a single device. Wired to the existing fleet
+ * command endpoint (POST /fleet/commands) via apiClient.sendFleetCommand with
+ * a single-device target. The realtime gateway delivers the command to online
+ * devices immediately and QUEUES it in Redis for offline devices (delivered on
+ * reconnect), so we report the backend's online/queued counts rather than
+ * blocking when the device is offline.
+ */
+export function DeviceControls({ deviceId }: DeviceControlsProps) {
+  const toast = useToast();
+  const [confirming, setConfirming] = useState<CommandMeta | null>(null);
+  const [loadingCommand, setLoadingCommand] = useState<DeviceControlCommand | null>(
+    null,
+  );
+
+  const send = async (meta: CommandMeta) => {
+    try {
+      setLoadingCommand(meta.command);
+      const result = await apiClient.sendFleetCommand({
+        command: meta.command,
+        target: { type: 'device', id: deviceId },
+      });
+      if (result.devicesOnline > 0) {
+        toast.success(`${meta.label} sent`);
+      } else {
+        toast.success(
+          `Device is offline — ${meta.label} queued and will run when it reconnects`,
+        );
+      }
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : 'Failed to send command to device',
+      );
+    } finally {
+      setLoadingCommand(null);
+      setConfirming(null);
+    }
+  };
+
+  const handleClick = (meta: CommandMeta) => {
+    if (meta.confirm) {
+      setConfirming(meta);
+    } else {
+      void send(meta);
+    }
+  };
+
+  return (
+    <div className="bg-[var(--surface)] rounded-lg shadow overflow-hidden">
+      <div className="px-6 py-4 border-b border-[var(--border)]">
+        <h2 className="text-lg font-semibold text-[var(--foreground)]">
+          Device Controls
+        </h2>
+      </div>
+      <div className="px-6 py-4">
+        <p className="text-sm text-[var(--foreground-secondary)] mb-4">
+          Send a remote command to this screen. Commands run immediately on online
+          devices and are queued for offline devices until they reconnect.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          {COMMANDS.map((meta) => (
+            <button
+              key={meta.command}
+              type="button"
+              onClick={() => handleClick(meta)}
+              disabled={loadingCommand !== null}
+              title={meta.description}
+              className="px-4 py-2 text-sm font-medium text-[var(--foreground)] border border-[var(--border)] rounded-lg hover:bg-[var(--surface-hover)] transition disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {loadingCommand === meta.command ? 'Sending…' : meta.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <ConfirmDialog
+        isOpen={confirming !== null}
+        title={confirming?.confirm?.title ?? ''}
+        message={confirming?.confirm?.message ?? ''}
+        confirmText="Send Command"
+        type="warning"
+        onConfirm={() => {
+          if (confirming) void send(confirming);
+        }}
+        onClose={() => setConfirming(null)}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes backlog **L7** — adds a per-device remote control panel (**reload / restart / clear-cache**) to the device detail page.

Drift-check finding: the command stack already exists end-to-end — fleet endpoint `POST /api/v1/fleet/commands` (`middleware/src/modules/fleet/`), realtime `broadcastCommand`, the Electron handlers in `display/src/electron/device-client.ts`, AND a fleet-wide web sibling (`web/src/components/fleet/FleetCommandDropdown.tsx`). The only gap was a **single-device** control surface on the detail page.

## What's added (web-only)
- **`DeviceControls`** component on the device detail page: **Reload Screen** (immediate), **Restart App** + **Clear Cache** (confirmation dialog), with toast feedback.
- Reuses the existing `apiClient.sendFleetCommand({ command, target: { type:'device', id } })`, the shared `ConfirmDialog`, and `useToast` — mirroring `FleetCommandDropdown`. **No new API-client surface.**

## Honest offline handling
The realtime `broadcastCommand` emits to the device room **and queues in Redis for offline devices** (delivered on reconnect). So the UI reports **"sent"** when `devicesOnline > 0` and **"queued … when it reconnects"** otherwise — truthful to the backend, no blocking, no false success.

- **Drift tag:** `Vizora-native` — reuses the fleet→realtime→device substrate; no backend / schema / device / operator changes.

## Verification
- `tsc --noEmit -p web/tsconfig.json` → **exit 0**.
- `DeviceControls.test.tsx` → **5/5 pass**: reload-immediate (no dialog), restart-confirm (via dialog), online "sent" vs offline "queued", error toast.

## Review
Independent diff review (compiles/APIs-exist · reaches-the-lever · honest-UX · cross-tenant · test-quality · conventions) — **clean pass**, one minor/acceptable note (test couples to the dialog's confirm-button label). Cross-tenant safety confirmed: `fleet.service.resolveTargetDevices` scopes `type:'device'` by `organizationId`.

> **History note:** the first commit on this branch referenced APIs that don't exist (`sendDeviceCommand`, `@/components/ui/ConfirmDialog`, `useToast().toast`) and did not compile. It was rewritten against the real APIs and the branch was amended; this PR is the corrected, verified version.

## Known follow-up (pre-existing, not introduced here)
The device detail page reads status once on mount (no live status subscription). With offline-queuing this is no longer a correctness issue for these controls (offline commands queue), so it's purely cosmetic. Out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)