### PR TITLE
fix(realtime): apply session invalidation to dashboard WS handshake

### DIFF
--- a/realtime/src/gateways/device.gateway.spec.ts
+++ b/realtime/src/gateways/device.gateway.spec.ts
@@ -34,6 +34,7 @@ describe('DeviceGateway', () => {
     setPendingPlaylist: jest.fn().mockResolvedValue(undefined),
     getPendingPlaylist: jest.fn().mockResolvedValue(null),
     exists: jest.fn().mockResolvedValue(false),
+    get: jest.fn().mockResolvedValue(null),
     getCachedPlaylist: jest.fn().mockResolvedValue(null),
     cachePlaylist: jest.fn().mockResolvedValue(undefined),
   };
@@ -264,6 +265,80 @@ describe('DeviceGateway', () => {
 
       await gateway.handleConnection(client as any);
       expect(client.disconnect).toHaveBeenCalled();
+    });
+
+    // Dashboard-user session invalidation — mirrors the REST JwtStrategy
+    // checks (PR #111) on the realtime handshake, reading the shared Redis
+    // keys middleware writes: user_revoked:${sub} and pwd_changed:${sub}.
+    it('should reject a dashboard user whose account was revoked (user_revoked:)', async () => {
+      mockJwtService.verify
+        .mockImplementationOnce(() => { throw new Error('invalid device token'); })
+        .mockReturnValueOnce({
+          sub: 'user-1',
+          email: 'test@example.com',
+          organizationId: 'org-1',
+          type: 'user',
+          jti: 'jti-1',
+        });
+      mockRedisService.exists.mockImplementation((key: string) =>
+        Promise.resolve(key === 'user_revoked:user-1'),
+      );
+
+      const client = createMockSocket();
+
+      await gateway.handleConnection(client as any);
+      expect(client.disconnect).toHaveBeenCalled();
+      expect(client.join).not.toHaveBeenCalledWith('org:org-1');
+    });
+
+    it('should reject a dashboard user token minted before the last password change (pwd_changed:)', async () => {
+      mockJwtService.verify
+        .mockImplementationOnce(() => { throw new Error('invalid device token'); })
+        .mockReturnValueOnce({
+          sub: 'user-1',
+          email: 'test@example.com',
+          organizationId: 'org-1',
+          type: 'user',
+          jti: 'jti-1',
+          iat: 1_999_999,
+        });
+      mockRedisService.exists.mockResolvedValue(false); // not revoked
+      mockRedisService.get.mockImplementation((key: string) =>
+        Promise.resolve(key === 'pwd_changed:user-1' ? '2000000' : null),
+      );
+
+      const client = createMockSocket();
+
+      await gateway.handleConnection(client as any);
+      expect(client.disconnect).toHaveBeenCalled();
+      expect(client.join).not.toHaveBeenCalledWith('org:org-1');
+    });
+
+    it('should accept a dashboard user token minted after the last password change', async () => {
+      mockJwtService.verify
+        .mockImplementationOnce(() => { throw new Error('invalid device token'); })
+        .mockReturnValueOnce({
+          sub: 'user-1',
+          email: 'test@example.com',
+          organizationId: 'org-1',
+          type: 'user',
+          jti: 'jti-1',
+          iat: 2_000_001,
+        });
+      mockRedisService.exists.mockResolvedValue(false);
+      mockRedisService.get.mockImplementation((key: string) =>
+        Promise.resolve(key === 'pwd_changed:user-1' ? '2000000' : null),
+      );
+
+      const client = createMockSocket();
+
+      await gateway.handleConnection(client as any);
+      // Assert the pwd_changed key was actually queried — without this, the
+      // test would stay green even if the whole check were deleted (a fresh
+      // login always connects). This makes it a real positive sentinel.
+      expect(mockRedisService.get).toHaveBeenCalledWith('pwd_changed:user-1');
+      expect(client.join).toHaveBeenCalledWith('org:org-1');
+      expect(client.disconnect).not.toHaveBeenCalled();
     });
 
     it('should rate limit excessive connections from same IP', async () => {

--- a/realtime/src/gateways/device.gateway.ts
+++ b/realtime/src/gateways/device.gateway.ts
@@ -54,6 +54,7 @@ interface UserPayload {
   organizationId: string;
   type?: string;
   jti?: string;
+  iat?: number; // issued-at (epoch seconds), set by jsonwebtoken — used for password-change session invalidation
 }
 
 type AuthPayload =
@@ -422,6 +423,34 @@ export class DeviceGateway
           const isRevoked = await this.redisService.exists(`revoked_token:${userPayload.jti}`);
           if (isRevoked) {
             this.logger.warn(`Connection rejected: User token revoked (jti: ${userPayload.jti})`);
+            client.disconnect();
+            return null;
+          }
+        }
+
+        // Mirror the REST JwtStrategy.validate session checks (PR #111) for the
+        // dashboard WebSocket handshake, which authenticates separately and
+        // previously only checked per-token revocation. The middleware writes
+        // these keys to the SAME Redis instance, so a stolen/other-device
+        // dashboard socket can't keep streaming after the account is
+        // deactivated or its password changed.
+        //
+        // (1) User-wide revocation — admin deactivation / self-delete.
+        const isUserRevoked = await this.redisService.exists(`user_revoked:${userPayload.sub}`);
+        if (isUserRevoked) {
+          this.logger.warn(`Connection rejected: user revoked (sub: ${userPayload.sub})`);
+          client.disconnect();
+          return null;
+        }
+
+        // (2) Password-change session invalidation — reject tokens minted
+        // before the last password change. Strict `<` so a fresh post-change
+        // login (iat >= marker) connects. Fail-open if the token has no iat
+        // (every middleware-issued token carries one — see JwtStrategy note).
+        if (userPayload.iat) {
+          const pwdChangedAt = await this.redisService.get(`pwd_changed:${userPayload.sub}`);
+          if (pwdChangedAt && userPayload.iat < Number(pwdChangedAt)) {
+            this.logger.warn(`Connection rejected: session expired by password change (sub: ${userPayload.sub})`);
             client.disconnect();
             return null;
           }


### PR DESCRIPTION
## Summary

Closes the documented residual from **PR #111**. The realtime gateway authenticates **dashboard** WebSocket clients separately (`device.gateway.ts` → `authenticateConnection`, user-JWT branch, `JWT_SECRET`) and previously checked only `revoked_token:${jti}`. So after a password change or account deactivation, a pre-change dashboard socket kept receiving `device:status` / `notification:new` / `screenshot:ready` streams **until it reconnected** — #111 invalidated the REST surface but not this one.

## Change
Mirror the two REST-side checks (merged in #111) onto the handshake, reading the **same Redis keys middleware writes** (realtime shares the same `REDIS_URL`):
- **`user_revoked:${sub}`** (admin deactivation / self-delete) via `exists()`
- **`pwd_changed:${sub}`** via `get()` + strict `iat < Number(...)` — a fresh post-change login (`iat ≥ marker`) still connects (no lockout)

Placed in the user-JWT block, after the `revoked_token` check, before `client.data` assignment. The block's existing `try/catch` makes a Redis failure **fail-closed** (reject the handshake), consistent with the `revoked_token` check already there. `iat` added to the realtime `UserPayload` interface.

- **Drift tag:** `Vizora-native` — reuses shared Redis + the gateway's auth block + existing `RedisService.get/exists`. No new substrate, no schema change. Faithful mirror of the merged `JwtStrategy.validate` pattern (same key names, operator, parse, iat guard). Middleware untouched.

## Known residual (bounded — separate-PR follow-up, NOT bolted on)
**Connect-time** check only. A socket opened **before** the change stays connected until it disconnects/reconnects — the gateway has never had per-message re-auth for any check (incl. `revoked_token`). Dashboard sockets are **read-only** status/notifications; the window is bounded by socket lifetime, and any reconnect re-checks. Net gain over `main`: previously deactivation/password-change had **zero** effect on connected dashboard sockets. Future hardening (own PR): Redis pub/sub force-disconnect on key write, or periodic sweep.

## Tests / verification (output read via jest JSON reporter — text layer flaky this session)
- `device.gateway.spec.ts` **+3**: `user_revoked` → disconnect + not-joined; pre-change `iat` → disconnect + not-joined; post-change `iat` → joins org room **and asserts `pwd_changed:` was queried** (real positive sentinel — would fail if the check were removed).
- Full realtime suite: **10 suites / 220 tests pass, 0 fail** (`success=true`). `tsc --noEmit` exit 0.

## Reviews (two independent passes — gate before PR)
1. Plan/scope drift-check: confirmed shared Redis, `iat` availability, exact insertion point — bounded, no blocker.
2. Adversarial diff review: **SAFE TO MERGE**, no critical/important. Surfaced one test-sentinel weakness (post-change test would pass even if the check were deleted) → **fixed** by asserting the `get` call. Connect-time residual documented above.

No self-merge — awaiting operator merge. **CI not green at push time → verify before merge** (note #111 had a late-registering `e2e` check; wait for all to report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)