### PR TITLE
feat(auth): alert on unrecognized login context

### DIFF
--- a/middleware/src/modules/auth/auth.controller.spec.ts
+++ b/middleware/src/modules/auth/auth.controller.spec.ts
@@ -34,6 +34,7 @@ describe('AuthController', () => {
     const mockAuthService = {
       register: jest.fn(),
       login: jest.fn(),
+      googleLogin: jest.fn(),
       refresh: jest.fn(),
       logout: jest.fn(),
       forgotPassword: jest.fn(),
@@ -72,6 +73,7 @@ describe('AuthController', () => {
     const mockRegisterRequest = {
       ip: '127.0.0.1',
       socket: { remoteAddress: '127.0.0.1' },
+      headers: { 'user-agent': 'Mozilla/5.0' },
     } as unknown as Request;
 
     it('should register a new user and set auth cookie', async () => {
@@ -110,7 +112,7 @@ describe('AuthController', () => {
       expect(result.data).not.toHaveProperty('token');
     });
 
-    it('should pass client IP to auth service', async () => {
+    it('should pass client IP and user agent to auth service', async () => {
       authService.register.mockResolvedValue({
         user: mockUser,
         organization: mockOrganization,
@@ -120,7 +122,7 @@ describe('AuthController', () => {
 
       await controller.register(registerDto, mockRegisterRequest, mockResponse as Response);
 
-      expect(authService.register).toHaveBeenCalledWith(registerDto, '127.0.0.1');
+      expect(authService.register).toHaveBeenCalledWith(registerDto, '127.0.0.1', 'Mozilla/5.0');
     });
 
     it('should propagate ConflictException when email exists', async () => {
@@ -136,6 +138,11 @@ describe('AuthController', () => {
       email: 'test@example.com',
       password: 'Password123!',
     };
+    const mockLoginRequest = {
+      ip: '203.0.113.10',
+      socket: { remoteAddress: '10.0.0.1' },
+      headers: { 'user-agent': 'Mozilla/5.0' },
+    } as unknown as Request;
 
     it('should login user and set auth cookie', async () => {
       authService.login.mockResolvedValue({
@@ -144,7 +151,7 @@ describe('AuthController', () => {
         expiresIn: AUTH_CONSTANTS.TOKEN_EXPIRY_SECONDS,
       });
 
-      const result = await controller.login(loginDto, mockResponse as Response);
+      const result = await controller.login(loginDto, mockLoginRequest, mockResponse as Response);
 
       expect(result.success).toBe(true);
       expect(result.data.user).toEqual(mockUser);
@@ -158,6 +165,21 @@ describe('AuthController', () => {
       );
     });
 
+    it('should pass login request metadata to auth service', async () => {
+      authService.login.mockResolvedValue({
+        user: mockUser,
+        token: 'jwt-token',
+        expiresIn: AUTH_CONSTANTS.TOKEN_EXPIRY_SECONDS,
+      });
+
+      await controller.login(loginDto, mockLoginRequest, mockResponse as Response);
+
+      expect(authService.login).toHaveBeenCalledWith(loginDto, {
+        ipAddress: '203.0.113.10',
+        userAgent: 'Mozilla/5.0',
+      });
+    });
+
     it('should not include token in response body', async () => {
       authService.login.mockResolvedValue({
         user: mockUser,
@@ -165,7 +187,7 @@ describe('AuthController', () => {
         expiresIn: AUTH_CONSTANTS.TOKEN_EXPIRY_SECONDS,
       });
 
-      const result = await controller.login(loginDto, mockResponse as Response);
+      const result = await controller.login(loginDto, mockLoginRequest, mockResponse as Response);
 
       expect(result.data).not.toHaveProperty('token');
     });
@@ -173,8 +195,57 @@ describe('AuthController', () => {
     it('should propagate UnauthorizedException for invalid credentials', async () => {
       authService.login.mockRejectedValue(new UnauthorizedException('Invalid email or password'));
 
-      await expect(controller.login(loginDto, mockResponse as Response))
+      await expect(controller.login(loginDto, mockLoginRequest, mockResponse as Response))
         .rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  describe('googleLogin', () => {
+    const googleDto = {
+      credential: 'google-id-token',
+    };
+    const mockGoogleRequest = {
+      ip: '203.0.113.20',
+      socket: { remoteAddress: '10.0.0.2' },
+      headers: { 'user-agent': 'Mozilla/5.0 Chrome/126.0' },
+    } as unknown as Request;
+
+    it('should login with Google and set auth cookie', async () => {
+      authService.googleLogin.mockResolvedValue({
+        user: mockUser,
+        token: 'jwt-token',
+        expiresIn: AUTH_CONSTANTS.TOKEN_EXPIRY_SECONDS,
+        isNewUser: false,
+      });
+
+      const result = await controller.googleLogin(googleDto, mockGoogleRequest, mockResponse as Response);
+
+      expect(result.success).toBe(true);
+      expect(result.data.user).toEqual(mockUser);
+      expect(mockResponse.cookie).toHaveBeenCalledWith(
+        AUTH_CONSTANTS.COOKIE_NAME,
+        'jwt-token',
+        expect.objectContaining({
+          httpOnly: true,
+          path: '/',
+        }),
+      );
+    });
+
+    it('should pass Google login request metadata to auth service', async () => {
+      authService.googleLogin.mockResolvedValue({
+        user: mockUser,
+        token: 'jwt-token',
+        expiresIn: AUTH_CONSTANTS.TOKEN_EXPIRY_SECONDS,
+        isNewUser: false,
+      });
+
+      await controller.googleLogin(googleDto, mockGoogleRequest, mockResponse as Response);
+
+      expect(authService.googleLogin).toHaveBeenCalledWith('google-id-token', {
+        ipAddress: '203.0.113.20',
+        userAgent: 'Mozilla/5.0 Chrome/126.0',
+      });
     });
   });
 
@@ -293,6 +364,7 @@ describe('AuthController', () => {
     const mockRegisterRequest = {
       ip: '127.0.0.1',
       socket: { remoteAddress: '127.0.0.1' },
+      headers: { 'user-agent': 'Mozilla/5.0' },
     } as unknown as Request;
 
     beforeEach(() => {

--- a/middleware/src/modules/auth/auth.controller.ts
+++ b/middleware/src/modules/auth/auth.controller.ts
@@ -113,7 +113,7 @@ export class AuthController {
     @Res({ passthrough: true }) res: Response,
   ) {
     const clientIp = req.ip || req.socket?.remoteAddress || '';
-    const result = await this.authService.register(dto, clientIp);
+    const result = await this.authService.register(dto, clientIp, req.headers?.['user-agent']);
 
     // Set httpOnly cookie with JWT token
     this.setAuthCookie(res, result.token);
@@ -149,9 +149,13 @@ export class AuthController {
   })
   async login(
     @Body() dto: LoginDto,
+    @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
   ) {
-    const result = await this.authService.login(dto);
+    const result = await this.authService.login(dto, {
+      ipAddress: req.ip || req.socket?.remoteAddress || '',
+      userAgent: req.headers?.['user-agent'],
+    });
 
     // Set httpOnly cookie with JWT token
     this.setAuthCookie(res, result.token);
@@ -184,9 +188,13 @@ export class AuthController {
   })
   async googleLogin(
     @Body() dto: GoogleLoginDto,
+    @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
   ) {
-    const result = await this.authService.googleLogin(dto.credential);
+    const result = await this.authService.googleLogin(dto.credential, {
+      ipAddress: req.ip || req.socket?.remoteAddress || '',
+      userAgent: req.headers?.['user-agent'],
+    });
 
     // Set httpOnly cookie with JWT token
     this.setAuthCookie(res, result.token);

--- a/middleware/src/modules/auth/auth.service.spec.ts
+++ b/middleware/src/modules/auth/auth.service.spec.ts
@@ -53,6 +53,8 @@ function mockGoogleFailure(message: string) {
   mockVerifyIdToken.mockRejectedValue(new Error(message));
 }
 
+const flushLoginAlertTasks = () => new Promise<void>((resolve) => setImmediate(resolve));
+
 // Mock bcryptjs
 jest.mock('bcryptjs', () => ({
   hash: jest.fn(),
@@ -113,7 +115,9 @@ describe('AuthService', () => {
         create: jest.fn(),
       },
       auditLog: {
-        create: jest.fn(),
+        create: jest.fn().mockResolvedValue({ id: 'audit-current' }),
+        findFirst: jest.fn().mockResolvedValue(null),
+        findMany: jest.fn().mockResolvedValue([]),
       },
       passwordResetToken: {
         findUnique: jest.fn(),
@@ -143,6 +147,7 @@ describe('AuthService', () => {
       sendPasswordResetEmail: jest.fn().mockResolvedValue(undefined),
       sendWelcomeEmail: jest.fn().mockResolvedValue(undefined),
       sendPasswordChangedEmail: jest.fn().mockResolvedValue(undefined),
+      sendUnrecognizedLoginEmail: jest.fn().mockResolvedValue(undefined),
     };
 
     mockGeoService = {
@@ -301,6 +306,32 @@ describe('AuthService', () => {
       });
     });
 
+    it('should seed initial login context on registration without sending an alert', async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue(null);
+      mockDatabaseService.organization.findUnique.mockResolvedValue(null);
+      mockDatabaseService.organization.create.mockResolvedValue(mockOrganization);
+      mockDatabaseService.user.create.mockResolvedValue(mockUser);
+      mockDatabaseService.auditLog.create.mockResolvedValue({});
+      (bcrypt.hash as jest.Mock).mockResolvedValue('hashed-password');
+
+      await service.register(
+        registerDto,
+        '198.51.100.10',
+        'Mozilla/5.0 Chrome/126.0',
+      );
+
+      expect(mockDatabaseService.auditLog.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          action: 'user_login',
+          entityType: 'user',
+          changes: { reason: 'registration' },
+          ipAddress: '198.51.100.10',
+          userAgent: 'Mozilla/5.0 Chrome/126.0',
+        }),
+      });
+      expect(mockMailService.sendUnrecognizedLoginEmail).not.toHaveBeenCalled();
+    });
+
     it('should set first user as admin', async () => {
       mockDatabaseService.user.findUnique.mockResolvedValue(null);
       mockDatabaseService.organization.findUnique.mockResolvedValue(null);
@@ -363,6 +394,14 @@ describe('AuthService', () => {
     const loginDto = {
       email: 'test@example.com',
       password: 'SecurePass123!',
+    };
+    const loginContext = {
+      ipAddress: '203.0.113.10',
+      userAgent: 'Mozilla/5.0 Chrome/125.0.6422.112 Safari/537.36',
+    };
+    const loginAuditLog = {
+      id: 'audit-current',
+      createdAt: new Date('2026-05-31T12:00:00.000Z'),
     };
 
     it('should successfully login a user', async () => {
@@ -527,6 +566,329 @@ describe('AuthService', () => {
         }),
       });
     });
+
+    it('should include login request metadata in the audit log entry', async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue({
+        ...mockUser,
+        organization: mockOrganization,
+      });
+      mockDatabaseService.user.update.mockResolvedValue(mockUser);
+      mockDatabaseService.auditLog.create.mockResolvedValue(loginAuditLog);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      await service.login(loginDto, loginContext);
+
+      expect(mockDatabaseService.auditLog.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          ipAddress: loginContext.ipAddress,
+          userAgent: loginContext.userAgent,
+        }),
+      });
+    });
+
+    it('should not send unrecognized-login email for the first metadata-bearing login', async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue({
+        ...mockUser,
+        organization: mockOrganization,
+      });
+      mockDatabaseService.user.update.mockResolvedValue(mockUser);
+      mockDatabaseService.auditLog.findFirst.mockResolvedValue(null);
+      mockDatabaseService.auditLog.create.mockResolvedValue(loginAuditLog);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      await service.login(loginDto, loginContext);
+      await flushLoginAlertTasks();
+
+      expect(mockDatabaseService.auditLog.findFirst).toHaveBeenCalledWith({
+        where: expect.objectContaining({
+          organizationId: mockUser.organizationId,
+          userId: mockUser.id,
+          action: 'user_login',
+          entityType: 'user',
+          id: { not: 'audit-current' },
+          createdAt: { lt: loginAuditLog.createdAt },
+          ipAddress: { not: null },
+          userAgent: { not: null },
+        }),
+        select: {
+          id: true,
+        },
+        orderBy: { createdAt: 'desc' },
+      });
+      expect(mockDatabaseService.auditLog.findMany).not.toHaveBeenCalled();
+      expect(mockMailService.sendUnrecognizedLoginEmail).not.toHaveBeenCalled();
+    });
+
+    it('should not send unrecognized-login email when the login context was seen before', async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue({
+        ...mockUser,
+        organization: mockOrganization,
+      });
+      mockDatabaseService.user.update.mockResolvedValue(mockUser);
+      mockDatabaseService.auditLog.findFirst.mockResolvedValue({ id: 'audit-1' });
+      mockDatabaseService.auditLog.findMany.mockResolvedValue([
+        {
+          userAgent: loginContext.userAgent,
+        },
+      ]);
+      mockDatabaseService.auditLog.create.mockResolvedValue(loginAuditLog);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      await service.login(loginDto, loginContext);
+      await flushLoginAlertTasks();
+
+      expect(mockDatabaseService.auditLog.findMany).toHaveBeenCalledWith({
+        where: expect.objectContaining({
+          organizationId: mockUser.organizationId,
+          userId: mockUser.id,
+          action: 'user_login',
+          entityType: 'user',
+          id: { not: 'audit-current' },
+          createdAt: { lt: loginAuditLog.createdAt },
+          ipAddress: loginContext.ipAddress,
+          userAgent: { not: null },
+        }),
+        select: {
+          userAgent: true,
+        },
+        orderBy: { createdAt: 'desc' },
+        take: 500,
+      });
+      expect(mockMailService.sendUnrecognizedLoginEmail).not.toHaveBeenCalled();
+    });
+
+    it('should treat browser patch-version changes as the same login context', async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue({
+        ...mockUser,
+        organization: mockOrganization,
+      });
+      mockDatabaseService.user.update.mockResolvedValue(mockUser);
+      mockDatabaseService.auditLog.findFirst.mockResolvedValue({ id: 'audit-1' });
+      mockDatabaseService.auditLog.findMany.mockResolvedValue([
+        {
+          userAgent: 'Mozilla/5.0 Chrome/125.0.6422.111 Safari/537.36',
+        },
+      ]);
+      mockDatabaseService.auditLog.create.mockResolvedValue(loginAuditLog);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      await service.login(loginDto, loginContext);
+      await flushLoginAlertTasks();
+
+      expect(mockMailService.sendUnrecognizedLoginEmail).not.toHaveBeenCalled();
+    });
+
+    it('should treat Firefox rv and browser version changes as the same login context', async () => {
+      const currentFirefoxContext = {
+        ...loginContext,
+        userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:127.0) Gecko/20100101 Firefox/127.0',
+      };
+      mockDatabaseService.user.findUnique.mockResolvedValue({
+        ...mockUser,
+        organization: mockOrganization,
+      });
+      mockDatabaseService.user.update.mockResolvedValue(mockUser);
+      mockDatabaseService.auditLog.findFirst.mockResolvedValue({ id: 'audit-1' });
+      mockDatabaseService.auditLog.findMany.mockResolvedValue([
+        {
+          userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:126.0) Gecko/20100101 Firefox/126.0',
+        },
+      ]);
+      mockDatabaseService.auditLog.create.mockResolvedValue(loginAuditLog);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      await service.login(loginDto, currentFirefoxContext);
+      await flushLoginAlertTasks();
+
+      expect(mockMailService.sendUnrecognizedLoginEmail).not.toHaveBeenCalled();
+    });
+
+    it('should treat mobile Edge browser version changes as the same login context', async () => {
+      const currentMobileEdgeContext = {
+        ...loginContext,
+        userAgent: 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36 EdgA/126.0.2592.56',
+      };
+      mockDatabaseService.user.findUnique.mockResolvedValue({
+        ...mockUser,
+        organization: mockOrganization,
+      });
+      mockDatabaseService.user.update.mockResolvedValue(mockUser);
+      mockDatabaseService.auditLog.findFirst.mockResolvedValue({ id: 'audit-1' });
+      mockDatabaseService.auditLog.findMany.mockResolvedValue([
+        {
+          userAgent: 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Mobile Safari/537.36 EdgA/125.0.2535.67',
+        },
+      ]);
+      mockDatabaseService.auditLog.create.mockResolvedValue(loginAuditLog);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      await service.login(loginDto, currentMobileEdgeContext);
+      await flushLoginAlertTasks();
+
+      expect(mockMailService.sendUnrecognizedLoginEmail).not.toHaveBeenCalled();
+    });
+
+    it('should send unrecognized-login email when prior metadata exists but no context matches', async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue({
+        ...mockUser,
+        organization: mockOrganization,
+      });
+      mockDatabaseService.user.update.mockResolvedValue(mockUser);
+      mockDatabaseService.auditLog.findFirst.mockResolvedValue({ id: 'audit-1' });
+      mockDatabaseService.auditLog.findMany.mockResolvedValue([
+        {
+          userAgent: 'Mozilla/5.0 Firefox/124.0',
+        },
+      ]);
+      mockDatabaseService.auditLog.create.mockResolvedValue(loginAuditLog);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      await service.login(loginDto, loginContext);
+      await flushLoginAlertTasks();
+
+      expect(mockMailService.sendUnrecognizedLoginEmail).toHaveBeenCalledWith(
+        mockUser.email,
+        mockUser.firstName,
+        expect.objectContaining({
+          ipAddress: loginContext.ipAddress,
+          userAgent: loginContext.userAgent,
+          occurredAt: expect.any(Date),
+        }),
+      );
+    });
+
+    it('should alert when the first post-registration login differs from the seeded signup context', async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue({
+        ...mockUser,
+        organization: mockOrganization,
+      });
+      mockDatabaseService.user.update.mockResolvedValue(mockUser);
+      mockDatabaseService.auditLog.findFirst.mockResolvedValue({ id: 'registration-login' });
+      mockDatabaseService.auditLog.findMany.mockResolvedValue([
+        {
+          userAgent: 'Mozilla/5.0 Chrome/126.0',
+        },
+      ]);
+      mockDatabaseService.auditLog.create.mockResolvedValue(loginAuditLog);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      await service.login(loginDto, {
+        ipAddress: '203.0.113.55',
+        userAgent: 'Mozilla/5.0 Firefox/127.0',
+      });
+      await flushLoginAlertTasks();
+
+      expect(mockMailService.sendUnrecognizedLoginEmail).toHaveBeenCalledWith(
+        mockUser.email,
+        mockUser.firstName,
+        expect.objectContaining({
+          ipAddress: '203.0.113.55',
+          userAgent: 'Mozilla/5.0 Firefox/127.0',
+        }),
+      );
+    });
+
+    it('should not fail login when unrecognized-login email sending fails', async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue({
+        ...mockUser,
+        organization: mockOrganization,
+      });
+      mockDatabaseService.user.update.mockResolvedValue(mockUser);
+      mockDatabaseService.auditLog.findFirst.mockResolvedValue({ id: 'audit-1' });
+      mockDatabaseService.auditLog.findMany.mockResolvedValue([
+        {
+          userAgent: 'Mozilla/5.0 Firefox/124.0',
+        },
+      ]);
+      mockDatabaseService.auditLog.create.mockResolvedValue(loginAuditLog);
+      mockMailService.sendUnrecognizedLoginEmail.mockRejectedValue(new Error('smtp down'));
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      const result = await service.login(loginDto, loginContext);
+      await flushLoginAlertTasks();
+
+      expect(result).toHaveProperty('token', 'mock-jwt-token');
+      expect(mockMailService.sendUnrecognizedLoginEmail).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return login response without waiting for alert-history lookup', async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue({
+        ...mockUser,
+        organization: mockOrganization,
+      });
+      mockDatabaseService.user.update.mockResolvedValue(mockUser);
+      mockDatabaseService.auditLog.create.mockResolvedValue(loginAuditLog);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      let resolveHistory!: (value: null) => void;
+      const pendingHistory = new Promise<null>((resolve) => {
+        resolveHistory = resolve;
+      });
+      mockDatabaseService.auditLog.findFirst.mockReturnValue(pendingHistory);
+
+      const loginPromise = service.login(loginDto, loginContext);
+      const raceResult = await Promise.race([
+        loginPromise.then(() => 'resolved'),
+        new Promise((resolve) => setTimeout(() => resolve('timed-out'), 25)),
+      ]);
+
+      resolveHistory(null);
+      await pendingHistory;
+      await flushLoginAlertTasks();
+
+      expect(raceResult).toBe('resolved');
+      await expect(loginPromise).resolves.toHaveProperty('token', 'mock-jwt-token');
+      expect(mockMailService.sendUnrecognizedLoginEmail).not.toHaveBeenCalled();
+    });
+
+    it('should not fail login when alert-history lookup fails', async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue({
+        ...mockUser,
+        organization: mockOrganization,
+      });
+      mockDatabaseService.user.update.mockResolvedValue(mockUser);
+      mockDatabaseService.auditLog.create.mockResolvedValue(loginAuditLog);
+      mockDatabaseService.auditLog.findFirst.mockRejectedValue(new Error('audit down'));
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      const result = await service.login(loginDto, loginContext);
+      await flushLoginAlertTasks();
+
+      expect(result).toHaveProperty('token', 'mock-jwt-token');
+      expect(mockMailService.sendUnrecognizedLoginEmail).not.toHaveBeenCalled();
+    });
+
+    it('should return login response without waiting for unrecognized-login email delivery', async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue({
+        ...mockUser,
+        organization: mockOrganization,
+      });
+      mockDatabaseService.user.update.mockResolvedValue(mockUser);
+      mockDatabaseService.auditLog.findFirst.mockResolvedValue({ id: 'audit-1' });
+      mockDatabaseService.auditLog.findMany.mockResolvedValue([]);
+      mockDatabaseService.auditLog.create.mockResolvedValue(loginAuditLog);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      let resolveMail!: () => void;
+      const pendingMail = new Promise<void>((resolve) => {
+        resolveMail = resolve;
+      });
+      mockMailService.sendUnrecognizedLoginEmail.mockReturnValue(pendingMail);
+
+      const loginPromise = service.login(loginDto, loginContext);
+      const raceResult = await Promise.race([
+        loginPromise.then(() => 'resolved'),
+        new Promise((resolve) => setTimeout(() => resolve('timed-out'), 25)),
+      ]);
+
+      resolveMail();
+      await pendingMail;
+      await flushLoginAlertTasks();
+
+      expect(raceResult).toBe('resolved');
+      await expect(loginPromise).resolves.toHaveProperty('token', 'mock-jwt-token');
+      expect(mockMailService.sendUnrecognizedLoginEmail).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('refresh', () => {
@@ -680,6 +1042,14 @@ describe('AuthService', () => {
   describe('googleLogin', () => {
     const originalEnv = process.env;
     const FAKE_TOKEN = 'opaque-google-id-token-string';
+    const googleLoginContext = {
+      ipAddress: '203.0.113.30',
+      userAgent: 'Mozilla/5.0 Firefox/127.0',
+    };
+    const googleLoginAuditLog = {
+      id: 'google-login-audit',
+      createdAt: new Date('2026-05-31T13:00:00.000Z'),
+    };
 
     beforeEach(() => {
       process.env = { ...originalEnv, GOOGLE_CLIENT_ID: 'test-google-client-id' };
@@ -699,9 +1069,10 @@ describe('AuthService', () => {
       };
       mockDatabaseService.user.findUnique.mockResolvedValue(oauthUser);
       mockDatabaseService.user.update.mockResolvedValue(oauthUser);
-      mockDatabaseService.auditLog.create.mockResolvedValue({});
+      mockDatabaseService.auditLog.create.mockResolvedValue(googleLoginAuditLog);
 
-      const result = await service.googleLogin(FAKE_TOKEN);
+      const result = await service.googleLogin(FAKE_TOKEN, googleLoginContext);
+      await flushLoginAlertTasks();
 
       expect(result).toHaveProperty('token', 'mock-jwt-token');
       expect(result).toHaveProperty('user');
@@ -710,6 +1081,58 @@ describe('AuthService', () => {
         idToken: FAKE_TOKEN,
         audience: 'test-google-client-id',
       });
+      expect(mockDatabaseService.auditLog.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          action: 'user_login',
+          entityType: 'user',
+          changes: { provider: 'google' },
+          ipAddress: googleLoginContext.ipAddress,
+          userAgent: googleLoginContext.userAgent,
+        }),
+      });
+      expect(mockDatabaseService.auditLog.findFirst).toHaveBeenCalledWith({
+        where: expect.objectContaining({
+          organizationId: mockUser.organizationId,
+          userId: mockUser.id,
+          action: 'user_login',
+          entityType: 'user',
+          id: { not: 'google-login-audit' },
+          createdAt: { lt: googleLoginAuditLog.createdAt },
+          ipAddress: { not: null },
+          userAgent: { not: null },
+        }),
+        select: {
+          id: true,
+        },
+        orderBy: { createdAt: 'desc' },
+      });
+    });
+
+    it('should send unrecognized-login email for an existing Google user from a new context', async () => {
+      mockGoogleSuccess(buildGooglePayload());
+      const oauthUser = {
+        ...mockUser,
+        passwordHash: '',
+        organization: mockOrganization,
+      };
+      mockDatabaseService.user.findUnique.mockResolvedValue(oauthUser);
+      mockDatabaseService.user.update.mockResolvedValue(oauthUser);
+      mockDatabaseService.auditLog.create.mockResolvedValue(googleLoginAuditLog);
+      mockDatabaseService.auditLog.findFirst.mockResolvedValue({ id: 'prior-login' });
+      mockDatabaseService.auditLog.findMany.mockResolvedValue([]);
+
+      await service.googleLogin(FAKE_TOKEN, googleLoginContext);
+      await flushLoginAlertTasks();
+
+      expect(mockMailService.sendUnrecognizedLoginEmail).toHaveBeenCalledWith(
+        mockUser.email,
+        mockUser.firstName,
+        expect.objectContaining({
+          ipAddress: googleLoginContext.ipAddress,
+          userAgent: googleLoginContext.userAgent,
+          occurredAt: expect.any(Date),
+        }),
+      );
     });
 
     it('should throw UnauthorizedException when google-auth-library rejects (expired/invalid signature)', async () => {
@@ -772,7 +1195,7 @@ describe('AuthService', () => {
       mockDatabaseService.auditLog.create.mockResolvedValue({});
       mockDatabaseService.user.update.mockResolvedValue(newUser);
 
-      const result = await service.googleLogin(FAKE_TOKEN);
+      const result = await service.googleLogin(FAKE_TOKEN, googleLoginContext);
 
       expect(result.isNewUser).toBe(true);
       expect(result).toHaveProperty('token');
@@ -786,6 +1209,16 @@ describe('AuthService', () => {
           include: { organization: true },
         }),
       );
+      expect(mockDatabaseService.auditLog.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          action: 'user_login',
+          entityType: 'user',
+          changes: { provider: 'google', reason: 'registration' },
+          ipAddress: googleLoginContext.ipAddress,
+          userAgent: googleLoginContext.userAgent,
+        }),
+      });
+      expect(mockMailService.sendUnrecognizedLoginEmail).not.toHaveBeenCalled();
     });
 
     it('should throw UnauthorizedException when payload is missing (verifyIdToken returns empty)', async () => {

--- a/middleware/src/modules/auth/auth.service.ts
+++ b/middleware/src/modules/auth/auth.service.ts
@@ -29,6 +29,12 @@ import { AlertRulesService } from '../notifications/alert-rules/alert-rules.serv
 // Account lockout constants
 const MAX_LOGIN_ATTEMPTS = 10;
 const LOCKOUT_TTL_SECONDS = 15 * 60; // 15 minutes
+const MAX_LOGIN_CONTEXT_USER_AGENTS = 500;
+
+interface LoginContext {
+  ipAddress?: string;
+  userAgent?: string | string[];
+}
 
 @Injectable()
 export class AuthService {
@@ -49,7 +55,7 @@ export class AuthService {
     private alertRulesService: AlertRulesService,
   ) {}
 
-  async register(dto: RegisterDto, clientIp?: string) {
+  async register(dto: RegisterDto, clientIp?: string, userAgent?: string | string[]) {
     // Check if email already exists
     const existingUser = await this.databaseService.user.findUnique({
       where: { email: dto.email },
@@ -127,6 +133,19 @@ export class AuthService {
         },
       });
 
+      await tx.auditLog.create({
+        data: {
+          organizationId: organization.id,
+          userId: user.id,
+          action: 'user_login',
+          entityType: 'user',
+          entityId: user.id,
+          changes: { reason: 'registration' },
+          ipAddress: clientIp || undefined,
+          userAgent: this.normalizeHeaderValue(userAgent),
+        },
+      });
+
       return { organization, user };
     });
 
@@ -174,7 +193,7 @@ export class AuthService {
     };
   }
 
-  async googleLogin(credential: string) {
+  async googleLogin(credential: string, context: LoginContext = {}) {
     // C2: Audience must be configured — fail closed if missing.
     const clientId = process.env.GOOGLE_CLIENT_ID;
     if (!clientId) {
@@ -277,6 +296,19 @@ export class AuthService {
           },
         });
 
+        await tx.auditLog.create({
+          data: {
+            organizationId: organization.id,
+            userId: newUser.id,
+            action: 'user_login',
+            entityType: 'user',
+            entityId: newUser.id,
+            changes: { provider: 'google', reason: 'registration' },
+            ipAddress: this.normalizeHeaderValue(context.ipAddress),
+            userAgent: this.normalizeHeaderValue(context.userAgent),
+          },
+        });
+
         return newUser;
       });
 
@@ -304,18 +336,8 @@ export class AuthService {
     // Generate JWT token
     const token = this.generateToken(user, user.organization);
 
-    // Log audit event for login
     if (!isNewUser) {
-      await this.databaseService.auditLog.create({
-        data: {
-          organizationId: user.organizationId,
-          userId: user.id,
-          action: 'user_login',
-          entityType: 'user',
-          entityId: user.id,
-          changes: { provider: 'google' },
-        },
-      });
+      await this.createLoginAuditAndCheckUnrecognizedLogin(user, context, { provider: 'google' });
     }
 
     return {
@@ -332,7 +354,141 @@ export class AuthService {
     };
   }
 
-  async login(dto: LoginDto) {
+  private normalizeHeaderValue(value?: string | string[]): string | undefined {
+    if (Array.isArray(value)) {
+      return value.find(Boolean);
+    }
+    return value || undefined;
+  }
+
+  private normalizeUserAgentForLoginContext(userAgent: string): string {
+    return userAgent
+      .replace(/\brv:[\d.]+/gi, 'rv')
+      .replace(/\b(AppleWebKit|Chrome|Chromium|Firefox|Version|Safari|EdgA|EdgiOS|Edg|OPR|CriOS|FxiOS|SamsungBrowser)\/[\d.]+/gi, '$1')
+      .replace(/\bMobile\/[A-Za-z0-9.]+/gi, 'Mobile')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  private hasRecognizedLoginContextUserAgent(
+    currentUserAgent: string,
+    priorLoginsFromSameIp: Array<{ userAgent: string | null }>,
+  ): boolean {
+    const normalizedCurrentUserAgent = this.normalizeUserAgentForLoginContext(currentUserAgent);
+
+    return priorLoginsFromSameIp.some((login) => {
+      if (!login.userAgent) {
+        return false;
+      }
+      return this.normalizeUserAgentForLoginContext(login.userAgent) === normalizedCurrentUserAgent;
+    });
+  }
+
+  private async sendUnrecognizedLoginEmailIfNeeded(
+    user: { id: string; organizationId: string; email: string; firstName: string },
+    currentAuditLogId: string,
+    currentAuditLogCreatedAt: Date,
+    details: { ipAddress: string; userAgent: string; occurredAt: Date },
+  ): Promise<void> {
+    const loginHistoryWhere = {
+      organizationId: user.organizationId,
+      userId: user.id,
+      action: 'user_login',
+      entityType: 'user',
+      id: { not: currentAuditLogId },
+      createdAt: { lt: currentAuditLogCreatedAt },
+      ipAddress: { not: null },
+      userAgent: { not: null },
+    };
+
+    const priorMetadataLogin = await this.databaseService.auditLog.findFirst({
+      where: loginHistoryWhere,
+      select: {
+        id: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    if (!priorMetadataLogin) {
+      return;
+    }
+
+    const priorLoginsFromSameIp = await this.databaseService.auditLog.findMany({
+      where: {
+        ...loginHistoryWhere,
+        ipAddress: details.ipAddress,
+      },
+      select: {
+        userAgent: true,
+      },
+      orderBy: { createdAt: 'desc' },
+      take: MAX_LOGIN_CONTEXT_USER_AGENTS,
+    });
+
+    const isRecognizedLoginContext = this.hasRecognizedLoginContextUserAgent(
+      details.userAgent,
+      priorLoginsFromSameIp,
+    );
+
+    if (isRecognizedLoginContext) {
+      return;
+    }
+
+    await this.mailService.sendUnrecognizedLoginEmail(user.email, user.firstName, details);
+  }
+
+  private checkUnrecognizedLoginInBackground(
+    user: { id: string; organizationId: string; email: string; firstName: string },
+    currentAuditLogId: string,
+    currentAuditLogCreatedAt: Date,
+    details: { ipAddress: string; userAgent: string; occurredAt: Date },
+  ): void {
+    void this.sendUnrecognizedLoginEmailIfNeeded(user, currentAuditLogId, currentAuditLogCreatedAt, details)
+      .catch((err) => {
+        this.logger.warn(
+          `Failed to process unrecognized-login alert for user ${user.id}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+  }
+
+  private async createLoginAuditAndCheckUnrecognizedLogin(
+    user: { id: string; organizationId: string; email: string; firstName: string },
+    context: LoginContext,
+    changes?: Record<string, unknown>,
+  ): Promise<void> {
+    const ipAddress = this.normalizeHeaderValue(context.ipAddress);
+    const userAgent = this.normalizeHeaderValue(context.userAgent);
+
+    const loginAuditLog = await this.databaseService.auditLog.create({
+      data: {
+        organizationId: user.organizationId,
+        userId: user.id,
+        action: 'user_login',
+        entityType: 'user',
+        entityId: user.id,
+        changes,
+        ipAddress,
+        userAgent,
+      },
+    });
+
+    // M12: alert on a successful login from a previously unseen login context.
+    // Use the existing audit log as the history source so we don't introduce a
+    // parallel device-history table. Run the history lookup after the required
+    // audit write, in the background, and only compare against rows older than
+    // this row so concurrent duplicate logins cannot mutually self-suppress.
+    // Lookup/mail failures fail open: a security notification must not block a
+    // successful login.
+    if (ipAddress && userAgent) {
+      this.checkUnrecognizedLoginInBackground(user, loginAuditLog.id, loginAuditLog.createdAt, {
+        ipAddress,
+        userAgent,
+        occurredAt: new Date(),
+      });
+    }
+  }
+
+  async login(dto: LoginDto, context: LoginContext = {}) {
     // Check account lockout — fail CLOSED if Redis is unreachable
     const lockoutKey = `login_attempts:${dto.email}`;
     let attempts = 0;
@@ -395,16 +551,8 @@ export class AuthService {
     // Generate JWT token
     const token = this.generateToken(user, user.organization);
 
-    // Log audit event
-    await this.databaseService.auditLog.create({
-      data: {
-        organizationId: user.organizationId,
-        userId: user.id,
-        action: 'user_login',
-        entityType: 'user',
-        entityId: user.id,
-      },
-    });
+    // Log audit event and run the M12 unrecognized-login alert check.
+    await this.createLoginAuditAndCheckUnrecognizedLogin(user, context);
 
     return {
       user: {

--- a/middleware/src/modules/mail/mail.service.spec.ts
+++ b/middleware/src/modules/mail/mail.service.spec.ts
@@ -66,3 +66,55 @@ describe('MailService.sendDeviceOfflineAlertEmail', () => {
     expect(html).toContain('a&quot;b&#39;c');
   });
 });
+
+describe('MailService.sendUnrecognizedLoginEmail', () => {
+  let service: MailService;
+  let sendMailSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    process.env.APP_URL = 'https://app.vizora.test';
+    service = new MailService();
+    sendMailSpy = jest.spyOn(service as unknown as { sendMail: jest.Func }, 'sendMail').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    delete process.env.APP_URL;
+    jest.restoreAllMocks();
+  });
+
+  it('sends via the auth sender with account review CTA', async () => {
+    await service.sendUnrecognizedLoginEmail('user@example.com', 'Ada', {
+      ipAddress: '203.0.113.10',
+      userAgent: 'Mozilla/5.0 Chrome/125.0',
+      occurredAt: new Date('2026-05-31T12:00:00.000Z'),
+    });
+
+    expect(sendMailSpy).toHaveBeenCalledTimes(1);
+    const [to, subject, html, label, sender] = sendMailSpy.mock.calls[0];
+
+    expect(to).toBe('user@example.com');
+    expect(subject).toBe('New login to your Vizora account');
+    expect(html).toContain('New login detected');
+    expect(html).toContain('https://app.vizora.test/dashboard/settings');
+    expect(html).toContain('Review Account');
+    expect(label).toBe('Unrecognized login');
+    expect(sender).toBe('auth');
+  });
+
+  it('escapes caller-supplied name, IP address, and user agent', async () => {
+    await service.sendUnrecognizedLoginEmail('user@example.com', '<Ada>', {
+      ipAddress: '203.0.113.10"><script>',
+      userAgent: 'Browser <img src=x onerror=alert(1)>',
+      occurredAt: new Date('2026-05-31T12:00:00.000Z'),
+    });
+
+    const [, , html] = sendMailSpy.mock.calls[0];
+
+    expect(html).toContain('&lt;Ada&gt;');
+    expect(html).toContain('203.0.113.10&quot;&gt;&lt;script&gt;');
+    expect(html).toContain('Browser &lt;img src=x onerror=alert(1)&gt;');
+    expect(html).not.toContain('<Ada>');
+    expect(html).not.toContain('203.0.113.10"><script>');
+    expect(html).not.toContain('<img src=x onerror=alert(1)>');
+  });
+});

--- a/middleware/src/modules/mail/mail.service.ts
+++ b/middleware/src/modules/mail/mail.service.ts
@@ -452,4 +452,52 @@ export class MailService {
     `);
     await this.sendMail(to, subject, html, 'Password changed', 'auth');
   }
+
+  /**
+   * Security notification sent after a successful login from a new context.
+   * This is intentionally framed as "new login context" rather than a durable
+   * trusted-device system: IPs and browser User-Agent strings can legitimately
+   * change. All caller-supplied values are escaped before interpolation.
+   */
+  async sendUnrecognizedLoginEmail(
+    to: string,
+    firstName: string,
+    details: { ipAddress: string; userAgent: string; occurredAt: Date },
+  ): Promise<void> {
+    const subject = 'New login to your Vizora account';
+    const html = this.wrapInTemplate(`
+          <h1 style="color:#F0ECE8;font-size:22px;font-weight:700;margin:0 0 8px 0;">New login detected</h1>
+          <p style="color:#8A9BA3;font-size:14px;line-height:1.6;margin:0 0 24px 0;">
+            Hi ${MailService.escapeHtml(firstName)},<br><br>
+            We noticed a successful login to your Vizora account from a new login context.
+            If this was you, no action is needed.
+          </p>
+          <table width="100%" cellpadding="0" cellspacing="0" style="margin:0 0 24px 0;">
+            <tr>
+              <td style="padding:12px 16px;background:#0A1E26;border-radius:8px 8px 0 0;border-bottom:1px solid #1B3D47;">
+                <span style="color:#5A6B73;font-size:12px;text-transform:uppercase;letter-spacing:0.5px;">Time</span><br>
+                <span style="color:#F0ECE8;font-size:14px;">${MailService.escapeHtml(details.occurredAt.toISOString())}</span>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:12px 16px;background:#0A1E26;border-bottom:1px solid #1B3D47;">
+                <span style="color:#5A6B73;font-size:12px;text-transform:uppercase;letter-spacing:0.5px;">IP address</span><br>
+                <span style="color:#F0ECE8;font-size:14px;">${MailService.escapeHtml(details.ipAddress)}</span>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:12px 16px;background:#0A1E26;border-radius:0 0 8px 8px;">
+                <span style="color:#5A6B73;font-size:12px;text-transform:uppercase;letter-spacing:0.5px;">Browser</span><br>
+                <span style="color:#F0ECE8;font-size:14px;word-break:break-word;">${MailService.escapeHtml(details.userAgent)}</span>
+              </td>
+            </tr>
+          </table>
+          ${this.ctaButton('Review Account', `${this.appUrl}/dashboard/settings`)}
+          <p style="color:#5A6B73;font-size:12px;line-height:1.5;margin:16px 0 0 0;">
+            If you do <strong style="color:#F0ECE8;">not</strong> recognize this login,
+            change your password immediately and contact support@vizora.cloud.
+          </p>
+    `);
+    await this.sendMail(to, subject, html, 'Unrecognized login', 'auth');
+  }
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,41 @@
 # Vizora - Task Tracker
 
-## Active: Customer-1 Smoke Hardening (2026-05-31)
+## Active: M12 Unrecognized Login Alert (2026-05-31)
+
+**Branch:** `feat/m12-unrecognized-login-alert`
+
+**Why now:** `backlog.md` marks M12 partial. Password-changed alerts shipped, but the remaining new-login/unrecognized-device alert is deferred. This is a repo-side P2 security/readiness item and does not require operator credentials.
+
+**New primitives introduced:** none planned. Use existing `AuditLog.ipAddress` + `AuditLog.userAgent` fields as login history instead of adding a parallel device-history table.
+
+**Hermes-first analysis:** not applicable. This is a synchronous auth/mail security notification path, not a business-agent, MCP, or AI/provider-spend workflow.
+
+**Plan**
+- [x] Drift-check existing auth/mail/audit support for login metadata.
+- [x] Add request IP/User-Agent propagation from `AuthController.login` to `AuthService.login`.
+- [x] Log `ipAddress` and `userAgent` on `user_login` audit rows.
+- [x] Send a non-blocking security email only when a successful password/Google login has prior metadata-bearing login history but no prior matching IP/User-Agent pair.
+- [x] Seed metadata-bearing login audit rows on password and Google registration so the first later different-context login can alert.
+- [x] Add MailService template and tests for HTML escaping.
+- [x] Add focused AuthService/AuthController tests for metadata propagation, audit writes, first-login suppression, recognized-login suppression, normalized browser-version matching, unrecognized-login email, and mail-failure non-blocking.
+- [x] Run focused tests and final review.
+- [ ] Open PR, wait for CI, and merge if clean.
+
+**Verification so far**
+- `pnpm install --frozen-lockfile` in isolated worktree (needed because worktree had no `node_modules`).
+- `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="auth.service|auth.controller|mail.service"`: PASS, 3 suites / 90 tests.
+- `NODE_OPTIONS=--use-system-ca pnpm --dir packages/database exec prisma generate`: PASS. Needed only for the fresh isolated worktree because generated Prisma client was absent.
+- `npx nx build @vizora/middleware`: PASS with existing webpack warnings.
+- `pnpm --filter @vizora/middleware test -- --runInBand`: PASS, 141 suites / 2739 tests.
+
+**Review notes**
+- Local `claude -p` review is blocked by operator auth (`Not logged in - Please run /login`). Fallback reviewers used via local subagent tool.
+- Reviewer findings fixed: mail send and alert-history lookup now run after audit write in a fail-open background task; same-IP history lookup is bounded; prior rows are constrained to `createdAt < currentAuditLog.createdAt`; existing Google OAuth logins now pass IP/User-Agent through the same audit/alert path; password and Google registration now seed metadata-bearing login rows without sending an alert; Firefox `rv:` and mobile Edge UA version normalization are covered by tests.
+- Final reviewer gate: CLEAN.
+
+---
+
+## Completed: Customer-1 Smoke Hardening (2026-05-31)
 
 **Branch:** `feat/customer1-smoke-hardening`
 


### PR DESCRIPTION
## Summary
- Capture request IP and User-Agent on password, Google, and registration login audit rows.
- Send fail-open security email for successful logins from a previously unseen IP/User-Agent context using existing AuditLog history.
- Add MailService template with HTML escaping and focused auth/mail regression coverage.

## Verification
- pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=auth.service|auth.controller|mail.service (PASS, 3 suites / 90 tests)
- NODE_OPTIONS=--use-system-ca pnpm --dir packages/database exec prisma generate (PASS, isolated worktree setup)
- npx nx build @vizora/middleware (PASS, existing 8 webpack warnings)
- pnpm --filter @vizora/middleware test -- --runInBand (PASS, 141 suites / 2739 tests)
- git diff --check (PASS; Git emitted Windows CRLF conversion warnings only)

## Review
- Local claude CLI unavailable: Not logged in. Fallback local reviewer subagent final gate: CLEAN.

## Deploy
- Not deployed. No env/secrets/schema changes.