### PR TITLE
fix: harden display delivery reliability

### DIFF
--- a/display/src/electron/device-client.spec.ts
+++ b/display/src/electron/device-client.spec.ts
@@ -302,6 +302,7 @@ describe('DeviceClient', () => {
       expect(registeredEvents).toContain('connect');
       expect(registeredEvents).toContain('disconnect');
       expect(registeredEvents).toContain('connect_error');
+      expect(registeredEvents).toContain('token:refresh');
       expect(registeredEvents).toContain('playlist:update');
       expect(registeredEvents).toContain('command');
       expect(registeredEvents).toContain('error');
@@ -320,6 +321,177 @@ describe('DeviceClient', () => {
 
       expect(mockConfig.onPlaylistUpdate).toHaveBeenCalledWith(playlist);
       expect(ack).toHaveBeenCalledWith({ ok: true });
+    });
+
+    it('should append the device token to protected playlist media URLs before rendering', async () => {
+      client.connect('device-token-123');
+
+      const playlistCall = mockSocket.on.mock.calls.find(
+        (call: any[]) => call[0] === 'playlist:update',
+      );
+      const ack = jest.fn();
+      const playlist = {
+        id: 'playlist-1',
+        items: [
+          {
+            id: 'item-1',
+            content: {
+              id: 'content-1',
+              url: 'http://localhost:3000/api/v1/device-content/content-1/file?variant=original',
+            },
+          },
+        ],
+      };
+
+      await playlistCall![1]({ playlist }, ack);
+
+      expect(mockConfig.onPlaylistUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          items: [
+            expect.objectContaining({
+              content: expect.objectContaining({
+                url: 'http://localhost:3000/api/v1/device-content/content-1/file?variant=original&token=device-token-123',
+              }),
+            }),
+          ],
+        }),
+      );
+      expect(playlist.items[0].content.url).toBe(
+        'http://localhost:3000/api/v1/device-content/content-1/file?variant=original',
+      );
+      expect(ack).toHaveBeenCalledWith({ ok: true });
+    });
+
+    it('should not append the device token to attacker-origin device-content lookalike URLs', async () => {
+      client.connect('device-token-123');
+
+      const playlistCall = mockSocket.on.mock.calls.find(
+        (call: any[]) => call[0] === 'playlist:update',
+      );
+      const ack = jest.fn();
+      const playlist = {
+        id: 'playlist-1',
+        items: [
+          {
+            id: 'item-1',
+            content: {
+              id: 'content-1',
+              url: 'https://evil.example/api/v1/device-content/content-1/file',
+            },
+          },
+        ],
+      };
+
+      await playlistCall![1]({ playlist }, ack);
+
+      expect(mockConfig.onPlaylistUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          items: [
+            expect.objectContaining({
+              content: expect.objectContaining({
+                url: 'https://evil.example/api/v1/device-content/content-1/file',
+              }),
+            }),
+          ],
+        }),
+      );
+      expect(ack).toHaveBeenCalledWith({ ok: true });
+    });
+
+    it('should normalize protected relative URLs to absolute API URLs before tokenizing', async () => {
+      client.connect('device-token-123');
+
+      const playlistCall = mockSocket.on.mock.calls.find(
+        (call: any[]) => call[0] === 'playlist:update',
+      );
+      const ack = jest.fn();
+
+      await playlistCall![1]({
+        playlist: {
+          id: 'playlist-1',
+          items: [
+            {
+              id: 'item-1',
+              content: {
+                id: 'content-1',
+                url: '/api/v1/device-content/content-1/file',
+              },
+            },
+          ],
+        },
+      }, ack);
+
+      expect(mockConfig.onPlaylistUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          items: [
+            expect.objectContaining({
+              content: expect.objectContaining({
+                url: 'http://localhost:3000/api/v1/device-content/content-1/file?token=device-token-123',
+              }),
+            }),
+          ],
+        }),
+      );
+      expect(ack).toHaveBeenCalledWith({ ok: true });
+    });
+
+    it('should consume refreshed device tokens for subsequent protected media URLs', async () => {
+      client.connect('old-token');
+
+      const refreshCall = mockSocket.on.mock.calls.find(
+        (call: any[]) => call[0] === 'token:refresh',
+      );
+      refreshCall![1]({ token: 'new-token' });
+
+      const playlistCall = mockSocket.on.mock.calls.find(
+        (call: any[]) => call[0] === 'playlist:update',
+      );
+      await playlistCall![1]({
+        playlist: {
+          id: 'playlist-1',
+          items: [
+            {
+              id: 'item-1',
+              content: {
+                id: 'content-1',
+                url: 'http://localhost:3000/api/v1/device-content/content-1/file',
+              },
+            },
+          ],
+        },
+      }, jest.fn());
+
+      expect(mockStore.set).toHaveBeenCalledWith('deviceToken', 'new-token');
+      expect(mockConfig.onPlaylistUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          items: [
+            expect.objectContaining({
+              content: expect.objectContaining({
+                url: 'http://localhost:3000/api/v1/device-content/content-1/file?token=new-token',
+              }),
+            }),
+          ],
+        }),
+      );
+    });
+
+    it('should update socket auth when a device token is refreshed', () => {
+      client.connect('old-token');
+      mockSocket.auth = {
+        token: 'old-token',
+        capabilities: { deliveryAck: true },
+      };
+
+      const refreshCall = mockSocket.on.mock.calls.find(
+        (call: any[]) => call[0] === 'token:refresh',
+      );
+      refreshCall![1]({ token: 'new-token' });
+
+      expect(mockSocket.auth).toEqual({
+        token: 'new-token',
+        capabilities: { deliveryAck: true },
+      });
+      expect(mockStore.set).toHaveBeenCalledWith('deviceToken', 'new-token');
     });
 
     it('should negative-ack playlist updates when applying fails', async () => {
@@ -444,6 +616,45 @@ describe('DeviceClient', () => {
         ok: false,
         error: 'push_content missing content URL',
       });
+    });
+
+    it('should append the device token before loading protected push_content URLs', async () => {
+      const electron = require('electron');
+      const logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+      try {
+        const mockWindow = {
+          webContents: {
+            getURL: jest.fn().mockReturnValue('file:///display/index.html'),
+          },
+          loadURL: jest.fn().mockResolvedValue(undefined),
+        };
+        electron.BrowserWindow.getAllWindows.mockReturnValue([mockWindow]);
+        client.connect('device-token-123');
+
+        const commandCall = mockSocket.on.mock.calls.find(
+          (call: any[]) => call[0] === 'command',
+        );
+        const ack = jest.fn();
+
+        await commandCall![1]({
+          type: 'push_content',
+          payload: {
+            content: {
+              id: 'content-1',
+              url: 'http://localhost:3000/api/v1/device-content/content-1/file',
+            },
+            duration: 1,
+          },
+        }, ack);
+
+        expect(mockWindow.loadURL).toHaveBeenCalledWith(
+          'http://localhost:3000/api/v1/device-content/content-1/file?token=device-token-123',
+        );
+        expect(logSpy.mock.calls.flat().join(' ')).not.toContain('device-token-123');
+        expect(ack).toHaveBeenCalledWith({ ok: true });
+      } finally {
+        logSpy.mockRestore();
+      }
     });
 
     it('should start heartbeat on connect event', () => {

--- a/display/src/electron/device-client.ts
+++ b/display/src/electron/device-client.ts
@@ -20,6 +20,7 @@ export class DeviceClient {
   private cachedDeviceIdentifier: string | null = null;
   private previousCpuTimes: { idle: number; total: number } | null = null;
   private overrideState: { previousUrl?: string; revertTimer: any; commandId?: string } | null = null;
+  private deviceToken: string | null = null;
 
   private mainWindow: any = null;
 
@@ -244,6 +245,8 @@ export class DeviceClient {
   }
 
   connect(token: string) {
+    this.deviceToken = token;
+
     // Fix localhost resolution to IPv4 for WebSocket
     const realtimeUrl = this.realtimeUrl.replace(/localhost/g, '127.0.0.1');
     console.log('[DeviceClient] Connecting to realtime gateway:', realtimeUrl);
@@ -276,6 +279,7 @@ export class DeviceClient {
       console.error('[DeviceClient] Connection error:', error.message);
       if (error.message.includes('unauthorized') || error.message.includes('invalid token')) {
         console.log('[DeviceClient] Token rejected, clearing and re-entering pairing');
+        this.deviceToken = null;
         this.store?.delete('deviceToken');
         this.socket?.disconnect();
         this.config.onPairingRequired();
@@ -286,10 +290,41 @@ export class DeviceClient {
       console.log('Received configuration:', config);
     });
 
-    this.socket.on('playlist:update', async (data, ack?: SocketAck) => {
-      console.log('Received playlist update:', data);
+    this.socket.on('token:refresh', (data) => {
+      if (!data?.token || typeof data.token !== 'string') {
+        return;
+      }
+
+      this.deviceToken = data.token;
+      if (this.socket) {
+        const socketWithAuth = this.socket as Socket & {
+          auth?: {
+            token?: string;
+            capabilities?: Record<string, unknown>;
+            [key: string]: unknown;
+          };
+        };
+        socketWithAuth.auth = {
+          ...(socketWithAuth.auth ?? {}),
+          token: data.token,
+          capabilities: {
+            ...(socketWithAuth.auth?.capabilities ?? {}),
+            deliveryAck: true,
+          },
+        };
+      }
       try {
-        await this.config.onPlaylistUpdate(data.playlist);
+        this.store?.set('deviceToken', data.token);
+      } catch (error) {
+        console.error('[DeviceClient] Failed to persist refreshed device token:', error);
+      }
+    });
+
+    this.socket.on('playlist:update', async (data, ack?: SocketAck) => {
+      console.log('Received playlist update:', this.redactDeviceTokenFromLogValue(data));
+      try {
+        const playlist = this.attachDeviceTokenToProtectedUrls(data.playlist);
+        await this.config.onPlaylistUpdate(playlist);
         ack?.({ ok: true });
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Failed to apply playlist';
@@ -300,7 +335,8 @@ export class DeviceClient {
     });
 
     this.socket.on('command', async (data, ack?: SocketAck) => {
-      console.log('Received command:', data);
+      const command = this.attachDeviceTokenToProtectedUrls(data);
+      console.log('Received command:', this.redactDeviceTokenFromLogValue(command));
       let ackSent = false;
       const sendAck = (response: { ok: boolean; error?: string }) => {
         ack?.(response);
@@ -308,15 +344,15 @@ export class DeviceClient {
       };
 
       try {
-        if (this.shouldAckBeforeCommandExecution(data)) {
+        if (this.shouldAckBeforeCommandExecution(command)) {
           sendAck({ ok: true });
           await this.waitForSelfTerminatingCommandAckFlush();
-          await this.handleCommand(data);
+          await this.handleCommand(command);
           return;
         }
 
-        await this.config.onCommand(data);
-        await this.handleCommand(data);
+        await this.config.onCommand(command);
+        await this.handleCommand(command);
         if (!ackSent) {
           sendAck({ ok: true });
         }
@@ -437,6 +473,83 @@ export class DeviceClient {
     await new Promise((resolve) => setTimeout(resolve, SELF_TERMINATING_COMMAND_ACK_FLUSH_MS));
   }
 
+  private attachDeviceTokenToProtectedUrls<T>(value: T): T {
+    if (Array.isArray(value)) {
+      return value.map((item) => this.attachDeviceTokenToProtectedUrls(item)) as T;
+    }
+
+    if (!value || typeof value !== 'object') {
+      return value;
+    }
+
+    const result: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      result[key] = key === 'url' && typeof entry === 'string'
+        ? this.appendDeviceTokenToProtectedUrl(entry)
+        : this.attachDeviceTokenToProtectedUrls(entry);
+    }
+
+    return result as T;
+  }
+
+  private appendDeviceTokenToProtectedUrl(rawUrl: string): string {
+    if (!this.deviceToken) {
+      return rawUrl;
+    }
+
+    try {
+      const isAbsolute = /^[a-z][a-z0-9+.-]*:/i.test(rawUrl);
+      const url = new URL(rawUrl, this.apiUrl);
+      const isProtectedDeviceContent =
+        /\/api\/v1\/device-content\/[^/]+\/file$/.test(url.pathname) ||
+        /\/device-content\/[^/]+\/file$/.test(url.pathname);
+      const apiOrigin = new URL(this.apiUrl).origin;
+
+      if (!isProtectedDeviceContent || url.origin !== apiOrigin || url.searchParams.has('token')) {
+        return rawUrl;
+      }
+
+      url.searchParams.set('token', this.deviceToken);
+      return url.toString();
+    } catch {
+      return rawUrl;
+    }
+  }
+
+  private redactDeviceTokenFromLogValue<T>(value: T): T {
+    if (Array.isArray(value)) {
+      return value.map((item) => this.redactDeviceTokenFromLogValue(item)) as T;
+    }
+
+    if (!value || typeof value !== 'object') {
+      return value;
+    }
+
+    const result: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      result[key] = key === 'url' && typeof entry === 'string'
+        ? this.redactDeviceTokenFromUrl(entry)
+        : this.redactDeviceTokenFromLogValue(entry);
+    }
+
+    return result as T;
+  }
+
+  private redactDeviceTokenFromUrl(rawUrl: string): string {
+    try {
+      const isAbsolute = /^[a-z][a-z0-9+.-]*:/i.test(rawUrl);
+      const url = new URL(rawUrl, this.apiUrl);
+      if (!url.searchParams.has('token')) {
+        return rawUrl;
+      }
+
+      url.searchParams.set('token', '[redacted]');
+      return isAbsolute ? url.toString() : `${url.pathname}${url.search}${url.hash}`;
+    } catch {
+      return rawUrl;
+    }
+  }
+
   private async handleCommand(command: any): Promise<void> {
     switch (command.type) {
       case 'reload':
@@ -520,7 +633,7 @@ export class DeviceClient {
 
           // Load the pushed content
           await pushWindow.loadURL(content.url);
-          console.log(`[DeviceClient] Override active: loading ${content.url} (commandId: ${commandId})`);
+          console.log(`[DeviceClient] Override active: loading ${this.redactDeviceTokenFromUrl(content.url)} (commandId: ${commandId})`);
 
           // Set auto-revert timer (duration is in minutes)
           const durationMs = (duration || 60) * 60 * 1000;

--- a/docs/plans/2026-05-31-display-delivery-reliability-follow-up.md
+++ b/docs/plans/2026-05-31-display-delivery-reliability-follow-up.md
@@ -1,0 +1,61 @@
+# Display Delivery Reliability Follow-up
+
+Date: 2026-05-31
+Branch: `feat/customer-performance-hardening-2`
+
+## Source Findings
+
+Read-only realtime/display and dashboard/customer reviewers found residual delivery risks after the customer dashboard performance push:
+
+1. Negative ACKs queue playlist or command work, but a still-connected device only replays that queue on reconnect.
+2. Fleet broadcast commands bypass `DeviceGateway.sendCommand`, so they do not use ACKs or the same queue semantics as single-device commands.
+3. Electron display playback/cache paths receive protected `/device-content/:id/file` URLs without a device token query, while the browser display app already appends the device token.
+4. Middleware single-display command callers send `{ displayId, command, payload }` to realtime, but realtime now validates `{ deviceId, command: { type, payload } }`.
+
+## New Primitives Introduced
+
+None. This pass tightens existing middleware display commands, realtime gateway delivery, and Electron display-client URL handling.
+
+## Hermes-first Analysis
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Realtime command replay | none applicable | Build in the existing Socket.IO gateway because this is device transport behavior, not agent orchestration. |
+| Fleet command broadcast | none applicable | Route through existing `DeviceGateway.sendCommand`. |
+| Electron protected media URL handling | none applicable | Build in the existing Electron display client where the device JWT is already available. |
+| Middleware display command DTOs | none applicable | Fix callers to match the existing realtime DTO contract. |
+
+Awesome-Hermes-agent ecosystem check: not applicable; no business-agent, MCP, AI-provider, or spend path is introduced.
+
+## Plan
+
+- [x] Add failing focused tests for pending playlist/command replay from heartbeat without restoring heartbeat response command drains.
+- [x] Route fleet broadcast commands through `DeviceGateway.sendCommand` and return delivered/queued/failed counts while preserving `devicesOnline`.
+- [x] Append the current Electron device token to protected `/device-content/:id/file` URLs before renderer playback/cache and `push_content` loads.
+- [x] Fix middleware display command calls to use realtime's validated nested command DTO.
+- [x] Run focused tests for realtime, display, middleware, and web touched paths.
+- [x] Run multi-review on the diff before broader tests.
+- [x] Run broader service tests/builds proportional to touched packages.
+- [ ] Open PR, wait for CI, merge if clean.
+
+## Verification Targets
+
+- `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern="device.gateway|app.controller|redis.service"` - pass, 4 suites / 112 tests.
+- `pnpm --filter @vizora/display test -- --runInBand --testPathPattern="device-client"` - pass, 1 suite / 46 tests.
+- `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="displays.service|fleet.service"` - pass, 4 suites / 72 tests.
+- `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="DeviceControls"` - pass, 1 suite / 6 tests.
+- `git diff --check` - pass; line-ending warnings only.
+- `pnpm --filter @vizora/realtime test -- --runInBand` - pass, 11 suites / 242 tests.
+- `pnpm --filter @vizora/display test -- --runInBand` - pass, 5 suites / 115 tests; existing MaxListeners warning remains in full display suite.
+- `pnpm --filter @vizora/middleware test -- --runInBand` - pass, 141 suites / 2761 tests.
+- `pnpm --filter @vizora/web test -- --runInBand` - pass, 82 suites / 882 tests; existing unrelated React `act(...)` warnings remain.
+- `npx nx build @vizora/middleware` - pass with existing webpack warnings.
+- `npx nx build @vizora/realtime` - pass with existing source-map/optional `ws` warnings.
+- `pnpm --filter @vizora/display build` - pass.
+- `NODE_OPTIONS=--max-old-space-size=4096 npx nx build @vizora/web` - pass with existing Next middleware/proxy and missing production API URL warnings.
+
+## Review Results
+
+- Internal API re-review: CLEAN.
+- Display-client re-review: CLEAN.
+- Realtime re-review: CLEAN after fixing in-flight stale playlist replay, command socket-handoff requeue semantics, and heartbeat replay backoff reset for newly queued work.

--- a/middleware/src/modules/displays/displays.service.spec.ts
+++ b/middleware/src/modules/displays/displays.service.spec.ts
@@ -489,9 +489,11 @@ describe('DisplaysService', () => {
       expect(httpService.post).toHaveBeenCalledWith(
         expect.stringContaining('/internal/command'),
         expect.objectContaining({
-          displayId: mockDisplayId,
-          command: 'screenshot',
-          payload: expect.objectContaining({ requestId: expect.any(String) }),
+          deviceId: mockDisplayId,
+          command: {
+            type: 'screenshot',
+            payload: expect.objectContaining({ requestId: expect.any(String) }),
+          },
         }),
         expect.objectContaining({
           headers: expect.objectContaining({ 'x-internal-api-key': expect.any(String) }),
@@ -542,6 +544,66 @@ describe('DisplaysService', () => {
           process.env.INTERNAL_API_SECRET = previousSecret;
         }
       }
+    });
+
+    it('should throw ServiceUnavailableException when realtime does not acknowledge screenshot delivery', async () => {
+      databaseService.display.findFirst.mockResolvedValue(mockDisplayWithRelations);
+      httpService.post.mockReturnValue(of({
+        data: {
+          success: false,
+          message: 'Command delivery failed: ack_timeout',
+        },
+      }) as any);
+
+      await expect(
+        service.requestScreenshot(mockOrganizationId, mockDisplayId)
+      ).rejects.toThrow(ServiceUnavailableException);
+    });
+  });
+
+  describe('display commands', () => {
+    beforeEach(() => {
+      httpService.post.mockReturnValue(of({ data: { success: true } }) as any);
+    });
+
+    it('should send disable commands using realtime internal command DTO shape', async () => {
+      databaseService.display.updateMany.mockResolvedValue({ count: 1 } as any);
+
+      await service.disableDevice(mockDisplayId, mockOrganizationId);
+
+      expect(httpService.post).toHaveBeenCalledWith(
+        expect.stringContaining('/internal/command'),
+        {
+          deviceId: mockDisplayId,
+          command: {
+            type: 'disable',
+            payload: undefined,
+          },
+        },
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'x-internal-api-key': expect.any(String) }),
+        }),
+      );
+    });
+
+    it('should send enable commands using realtime internal command DTO shape', async () => {
+      databaseService.display.updateMany.mockResolvedValue({ count: 1 } as any);
+
+      await service.enableDevice(mockDisplayId, mockOrganizationId);
+
+      expect(httpService.post).toHaveBeenCalledWith(
+        expect.stringContaining('/internal/command'),
+        {
+          deviceId: mockDisplayId,
+          command: {
+            type: 'enable',
+            payload: undefined,
+          },
+        },
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'x-internal-api-key': expect.any(String) }),
+        }),
+      );
     });
   });
 

--- a/middleware/src/modules/displays/displays.service.ts
+++ b/middleware/src/modules/displays/displays.service.ts
@@ -671,13 +671,20 @@ export class DisplaysService {
       await this.circuitBreaker.executeWithFallback(
         'realtime-service',
         async () => {
-          await firstValueFrom(
+          const response = await firstValueFrom(
             this.httpService.post(url, {
-              displayId,
-              command: 'screenshot',
-              payload: { requestId },
+              deviceId: displayId,
+              command: {
+                type: 'screenshot',
+                payload: { requestId },
+              },
             }, { headers }),
           );
+          if (response.data?.success === false) {
+            throw new ServiceUnavailableException(
+              response.data?.message || 'Screenshot command was not acknowledged by the realtime service',
+            );
+          }
           this.logger.log(`Screenshot requested for display ${displayId} (requestId: ${requestId})`);
         },
         (error) => {
@@ -824,9 +831,11 @@ export class DisplaysService {
       async () => {
         await firstValueFrom(
           this.httpService.post(url, {
-            displayId,
-            command,
-            payload,
+            deviceId: displayId,
+            command: {
+              type: command,
+              payload,
+            },
           }, { headers }),
         );
         this.logger.log(`Command '${command}' sent to device ${displayId}`);

--- a/middleware/src/modules/fleet/fleet.service.spec.ts
+++ b/middleware/src/modules/fleet/fleet.service.spec.ts
@@ -274,8 +274,41 @@ describe('FleetService', () => {
       expect(result.devicesTargeted).toBe(1);
       expect(result.devicesOnline).toBe(1);
       expect(result.devicesQueued).toBe(0);
+      expect(result.devicesDelivered).toBe(1);
+      expect(result.devicesFailed).toBe(0);
       expect(result.commandId).toBeDefined();
       expect(circuitBreaker.executeWithFallback).toHaveBeenCalled();
+    });
+
+    it('should use gateway delivered queued and failed counts when available', async () => {
+      db.display.findFirst.mockResolvedValue({
+        id: mockDeviceId,
+        nickname: 'Test',
+        organizationId: mockOrgId,
+      });
+      httpService.post.mockReturnValue(of({
+        data: {
+          devicesOnline: 1,
+          delivered: 0,
+          queued: 1,
+          failed: 0,
+        },
+      }) as any);
+
+      const result = await service.sendCommand(
+        mockOrgId,
+        mockUserId,
+        'admin',
+        {
+          command: 'reload' as const,
+          target: { type: 'device' as const, id: mockDeviceId },
+        },
+      );
+
+      expect(result.devicesOnline).toBe(1);
+      expect(result.devicesDelivered).toBe(0);
+      expect(result.devicesQueued).toBe(1);
+      expect(result.devicesFailed).toBe(0);
     });
 
     it('should resolve content from DB and include it in gateway payload for push_content', async () => {

--- a/middleware/src/modules/fleet/fleet.service.ts
+++ b/middleware/src/modules/fleet/fleet.service.ts
@@ -30,6 +30,9 @@ interface ResolvedTarget {
 
 interface GatewayBroadcastResult {
   devicesOnline: number;
+  delivered?: number;
+  queued?: number;
+  failed?: number;
 }
 
 interface OverrideRecord {
@@ -116,13 +119,15 @@ export class FleetService {
     // Call gateway broadcast — command shape: { type, payload, commandId }
     // For simple commands (reload, restart): payload is empty
     // For push_content: payload contains { content, duration, priority }
-    const { devicesOnline } = await this.callGatewayBroadcast(deviceIds, {
+    const gatewayResult = await this.callGatewayBroadcast(deviceIds, {
       commandId,
       command: dto.command,
       payload: gatewayPayload,
     });
-
-    const devicesQueued = deviceIds.length - devicesOnline;
+    const devicesOnline = gatewayResult.devicesOnline;
+    const devicesDelivered = gatewayResult.delivered ?? devicesOnline;
+    const devicesQueued = gatewayResult.queued ?? Math.max(deviceIds.length - devicesOnline, 0);
+    const devicesFailed = gatewayResult.failed ?? 0;
 
     // Handle emergency override with push_content
     if (
@@ -153,6 +158,8 @@ export class FleetService {
       devicesTargeted: deviceIds.length,
       devicesOnline,
       devicesQueued,
+      devicesDelivered,
+      devicesFailed,
     };
   }
 
@@ -280,7 +287,12 @@ export class FleetService {
       },
     );
 
-    return { devicesOnline: result?.devicesOnline ?? 0 };
+    return {
+      devicesOnline: result?.devicesOnline ?? 0,
+      delivered: result?.delivered,
+      queued: result?.queued,
+      failed: result?.failed,
+    };
   }
 
   async createOverride(

--- a/realtime/src/app/app.controller.spec.ts
+++ b/realtime/src/app/app.controller.spec.ts
@@ -51,10 +51,9 @@ describe('AppController', () => {
   describe('broadcastCommand', () => {
     const baseCommand = { type: 'clear_override', payload: { reason: 'test' }, commandId: 'cmd-1' };
 
-    it('should emit to each device room and return correct devicesOnline count', async () => {
-      // Device A is online (has a room with 1 socket)
+    it('should send each broadcast command through DeviceGateway and return delivery counts', async () => {
+      (mockDeviceGateway.sendCommand as jest.Mock).mockResolvedValue({ delivered: true });
       mockRooms.set('device:dev-a', new Set(['socket-1']));
-      // Device B is also online
       mockRooms.set('device:dev-b', new Set(['socket-2']));
 
       const result = await controller.broadcastCommand({
@@ -62,64 +61,66 @@ describe('AppController', () => {
         command: baseCommand,
       });
 
-      expect(result.devicesOnline).toBe(2);
-      expect(mockTo).toHaveBeenCalledWith('device:dev-a');
-      expect(mockTo).toHaveBeenCalledWith('device:dev-b');
-      expect(mockEmit).toHaveBeenCalledTimes(2);
-      expect(mockEmit).toHaveBeenCalledWith('command', expect.objectContaining({
-        type: 'clear_override',
-        payload: { reason: 'test' },
-        commandId: 'cmd-1',
-        timestamp: expect.any(String),
-      }));
+      expect(result).toEqual({
+        devicesOnline: 2,
+        delivered: 2,
+        queued: 0,
+        failed: 0,
+      });
+      expect(mockDeviceGateway.sendCommand).toHaveBeenCalledWith('dev-a', baseCommand);
+      expect(mockDeviceGateway.sendCommand).toHaveBeenCalledWith('dev-b', baseCommand);
+      expect(mockTo).not.toHaveBeenCalled();
+      expect(mockEmit).not.toHaveBeenCalled();
     });
 
-    it('should queue commands for offline devices via addDeviceCommand', async () => {
-      // Device A is online
+    it('should count gateway-queued commands without writing a parallel queue path', async () => {
+      (mockDeviceGateway.sendCommand as jest.Mock)
+        .mockResolvedValueOnce({ delivered: true })
+        .mockResolvedValueOnce({ delivered: false, reason: 'no_sockets' });
       mockRooms.set('device:dev-a', new Set(['socket-1']));
-      // Device B is offline (no room entry)
 
       const result = await controller.broadcastCommand({
         deviceIds: ['dev-a', 'dev-b'],
         command: baseCommand,
       });
 
-      expect(result.devicesOnline).toBe(1);
-      // Should NOT queue for online device
-      expect(mockRedisService.addDeviceCommand).not.toHaveBeenCalledWith(
-        'dev-a',
-        expect.anything(),
-      );
-      // Should queue for offline device
-      expect(mockRedisService.addDeviceCommand).toHaveBeenCalledWith(
-        'dev-b',
-        expect.objectContaining({
-          type: 'clear_override',
-          timestamp: expect.any(String),
-        }),
-      );
+      expect(result).toEqual({
+        devicesOnline: 1,
+        delivered: 1,
+        queued: 1,
+        failed: 0,
+      });
+      expect(mockRedisService.addDeviceCommand).not.toHaveBeenCalled();
     });
 
-    it('should queue all commands when all devices are offline', async () => {
+    it('should count all offline commands as queued by the gateway', async () => {
+      (mockDeviceGateway.sendCommand as jest.Mock).mockResolvedValue({ delivered: false, reason: 'no_sockets' });
+
       const result = await controller.broadcastCommand({
         deviceIds: ['dev-x', 'dev-y'],
         command: { type: 'reload' },
       });
 
-      expect(result.devicesOnline).toBe(0);
-      expect(mockRedisService.addDeviceCommand).toHaveBeenCalledTimes(2);
+      expect(result).toEqual({
+        devicesOnline: 0,
+        delivered: 0,
+        queued: 2,
+        failed: 0,
+      });
+      expect(mockRedisService.addDeviceCommand).not.toHaveBeenCalled();
     });
 
-    it('should add a timestamp to the command', async () => {
+    it('should leave timestamping to DeviceGateway', async () => {
+      (mockDeviceGateway.sendCommand as jest.Mock).mockResolvedValue({ delivered: true });
+      const command = { type: 'reload' };
+      mockRooms.set('device:dev-a', new Set(['socket-1']));
+
       await controller.broadcastCommand({
         deviceIds: ['dev-a'],
-        command: { type: 'reload' },
+        command,
       });
 
-      expect(mockEmit).toHaveBeenCalledWith(
-        'command',
-        expect.objectContaining({ timestamp: expect.any(String) }),
-      );
+      expect(mockDeviceGateway.sendCommand).toHaveBeenCalledWith('dev-a', command);
     });
 
     it('should handle empty deviceIds array', async () => {
@@ -128,9 +129,34 @@ describe('AppController', () => {
         command: baseCommand,
       });
 
-      expect(result.devicesOnline).toBe(0);
+      expect(result).toEqual({
+        devicesOnline: 0,
+        delivered: 0,
+        queued: 0,
+        failed: 0,
+      });
       expect(mockTo).not.toHaveBeenCalled();
       expect(mockRedisService.addDeviceCommand).not.toHaveBeenCalled();
+    });
+
+    it('should count unexpected gateway errors as failed deliveries', async () => {
+      (mockDeviceGateway.sendCommand as jest.Mock)
+        .mockResolvedValueOnce({ delivered: true })
+        .mockRejectedValueOnce(new Error('gateway unavailable'));
+      mockRooms.set('device:dev-a', new Set(['socket-1']));
+      mockRooms.set('device:dev-b', new Set(['socket-2']));
+
+      const result = await controller.broadcastCommand({
+        deviceIds: ['dev-a', 'dev-b'],
+        command: baseCommand,
+      });
+
+      expect(result).toEqual({
+        devicesOnline: 2,
+        delivered: 1,
+        queued: 0,
+        failed: 1,
+      });
     });
   });
 

--- a/realtime/src/app/app.controller.ts
+++ b/realtime/src/app/app.controller.ts
@@ -217,25 +217,40 @@ export class AppController {
   async broadcastCommand(
     @Body() data: BroadcastCommandDto,
   ) {
-    const commandWithTimestamp = {
-      ...data.command,
-      timestamp: new Date().toISOString(),
-    };
-
-    const results = await Promise.allSettled(
-      data.deviceIds.map(async (deviceId) => {
+    const onlineDevices = new Set(
+      data.deviceIds.filter((deviceId) => {
         const room = this.deviceGateway.server.sockets.adapter.rooms.get(`device:${deviceId}`);
-        const isOnline = room && room.size > 0;
-        this.deviceGateway.server.to(`device:${deviceId}`).emit('command', commandWithTimestamp);
-        if (!isOnline) {
-          await this.redisService.addDeviceCommand(deviceId, commandWithTimestamp);
-        }
-        return isOnline;
+        return Boolean(room && room.size > 0);
       }),
     );
-    const devicesOnline = results.filter(r => r.status === 'fulfilled' && r.value).length;
 
-    return { devicesOnline };
+    const results = await Promise.allSettled(
+      data.deviceIds.map((deviceId) => this.deviceGateway.sendCommand(deviceId, data.command)),
+    );
+
+    let delivered = 0;
+    let queued = 0;
+    let failed = 0;
+
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        failed += 1;
+        continue;
+      }
+
+      if (result.value.delivered) {
+        delivered += 1;
+      } else {
+        queued += 1;
+      }
+    }
+
+    return {
+      devicesOnline: onlineDevices.size,
+      delivered,
+      queued,
+      failed,
+    };
   }
 
   @Post('notifications/broadcast')

--- a/realtime/src/dto/internal-api.dto.ts
+++ b/realtime/src/dto/internal-api.dto.ts
@@ -31,6 +31,10 @@ export class DeviceCommandDto {
   type!: DeviceCommandType;
 
   @IsOptional()
+  @IsString()
+  commandId?: string;
+
+  @IsOptional()
   @IsObject()
   payload?: Record<string, unknown>;
 }

--- a/realtime/src/gateways/device.gateway.spec.ts
+++ b/realtime/src/gateways/device.gateway.spec.ts
@@ -32,6 +32,7 @@ describe('DeviceGateway', () => {
     getDeviceCommands: jest.fn().mockResolvedValue([]),
     addDeviceCommand: jest.fn().mockResolvedValue(undefined),
     setPendingPlaylist: jest.fn().mockResolvedValue(undefined),
+    deletePendingPlaylist: jest.fn().mockResolvedValue(undefined),
     getPendingPlaylist: jest.fn().mockResolvedValue(null),
     exists: jest.fn().mockResolvedValue(false),
     get: jest.fn().mockResolvedValue(null),
@@ -424,14 +425,131 @@ describe('DeviceGateway', () => {
       expect(mockHeartbeatService.processHeartbeat).toHaveBeenCalled();
     });
 
-    it('should not drain queued commands through heartbeat responses', async () => {
-      const client = createMockSocket();
+    it('should replay pending deliveries after heartbeat without returning command drains', async () => {
+      const emit = jest.fn((_event: string, _payload: any, ackCb?: (ack?: { ok: boolean }) => void) => {
+        ackCb?.({ ok: true });
+      });
+      const client = createMockSocket({
+        connected: true,
+        data: {
+          deviceId: 'device-1',
+          organizationId: 'org-1',
+          deliveryAckCapable: true,
+        },
+        emit,
+      });
+      const pendingPlaylist = { id: 'playlist-pending', items: [] };
+      const pendingCommand = { type: 'reload', timestamp: '2026-05-31T00:00:00.000Z' };
+      mockRedisService.getPendingPlaylist.mockResolvedValueOnce(pendingPlaylist);
+      mockRedisService.getDeviceCommands.mockResolvedValueOnce([pendingCommand]);
+      (gateway as any).deviceSockets.set('device-1', 'socket-1');
 
       const result = await gateway.handleHeartbeat(client as any, {} as any);
+      for (let i = 0; i < 8; i += 1) {
+        await Promise.resolve();
+      }
 
       expect(result.success).toBe(true);
       expect(result.data.commands).toEqual([]);
+      expect(mockRedisService.getPendingPlaylist).toHaveBeenCalledWith('device-1');
+      expect(mockRedisService.getDeviceCommands).toHaveBeenCalledWith('device-1');
+      expect(emit).toHaveBeenCalledWith(
+        'playlist:update',
+        expect.objectContaining({
+          playlist: pendingPlaylist,
+          timestamp: expect.any(String),
+        }),
+        expect.any(Function),
+      );
+      expect(emit).toHaveBeenCalledWith('command', pendingCommand, expect.any(Function));
+      expect(mockRedisService.setPendingPlaylist).not.toHaveBeenCalledWith('device-1', pendingPlaylist);
+      expect(mockRedisService.addDeviceCommand).not.toHaveBeenCalledWith('device-1', pendingCommand);
+    });
+
+    it('should not drain pending deliveries from stale socket heartbeats', async () => {
+      const client = createMockSocket({
+        id: 'socket-old',
+        connected: true,
+        data: {
+          deviceId: 'device-1',
+          organizationId: 'org-1',
+          deliveryAckCapable: true,
+        },
+      });
+      (gateway as any).deviceSockets.set('device-1', 'socket-new');
+
+      const result = await gateway.handleHeartbeat(client as any, {} as any);
+      for (let i = 0; i < 4; i += 1) {
+        await Promise.resolve();
+      }
+
+      expect(result.success).toBe(true);
+      expect(result.data.commands).toEqual([]);
+      expect(mockRedisService.getPendingPlaylist).not.toHaveBeenCalled();
       expect(mockRedisService.getDeviceCommands).not.toHaveBeenCalled();
+    });
+
+    it('should requeue remaining pending commands if the active socket changes during replay', async () => {
+      const pendingCommands = [
+        { type: 'reload', timestamp: '2026-05-31T00:00:00.000Z' },
+        { type: 'clear_cache', timestamp: '2026-05-31T00:00:01.000Z' },
+      ];
+      const emit = jest.fn((_event: string, _payload: any, ackCb?: (ack?: { ok: boolean }) => void) => {
+        ackCb?.({ ok: true });
+        (gateway as any).deviceSockets.set('device-1', 'socket-new');
+      });
+      const client = createMockSocket({
+        connected: true,
+        data: {
+          deviceId: 'device-1',
+          organizationId: 'org-1',
+          deliveryAckCapable: true,
+        },
+        emit,
+      });
+      (gateway as any).deviceSockets.set('device-1', 'socket-1');
+      mockRedisService.getDeviceCommands.mockResolvedValueOnce(pendingCommands);
+
+      const result = await (gateway as any).deliverPendingCommands(client, 'device-1');
+
+      expect(result).toEqual({ delivered: 0, requeued: 2, skipped: false, shouldBackoff: false });
+      expect(emit).toHaveBeenCalledTimes(1);
+      expect(mockRedisService.addDeviceCommand).toHaveBeenCalledWith('device-1', pendingCommands[0]);
+      expect(mockRedisService.addDeviceCommand).toHaveBeenCalledWith('device-1', pendingCommands[1]);
+    });
+
+    it('should back off heartbeat replay after failed pending delivery', async () => {
+      const emit = jest.fn((_event: string, _payload: any, ackCb?: (ack?: { ok: boolean; error?: string }) => void) => {
+        ackCb?.({ ok: false, error: 'renderer failed' });
+      });
+      const client = createMockSocket({
+        connected: true,
+        data: {
+          deviceId: 'device-1',
+          organizationId: 'org-1',
+          deliveryAckCapable: true,
+        },
+        emit,
+      });
+      (gateway as any).deviceSockets.set('device-1', 'socket-1');
+      mockRedisService.getPendingPlaylist.mockResolvedValueOnce({ id: 'playlist-pending', items: [] });
+
+      await gateway.handleHeartbeat(client as any, {} as any);
+      for (let i = 0; i < 8; i += 1) {
+        await Promise.resolve();
+      }
+      expect(mockRedisService.setPendingPlaylist).toHaveBeenCalledWith(
+        'device-1',
+        expect.objectContaining({ id: 'playlist-pending' }),
+      );
+
+      mockRedisService.getPendingPlaylist.mockClear();
+      await gateway.handleHeartbeat(client as any, {} as any);
+      for (let i = 0; i < 4; i += 1) {
+        await Promise.resolve();
+      }
+
+      expect(mockRedisService.getPendingPlaylist).not.toHaveBeenCalled();
     });
 
     it('should not write to DB when status has not changed', async () => {
@@ -730,15 +848,68 @@ describe('DeviceGateway', () => {
       );
     });
 
+    it('should clear stale pending playlist after a newer playlist is acknowledged', async () => {
+      const playlist = { id: 'p-new', name: 'New Playlist', items: [] };
+
+      const result = await gateway.sendPlaylistUpdate('device-1', playlist as any);
+
+      expect(result).toEqual({ delivered: true });
+      expect(mockRedisService.deletePendingPlaylist).toHaveBeenCalledWith('device-1');
+    });
+
+    it('should not replay an already-consumed pending playlist after a newer playlist is acknowledged', async () => {
+      const oldPlaylist = { id: 'p-old', name: 'Old Playlist', items: [] };
+      const newPlaylist = { id: 'p-new', name: 'New Playlist', items: [] };
+      const pendingClientEmit = jest.fn((_event: string, _payload: any, ackCb?: (ack?: { ok: boolean }) => void) => {
+        ackCb?.({ ok: true });
+      });
+      const pendingClient = createMockSocket({
+        connected: true,
+        data: {
+          deviceId: 'device-1',
+          organizationId: 'org-1',
+          deliveryAckCapable: true,
+        },
+        emit: pendingClientEmit,
+      });
+      let resolveDisplay!: (value: any) => void;
+      const displayLookup = new Promise(resolve => {
+        resolveDisplay = resolve;
+      });
+      mockRedisService.getPendingPlaylist.mockResolvedValueOnce(oldPlaylist);
+      mockDatabaseService.display.findUnique.mockReturnValueOnce(displayLookup);
+      (gateway as any).deviceSockets.set('device-1', 'socket-1');
+
+      const replay = (gateway as any).deliverPendingPlaylist(pendingClient, 'device-1');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const pushResult = await gateway.sendPlaylistUpdate('device-1', newPlaylist as any);
+      resolveDisplay({ metadata: {} });
+      const replayResult = await replay;
+
+      expect(pushResult).toEqual({ delivered: true });
+      expect(replayResult).toBe('skipped');
+      expect(pendingClientEmit).not.toHaveBeenCalledWith(
+        'playlist:update',
+        expect.objectContaining({ playlist: oldPlaylist }),
+        expect.any(Function),
+      );
+      expect(mockRedisService.setPendingPlaylist).not.toHaveBeenCalledWith('device-1', oldPlaylist);
+      expect(mockRedisService.deletePendingPlaylist).toHaveBeenCalledWith('device-1');
+    });
+
     it('should return no_sockets when no devices connected', async () => {
       mockServer.in.mockReturnValueOnce({
         fetchSockets: jest.fn().mockResolvedValue([]),
       });
       const playlist = { id: 'p-1', name: 'Test', items: [] };
+      (gateway as any).heartbeatReplayState.set('device-99', { failures: 5, lastAttemptAt: Date.now() });
 
       const result = await gateway.sendPlaylistUpdate('device-99', playlist as any);
 
       expect(result).toEqual({ delivered: false, reason: 'no_sockets' });
+      expect((gateway as any).heartbeatReplayState.has('device-99')).toBe(false);
     });
 
     it('should requeue playlist when the device sends a negative ack', async () => {
@@ -802,6 +973,7 @@ describe('DeviceGateway', () => {
         fetchSockets: jest.fn().mockResolvedValue([]),
       });
       const command = { type: 'clear_cache' as any, payload: {} };
+      (gateway as any).heartbeatReplayState.set('device-99', { failures: 5, lastAttemptAt: Date.now() });
 
       const result = await gateway.sendCommand('device-99', command);
 
@@ -810,6 +982,7 @@ describe('DeviceGateway', () => {
         'device-99',
         expect.objectContaining({ type: 'clear_cache', timestamp: expect.any(String) }),
       );
+      expect((gateway as any).heartbeatReplayState.has('device-99')).toBe(false);
     });
 
     it('should queue command when the device sends a negative ack', async () => {

--- a/realtime/src/gateways/device.gateway.ts
+++ b/realtime/src/gateways/device.gateway.ts
@@ -72,6 +72,19 @@ interface DeliveryResult {
   legacy?: boolean;
 }
 
+type PendingPlaylistDeliveryStatus = 'none' | 'delivered' | 'requeued' | 'deferred' | 'skipped';
+
+type PendingCommandDeliveryResult = {
+  delivered: number;
+  requeued: number;
+  skipped: boolean;
+  shouldBackoff: boolean;
+};
+
+const HEARTBEAT_REPLAY_BASE_DELAY_MS = 15000;
+const HEARTBEAT_REPLAY_MAX_DELAY_MS = 300000;
+const HEARTBEAT_REPLAY_MAX_FAILURES = 5;
+
 @WebSocketGateway({
   cors: {
     origin: process.env.CORS_ORIGIN?.split(',').map(s => s.trim()) || ['http://localhost:3001'],
@@ -112,6 +125,8 @@ export class DeviceGateway
 
   // Per-message rate limiting: socketId -> { count, resetAt }
   private readonly messageRates: Map<string, { count: number; resetAt: number }> = new Map();
+  private readonly heartbeatReplayState: Map<string, { failures: number; lastAttemptAt: number }> = new Map();
+  private readonly pendingPlaylistReplayVersions: Map<string, number> = new Map();
 
   // Interval handles for cleanup (stored for proper teardown)
   private cleanupIntervals: ReturnType<typeof setInterval>[] = [];
@@ -164,6 +179,89 @@ export class DeviceGateway
         reason: message === 'ack_timeout' ? 'ack_timeout' : 'negative_ack',
       };
     }
+  }
+
+  private isActiveDeviceSocket(client: { id?: string }, deviceId: string): boolean {
+    return this.deviceSockets.get(deviceId) === client.id;
+  }
+
+  private shouldAttemptHeartbeatReplay(deviceId: string): boolean {
+    const state = this.heartbeatReplayState.get(deviceId);
+    if (!state) {
+      this.heartbeatReplayState.set(deviceId, { failures: 0, lastAttemptAt: Date.now() });
+      return true;
+    }
+
+    if (state.failures >= HEARTBEAT_REPLAY_MAX_FAILURES) {
+      return false;
+    }
+
+    const delayMs = Math.min(
+      HEARTBEAT_REPLAY_BASE_DELAY_MS * 2 ** state.failures,
+      HEARTBEAT_REPLAY_MAX_DELAY_MS,
+    );
+    if (Date.now() - state.lastAttemptAt < delayMs) {
+      return false;
+    }
+
+    state.lastAttemptAt = Date.now();
+    return true;
+  }
+
+  private recordHeartbeatReplayResult(deviceId: string, hadRequeue: boolean): void {
+    if (!hadRequeue) {
+      this.heartbeatReplayState.delete(deviceId);
+      return;
+    }
+
+    const state = this.heartbeatReplayState.get(deviceId) ?? { failures: 0, lastAttemptAt: Date.now() };
+    this.heartbeatReplayState.set(deviceId, {
+      failures: state.failures + 1,
+      lastAttemptAt: Date.now(),
+    });
+  }
+
+  private resetHeartbeatReplayBackoff(deviceId: string): void {
+    this.heartbeatReplayState.delete(deviceId);
+  }
+
+  private async clearPendingPlaylist(deviceId: string): Promise<void> {
+    this.pendingPlaylistReplayVersions.set(
+      deviceId,
+      (this.pendingPlaylistReplayVersions.get(deviceId) ?? 0) + 1,
+    );
+
+    try {
+      await this.redisService.deletePendingPlaylist(deviceId);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.warn(`Failed to clear pending playlist for device ${deviceId}: ${message}`);
+    }
+  }
+
+  private isPendingPlaylistReplayCurrent(deviceId: string, replayVersion: number): boolean {
+    return (this.pendingPlaylistReplayVersions.get(deviceId) ?? 0) === replayVersion;
+  }
+
+  private async requeuePendingPlaylistIfCurrent(
+    deviceId: string,
+    playlist: Playlist,
+    replayVersion: number,
+    status: PendingPlaylistDeliveryStatus = 'requeued',
+  ): Promise<PendingPlaylistDeliveryStatus> {
+    if (!this.isPendingPlaylistReplayCurrent(deviceId, replayVersion)) {
+      return 'skipped';
+    }
+
+    await this.redisService.setPendingPlaylist(deviceId, playlist);
+    return status;
+  }
+
+  private async requeuePendingCommands(deviceId: string, commands: DeviceCommand[]): Promise<number> {
+    for (const command of commands) {
+      await this.redisService.addDeviceCommand(deviceId, command);
+    }
+    return commands.length;
   }
 
   constructor(
@@ -704,8 +802,8 @@ export class DeviceGateway
       // Check for a pending playlist queued while the device was offline.
       // This takes priority over the DB query since it represents a more
       // recent assignment that the device missed.
-      const delivered = await this.deliverPendingPlaylist(client, deviceId);
-      if (delivered) return;
+      const deliveryStatus = await this.deliverPendingPlaylist(client, deviceId);
+      if (deliveryStatus !== 'none' && deliveryStatus !== 'skipped') return;
 
       this.logger.debug(`Fetching playlist for device: ${deviceId}`);
       const display = await this.databaseService.display.findUnique({
@@ -1066,6 +1164,8 @@ export class DeviceGateway
       const duration = (Date.now() - startTime) / 1000;
       this.metricsService.recordHeartbeat(deviceId, true, duration);
 
+      void this.replayPendingDeliveries(client, deviceId);
+
       return createSuccessResponse({
         nextHeartbeatIn: 15000,
         commands: [],
@@ -1190,17 +1290,22 @@ export class DeviceGateway
    * The pending playlist has pre-resolved content URLs from sendPlaylistUpdate().
    * Returns true if a pending playlist was found and delivered (or re-queued).
    */
-  private async deliverPendingPlaylist(client: Socket, deviceId: string): Promise<boolean> {
+  private async deliverPendingPlaylist(client: Socket, deviceId: string): Promise<PendingPlaylistDeliveryStatus> {
+    if (!this.isActiveDeviceSocket(client, deviceId)) {
+      this.logger.debug(`Skipping pending playlist delivery for stale socket ${client.id} (device ${deviceId})`);
+      return 'skipped';
+    }
+
+    const replayVersion = this.pendingPlaylistReplayVersions.get(deviceId) ?? 0;
     const pendingPlaylist = await this.redisService.getPendingPlaylist(deviceId);
-    if (!pendingPlaylist) return false;
+    if (!pendingPlaylist) return 'none';
 
     this.logger.log(`Delivering pending playlist to device ${deviceId} (queued while offline)`);
 
-    // Re-queue if the client disconnected between Redis read and now
-    if (!client.connected) {
-      this.logger.warn(`Device ${deviceId} disconnected before pending playlist delivery — re-queuing`);
-      await this.redisService.setPendingPlaylist(deviceId, pendingPlaylist);
-      return true;
+    // Re-queue if the active client changed or disconnected after the atomic Redis consume.
+    if (!this.isActiveDeviceSocket(client, deviceId) || !client.connected) {
+      this.logger.warn(`Device ${deviceId} disconnected before pending playlist delivery - re-queuing`);
+      return this.requeuePendingPlaylistIfCurrent(deviceId, pendingPlaylist, replayVersion, 'deferred');
     }
 
     // Fetch display metadata for config (qrOverlay etc.)
@@ -1208,6 +1313,17 @@ export class DeviceGateway
       where: { id: deviceId },
       select: { metadata: true },
     });
+
+    if (!this.isPendingPlaylistReplayCurrent(deviceId, replayVersion)) {
+      this.logger.debug(`Skipping stale pending playlist replay for device ${deviceId}`);
+      return 'skipped';
+    }
+
+    if (!this.isActiveDeviceSocket(client, deviceId) || !client.connected) {
+      this.logger.warn(`Device ${deviceId} disconnected before pending playlist delivery - re-queuing`);
+      return this.requeuePendingPlaylistIfCurrent(deviceId, pendingPlaylist, replayVersion, 'deferred');
+    }
+
     const configMetadata = (displayForConfig?.metadata as Record<string, any>) || {};
     client.emit('config', {
       heartbeatInterval: 15000,
@@ -1216,10 +1332,25 @@ export class DeviceGateway
       qrOverlay: configMetadata.qrOverlay || null,
     });
 
+    if (!this.isPendingPlaylistReplayCurrent(deviceId, replayVersion)) {
+      this.logger.debug(`Skipping stale pending playlist replay for device ${deviceId}`);
+      return 'skipped';
+    }
+
     const result = await this.emitWithDeliveryAck(client, 'playlist:update', {
       playlist: pendingPlaylist,
       timestamp: new Date().toISOString(),
     });
+
+    if (!this.isPendingPlaylistReplayCurrent(deviceId, replayVersion)) {
+      this.logger.debug(`Ignoring stale pending playlist replay result for device ${deviceId}`);
+      return 'skipped';
+    }
+
+    if (!this.isActiveDeviceSocket(client, deviceId) || !client.connected) {
+      this.logger.warn(`Device ${deviceId} changed sockets during pending playlist delivery - re-queuing`);
+      return this.requeuePendingPlaylistIfCurrent(deviceId, pendingPlaylist, replayVersion, 'deferred');
+    }
 
     if (result.delivered) {
       this.logger.log(
@@ -1229,25 +1360,81 @@ export class DeviceGateway
       );
     } else {
       this.logger.warn(`Pending playlist ${result.reason || 'delivery failure'} for device ${deviceId} - re-queuing`);
-      await this.redisService.setPendingPlaylist(deviceId, pendingPlaylist);
+      return this.requeuePendingPlaylistIfCurrent(deviceId, pendingPlaylist, replayVersion);
     }
-    return true;
+    return 'delivered';
   }
 
-  private async deliverPendingCommands(client: Socket, deviceId: string): Promise<void> {
+  private async deliverPendingCommands(client: Socket, deviceId: string): Promise<PendingCommandDeliveryResult> {
+    if (!this.isActiveDeviceSocket(client, deviceId)) {
+      this.logger.debug(`Skipping pending command delivery for stale socket ${client.id} (device ${deviceId})`);
+      return { delivered: 0, requeued: 0, skipped: true, shouldBackoff: false };
+    }
+
     const pendingCommands = await this.redisService.getDeviceCommands(deviceId);
     if (pendingCommands.length === 0) {
-      return;
+      return { delivered: 0, requeued: 0, skipped: false, shouldBackoff: false };
     }
 
     this.logger.log(`Delivering ${pendingCommands.length} pending command(s) to device ${deviceId}`);
-    for (const cmd of pendingCommands) {
+    let delivered = 0;
+    let requeued = 0;
+    for (let index = 0; index < pendingCommands.length; index += 1) {
+      const cmd = pendingCommands[index];
+      if (!this.isActiveDeviceSocket(client, deviceId) || !client.connected) {
+        this.logger.warn(`Device ${deviceId} disconnected before pending command delivery - re-queuing remaining commands`);
+        requeued += await this.requeuePendingCommands(deviceId, pendingCommands.slice(index));
+        return { delivered, requeued, skipped: false, shouldBackoff: false };
+      }
+
       const result = await this.emitWithDeliveryAck(client, 'command', cmd);
+      if (!this.isActiveDeviceSocket(client, deviceId) || !client.connected) {
+        this.logger.warn(`Device ${deviceId} changed sockets during pending command delivery - re-queuing current and remaining commands`);
+        requeued += await this.requeuePendingCommands(deviceId, pendingCommands.slice(index));
+        return { delivered, requeued, skipped: false, shouldBackoff: false };
+      }
+
       if (!result.delivered) {
         this.logger.warn(`Pending command ${cmd.type} ${result.reason || 'delivery failure'} for device ${deviceId} - re-queuing`);
         await this.redisService.addDeviceCommand(deviceId, cmd);
+        requeued += 1;
+      } else {
+        delivered += 1;
       }
     }
+    return { delivered, requeued, skipped: false, shouldBackoff: requeued > 0 };
+  }
+
+  private async replayPendingDeliveries(client: Socket, deviceId: string): Promise<void> {
+    if (!this.isActiveDeviceSocket(client, deviceId)) {
+      this.logger.debug(`Skipping heartbeat pending replay for stale socket ${client.id} (device ${deviceId})`);
+      return;
+    }
+
+    if (!this.shouldAttemptHeartbeatReplay(deviceId)) {
+      return;
+    }
+
+    let hadRequeue = false;
+    try {
+      const playlistResult = await this.deliverPendingPlaylist(client, deviceId);
+      hadRequeue = hadRequeue || playlistResult === 'requeued';
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.warn(`Failed to replay pending playlist for device ${deviceId}: ${message}`);
+      hadRequeue = true;
+    }
+
+    try {
+      const commandResult = await this.deliverPendingCommands(client, deviceId);
+      hadRequeue = hadRequeue || commandResult.shouldBackoff;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.warn(`Failed to replay pending commands for device ${deviceId}: ${message}`);
+      hadRequeue = true;
+    }
+
+    this.recordHeartbeatReplayResult(deviceId, hadRequeue);
   }
 
   // Admin methods (called from API)
@@ -1275,6 +1462,7 @@ export class DeviceGateway
     if (sockets.length === 0) {
       this.logger.warn(`pushPlaylist: no sockets in room ${roomName} for device ${deviceId} — queuing for reconnect`);
       await this.redisService.setPendingPlaylist(deviceId, resolvedPlaylist);
+      this.resetHeartbeatReplayBackoff(deviceId);
       return { delivered: false, reason: 'no_sockets' };
     }
 
@@ -1299,10 +1487,12 @@ export class DeviceGateway
     if (!anyAcknowledged) {
       this.logger.warn(`pushPlaylist: all sockets timed out for device ${deviceId} — queuing for reconnect`);
       await this.redisService.setPendingPlaylist(deviceId, resolvedPlaylist);
+      this.resetHeartbeatReplayBackoff(deviceId);
       return { delivered: false, reason: failureReason };
     }
 
     this.logger.log(`Sent playlist update to device: ${deviceId} (acknowledged)`);
+    await this.clearPendingPlaylist(deviceId);
     return { delivered: true };
   }
 
@@ -1314,6 +1504,7 @@ export class DeviceGateway
     if (sockets.length === 0) {
       this.logger.warn(`sendCommand: no sockets for device ${deviceId} — queuing`);
       await this.redisService.addDeviceCommand(deviceId, commandWithTimestamp);
+      this.resetHeartbeatReplayBackoff(deviceId);
       return { delivered: false, reason: 'no_sockets' };
     }
 
@@ -1333,6 +1524,7 @@ export class DeviceGateway
     if (!anyAcknowledged) {
       this.logger.warn(`sendCommand: all sockets timed out for device ${deviceId} — queuing`);
       await this.redisService.addDeviceCommand(deviceId, commandWithTimestamp);
+      this.resetHeartbeatReplayBackoff(deviceId);
       return { delivered: false, reason: failureReason };
     }
 

--- a/realtime/src/services/redis.service.spec.ts
+++ b/realtime/src/services/redis.service.spec.ts
@@ -157,6 +157,14 @@ describe('RedisService', () => {
       const result = await service.getCachedPlaylist('device-1');
       expect(result).toBeNull();
     });
+
+    it('should delete pending playlist', async () => {
+      await service.deletePendingPlaylist('device-1');
+
+      expect((service as any).redis.del).toHaveBeenCalledWith(
+        'device:pending-playlist:device-1',
+      );
+    });
   });
 
   describe('increment', () => {

--- a/realtime/src/services/redis.service.ts
+++ b/realtime/src/services/redis.service.ts
@@ -218,6 +218,11 @@ export class RedisService implements OnModuleDestroy {
     await this.redis.setex(key, 1800, JSON.stringify(playlist)); // 30 minutes
   }
 
+  async deletePendingPlaylist(deviceId: string): Promise<void> {
+    const key = `device:pending-playlist:${deviceId}`;
+    await this.redis.del(key);
+  }
+
   /**
    * Get and consume a pending playlist for a device (atomic read + delete).
    * Returns null if no pending playlist exists.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,55 @@
 # Vizora - Task Tracker
 
+## In Progress: Display Delivery Reliability Follow-up (2026-05-31)
+
+**Branch:** `feat/customer-performance-hardening-2`
+
+**Plan/design:** `docs/plans/2026-05-31-display-delivery-reliability-follow-up.md`
+
+**Why now:** The post-merge customer/realtime review found customer-visible playback and remote-control reliability gaps that are repo-side, testable, and do not need operator secrets or production state changes.
+
+**New primitives introduced:** none. Use existing middleware display command callers, realtime `DeviceGateway`, Redis pending-delivery queues, and Electron display client.
+
+**Hermes-first analysis:** not applicable. This is realtime/device transport and Electron display playback reliability; it does not introduce business agents, MCP tools, AI provider calls, or spend paths.
+
+**Plan**
+- [x] Add failing focused tests for heartbeat-triggered pending playlist/command replay without returning queued commands in the heartbeat response.
+- [x] Route realtime fleet broadcast commands through `DeviceGateway.sendCommand`.
+- [x] Append Electron device JWT query tokens to protected `/device-content/:id/file` URLs before playback/cache and `push_content`.
+- [x] Fix middleware display command callers to send realtime's nested `{ deviceId, command: { type, payload } }` shape.
+- [x] Run focused realtime/display/middleware tests.
+- [x] Run multi-review on the diff before broader tests.
+- [x] Run broader package tests/builds proportional to touched packages.
+- [ ] Open PR, wait for CI, merge if clean.
+
+**Verification so far**
+- `NODE_OPTIONS=--use-system-ca pnpm --dir packages/database exec prisma generate` - pass; needed in fresh worktree before realtime tests could import `@vizora/database`.
+- `npx nx build @vizora/database` - pass.
+- `git diff --check` - pass; line-ending warnings only.
+- `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern="device.gateway|app.controller|redis.service"` - pass, 4 suites / 112 tests.
+- `pnpm --filter @vizora/display test -- --runInBand --testPathPattern="device-client"` - pass, 1 suite / 46 tests.
+- `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="displays.service|fleet.service"` - pass, 4 suites / 72 tests.
+- `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="DeviceControls"` - pass, 1 suite / 6 tests.
+- `pnpm --filter @vizora/realtime test -- --runInBand` - pass, 11 suites / 242 tests.
+- `pnpm --filter @vizora/display test -- --runInBand` - pass, 5 suites / 115 tests; existing MaxListeners warning remains in full display suite.
+- `pnpm --filter @vizora/middleware test -- --runInBand` - pass, 141 suites / 2761 tests.
+- `pnpm --filter @vizora/web test -- --runInBand` - pass, 82 suites / 882 tests; existing unrelated React `act(...)` warnings remain.
+- `npx nx build @vizora/middleware` - pass with existing webpack warnings.
+- `npx nx build @vizora/realtime` - pass with existing source-map/optional `ws` warnings.
+- `pnpm --filter @vizora/display build` - pass.
+- `NODE_OPTIONS=--max-old-space-size=4096 npx nx build @vizora/web` - pass with existing Next middleware/proxy and missing production API URL warnings.
+
+**Review inputs**
+- Realtime/display reviewer: high findings on negative-ACK replay, broadcast bypassing ACK/queue path, Electron protected media URLs, and middleware single-device command DTO drift.
+- Customer dashboard reviewer: high findings on paginated dashboard datasets, duplicate sockets, and analytics error masking; these are queued after this delivery reliability slice.
+- Middleware performance reviewer: high findings on template/content list payloads and buffered uploads; these are queued after this delivery reliability slice.
+- Deployment/backlog reviewer: prod deployment is blocked by dirty/diverged production checkout; do not pull/reset/deploy until prod-only work is reconciled.
+- Internal API final re-review: CLEAN after preserving `devicesOnline`, whitelisting `commandId`, and checking screenshot gateway `success: false`.
+- Display-client final re-review: CLEAN after refreshing live Socket.IO `auth.token` alongside persisted device token.
+- Realtime final re-review: CLEAN after generation-guarded pending playlist replay, active-socket command replay rechecks, and non-poisoning socket-handoff requeues.
+
+---
+
 ## In Progress: Customer Dashboard + Playback Performance Push (2026-05-31)
 
 **Branch:** `feat/customer-dashboard-performance-push`

--- a/web/src/components/devices/DeviceControls.test.tsx
+++ b/web/src/components/devices/DeviceControls.test.tsx
@@ -28,6 +28,8 @@ const onlineResult = {
   devicesTargeted: 1,
   devicesOnline: 1,
   devicesQueued: 0,
+  devicesDelivered: 1,
+  devicesFailed: 0,
 };
 
 describe('DeviceControls', () => {
@@ -82,6 +84,7 @@ describe('DeviceControls', () => {
       ...onlineResult,
       devicesOnline: 0,
       devicesQueued: 1,
+      devicesDelivered: 0,
     });
     render(<DeviceControls deviceId="dev-1" />);
 
@@ -102,6 +105,21 @@ describe('DeviceControls', () => {
 
     await waitFor(() =>
       expect(mockError).toHaveBeenCalledWith('network down'),
+    );
+  });
+
+  it('shows an error toast when realtime reports delivery failure', async () => {
+    sendFleetCommand.mockResolvedValueOnce({
+      ...onlineResult,
+      devicesDelivered: 0,
+      devicesFailed: 1,
+    });
+    render(<DeviceControls deviceId="dev-1" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reload Screen' }));
+
+    await waitFor(() =>
+      expect(mockError).toHaveBeenCalledWith('Reload Screen failed to reach the device'),
     );
   });
 });

--- a/web/src/components/devices/DeviceControls.tsx
+++ b/web/src/components/devices/DeviceControls.tsx
@@ -72,12 +72,15 @@ export function DeviceControls({ deviceId }: DeviceControlsProps) {
         command: meta.command,
         target: { type: 'device', id: deviceId },
       });
-      if (result.devicesOnline > 0) {
-        toast.success(`${meta.label} sent`);
-      } else {
+      const devicesDelivered = result.devicesDelivered ?? result.devicesOnline;
+      if ((result.devicesFailed ?? 0) > 0 && devicesDelivered === 0 && result.devicesQueued === 0) {
+        toast.error(`${meta.label} failed to reach the device`);
+      } else if (result.devicesQueued > 0 && devicesDelivered === 0) {
         toast.success(
           `Device is offline — ${meta.label} queued and will run when it reconnects`,
         );
+      } else {
+        toast.success(`${meta.label} sent`);
       }
     } catch (err) {
       toast.error(

--- a/web/src/lib/api/fleet.ts
+++ b/web/src/lib/api/fleet.ts
@@ -13,6 +13,8 @@ declare module './client' {
       devicesTargeted: number;
       devicesOnline: number;
       devicesQueued: number;
+      devicesDelivered?: number;
+      devicesFailed?: number;
     }>;
     getActiveOverrides(): Promise<Array<{
       commandId: string;


### PR DESCRIPTION
﻿## Summary
- replay queued realtime playlist/command deliveries after heartbeats without reintroducing heartbeat command drains
- route broadcast fleet commands through the ACK/queue-aware gateway path and preserve delivery counts through middleware/web
- append and refresh Electron device JWTs for protected device-content playback URLs without leaking tokens to logs or attacker origins
- fix middleware display command payloads to match realtime's validated nested command DTO

## Review
- Internal API reviewer: CLEAN
- Display-client reviewer: CLEAN
- Realtime reviewer: CLEAN

## Verification
- `NODE_OPTIONS=--use-system-ca pnpm --dir packages/database exec prisma generate`
- `npx nx build @vizora/database`
- `git diff --check` (line-ending warnings only)
- `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern="device.gateway|app.controller|redis.service"` (4 suites / 112 tests)
- `pnpm --filter @vizora/display test -- --runInBand --testPathPattern="device-client"` (1 suite / 46 tests)
- `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="displays.service|fleet.service"` (4 suites / 72 tests)
- `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="DeviceControls"` (1 suite / 6 tests)
- `pnpm --filter @vizora/realtime test -- --runInBand` (11 suites / 242 tests)
- `pnpm --filter @vizora/display test -- --runInBand` (5 suites / 115 tests; existing MaxListeners warning remains)
- `pnpm --filter @vizora/middleware test -- --runInBand` (141 suites / 2761 tests)
- `pnpm --filter @vizora/web test -- --runInBand` (82 suites / 882 tests; existing unrelated React act warnings remain)
- `npx nx build @vizora/middleware` (existing webpack warnings)
- `npx nx build @vizora/realtime` (existing source-map/optional ws warnings)
- `pnpm --filter @vizora/display build`
- `NODE_OPTIONS=--max-old-space-size=4096 npx nx build @vizora/web` (existing Next middleware/proxy and missing production API URL warnings)

## Deployment note
Production deploy remains blocked until the dirty/diverged production checkout is reconciled. Do not pull/reset/deploy over prod-local work.
