### PR TITLE
feat(realtime): mid-session WS teardown for invalidated dashboard sessions

### DIFF
--- a/docs/plans/2026-05-31-realtime-ws-session-teardown.md
+++ b/docs/plans/2026-05-31-realtime-ws-session-teardown.md
@@ -1,0 +1,162 @@
+# Realtime WS mid-session teardown (session-invalidation follow-up)
+
+**Date:** 2026-05-31
+**Branch:** `feat/realtime-ws-session-teardown`
+**Drift tag:** `Vizora-native` — extends the realtime gateway's existing auth checks + its existing periodic-cleanup-interval pattern. Reuses Redis keys already written by middleware. No new infra, no schema migration, **no middleware change**.
+
+## Problem (the residual from PR #112)
+
+PR #112 added **connect-time** session-invalidation checks to the dashboard WebSocket
+handshake (`device.gateway.ts authenticateConnection`, user-JWT branch): it rejects a
+handshake when `user_revoked:${sub}` exists or the token's `iat < pwd_changed:${sub}`.
+
+But the gateway authenticates **only at handshake** — there is no per-message re-auth and
+no teardown of *already-connected* sockets. So a dashboard socket that connected *before*
+a password change / account deactivation keeps receiving its streams (`device:status`,
+`notification:new`, `screenshot:ready`) until it naturally disconnects/reconnects (tab
+close, refresh, network drop, server restart). Window = socket lifetime.
+
+Severity: MEDIUM. Dashboard sockets are **read-only** (status/notifications); they cannot
+issue commands. But a stolen/again-deactivated session keeping a live read stream is a
+confidentiality gap the session-invalidation story should close.
+
+## Verified ground truth
+
+- Dashboard user connect: `handleConnection` (~240-248) joins `org:${orgId}`, stores
+  `client.data.{userId, organizationId, isDashboard:true}`. The verified `userPayload`
+  (incl. `iat`) is available in `authenticateConnection` (~412-465). **`iat` is NOT
+  currently stored on `client.data`.**
+- The two Redis keys already exist and are read at connect-time today:
+  `user_revoked:${userId}` (boolean, `exists`) and `pwd_changed:${userId}`
+  (epoch-seconds, `get`). Written by middleware: `pwd_changed:` via
+  `auth.service.markPasswordChanged` (changePassword + resetPassword); `user_revoked:`
+  via `auth.service.deleteAccount` (:928), `users.service.deactivate` (:215),
+  `users-admin.service` (:339).
+- `realtime/src/services/redis.service.ts` exposes `get`/`exists` (used by #112).
+- The gateway ALREADY runs periodic cleanup via `this.cleanupIntervals.push(setInterval(
+  ..., 60000 / 5*60*1000))` in its constructor, cleared in `onModuleDestroy`.
+- Socket.IO 4.8: `server.in(room).fetchSockets()` + `socket.disconnect(true)` available.
+
+## Mechanism decision
+
+Two options were named in the follow-up note: **(A) HTTP push on key-write** vs
+**(B) realtime-side periodic sweep**. **Recommendation: B (sweep).**
+
+### B — Periodic sweep (RECOMMENDED)
+
+A new gateway interval (mirroring the existing cleanup loops) periodically re-applies the
+same checks the handshake already does, to *connected* dashboard sockets:
+
+```
+every SWEEP_INTERVAL (default 60s):
+  sockets = server.fetchSockets() filtered to client.data.isDashboard
+  group by client.data.userId  (dedup Redis reads → one pair of reads per distinct user)
+  for each userId:
+    if exists(user_revoked:userId):            disconnect ALL that user's sockets
+    else:
+      pc = get(pwd_changed:userId)
+      if pc: for each socket: if socket.data.tokenIat < Number(pc): disconnect that socket
+  emit 'session:expired' to the socket just before disconnect(true) so the dashboard UI
+  can show a "signed out" state instead of a silent drop.
+```
+
+Requires one extra field at connect: `client.data.tokenIat = userPayload.iat` (so the
+per-socket `pwd_changed` comparison works; `user_revoked` needs only `userId`).
+
+**Why B over A:**
+1. **Zero middleware changes.** A would inject `HttpService` into `AuthService` (which has
+   none today) + a new realtime endpoint + DTO + gateway method + a `user:${sub}` room,
+   and to cover `user_revoked:` would wire HTTP calls into 3 separate services. B touches
+   only `device.gateway.ts` (+ its spec).
+2. **Covers BOTH keys (and any future one) uniformly** — it just re-runs the handshake
+   checks. A would need wiring at every current and future key-write site.
+3. **Reuses the gateway's existing `cleanupIntervals` pattern** — not a new substrate; one
+   more `setInterval` alongside the rate-limit / stale-entry sweeps already there.
+4. **Proportionate.** Read-only streams; a ≤60s teardown lag closes the "tab left open"
+   residual, while #112's connect-time check already handles reconnect/refresh instantly.
+
+**Cost & mitigations:** one `fetchSockets()` + ≤2 Redis reads per *distinct connected
+dashboard user* per interval (dedup by userId, not per-socket). Devices excluded
+(`isDashboard` filter). 60s interval. Negligible for realistic dashboard concurrency.
+
+### A — HTTP push on key-write (rejected for this PR)
+
+Immediate teardown, but: injects HTTP into auth (+3 services for user_revoked), new
+endpoint/DTO/room, more files, more cross-service coupling. The immediacy isn't worth it
+for read-only streams. (If a future requirement needs <1s teardown, A can be added on top
+— the `user:` room + endpoint — without removing B.)
+
+## Plan-gate review outcome (2026-05-31): BUILD Plan B + 4 refinements
+
+Independent review verified all load-bearing facts (dashboard sockets read-only — every
+mutating `@SubscribeMessage` is gated by `WsDeviceGuard` requiring `client.data.deviceId`;
+`iat` not stored; `cleanupIntervals`/`onModuleDestroy` pattern; Redis `get`/`exists`;
+single `markPasswordChanged` chokepoint; 3 `user_revoked:` sites; no HttpService in
+AuthService). Verdict: Plan B correct, ≤60s lag acceptable (no write path for dashboards),
+no correctness reason forces Plan A. Required refinements folded in below:
+
+1. **Track dashboard sockets in an in-memory `Map<userId, Set<socketId>>`** (mirror the
+   existing `deviceSockets` map) — populated on dashboard connect, cleaned on disconnect.
+   The sweep iterates THIS map (only dashboard users), not `server.fetchSockets()` over the
+   whole device fleet. Disconnect via the local `this.server.sockets.sockets.get(socketId)`
+   (realtime is single-instance).
+2. **`pwd_changed` decision is per-socket** (per-tab `client.data.tokenIat`), NOT collapsed
+   to user level — two tabs (one pre-change, one post-change) must be handled independently:
+   kill the old, keep the new.
+3. **Reentrancy guard** (`if (this.sweepRunning) return;`) + **per-user try/catch** so a
+   Redis throw skips that user, never crashes the interval.
+4. **Hardcode 60s** as a module-level `const SESSION_SWEEP_INTERVAL_MS = 60_000;` — no new
+   env var (consistent with the existing hardcoded cleanup intervals; avoids the
+   .env/AGENTS/CLAUDE doc surface for a value nobody will tune).
+
+## Files (Plan B, final)
+
+- `realtime/src/gateways/device.gateway.ts`:
+  - new field `dashboardSockets: Map<string, Set<string>>` (userId → socketIds).
+  - dashboard connect branch (`handleConnection` user kind): store
+    `client.data.tokenIat = authResult.payload.iat`; add socketId to `dashboardSockets`.
+  - `handleDisconnect`: remove dashboard socketId from `dashboardSockets` (clean empty sets).
+  - `private async sweepInvalidatedSessions()` with reentrancy guard + per-user try/catch:
+    for each userId in `dashboardSockets`, read `user_revoked:` (exists) once + `pwd_changed:`
+    (get) once; if revoked → disconnect all that user's sockets; else per socket, if
+    `tokenIat < Number(pwd_changed)` → disconnect that socket. `emit('session:expired')`
+    immediately before `socket.disconnect(true)`.
+  - constructor: `this.cleanupIntervals.push(setInterval(() => this.sweepInvalidatedSessions(), SESSION_SWEEP_INTERVAL_MS))`.
+  - `UserPayload.iat?: number` already added in #112 — confirm.
+- `realtime/src/gateways/device.gateway.spec.ts`: tests —
+  - sweep disconnects all sockets of a user whose `user_revoked:` is set;
+  - sweep disconnects a socket whose `tokenIat < pwd_changed:`;
+  - sweep does NOT disconnect a post-change socket (`tokenIat >= pwd_changed:`) — and with
+    two sockets for one user (one pre-, one post-change) only the pre-change one drops;
+  - device sockets are never in `dashboardSockets` → never swept;
+  - dedup: one `exists` + one `get` per distinct user regardless of socket count;
+  - emits `session:expired` before disconnect;
+  - a Redis throw for one user doesn't prevent others being swept (per-user try/catch);
+  - disconnect on dashboard removes the entry from `dashboardSockets`.
+
+## Failure modes / residuals
+
+- **Redis down during sweep:** `get`/`exists` throw → catch per-user, log, skip that user
+  this cycle (don't crash the interval). Worst case: teardown deferred to next cycle or to
+  the connect-time check on reconnect. Non-blocking, matches the gateway's resilient-loop
+  posture.
+- **iat-absent socket:** if a connected socket has no stored `tokenIat`, skip its
+  `pwd_changed` check (fail-open, same as #112's connect-time guard). `user_revoked` still
+  applies (no iat needed).
+- **Up-to-60s lingering window** between key-write and sweep — accepted (read-only streams;
+  connect-time check covers reconnect). Documented.
+- **Same-second `iat == pwd_changed`** passes (strict `<`) — consistent with #112, never
+  rejects the fresh post-change login's socket.
+
+## Out of scope (do NOT bolt on)
+
+- Per-message re-auth (heavier; not needed for read-only streams).
+- HTTP-push immediacy (Plan A) — only if a sub-second requirement appears.
+- M12 new-login/unrecognized-device alert (separate, needs schema migration).
+
+## Verification plan
+
+- `device.gateway.spec.ts` via `pnpm --filter @vizora/realtime test -- --runTestsByPath`
+  (read JSON reporter output — text layer flaky this session).
+- `tsc --noEmit` exit 0; middleware untouched (`git diff origin/main -- middleware` empty).
+- Two independent reviews (plan-gate now; adversarial on the diff) before PR. No self-merge.

--- a/realtime/src/gateways/device.gateway.session-sweep.spec.ts
+++ b/realtime/src/gateways/device.gateway.session-sweep.spec.ts
@@ -1,0 +1,193 @@
+import { DeviceGateway } from './device.gateway';
+
+/**
+ * Focused unit tests for the mid-session invalidation sweep added in
+ * feat/realtime-ws-session-teardown. Kept in a separate spec so it constructs
+ * the gateway with minimal mocks and pokes the private `sweepInvalidatedSessions`
+ * directly — the residual closed here is connect-time-only invalidation (PR #112).
+ */
+
+type FakeSocket = {
+  id: string;
+  data: { isDashboard?: boolean; userId?: string; tokenIat?: number };
+  emit: jest.Mock;
+  disconnect: jest.Mock;
+};
+
+function makeSocket(id: string, userId: string, tokenIat?: number): FakeSocket {
+  return {
+    id,
+    data: { isDashboard: true, userId, tokenIat },
+    emit: jest.fn(),
+    disconnect: jest.fn(),
+  };
+}
+
+describe('DeviceGateway session-invalidation sweep', () => {
+  let gateway: DeviceGateway;
+  let redis: { exists: jest.Mock; get: jest.Mock };
+  let socketMap: Map<string, FakeSocket>;
+
+  const noop = () => undefined;
+
+  beforeEach(() => {
+    redis = {
+      exists: jest.fn().mockResolvedValue(false),
+      get: jest.fn().mockResolvedValue(null),
+    };
+
+    // Only redisService is exercised by the sweep; the rest are inert stubs.
+    gateway = new DeviceGateway(
+      {} as never, // jwtService
+      redis as never, // redisService
+      {} as never, // heartbeatService
+      {} as never, // playlistService
+      {} as never, // notificationService
+      {} as never, // metricsService
+      {} as never, // databaseService
+      {} as never, // storageService
+    );
+
+    // Stop the real cleanup intervals the constructor started.
+    for (const interval of (gateway as unknown as { cleanupIntervals: NodeJS.Timeout[] }).cleanupIntervals) {
+      clearInterval(interval);
+    }
+
+    socketMap = new Map();
+    (gateway as unknown as { server: unknown }).server = {
+      sockets: { sockets: socketMap },
+    };
+  });
+
+  function seed(userId: string, sockets: FakeSocket[]) {
+    const set = new Set<string>();
+    for (const s of sockets) {
+      socketMap.set(s.id, s);
+      set.add(s.id);
+    }
+    (gateway as unknown as { dashboardSockets: Map<string, Set<string>> }).dashboardSockets.set(userId, set);
+  }
+
+  function runSweep(): Promise<void> {
+    return (gateway as unknown as { sweepInvalidatedSessions(): Promise<void> }).sweepInvalidatedSessions();
+  }
+
+  it('disconnects ALL of a user\'s sockets when user_revoked is set', async () => {
+    redis.exists.mockResolvedValue(true);
+    const a = makeSocket('a', 'u1', 1000);
+    const b = makeSocket('b', 'u1', 9999);
+    seed('u1', [a, b]);
+
+    await runSweep();
+
+    expect(a.disconnect).toHaveBeenCalledWith(true);
+    expect(b.disconnect).toHaveBeenCalledWith(true);
+    expect(a.emit).toHaveBeenCalledWith('session:expired', { reason: 'revoked' });
+    expect(b.emit).toHaveBeenCalledWith('session:expired', { reason: 'revoked' });
+    // user_revoked short-circuits before pwd_changed.
+    expect(redis.get).not.toHaveBeenCalled();
+  });
+
+  it('disconnects only the pre-change socket on pwd_changed (per-tab iat)', async () => {
+    redis.exists.mockResolvedValue(false);
+    redis.get.mockResolvedValue('5000'); // pwd_changed epoch
+    const stale = makeSocket('stale', 'u1', 4000); // iat < 5000 -> killed
+    const fresh = makeSocket('fresh', 'u1', 6000); // iat >= 5000 -> survives
+    seed('u1', [stale, fresh]);
+
+    await runSweep();
+
+    expect(stale.disconnect).toHaveBeenCalledWith(true);
+    expect(stale.emit).toHaveBeenCalledWith('session:expired', { reason: 'password_changed' });
+    expect(fresh.disconnect).not.toHaveBeenCalled();
+    expect(fresh.emit).not.toHaveBeenCalled();
+  });
+
+  it('treats iat === pwd_changed as surviving (strict <, matches connect-time guard)', async () => {
+    redis.exists.mockResolvedValue(false);
+    redis.get.mockResolvedValue('5000');
+    const sameSecond = makeSocket('s', 'u1', 5000);
+    seed('u1', [sameSecond]);
+
+    await runSweep();
+
+    expect(sameSecond.disconnect).not.toHaveBeenCalled();
+  });
+
+  it('dedups Redis reads to one exists + one get per distinct user regardless of socket count', async () => {
+    redis.exists.mockResolvedValue(false);
+    redis.get.mockResolvedValue('5000');
+    seed('u1', [makeSocket('a', 'u1', 4000), makeSocket('b', 'u1', 4500), makeSocket('c', 'u1', 6000)]);
+
+    await runSweep();
+
+    expect(redis.exists).toHaveBeenCalledTimes(1);
+    expect(redis.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing for a user with neither key set', async () => {
+    const s = makeSocket('a', 'u1', 1000);
+    seed('u1', [s]);
+
+    await runSweep();
+
+    expect(s.disconnect).not.toHaveBeenCalled();
+    expect(s.emit).not.toHaveBeenCalled();
+  });
+
+  it('skips a socket with no stored tokenIat on pwd_changed (fail-open), but user_revoked still applies', async () => {
+    redis.get.mockResolvedValue('5000');
+    const noIat = makeSocket('a', 'u1', undefined);
+    seed('u1', [noIat]);
+
+    await runSweep();
+    expect(noIat.disconnect).not.toHaveBeenCalled();
+
+    // Now revoke the same user — fail-open no longer protects them.
+    redis.exists.mockResolvedValue(true);
+    await runSweep();
+    expect(noIat.disconnect).toHaveBeenCalledWith(true);
+  });
+
+  it('continues sweeping other users when one user\'s Redis read throws', async () => {
+    redis.exists.mockImplementation(async (key: string) => {
+      if (key.includes('u1')) throw new Error('redis down');
+      return true; // u2 revoked
+    });
+    const s1 = makeSocket('s1', 'u1', 1000);
+    const s2 = makeSocket('s2', 'u2', 1000);
+    seed('u1', [s1]);
+    seed('u2', [s2]);
+
+    await expect(runSweep()).resolves.toBeUndefined();
+    expect(s1.disconnect).not.toHaveBeenCalled();
+    expect(s2.disconnect).toHaveBeenCalledWith(true);
+  });
+
+  it('drops a stale dashboardSockets entry when its socket is already gone', async () => {
+    redis.exists.mockResolvedValue(true);
+    const set = new Set<string>(['ghost']);
+    (gateway as unknown as { dashboardSockets: Map<string, Set<string>> }).dashboardSockets.set('u1', set);
+    // 'ghost' is intentionally NOT in socketMap.
+
+    await runSweep();
+
+    expect(set.has('ghost')).toBe(false);
+  });
+
+  it('is reentrancy-guarded: a concurrent run is a no-op', async () => {
+    (gateway as unknown as { sweepRunning: boolean }).sweepRunning = true;
+    seed('u1', [makeSocket('a', 'u1', 1000)]);
+
+    await runSweep();
+
+    expect(redis.exists).not.toHaveBeenCalled();
+  });
+
+  it('short-circuits when there are no dashboard sockets', async () => {
+    await runSweep();
+    expect(redis.exists).not.toHaveBeenCalled();
+  });
+
+  void noop;
+});

--- a/realtime/src/gateways/device.gateway.ts
+++ b/realtime/src/gateways/device.gateway.ts
@@ -90,6 +90,15 @@ export class DeviceGateway
   // 2.5: Device socket deduplication (deviceId -> socketId)
   private readonly deviceSockets: Map<string, string> = new Map();
 
+  // Dashboard (user) sockets: userId -> set of socketIds. Lets the periodic
+  // session-invalidation sweep target ONLY dashboard sockets (not the device
+  // fleet) and disconnect a specific user's live sockets mid-session — closing
+  // the connect-time-only residual from PR #112.
+  private readonly dashboardSockets: Map<string, Set<string>> = new Map();
+
+  // Reentrancy guard so a slow sweep (Redis latency) can't overlap itself.
+  private sweepRunning = false;
+
   // Per-message rate limiting: socketId -> { count, resetAt }
   private readonly messageRates: Map<string, { count: number; resetAt: number }> = new Map();
 
@@ -118,6 +127,9 @@ export class DeviceGateway
     this.cleanupIntervals.push(setInterval(() => this.cleanupMessageRateLimits(), 60000));
     // Periodically clean up stale deviceStatusCache entries (every 5 min)
     this.cleanupIntervals.push(setInterval(() => this.cleanupStaleEntries(), 5 * 60 * 1000));
+    // Periodically tear down dashboard sockets whose session was invalidated
+    // mid-connection (password change / deactivation) — see sweepInvalidatedSessions.
+    this.cleanupIntervals.push(setInterval(() => this.sweepInvalidatedSessions(), 60000));
   }
 
   async onModuleDestroy() {
@@ -228,6 +240,88 @@ export class DeviceGateway
     }
   }
 
+  /**
+   * Periodically tear down dashboard sockets whose session was invalidated AFTER
+   * they connected. PR #112 added these checks at connect-time only; a socket
+   * established before a password change / account deactivation otherwise keeps
+   * streaming until it reconnects. This re-applies the handshake checks to the
+   * in-memory `dashboardSockets` map (dashboard sockets only — never devices).
+   *
+   * Per distinct user: one `exists(user_revoked:)` + one `get(pwd_changed:)`.
+   * - user_revoked → disconnect ALL that user's sockets (no iat needed).
+   * - pwd_changed  → per-socket: disconnect only sockets whose token iat predates
+   *                  the change (strict `<`, matching the connect-time guard, so a
+   *                  fresh post-change login's socket survives). Sockets without a
+   *                  stored tokenIat are fail-open here (same as the connect-time
+   *                  guard) but still caught by the user_revoked branch.
+   *
+   * Reentrancy-guarded (first async cleanup interval — a slow Redis cycle must not
+   * overlap itself); per-user try/catch so one user's Redis error never aborts the
+   * sweep; whole body wrapped so an unexpected throw can't leak out of setInterval.
+   */
+  private async sweepInvalidatedSessions(): Promise<void> {
+    if (this.sweepRunning || this.dashboardSockets.size === 0) {
+      return;
+    }
+    this.sweepRunning = true;
+    try {
+      // Snapshot userIds so concurrent connect/disconnect can't mutate mid-iteration.
+      for (const userId of Array.from(this.dashboardSockets.keys())) {
+        try {
+          const socketIds = this.dashboardSockets.get(userId);
+          if (!socketIds || socketIds.size === 0) {
+            continue;
+          }
+
+          const revoked = await this.redisService.exists(`user_revoked:${userId}`);
+          let pwdChangedAt: number | null = null;
+          if (!revoked) {
+            const pc = await this.redisService.get(`pwd_changed:${userId}`);
+            pwdChangedAt = pc ? Number(pc) : null;
+            if (pwdChangedAt === null) {
+              continue; // Nothing to enforce for this user this cycle.
+            }
+          }
+
+          for (const socketId of Array.from(socketIds)) {
+            const socket = this.server.sockets.sockets.get(socketId);
+            if (!socket) {
+              // Socket already gone; drop the stale entry defensively.
+              socketIds.delete(socketId);
+              continue;
+            }
+            const tokenIat = socket.data?.tokenIat;
+            const expiredByPwd =
+              typeof tokenIat === 'number' &&
+              pwdChangedAt !== null &&
+              tokenIat < pwdChangedAt;
+            if (revoked || expiredByPwd) {
+              const reason = revoked ? 'revoked' : 'password_changed';
+              // Emit before the forced disconnect so the dashboard can show a
+              // "signed out" state instead of a silent drop. handleDisconnect
+              // owns removing the socketId from dashboardSockets.
+              socket.emit('session:expired', { reason });
+              socket.disconnect(true);
+              this.logger.log(
+                `Session sweep: disconnected dashboard socket ${socketId} (user: ${userId}, reason: ${reason})`,
+              );
+            }
+          }
+        } catch (err) {
+          this.logger.warn(
+            `Session sweep failed for user ${userId}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    } catch (err) {
+      this.logger.warn(
+        `Session sweep aborted: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      this.sweepRunning = false;
+    }
+  }
+
   async handleConnection(client: Socket) {
     try {
       // Step 1: Rate limiting
@@ -244,8 +338,25 @@ export class DeviceGateway
       // User/dashboard connections: join org room and send current device statuses
       if (authResult.kind === 'user') {
         const orgId = authResult.payload.organizationId;
+        const userId = authResult.payload.sub;
         await client.join(`org:${orgId}`);
-        this.logger.log(`Dashboard client joined org:${orgId} (user: ${authResult.payload.sub}, socket: ${client.id})`);
+
+        // Store the token's iat + register this dashboard socket so the periodic
+        // sweep can invalidate it mid-session if the user's password changes or
+        // their account is deactivated after they connected (PR #112 only checked
+        // at connect-time). iat is per-socket so two tabs (pre/post change) are
+        // torn down independently.
+        client.data.userId = userId;
+        client.data.isDashboard = true;
+        client.data.tokenIat = authResult.payload.iat;
+        let userSockets = this.dashboardSockets.get(userId);
+        if (!userSockets) {
+          userSockets = new Set();
+          this.dashboardSockets.set(userId, userSockets);
+        }
+        userSockets.add(client.id);
+
+        this.logger.log(`Dashboard client joined org:${orgId} (user: ${userId}, socket: ${client.id})`);
 
         // Send current device statuses so dashboard has accurate state on connect
         await this.sendDeviceStatusCatchUp(client, orgId);
@@ -743,6 +854,16 @@ export class DeviceGateway
     // Clean up per-message rate limit entry for this socket
     this.messageRates.delete(client.id);
 
+    // Deregister dashboard (user) sockets from the sweep map. Pure in-memory
+    // bookkeeping (no I/O), so kept outside the try below.
+    const dashUserId = client.data?.userId;
+    if (dashUserId && client.data?.isDashboard) {
+      const set = this.dashboardSockets.get(dashUserId);
+      if (set) {
+        set.delete(client.id);
+        if (set.size === 0) this.dashboardSockets.delete(dashUserId);
+      }
+    }
 
     try {
       const deviceId = client.data?.deviceId;


### PR DESCRIPTION
## What

Closes the **connect-time-only** residual from PR #112. The dashboard WebSocket handshake already rejects revoked/password-changed sessions *at connect*, but a socket established **before** the change kept streaming until it reconnected (no per-message re-auth, no teardown). This adds a periodic **60s sweep** in the realtime gateway that disconnects already-connected dashboard sockets whose session was invalidated after connect.

## How (Plan B — sweep; plan-gate reviewed)

- **`device.gateway.ts`**
  - `dashboardSockets: Map<userId, Set<socketId>>` populated on dashboard connect, cleaned in `handleDisconnect`.
  - `client.data.tokenIat` stored at connect (per-tab/per-socket).
  - `sweepInvalidatedSessions()`: per distinct user, one `exists(user_revoked:)` + one `get(pwd_changed:)`. `user_revoked` → disconnect ALL that user's sockets; `pwd_changed` → per-socket strict `iat < marker` (fresh post-change login survives). Emits `session:expired` before `disconnect(true)`. Reentrancy guard + per-user try/catch + outer wrap (first async cleanup interval).
  - 60s interval pushed into the existing `cleanupIntervals` (auto-cleared in `onModuleDestroy`).
- **No middleware change, no schema change** — reuses the Redis keys middleware already writes (`pwd_changed:`, `user_revoked:`) on the shared Redis instance.
- Dashboard sockets are read-only (every mutating `@SubscribeMessage` is device-gated via `WsDeviceGuard`); devices are never swept.

## Tests

`realtime/src/gateways/device.gateway.session-sweep.spec.ts` — 10 cases: revoked→all, pwd_changed per-tab, strict-`<` (same-second survives), Redis dedup, fail-open without iat (+ revoked still applies), per-user error isolation, stale-entry cleanup, reentrancy, empty short-circuit.

**Realtime: 230/230 tests pass.** `device.gateway.ts` type-checks clean.

## Design

`docs/plans/2026-05-31-realtime-ws-session-teardown.md` (includes the plan-gate review outcome: Plan B over HTTP-push, hardcode 60s, in-memory map).

## Out of scope (documented)

Per-message re-auth; HTTP-push sub-second immediacy; a web-side `session:expired` listener for the "signed out" UX (currently degrades to a silent drop, same as today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)