### PR TITLE
feat(auth): email user when their password is changed (M12)

### DIFF
--- a/middleware/src/modules/auth/auth.service.spec.ts
+++ b/middleware/src/modules/auth/auth.service.spec.ts
@@ -138,6 +138,7 @@ describe('AuthService', () => {
     mockMailService = {
       sendPasswordResetEmail: jest.fn().mockResolvedValue(undefined),
       sendWelcomeEmail: jest.fn().mockResolvedValue(undefined),
+      sendPasswordChangedEmail: jest.fn().mockResolvedValue(undefined),
     };
 
     mockGeoService = {
@@ -795,6 +796,54 @@ describe('AuthService', () => {
 
       await expect(service.googleLogin('malformed')).rejects.toThrow(UnauthorizedException);
       await expect(service.googleLogin('malformed')).rejects.toThrow('Invalid Google token');
+    });
+  });
+
+  describe('changePassword', () => {
+    it('changes the password, invalidates the cache, and sends the security email (M12)', async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue(mockUser);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+      (bcrypt.hash as jest.Mock).mockResolvedValue('new-hashed-password');
+      mockDatabaseService.user.update.mockResolvedValue({ ...mockUser });
+
+      await service.changePassword('user-123', 'current-pw', 'new-pw');
+
+      expect(mockDatabaseService.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-123' },
+        data: { passwordHash: 'new-hashed-password' },
+      });
+      expect(mockRedisService.del).toHaveBeenCalledWith('user_auth:user-123');
+      // Security alert: the user is emailed that their password changed.
+      expect(mockMailService.sendPasswordChangedEmail).toHaveBeenCalledWith(
+        mockUser.email,
+        mockUser.firstName,
+      );
+    });
+
+    it('throws and does NOT email when the current password is wrong', async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue(mockUser);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+
+      await expect(
+        service.changePassword('user-123', 'wrong-pw', 'new-pw'),
+      ).rejects.toThrow(UnauthorizedException);
+
+      expect(mockDatabaseService.user.update).not.toHaveBeenCalled();
+      expect(mockMailService.sendPasswordChangedEmail).not.toHaveBeenCalled();
+    });
+
+    it('still succeeds when the security email fails (non-blocking)', async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue(mockUser);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+      (bcrypt.hash as jest.Mock).mockResolvedValue('new-hashed-password');
+      mockDatabaseService.user.update.mockResolvedValue({ ...mockUser });
+      mockMailService.sendPasswordChangedEmail.mockRejectedValue(new Error('smtp down'));
+
+      await expect(
+        service.changePassword('user-123', 'current-pw', 'new-pw'),
+      ).resolves.toBeUndefined();
+
+      expect(mockDatabaseService.user.update).toHaveBeenCalled();
     });
   });
 });

--- a/middleware/src/modules/auth/auth.service.ts
+++ b/middleware/src/modules/auth/auth.service.ts
@@ -627,6 +627,18 @@ export class AuthService {
 
     // Invalidate user cache so next auth uses fresh data
     await this.redisService.del(`user_auth:${userId}`);
+
+    // Security notification (M12): tell the user their password changed, so an
+    // unauthorized change is noticed. Non-blocking — sendMail already swallows
+    // its own errors, but guard here too so a mail-layer throw can never fail
+    // the password change itself.
+    try {
+      await this.mailService.sendPasswordChangedEmail(user.email, user.firstName);
+    } catch (err) {
+      this.logger.warn(
+        `Failed to send password-changed email for user ${userId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   async updateProfile(userId: string, data: { firstName?: string; lastName?: string }) {

--- a/middleware/src/modules/mail/mail.service.ts
+++ b/middleware/src/modules/mail/mail.service.ts
@@ -428,4 +428,31 @@ export class MailService {
 
     await this.sendMail(to, subject, html, 'Password reset', 'auth');
   }
+
+  /**
+   * Security notification sent after a user's password is changed (M12).
+   * Confirms the change and gives the user a recovery path if it wasn't them.
+   * Contains no secrets — only the display name + static copy. firstName is
+   * user-controlled, so it's escaped before interpolation.
+   */
+  async sendPasswordChangedEmail(to: string, firstName: string): Promise<void> {
+    const subject = 'Your Vizora password was changed';
+    const html = this.wrapInTemplate(`
+          <h1 style="color:#F0ECE8;font-size:22px;font-weight:700;margin:0 0 8px 0;">Your password was changed</h1>
+          <p style="color:#8A9BA3;font-size:14px;line-height:1.6;margin:0 0 24px 0;">
+            Hi ${MailService.escapeHtml(firstName)},<br><br>
+            This is a confirmation that the password for your Vizora account was just changed.
+            For your security, you've been signed out everywhere and will need to log in again.
+          </p>
+          <p style="color:#8A9BA3;font-size:14px;line-height:1.6;margin:0 0 24px 0;">
+            If you made this change, no further action is needed.
+          </p>
+          ${this.ctaButton('Go to Dashboard', this.dashboardUrl)}
+          <p style="color:#5A6B73;font-size:12px;line-height:1.5;margin:16px 0 0 0;">
+            If you did <strong style="color:#F0ECE8;">not</strong> change your password, reset it immediately
+            and contact support@vizora.cloud — your account may be compromised.
+          </p>
+    `);
+    await this.sendMail(to, subject, html, 'Password changed', 'auth');
+  }
 }

--- a/middleware/src/modules/mail/mail.service.ts
+++ b/middleware/src/modules/mail/mail.service.ts
@@ -442,9 +442,6 @@ export class MailService {
           <p style="color:#8A9BA3;font-size:14px;line-height:1.6;margin:0 0 24px 0;">
             Hi ${MailService.escapeHtml(firstName)},<br><br>
             This is a confirmation that the password for your Vizora account was just changed.
-            For your security, you've been signed out everywhere and will need to log in again.
-          </p>
-          <p style="color:#8A9BA3;font-size:14px;line-height:1.6;margin:0 0 24px 0;">
             If you made this change, no further action is needed.
           </p>
           ${this.ctaButton('Go to Dashboard', this.dashboardUrl)}


### PR DESCRIPTION
## Summary

Closes the bounded half of backlog **M12 (security alert emails)** — notify a user when **their password is changed**.

When a logged-in user changes their password via `AuthService.changePassword`, nothing was sent. So a password rotated by someone who knew the current password (e.g. an attacker in an open session) went **unnoticed**. Note the forgot-password **reset** flow only sends a reset *link* (`sendPasswordResetEmail`), not a "changed" confirmation — so there was no existing method to reuse.

## Change
- **`mail.service.ts`**: new `sendPasswordChangedEmail(to, firstName)`, mirroring `sendPasswordResetEmail` — `auth` sender, `firstName` escaped via `MailService.escapeHtml`, static security copy, **no secrets**, with recovery guidance if it wasn't the user.
- **`auth.service.ts`**: call it after the successful password update + cache invalidation, **non-blocking** (`try/catch` + `logger.warn`) so a mail failure can never fail the change. Sent **only on success** — every validation failure throws first. `MailService` was already injected (constructor) and `MailModule` is `@Global`, so **no DI/module change**.

- **Drift tag:** `Vizora-native` — reuses the existing MailService/template substrate; **zero schema change**.

## Scope note
This is the **password-changed** half. The **new-login / unrecognized-device** alert half of M12 is deferred — it needs a schema migration (login IP / device history) + detection design, a separate larger task.

## Tests / verification (output read)
- `auth.service.spec.ts`: adds `sendPasswordChangedEmail` to the mail mock + a `describe('changePassword')` block — happy path asserts the email is sent with `(email, firstName)`; wrong-current-password asserts it throws with **no update and no email**; email-rejects asserts the change **still resolves** (non-blocking guarantee).
- Integrity run (auth + mail + users): **120 tests pass across 3 suites**. `tsc --noEmit` → **exit 0**.

## Review
Independent diff review (DI / reaches-the-lever / failure-isolation / security-sensitivity / test-quality / regressions) — **clean, no critical/important/minor blocking findings**. Confirmed: email sent only on success, XSS-safe (escaped name), no secrets, no other `changePassword` caller affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)