### PR TITLE
fix(auth): invalidate sessions on password change/reset (M12 follow-up)

### DIFF
--- a/docs/plans/2026-05-31-session-invalidation-on-password-change.md
+++ b/docs/plans/2026-05-31-session-invalidation-on-password-change.md
@@ -1,0 +1,149 @@
+# Session invalidation on password change (M12 security follow-up)
+
+**Date:** 2026-05-31
+**Branch:** `fix/session-invalidation-on-password-change`
+**Drift tag:** `Vizora-native` — reuses the existing Redis + `JwtStrategy.validate` revocation substrate. No new infra, **no schema migration**.
+
+## Problem
+
+`AuthService.changePassword` (auth.service.ts:606) updates the password hash and
+clears the `user_auth:${userId}` cache, but does **not** invalidate existing JWTs.
+Vizora revocation today is:
+
+- `revoked_token:${jti}` — single-token (logout / refresh). `JwtStrategy.validate:84`.
+- `user_revoked:${sub}` — **boolean** "kill ALL tokens for this user", written only by
+  account deletion / admin deactivation. `JwtStrategy.validate:98`.
+
+A 7-day-lived stolen/other-device session survives a password change until natural
+expiry. A push security review (HIGH) flagged this on PR #110; the email copy was
+corrected, with the real fix deferred to this PR.
+
+**Why not the boolean `user_revoked:`** — `changePassword` returns no new token
+(controller:81 returns only a message), so the user must re-login. A boolean
+`user_revoked:${sub}` would also reject that fresh re-login (same `sub`, key still
+present) — locking the user out until the 7-day TTL. The reviewer called this out.
+
+## Design — Redis revoked-AT timestamp + `iat` comparison
+
+Precise, not blunt: reject tokens minted *before* the change; allow any token minted
+*after*.
+
+1. **Write on change** — write the marker on **BOTH** password-change paths
+   (plan-gate review finding — the forgot-password takeover is the higher-severity
+   case and must not be skipped):
+   - `changePassword` (logged-in user) — after the existing `user_auth:` cache clear.
+   - `resetPassword` (forgot-password token flow, auth.service.ts:549) — after the
+     transaction commits + the `login_attempts:` del (line 603). userId is
+     `tokenRecord.userId`. **This is the primary attack-surface case:** an attacker who
+     resets a stolen-email account must kill the legitimate user's live sessions.
+
+   Both call a shared private helper to avoid drift:
+   ```ts
+   private async markPasswordChanged(userId: string): Promise<void> {
+     try {
+       await this.redisService.set(
+         `pwd_changed:${userId}`,
+         String(Math.floor(Date.now() / 1000)),
+         AUTH_CONSTANTS.TOKEN_EXPIRY_SECONDS, // 7d — self-expiring; all pre-change tokens dead by then
+       );
+     } catch (err) {
+       this.logger.warn(`Failed to write pwd_changed marker for user ${userId}: ${err instanceof Error ? err.message : String(err)}`);
+     }
+   }
+   ```
+   New distinct key `pwd_changed:` — does NOT overload the boolean `user_revoked:`
+   (different semantics: "kill ALL incl. new" vs "kill pre-timestamp only").
+
+   **resetPassword lockout note:** like changePassword, resetPassword returns no
+   token (controller:432 returns only a message) — the user logs in afterward, fresh
+   `iat ≥ marker`, passes. No lockout.
+
+2. **Check in `JwtStrategy.validate`** — add right after the existing
+   `user_revoked` check (line ~101), BEFORE the `user_auth:` cache read (so a cached
+   user can't skip it for 60s):
+   ```ts
+   if (payload.iat) {
+     const pwdChangedAt = await this.redisService.get(`pwd_changed:${payload.sub}`);
+     if (pwdChangedAt && payload.iat < Number(pwdChangedAt)) {
+       throw new UnauthorizedException('Session expired — please log in again');
+     }
+   }
+   ```
+   Add `iat?: number` to the `JwtPayload` interface (present at runtime via
+   jsonwebtoken; `signOptions` has no `noTimestamp`).
+
+## Why it's precise (no lockout of the fresh login)
+
+- User's current token: `iat < change_time` → **rejected** next request. Old session
+  (incl. attacker / other device) killed. ✓
+- Re-login after change: `login()` mints a new token whose `iat = login_time ≥ change_time`
+  → `iat < stored` is false → **passes**. ✓ (login happens after the change, almost
+  always a later second; even same-second `iat == stored` passes since comparison is `<`.)
+- Refresh bypass: `/auth/refresh` is **not `@Public`** → global `APP_GUARD` runs
+  `JwtStrategy.validate` on the OLD token first → rejected before refresh issues a new
+  one. No bypass. ✓ (verified auth.controller.ts:refresh)
+
+## Residual risks (documented, accepted)
+
+- **1-second sliver:** an old token with `iat` in the *exact same second* as the change
+  survives (`iat == stored`, not `<`). Negligible vs the current 7-day survival; using
+  `<` is required to never reject the fresh login. Accepted.
+- **Redis down on write:** if the `set` fails, old tokens survive (same failure mode as
+  today). Wrap in try/catch + `logger.warn` so it never fails the password change
+  (consistent with the existing non-blocking email). Not worse than status quo.
+- **Redis down on read (validate):** `redisService.get` throwing would reject the
+  request. Existing `revoked_token`/`user_revoked` checks already call Redis in validate
+  with no catch, so this matches established behavior — not a new failure mode. (If we
+  wanted fail-open we'd diverge from the existing pattern; keep consistent.)
+
+## Files
+
+- `middleware/src/modules/auth/auth.service.ts` — `markPasswordChanged()` helper; call it
+  in BOTH `changePassword` and `resetPassword`.
+- `middleware/src/modules/auth/strategies/jwt.strategy.ts` — `iat` on `JwtPayload` + the check
+  (after `user_revoked`, before the `user_auth:` cache read).
+- `middleware/src/modules/auth/auth.service.spec.ts` — assert the key is written on BOTH
+  changePassword and resetPassword.
+- `middleware/src/modules/auth/strategies/jwt.strategy.spec.ts` — assert: pre-change token
+  rejected; post-change token passes; no-key passes; same-second passes; missing-`iat` passes
+  (no crash).
+
+## Plan-gate review note (addressed)
+
+Independent review flagged that `resetPassword` (the forgot-password flow) was missing from
+the original scope — it's the highest-severity case (attacker resets a stolen account → must
+kill the legit user's sessions). Added above. Also confirmed: `iat` must be added to the
+`JwtPayload` interface (else the check is a silent no-op); the check goes before the 60s
+`user_auth:` cache early-return; `JwtAuthGuard` is the global `APP_GUARD` (auth.module.ts:49)
+so `/auth/refresh` (guarded, not `@Public`) re-validates the old token first — no bypass.
+
+## Known residual — realtime dashboard WebSocket (MEDIUM, documented, NOT fixed here)
+
+Second (adversarial) review found: the realtime gateway authenticates **dashboard**
+WebSocket clients independently (`realtime/src/gateways/device.gateway.ts:414-436`,
+`JWT_SECRET`). It checks `revoked_token:${jti}` but **not** `user_revoked:` **nor**
+`pwd_changed:`. So a dashboard socket connected with a pre-change token keeps its
+**read-mostly** streams (device-status / notifications) alive after a password change
+until it reconnects.
+
+- **Not introduced by this PR** — pre-existing; the gateway already omits the
+  `user_revoked:` deactivation kill-switch too, so its gap is broader than password
+  change alone.
+- **Not bolted in here** — it's a separate service + separate auth surface; folding a
+  realtime-handshake change into a REST auth PR is exactly the scope-creep we avoid.
+- **Scope of this PR's claim:** REST API sessions (the primary surface + every
+  account-mutating path) are invalidated. Realtime dashboard streams are not, yet.
+- **Follow-up (recorded in tasks/todo.md):** extend the realtime dashboard handshake to
+  consult `pwd_changed:` (and ideally `user_revoked:`) — it already shares Redis. Its own
+  PR + review.
+
+## Out of scope (do NOT bolt on)
+
+- DB `passwordChangedAt` column (heavier option a) — only if this Redis path proves brittle.
+- M12 new-login / unrecognized-device alert (separate, needs device-history migration).
+
+## Verification plan
+
+- `jwt.strategy.spec.ts` + `auth.service.spec.ts` via `--runTestsByPath` (read output).
+- `tsc --noEmit` exit 0.
+- Two independent review passes (orthogonal vectors) before PR. No self-merge.

--- a/middleware/src/modules/auth/auth.service.spec.ts
+++ b/middleware/src/modules/auth/auth.service.spec.ts
@@ -115,6 +115,10 @@ describe('AuthService', () => {
       auditLog: {
         create: jest.fn(),
       },
+      passwordResetToken: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+      },
       // Mock $transaction to execute the callback with the same mock database
       $transaction: jest.fn().mockImplementation(async (callback) => {
         return callback(mockDatabaseService);
@@ -813,6 +817,13 @@ describe('AuthService', () => {
         data: { passwordHash: 'new-hashed-password' },
       });
       expect(mockRedisService.del).toHaveBeenCalledWith('user_auth:user-123');
+      // Session invalidation: writes the pwd_changed marker so pre-change
+      // tokens (other devices / stolen) are rejected by JwtStrategy.validate.
+      expect(mockRedisService.set).toHaveBeenCalledWith(
+        'pwd_changed:user-123',
+        expect.any(String),
+        expect.any(Number),
+      );
       // Security alert: the user is emailed that their password changed.
       expect(mockMailService.sendPasswordChangedEmail).toHaveBeenCalledWith(
         mockUser.email,
@@ -844,6 +855,38 @@ describe('AuthService', () => {
       ).resolves.toBeUndefined();
 
       expect(mockDatabaseService.user.update).toHaveBeenCalled();
+    });
+  });
+
+  describe('resetPassword', () => {
+    it('writes the pwd_changed marker so the reset kills pre-reset sessions (takeover defense)', async () => {
+      // forgot-password reset is the primary account-takeover case: an attacker
+      // who resets a stolen-email account must invalidate the legit user's
+      // live sessions. Reset returns no token; the user logs in afterward.
+      mockDatabaseService.passwordResetToken.findUnique.mockResolvedValue({
+        id: 'tok-1',
+        userId: 'user-123',
+        token: 'hashed',
+        usedAt: null,
+        expiresAt: new Date(Date.now() + 60_000),
+        user: { id: 'user-123', email: 'test@example.com', organizationId: 'org-123' },
+      });
+      mockDatabaseService.user.update.mockResolvedValue({ id: 'user-123' });
+      mockDatabaseService.passwordResetToken.update.mockResolvedValue({ id: 'tok-1' });
+      (bcrypt.hash as jest.Mock).mockResolvedValue('new-hashed-password');
+
+      await service.resetPassword('raw-token', 'new-pw');
+
+      expect(mockDatabaseService.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-123' },
+        data: { passwordHash: 'new-hashed-password' },
+      });
+      expect(mockRedisService.del).toHaveBeenCalledWith('user_auth:user-123');
+      expect(mockRedisService.set).toHaveBeenCalledWith(
+        'pwd_changed:user-123',
+        expect.any(String),
+        expect.any(Number),
+      );
     });
   });
 });

--- a/middleware/src/modules/auth/auth.service.ts
+++ b/middleware/src/modules/auth/auth.service.ts
@@ -601,6 +601,40 @@ export class AuthService {
 
     // Clear login attempt counter for this user
     await this.redisService.del(`login_attempts:${tokenRecord.user.email}`);
+
+    // Invalidate user cache + kill all sessions issued before this reset. This
+    // is the primary account-takeover case: an attacker who resets a stolen
+    // account must not leave the legitimate user's live sessions valid.
+    await this.redisService.del(`user_auth:${tokenRecord.userId}`);
+    await this.markPasswordChanged(tokenRecord.userId);
+  }
+
+  /**
+   * Record the moment a user's password changed so JwtStrategy.validate can
+   * reject any token minted before it (session invalidation). Stored as a
+   * Redis epoch-seconds timestamp under `pwd_changed:${userId}` with the same
+   * 7-day TTL as the token lifetime — by expiry, every pre-change token is
+   * already dead, so the key self-cleans.
+   *
+   * Non-blocking: a Redis failure must never fail the password change. The
+   * worst case on failure is the status quo (old tokens survive to natural
+   * expiry), so we log and continue rather than throw.
+   *
+   * Uses `<` (strict) in the validate-side comparison, so the user's fresh
+   * post-change login (iat >= this timestamp) is never rejected.
+   */
+  private async markPasswordChanged(userId: string): Promise<void> {
+    try {
+      await this.redisService.set(
+        `pwd_changed:${userId}`,
+        String(Math.floor(Date.now() / 1000)),
+        AUTH_CONSTANTS.TOKEN_EXPIRY_SECONDS,
+      );
+    } catch (err) {
+      this.logger.warn(
+        `Failed to write pwd_changed marker for user ${userId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   async changePassword(userId: string, currentPassword: string, newPassword: string) {
@@ -627,6 +661,11 @@ export class AuthService {
 
     // Invalidate user cache so next auth uses fresh data
     await this.redisService.del(`user_auth:${userId}`);
+
+    // Kill all sessions issued before this change (other devices / a stolen
+    // session). JwtStrategy.validate rejects tokens with iat < this timestamp;
+    // the user's fresh re-login passes.
+    await this.markPasswordChanged(userId);
 
     // Security notification (M12): tell the user their password changed, so an
     // unauthorized change is noticed. Non-blocking — sendMail already swallows

--- a/middleware/src/modules/auth/strategies/jwt.strategy.spec.ts
+++ b/middleware/src/modules/auth/strategies/jwt.strategy.spec.ts
@@ -337,6 +337,93 @@ describe('JwtStrategy', () => {
       });
     });
 
+    describe('password-change session invalidation (pwd_changed:)', () => {
+      const mockUser = {
+        id: 'user-123',
+        email: 'test@example.com',
+        firstName: 'Test',
+        lastName: 'User',
+        organizationId: 'org-123',
+        role: 'admin',
+        isActive: true,
+        organization: {
+          id: 'org-123',
+          name: 'Test Organization',
+          storageUsedBytes: BigInt(0),
+          storageQuotaBytes: BigInt(1073741824),
+        },
+      };
+
+      const basePayload: JwtPayload = {
+        sub: 'user-123',
+        email: 'test@example.com',
+        organizationId: 'org-123',
+        role: 'admin',
+      };
+
+      // exists() stays false (no jti/user revocation). get() returns the
+      // change-timestamp for `pwd_changed:` and null for the user_auth cache,
+      // so each test exercises the DB path unless it asserts a rejection first.
+      const withPwdChangedAt = (ts: number) =>
+        mockRedisService.get.mockImplementation((key: string) =>
+          Promise.resolve(key.startsWith('pwd_changed:') ? String(ts) : null),
+        );
+
+      beforeEach(() => {
+        mockDatabaseService.user.findUnique.mockResolvedValue(mockUser as any);
+      });
+
+      it('rejects a token minted BEFORE the last password change', async () => {
+        withPwdChangedAt(2_000_000);
+        await expect(
+          strategy.validate({ ...basePayload, iat: 1_999_999 }),
+        ).rejects.toThrow('Session expired — please log in again');
+      });
+
+      it('does not hit the database for a pre-change (rejected) token', async () => {
+        withPwdChangedAt(2_000_000);
+        await strategy.validate({ ...basePayload, iat: 1_999_999 }).catch(() => {});
+        expect(mockDatabaseService.user.findUnique).not.toHaveBeenCalled();
+      });
+
+      it('passes a token minted AFTER the last password change', async () => {
+        withPwdChangedAt(2_000_000);
+        const result = await strategy.validate({ ...basePayload, iat: 2_000_001 });
+        expect(result).toMatchObject({ id: 'user-123' });
+      });
+
+      it('passes a token minted in the SAME second as the change (strict <, no lockout)', async () => {
+        withPwdChangedAt(2_000_000);
+        const result = await strategy.validate({ ...basePayload, iat: 2_000_000 });
+        expect(result).toMatchObject({ id: 'user-123' });
+      });
+
+      it('passes when no pwd_changed: marker exists', async () => {
+        mockRedisService.get.mockResolvedValue(null);
+        const result = await strategy.validate({ ...basePayload, iat: 2_000_000 });
+        expect(result).toMatchObject({ id: 'user-123' });
+      });
+
+      it('passes when the token carries no iat (check is a safe no-op)', async () => {
+        withPwdChangedAt(2_000_000);
+        const result = await strategy.validate(basePayload); // no iat
+        expect(result).toMatchObject({ id: 'user-123' });
+      });
+
+      it('checks pwd_changed BEFORE the user_auth cache (cache cannot skip invalidation)', async () => {
+        // A cache HIT would normally short-circuit; the pwd_changed check runs
+        // first, so a stale cached user with a pre-change token is still rejected.
+        mockRedisService.get.mockImplementation((key: string) => {
+          if (key.startsWith('pwd_changed:')) return Promise.resolve('2000000');
+          if (key.startsWith('user_auth:')) return Promise.resolve(JSON.stringify(mockUser));
+          return Promise.resolve(null);
+        });
+        await expect(
+          strategy.validate({ ...basePayload, iat: 1_999_999 }),
+        ).rejects.toThrow('Session expired — please log in again');
+      });
+    });
+
     describe('token type handling', () => {
       it('should treat undefined type as user token', async () => {
         const payload: JwtPayload = {

--- a/middleware/src/modules/auth/strategies/jwt.strategy.ts
+++ b/middleware/src/modules/auth/strategies/jwt.strategy.ts
@@ -107,6 +107,12 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     // (other device, or a stolen token) and must die. Strict `<` so the user's
     // fresh post-change login (iat >= timestamp) is never rejected. Placed
     // before the user_auth: cache read so a cached user can't skip it.
+    // Fail-OPEN on a token with no `iat` (the `if (payload.iat)` guard skips
+    // the check). Acceptable today: every token generateToken() produces carries
+    // iat (jsonwebtoken sets it unless signOptions has `noTimestamp`, which we
+    // don't). If a future code path mints iat-less user tokens, this check
+    // silently stops invalidating them — re-evaluate then. Strict `<` so the
+    // user's fresh post-change login (iat >= marker, incl. same-second) passes.
     if (payload.iat) {
       const pwdChangedAt = await this.redisService.get(`pwd_changed:${payload.sub}`);
       if (pwdChangedAt && payload.iat < Number(pwdChangedAt)) {

--- a/middleware/src/modules/auth/strategies/jwt.strategy.ts
+++ b/middleware/src/modules/auth/strategies/jwt.strategy.ts
@@ -14,6 +14,7 @@ export interface JwtPayload {
   isSuperAdmin?: boolean;
   type?: string; // 'user' or 'device'
   jti?: string; // JWT ID for token revocation
+  iat?: number; // issued-at (epoch seconds) — set by jsonwebtoken; used for password-change session invalidation
 }
 
 /** Shape of request.user set by JwtStrategy.validate() */
@@ -98,6 +99,19 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     const isUserRevoked = await this.redisService.exists(`user_revoked:${payload.sub}`);
     if (isUserRevoked) {
       throw new UnauthorizedException('User account is no longer active');
+    }
+
+    // Reject tokens minted BEFORE the user's last password change (session
+    // invalidation). changePassword / resetPassword write `pwd_changed:${sub}`
+    // = epoch-seconds; any token with an older `iat` is a pre-change session
+    // (other device, or a stolen token) and must die. Strict `<` so the user's
+    // fresh post-change login (iat >= timestamp) is never rejected. Placed
+    // before the user_auth: cache read so a cached user can't skip it.
+    if (payload.iat) {
+      const pwdChangedAt = await this.redisService.get(`pwd_changed:${payload.sub}`);
+      if (pwdChangedAt && payload.iat < Number(pwdChangedAt)) {
+        throw new UnauthorizedException('Session expired — please log in again');
+      }
     }
 
     // Check Redis cache first to avoid DB hit on every request


### PR DESCRIPTION
## Summary

Closes the **HIGH** security gap a push security review flagged on PR #110: `AuthService.changePassword` only cleared the `user_auth:` cache, so existing JWTs (other devices, a **stolen session**) survived a password change until natural 7-day expiry. `resetPassword` — the higher-severity **account-takeover** path (attacker resets a stolen-email account) — also left the legitimate user's sessions live.

**Vizora-native, no schema migration** — reuses Redis + `JwtStrategy.validate`. (The heavier DB `passwordChangedAt` option was explicitly avoided per operator guidance; this lighter path is precise enough to never lock out the fresh login.)

## Change
- **`markPasswordChanged(userId)`** helper writes `pwd_changed:${userId}` = epoch-seconds (TTL = 7d token lifetime → self-cleaning). **Non-blocking** try/catch — a Redis failure logs + continues (worst case = pre-fix status quo); never fails the password change.
- Called from **both** `changePassword` and `resetPassword`; `resetPassword` now also clears `user_auth:` (parity with `changePassword`).
- **`JwtStrategy.validate`** rejects tokens with `iat < pwd_changed:${sub}` (**strict `<`** → the user's fresh post-change re-login always passes). Placed **after** the `user_revoked` check and **before** the `user_auth:` 60s cache read (a cached user can't ride a pre-change token). `iat` added to `JwtPayload`.

## Security properties verified
- **No bypass:** `/auth/refresh` is guarded (`@UseGuards(JwtAuthGuard)`, not `@Public`) → the old token hits `validate` first and is rejected before a new one is minted. Device tokens rejected earlier; MCP uses its own guard.
- **No lockout:** `changePassword`/`resetPassword` return no token; the user re-logs in with `iat ≥ marker`; strict `<` passes same-second.
- **Fail modes:** Redis-down on write → swallowed (status quo); on read → 500, consistent with the existing uncaught `exists()` checks above it (not a new dependency). A corrupted key fail-opens for one user only (degrades to status quo), no attacker-writable path (`sub` is the authenticated subject).

## Known residual (documented, **separate follow-up — not bolted in**)
The realtime gateway authenticates **dashboard** WebSocket clients independently (`realtime/src/gateways/device.gateway.ts:414-436`, `JWT_SECRET`) and checks `revoked_token:` but **not** `pwd_changed:`/`user_revoked:`. A pre-change dashboard socket keeps **read-mostly** streams (status/notifications) alive until reconnect. Pre-existing, separate service + auth surface; folding it in would be scope-creep. **This PR's claim is scoped to REST API sessions** (the primary surface + all account-mutating paths). Follow-up recorded in `tasks/todo.md`.

## Tests / verification (output read)
- `jwt.strategy.spec.ts` **+7**: pre-change reject (+ no-DB-hit), post-change pass, same-second pass (no lockout), no-marker pass, no-`iat` safe no-op, cache-skip guard.
- `auth.service.spec.ts` **+2**: `changePassword` writes the marker; `resetPassword` takeover-defense writes the marker.
- **Auth module: 8 suites / 227 tests pass.** `tsc --noEmit` exit 0.

## Reviews (two independent, orthogonal passes — gate before PR)
1. **Plan-gate:** found the `resetPassword` scope gap (originally `changePassword`-only) → fixed before any code.
2. **Adversarial (bypass/race/failure):** **SAFE TO MERGE** for the REST surface; surfaced the realtime MEDIUM residual above (documented, not blocking).

No self-merge — awaiting operator merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)