### PR TITLE
fix(content): make generic-api widget render (O8) — add missing template

### DIFF
--- a/middleware/src/modules/content/template-rendering.service.spec.ts
+++ b/middleware/src/modules/content/template-rendering.service.spec.ts
@@ -14,7 +14,10 @@ jest.mock('isomorphic-dompurify', () => ({
 }));
 
 // Import after mocking
+import * as fs from 'fs';
+import * as path from 'path';
 import { TemplateRenderingService } from './template-rendering.service';
+import { GenericApiDataSource } from './widget-data-sources/generic-api.data-source';
 
 // Mock fetch globally
 const mockFetch = jest.fn();
@@ -640,6 +643,41 @@ describe('TemplateRenderingService', () => {
       expect(result).toContain('Menu');
       expect(result).toContain('Burger');
       expect(result).toContain('Fries');
+    });
+  });
+
+  describe('generic-api widget template (O8)', () => {
+    // End-to-end proof for the O8 fix: getDefaultTemplate() now points at
+    // widget-templates/generic-api.hbs (filename, not inline markup). Confirm
+    // that file exists and renders the data source's sample data into the
+    // styled list using only built-in helpers — not the "No data" fallback.
+    const hbsPath = path.join(__dirname, 'widget-templates', 'generic-api.hbs');
+
+    it('the .hbs file the data source points at exists on disk', () => {
+      const source = new GenericApiDataSource({} as any);
+      const filename = source.getDefaultTemplate();
+      expect(fs.existsSync(path.join(__dirname, 'widget-templates', `${filename}.hbs`))).toBe(true);
+    });
+
+    it('renders array sample data into the list (not the empty fallback)', () => {
+      const hbs = fs.readFileSync(hbsPath, 'utf-8');
+      const sample = new GenericApiDataSource({} as any).getSampleData();
+
+      const result = service.renderTemplate(hbs, sample);
+
+      expect(result).toContain('generic-api-widget');
+      expect(result).toContain('<ul');
+      expect(result).toContain('Sample Item A'); // {{#each data}} → {{this.name}}
+      expect(result).not.toContain('No data available');
+    });
+
+    it('renders the empty fallback when data is missing', () => {
+      const hbs = fs.readFileSync(hbsPath, 'utf-8');
+
+      const result = service.renderTemplate(hbs, {});
+
+      expect(result).toContain('No data available');
+      expect(result).not.toContain('<ul');
     });
   });
 });

--- a/middleware/src/modules/content/widget-data-sources/generic-api.data-source.spec.ts
+++ b/middleware/src/modules/content/widget-data-sources/generic-api.data-source.spec.ts
@@ -320,10 +320,14 @@ describe('GenericApiDataSource', () => {
       expect(schema).toHaveProperty('url');
     });
 
-    it('getDefaultTemplate returns a Handlebars string', () => {
+    it('getDefaultTemplate returns the .hbs filename token, not inline markup', () => {
+      // loadWidgetTemplate() is filename-based (reads widget-templates/<name>.hbs).
+      // Returning inline Handlebars made it sanitize the markup to a garbage
+      // filename, miss the .hbs, and throw — so generic-api widgets never
+      // rendered. The contract is a bare filename, like every other source.
       const tpl = dataSource.getDefaultTemplate();
-      expect(typeof tpl).toBe('string');
-      expect(tpl).toContain('{{');
+      expect(tpl).toBe('generic-api');
+      expect(tpl).not.toContain('{{');
     });
 
     it('getSampleData returns a structurally-valid sample', () => {

--- a/middleware/src/modules/content/widget-data-sources/generic-api.data-source.ts
+++ b/middleware/src/modules/content/widget-data-sources/generic-api.data-source.ts
@@ -178,17 +178,14 @@ export class GenericApiDataSource implements WidgetDataSource {
   }
 
   getDefaultTemplate(): string {
-    return `
-{{#if data}}
-  {{#if (isArray data)}}
-    <ul>{{#each data}}<li>{{this}}</li>{{/each}}</ul>
-  {{else}}
-    <pre>{{json data}}</pre>
-  {{/if}}
-{{else}}
-  <p>No data.</p>
-{{/if}}
-`.trim();
+    // Return the template FILENAME (without .hbs), matching the contract every
+    // other data source follows (weather → 'weather', rss → 'rss', …).
+    // loadWidgetTemplate() is filename-based: it sanitizes this value and loads
+    // widget-templates/<name>.hbs. Returning inline Handlebars here made it
+    // sanitize the markup to a garbage filename, miss the existing
+    // widget-templates/generic-api.hbs, and silently fall back to a raw
+    // <pre> JSON dump instead of the styled list the .hbs renders.
+    return 'generic-api';
   }
 
   getSampleData(): Record<string, unknown> {

--- a/middleware/src/modules/content/widget-templates/generic-api.hbs
+++ b/middleware/src/modules/content/widget-templates/generic-api.hbs
@@ -1,0 +1,14 @@
+<div class="generic-api-widget" style="height:100%;width:100%;box-sizing:border-box;padding:24px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#ffffff;color:#0f172a;overflow:hidden;">
+  {{#if data}}
+  <ul style="list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:12px;">
+    {{#each data}}
+    <li style="display:flex;justify-content:space-between;align-items:baseline;gap:16px;padding:12px 16px;border:1px solid #e2e8f0;border-radius:10px;">
+      <span style="font-size:18px;font-weight:600;color:#0f172a;">{{this.name}}{{this.title}}</span>
+      {{#if this.price}}<span style="font-size:18px;font-variant-numeric:tabular-nums;color:#2563eb;">{{this.price}}</span>{{/if}}
+    </li>
+    {{/each}}
+  </ul>
+  {{else}}
+  <p style="text-align:center;color:#64748b;font-size:18px;">No data available</p>
+  {{/if}}
+</div>

--- a/middleware/webpack.config.js
+++ b/middleware/webpack.config.js
@@ -17,7 +17,21 @@ module.exports = {
       compiler: 'tsc',
       main: './src/main.ts',
       tsConfig: './tsconfig.app.json',
-      assets: ['./src/assets'],
+      // Widget Handlebars templates are read at runtime via
+      // fs.readFileSync(path.join(__dirname, 'widget-templates', ...)) in
+      // content.service.ts. Once bundled, __dirname is dist/, so the .hbs
+      // files must be copied next to main.js — otherwise loadWidgetTemplate
+      // throws for EVERY widget type in production (weather, rss-*, social-*,
+      // generic-api). They render in dev/test because __dirname there is the
+      // source dir that already holds them.
+      assets: [
+        './src/assets',
+        {
+          glob: '**/*.hbs',
+          input: './src/modules/content/widget-templates',
+          output: './widget-templates',
+        },
+      ],
       optimization: false,
       outputHashing: 'none',
       generatePackageJson: true,


### PR DESCRIPTION
## Summary

Closes backlog **O8** (generic API-to-screen data source) — and fixes a latent prod bug affecting **all** widget types. The `GenericApiDataSource` was registered and reachable (`POST /widgets`, `/widgets/preview`, `/widgets/:id/refresh`) but creating/previewing one always threw 400, and even the working widget types never rendered in production.

## Two root causes

**1. Wrong `getDefaultTemplate()` contract.** It returned an **inline Handlebars string**, but `ContentService.loadWidgetTemplate()` is **filename-based**: it sanitizes the value (`replace(/[^a-zA-Z0-9_-]/g,'')`), reads `widget-templates/<name>.hbs`, and **throws `BadRequestException` on miss**. The inline markup sanitized to a garbage filename, and **no `generic-api.hbs` existed**. Fix: return `'generic-api'` (matching every other source) + add the missing `.hbs` (built-in `{{#if}}`/`{{#each}}` only → no new `TemplateRenderingService` helper; DOMPurify-allowlisted tags only → survives the device render path).

**2. Widget templates never shipped to prod.** `webpack.config.js` had `assets: ['./src/assets']` only — **verified by local build that `dist/` contained 0 `.hbs`**. Prod runs the bundle (`ecosystem.config.js` → `dist/middleware/main.js`) and `loadWidgetTemplate` reads `__dirname/widget-templates/<name>.hbs`, so **every** widget type (weather, rss-*, social-*, generic-api) threw 400 in production — a pre-existing latent bug. Fix: copy `widget-templates/**/*.hbs` → `dist/widget-templates` via the Nx assets glob (also deduped the file's copy-paste-doubled keys). **Verified: build exit 0, `dist/widget-templates/` now holds all 8 templates (was 0).**

- **Drift tag:** `Vizora-native` — completes an existing widget-source; reuses `loadWidgetTemplate`/`renderTemplate`/the bundle asset pipeline. No new infra, schema, config, device, or operator changes.

## Notes
- **Scalar-array narrowing (minor, v1):** old inline rendered scalar arrays via `{{this}}`; the new `.hbs` targets arrays of objects (`{{this.name}}`/`{{this.price}}`). Acceptable v1 narrowing per the source's documented lean cut.
- **Backend closure:** create/preview/refresh now work and `GET /widgets/types` is correct. Surfacing `generic-api` in the web widget-create UI is a separate follow-up (no frontend reads `defaultTemplate`, so the metadata change is safe).
- **Optional future hardening (not in this PR):** a boot-time check that a known `.hbs` is loadable would catch any future source-vs-bundle path drift at startup rather than on first widget creation.

## Verification (output read, not assumed)
- Content module suite (run via `--runTestsByPath`): **15 suites / 648 pass / 3 skip, exit 0**. `generic-api.data-source` **31/31** incl. the tightened contract test; `template-rendering.service` incl. 3 new render tests (file-exists-on-disk; sample data → styled `<ul>`; empty data → fallback).
- `tsc --noEmit` → **exit 0**.
- `npx nx build @vizora/middleware` → **exit 0**, `dist/widget-templates/` contains all 8 `.hbs`.

## Review
Two independent reviews: the code/template/tests diff, and a focused review of the webpack asset change (build/deploy infra). Both clean/approve. The asset-glob output path was confirmed correct against the runtime `__dirname/widget-templates` resolution and verified by dist inspection.

> Process note: an early in-progress version referenced a `.hbs` that didn't exist and ran the wrong test command; nothing false was merged. The asset-copy gap was caught by review, **verified real by local build (0 .hbs in dist)**, and fixed here — not waved off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)