### PR TITLE
fix: harden customer dashboard readiness paths

### DIFF
--- a/display/src/renderer/app.ts
+++ b/display/src/renderer/app.ts
@@ -341,7 +341,7 @@ class DisplayApp {
           console.log('[App] Attempting recovery after unexpected errors...');
         }
       }
-    }, 2000); // Check every 2 seconds
+    }, 8000); // Stay under the pairing status endpoint's 10/min throttle
 
     this.pairingCheckInterval = pollInterval;
   }

--- a/docs/plans/2026-05-31-customer-dashboard-quality-performance-pass.md
+++ b/docs/plans/2026-05-31-customer-dashboard-quality-performance-pass.md
@@ -1,0 +1,65 @@
+# Customer Dashboard Quality + Performance Pass
+
+**Goal:** Remove misleading customer-facing dashboard behavior and fix launch-critical correctness issues found by reviewer agents after PR #120.
+
+**Branch:** `feat/customer-dashboard-quality-pass`
+
+**New primitives introduced:** small web formatting/pagination helpers only; no new service, process, table, env var, agent, or external provider path.
+
+**Hermes-first analysis:**
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Customer dashboard UI correctness | none applicable | Build in Vizora web; not an agent/Hermes task. |
+| Device playback/pairing correctness | none applicable | Build in existing display/realtime/middleware paths. |
+| SMTP config parity | none applicable | Fix existing mail service env handling. |
+
+Awesome-Hermes ecosystem check: no agent orchestration or MCP skill work is introduced, so Hermes is not the right substrate for this pass.
+
+## Reviewed Findings
+
+- Dashboard/device/content/playlist/schedule pages treat default-paginated `limit=10` API responses as complete.
+- Fleet command and emergency override toasts ignore `devicesDelivered` / `devicesFailed`.
+- Device Health dashboard fabricates random health metrics on refresh.
+- Content library `Clear all` does not clear tag filters, and bulk image upload asks the backend to generate thumbnails after upload even though the upload endpoint already does it.
+- SMTP startup checks accept `SMTP_PASS`, but `MailService` only reads `SMTP_PASSWORD`.
+- Layout zone resolvers emit `playlist` / `content` fields that renderers do not read.
+- Realtime queued commands replay newest-first.
+- Fleet `push_content` maps non-existent Prisma `Content.title` / `thumbnailUrl` fields.
+- Pairing clients poll every 2s against a 10/min throttle.
+
+## Implementation Checklist
+
+- [x] Add failing tests for SMTP env parity, command FIFO, fleet content field mapping, fleet command result messaging, stable health data, content tag clearing, duplicate thumbnail prevention, layout zone compatibility, pairing poll cadence, and paginated dashboard list/picker loading.
+- [x] Implement the minimal fixes in existing Vizora-native modules.
+- [x] Add focused tests for the changed files.
+- [x] Run focused suites for middleware, realtime, web, and display.
+- [x] Dispatch subagent diff reviews before broad tests.
+- [x] Run broader affected service suites/builds.
+- [ ] Commit, open/merge PR if CI is green.
+- [ ] Deploy only if the prod worktree safety gate is clear; current prod checkout is dirty/diverged, so deployment remains blocked until reconciled.
+
+## Review Gate
+
+- Backend/realtime reviewer: high tenant-scope and medium duration-unit findings fixed; final re-review CLEAN.
+- Frontend/customer UX reviewer: device SSR envelope, dashboard pagination, health refresh, health sorting, no-target command, partial-refresh, and capped-pagination findings fixed; final re-review CLEAN.
+- Performance/readiness reviewer: dashboard pagination and partial-refresh findings fixed; final re-review CLEAN.
+
+## Focused Verification
+
+- `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="mail.service|fleet.service|content.service"` - pass, 3 suites / 126 tests.
+- `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern="redis.service|device.gateway"` - pass, 3 suites / 107 tests.
+- `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="pagination|dashboard/content|dashboard/devices|dashboard/playlists|dashboard/schedules|dashboard/health|dashboard/__tests__|EmergencyOverrideModal|FleetCommandDropdown|commandResultMessage|useDeviceConnection|usePlaylistPlayer|usePairing|DeviceHealthMonitor"` - pass, 14 suites / 106 tests; existing React act warnings and intentional negative-path console errors remain.
+
+## Broad Verification
+
+- `pnpm --filter @vizora/middleware test -- --runInBand` - pass, 141 suites / 2763 tests.
+- `pnpm --filter @vizora/realtime test -- --runInBand` - pass, 11 suites / 245 tests.
+- `pnpm --filter @vizora/display test -- --runInBand` - pass, 5 suites / 115 tests; known MaxListeners warning and expected negative-path logs remain.
+- `pnpm --filter @vizora/web test -- --runInBand` - pass, 86 suites / 905 tests; existing React act warnings and expected negative-path logs remain.
+- `npx nx build @vizora/middleware` - pass with existing webpack warnings.
+- `npx nx build @vizora/realtime` - pass with existing source-map / optional `ws` warnings.
+- `pnpm --filter @vizora/display build` - pass.
+- `NODE_OPTIONS=--max-old-space-size=4096 npx nx build @vizora/web` - pass with existing Next middleware/proxy and missing production API URL warnings.
+- Direct ESLint equivalent (`ESLINT_USE_FLAT_CONFIG=false eslint "middleware/src/**/*.ts" "realtime/src/**/*.ts"`) - exit 0, 187 warnings, no errors. Local `pnpm lint` wrapper is Windows-incompatible because the script uses Unix-style env assignment.
+- `git diff --check` - pass; line-ending warnings only.

--- a/middleware/src/modules/content/content.service.spec.ts
+++ b/middleware/src/modules/content/content.service.spec.ts
@@ -252,6 +252,78 @@ describe('ContentService', () => {
     });
   });
 
+  describe('getResolvedLayout', () => {
+    it('emits display-compatible resolvedPlaylist and resolvedContent zone fields', async () => {
+      mockDatabaseService.content.findFirst.mockResolvedValue({
+        ...mockContent,
+        id: 'layout-1',
+        type: 'layout',
+        metadata: {
+          zones: [
+            { id: 'zone-playlist', gridArea: 'main', playlistId: 'playlist-1' },
+            { id: 'zone-content', gridArea: 'side', contentId: 'content-2' },
+          ],
+        },
+      });
+      mockDatabaseService.playlist = {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'playlist-1',
+            name: 'Menu Loop',
+            items: [
+              {
+                id: 'item-1',
+                contentId: 'content-1',
+                duration: 15,
+                order: 0,
+                content: {
+                  id: 'content-1',
+                  name: 'Menu Image',
+                  type: 'image',
+                  url: '/menu.png',
+                  thumbnail: '/thumb.png',
+                },
+              },
+            ],
+          },
+        ]),
+      };
+      mockDatabaseService.content.findMany.mockResolvedValue([
+        {
+          id: 'content-2',
+          name: 'Weather',
+          type: 'url',
+          url: 'https://example.com/weather',
+          thumbnail: null,
+        },
+      ]);
+
+      const result = await service.getResolvedLayout('org-123', 'layout-1');
+      const zones = result.metadata.zones as any[];
+
+      expect(zones[0].resolvedPlaylist).toEqual(
+        expect.objectContaining({
+          id: 'playlist-1',
+          name: 'Menu Loop',
+          items: expect.arrayContaining([
+            expect.objectContaining({
+              content: expect.objectContaining({ name: 'Menu Image' }),
+            }),
+          ]),
+        }),
+      );
+      expect(zones[0].playlist).toBeUndefined();
+      expect(zones[1].resolvedContent).toEqual(
+        expect.objectContaining({
+          id: 'content-2',
+          name: 'Weather',
+          url: 'https://example.com/weather',
+        }),
+      );
+      expect(zones[1].content).toBeUndefined();
+    });
+  });
+
   describe('update', () => {
     const updateDto = { name: 'Updated Content' };
 

--- a/middleware/src/modules/content/content.service.ts
+++ b/middleware/src/modules/content/content.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException, BadRequestException, ForbiddenException, Logger } from '@nestjs/common';
+import { Injectable, NotFoundException, BadRequestException, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Prisma } from '@vizora/database';
 import { DatabaseService } from '../database/database.service';
@@ -1377,7 +1377,7 @@ export class ContentService {
       if (zone.playlistId) {
         const playlist = playlistMap.get(zone.playlistId as string);
         if (playlist) {
-          resolved.playlist = {
+          resolved.resolvedPlaylist = {
             id: playlist.id,
             name: playlist.name,
             items: playlist.items.map((item) => ({
@@ -1394,7 +1394,7 @@ export class ContentService {
       if (zone.contentId) {
         const content = contentMap.get(zone.contentId as string);
         if (content) {
-          resolved.content = this.mapContentResponse(content as unknown as Record<string, unknown>);
+          resolved.resolvedContent = this.mapContentResponse(content as unknown as Record<string, unknown>);
         }
       }
 

--- a/middleware/src/modules/fleet/fleet.service.spec.ts
+++ b/middleware/src/modules/fleet/fleet.service.spec.ts
@@ -319,10 +319,10 @@ describe('FleetService', () => {
       });
       db.content.findFirst.mockResolvedValue({
         id: 'content-1',
-        title: 'Promo Video',
+        name: 'Promo Video',
         type: 'video',
         url: 'https://cdn.example.com/video.mp4',
-        thumbnailUrl: 'https://cdn.example.com/thumb.jpg',
+        thumbnail: 'https://cdn.example.com/thumb.jpg',
         organizationId: mockOrgId,
       });
 
@@ -347,9 +347,10 @@ describe('FleetService', () => {
           payload: expect.objectContaining({
             content: expect.objectContaining({
               id: 'content-1',
-              title: 'Promo Video',
+              name: 'Promo Video',
               type: 'video',
               url: 'https://cdn.example.com/video.mp4',
+              thumbnail: 'https://cdn.example.com/thumb.jpg',
             }),
             duration: 30,
             priority: 'normal',
@@ -403,10 +404,10 @@ describe('FleetService', () => {
       });
       db.content.findFirst.mockResolvedValue({
         id: 'content-2',
-        title: 'Uploaded Image',
+        name: 'Uploaded Image',
         type: 'image',
         url: 'minio://vizora-content/images/photo.png',
-        thumbnailUrl: null,
+        thumbnail: '/static/thumbnails/content-2.jpg',
         organizationId: mockOrgId,
       });
 
@@ -423,6 +424,10 @@ describe('FleetService', () => {
       expect(body.command.payload.content.url).toBe(
         'http://localhost:3000/api/v1/device-content/content-2/file',
       );
+      expect(body.command.payload.content.name).toBe('Uploaded Image');
+      expect(body.command.payload.content.thumbnail).toBe('/static/thumbnails/content-2.jpg');
+      expect(body.command.payload.content.title).toBeUndefined();
+      expect(body.command.payload.content.thumbnailUrl).toBeUndefined();
     });
   });
 

--- a/middleware/src/modules/fleet/fleet.service.ts
+++ b/middleware/src/modules/fleet/fleet.service.ts
@@ -2,7 +2,6 @@ import {
   Injectable,
   Logger,
   NotFoundException,
-  ForbiddenException,
   BadRequestException,
   ServiceUnavailableException,
 } from '@nestjs/common';
@@ -106,10 +105,10 @@ export class FleetService {
       gatewayPayload = {
         content: {
           id: resolvedContent.id,
-          title: resolvedContent.title,
+          name: resolvedContent.name,
           type: resolvedContent.type,
           url: resolvedUrl,
-          thumbnailUrl: resolvedContent.thumbnailUrl,
+          thumbnail: resolvedContent.thumbnail,
         },
         duration,
         priority: dto.payload.priority || 'normal',
@@ -138,7 +137,7 @@ export class FleetService {
         orgId,
         commandId,
         dto.payload.contentId,
-        resolvedContent?.title || 'Emergency content',
+        resolvedContent?.name || 'Emergency content',
         dto.target.type,
         dto.target.id,
         targetName,

--- a/middleware/src/modules/mail/mail.service.spec.ts
+++ b/middleware/src/modules/mail/mail.service.spec.ts
@@ -1,4 +1,9 @@
+import * as nodemailer from 'nodemailer';
 import { MailService } from './mail.service';
+
+jest.mock('nodemailer', () => ({
+  createTransport: jest.fn(() => ({ sendMail: jest.fn() })),
+}));
 
 describe('MailService.escapeHtml', () => {
   it('escapes &, <, >, ", and \'', () => {
@@ -18,6 +23,38 @@ describe('MailService.escapeHtml', () => {
 
   it('returns plain text unchanged', () => {
     expect(MailService.escapeHtml('Lobby Display 01')).toBe('Lobby Display 01');
+  });
+});
+
+describe('MailService SMTP config', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.SMTP_PASSWORD;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('accepts SMTP_PASS as the documented password alias', () => {
+    process.env.SMTP_HOST = 'smtp.resend.com';
+    process.env.SMTP_PORT = '587';
+    process.env.SMTP_USER = 'resend';
+    process.env.SMTP_PASS = 'resend-secret';
+
+    new MailService();
+
+    expect(nodemailer.createTransport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        host: 'smtp.resend.com',
+        port: 587,
+        secure: false,
+        auth: { user: 'resend', pass: 'resend-secret' },
+      }),
+    );
   });
 });
 

--- a/middleware/src/modules/mail/mail.service.ts
+++ b/middleware/src/modules/mail/mail.service.ts
@@ -24,11 +24,11 @@ export class MailService {
     const host = process.env.SMTP_HOST;
     const port = parseInt(process.env.SMTP_PORT || '587', 10);
     const user = process.env.SMTP_USER;
-    const pass = process.env.SMTP_PASSWORD;
+    const pass = process.env.SMTP_PASSWORD || process.env.SMTP_PASS;
 
     if (!host || !user || !pass) {
       this.logger.warn(
-        'SMTP not configured (SMTP_HOST, SMTP_USER, SMTP_PASSWORD required). ' +
+        'SMTP not configured (SMTP_HOST, SMTP_USER, SMTP_PASSWORD or SMTP_PASS required). ' +
         'Email sending is disabled. Password reset links will be logged to console.',
       );
       return;

--- a/realtime/src/gateways/device.gateway.spec.ts
+++ b/realtime/src/gateways/device.gateway.spec.ts
@@ -75,9 +75,11 @@ describe('DeviceGateway', () => {
     },
     playlist: {
       findUnique: jest.fn().mockResolvedValue(null),
+      findFirst: jest.fn().mockResolvedValue(null),
     },
     content: {
       findUnique: jest.fn().mockResolvedValue(null),
+      findFirst: jest.fn().mockResolvedValue(null),
     },
   };
 
@@ -160,6 +162,115 @@ describe('DeviceGateway', () => {
 
   afterEach(() => {
     jest.useRealTimers();
+  });
+
+  describe('layout content resolution', () => {
+    it('emits display-compatible resolvedPlaylist and resolvedContent zone fields', async () => {
+      mockDatabaseService.playlist.findFirst.mockResolvedValueOnce({
+        id: 'playlist-1',
+        name: 'Menu Loop',
+        items: [
+          {
+            id: 'item-1',
+            contentId: 'content-1',
+            duration: 10,
+            order: 0,
+            content: {
+              id: 'content-1',
+              name: 'Menu Image',
+              type: 'image',
+              url: 'minio://org/content-1.png',
+              thumbnail: '/thumb.png',
+              mimeType: 'image/png',
+              duration: 10,
+            },
+          },
+        ],
+      });
+      mockDatabaseService.content.findFirst.mockResolvedValueOnce({
+        id: 'content-2',
+        name: 'Weather',
+        type: 'url',
+        url: 'https://example.com/weather',
+        thumbnail: null,
+        mimeType: null,
+        duration: null,
+      });
+
+      const result = await (gateway as any).resolveLayoutContent({
+        id: 'layout-1',
+        type: 'layout',
+        metadata: {
+          zones: [
+            { id: 'zone-playlist', gridArea: 'main', playlistId: 'playlist-1' },
+            { id: 'zone-content', gridArea: 'side', contentId: 'content-2' },
+          ],
+        },
+      }, 'org-1');
+
+      expect(result.metadata.zones[0].resolvedPlaylist).toEqual(
+        expect.objectContaining({
+          id: 'playlist-1',
+          items: expect.arrayContaining([
+            expect.objectContaining({
+              content: expect.objectContaining({
+                id: 'content-1',
+                name: 'Menu Image',
+                url: 'http://localhost:3000/api/v1/device-content/content-1/file',
+              }),
+            }),
+          ]),
+        }),
+      );
+      expect(result.metadata.zones[0].playlist).toBeUndefined();
+      expect(result.metadata.zones[1].resolvedContent).toEqual(
+        expect.objectContaining({
+          id: 'content-2',
+          name: 'Weather',
+          url: 'https://example.com/weather',
+        }),
+      );
+      expect(result.metadata.zones[1].content).toBeUndefined();
+      expect(mockDatabaseService.playlist.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'playlist-1', organizationId: 'org-1' },
+        }),
+      );
+      expect(mockDatabaseService.content.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'content-2', organizationId: 'org-1' },
+        }),
+      );
+    });
+
+    it('does not resolve cross-organization layout zone references', async () => {
+      mockDatabaseService.playlist.findFirst.mockResolvedValueOnce(null);
+      mockDatabaseService.content.findFirst.mockResolvedValueOnce(null);
+
+      const result = await (gateway as any).resolveLayoutContent({
+        id: 'layout-1',
+        type: 'layout',
+        metadata: {
+          zones: [
+            { id: 'zone-playlist', gridArea: 'main', playlistId: 'other-org-playlist' },
+            { id: 'zone-content', gridArea: 'side', contentId: 'other-org-content' },
+          ],
+        },
+      }, 'org-1');
+
+      expect(result.metadata.zones[0].resolvedPlaylist).toBeUndefined();
+      expect(result.metadata.zones[1].resolvedContent).toBeUndefined();
+      expect(mockDatabaseService.playlist.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'other-org-playlist', organizationId: 'org-1' },
+        }),
+      );
+      expect(mockDatabaseService.content.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'other-org-content', organizationId: 'org-1' },
+        }),
+      );
+    });
   });
 
   describe('handleConnection', () => {

--- a/realtime/src/gateways/device.gateway.ts
+++ b/realtime/src/gateways/device.gateway.ts
@@ -863,7 +863,7 @@ export class DeviceGateway
 
             // Resolve layout content inline so devices receive self-contained data
             if (baseItem.content?.type === 'layout') {
-              baseItem.content = await this.resolveLayoutContent(baseItem.content);
+              baseItem.content = await this.resolveLayoutContent(baseItem.content, orgId);
             }
 
             return baseItem;
@@ -1787,7 +1787,7 @@ export class DeviceGateway
    * Returns a self-contained layout object that devices can render without
    * additional API calls.
    */
-  private async resolveLayoutContent(content: any): Promise<any> {
+  private async resolveLayoutContent(content: any, organizationId: string): Promise<any> {
     const metadata = (content.metadata as Record<string, any>) || {};
     const zones = metadata.zones || [];
 
@@ -1798,8 +1798,8 @@ export class DeviceGateway
         // Resolve playlist content for zone
         if (zone.playlistId) {
           try {
-            const playlist = await this.databaseService.playlist.findUnique({
-              where: { id: zone.playlistId },
+            const playlist = await this.databaseService.playlist.findFirst({
+              where: { id: zone.playlistId, organizationId },
               include: {
                 items: {
                   include: { content: true },
@@ -1809,7 +1809,7 @@ export class DeviceGateway
             });
 
             if (playlist) {
-              resolved.playlist = {
+              resolved.resolvedPlaylist = {
                 id: playlist.id,
                 name: playlist.name,
                 items: (playlist.items || []).map((item: any) => {
@@ -1841,8 +1841,8 @@ export class DeviceGateway
         // Resolve single content for zone
         if (zone.contentId) {
           try {
-            const zoneContent = await this.databaseService.content.findUnique({
-              where: { id: zone.contentId },
+            const zoneContent = await this.databaseService.content.findFirst({
+              where: { id: zone.contentId, organizationId },
             });
 
             if (zoneContent) {
@@ -1852,7 +1852,7 @@ export class DeviceGateway
                 contentUrl = `${apiBaseUrl}/api/v1/device-content/${zoneContent.id}/file`;
               }
 
-              resolved.content = {
+              resolved.resolvedContent = {
                 id: zoneContent.id,
                 name: zoneContent.name,
                 type: zoneContent.type,

--- a/realtime/src/services/redis.service.spec.ts
+++ b/realtime/src/services/redis.service.spec.ts
@@ -10,6 +10,7 @@ const mockRedis = {
   incr: jest.fn().mockResolvedValue(1),
   expire: jest.fn().mockResolvedValue(1),
   lpush: jest.fn().mockResolvedValue(1),
+  rpush: jest.fn().mockResolvedValue(1),
   lrange: jest.fn().mockResolvedValue([]),
   multi: jest.fn().mockReturnValue({
     lrange: jest.fn().mockReturnThis(),
@@ -136,6 +137,39 @@ describe('RedisService', () => {
     it('should get device commands', async () => {
       const commands = await service.getDeviceCommands('device-1');
       expect(Array.isArray(commands)).toBe(true);
+    });
+
+    it('stores and replays queued commands in FIFO order', async () => {
+      const first = { type: 'clear_cache' as any, payload: { order: 1 } };
+      const second = { type: 'reload' as any, payload: { order: 2 } };
+
+      await service.addDeviceCommand('device-1', first);
+      await service.addDeviceCommand('device-1', second);
+
+      expect((service as any).redis.rpush).toHaveBeenNthCalledWith(
+        1,
+        'device:commands:device-1',
+        JSON.stringify(first),
+      );
+      expect((service as any).redis.rpush).toHaveBeenNthCalledWith(
+        2,
+        'device:commands:device-1',
+        JSON.stringify(second),
+      );
+
+      (service as any).redis.multi.mockReturnValueOnce({
+        lrange: jest.fn().mockReturnThis(),
+        del: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([
+          [null, [JSON.stringify(first), JSON.stringify(second)]],
+          [null, 1],
+        ]),
+      });
+
+      await expect(service.getDeviceCommands('device-1')).resolves.toEqual([
+        first,
+        second,
+      ]);
     });
   });
 

--- a/realtime/src/services/redis.service.ts
+++ b/realtime/src/services/redis.service.ts
@@ -168,7 +168,7 @@ export class RedisService implements OnModuleDestroy {
    */
   async addDeviceCommand(deviceId: string, command: DeviceCommand): Promise<void> {
     const key = `device:commands:${deviceId}`;
-    await this.redis.lpush(key, JSON.stringify(command));
+    await this.redis.rpush(key, JSON.stringify(command));
     await this.redis.expire(key, 300); // 5 minutes
   }
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,13 @@
 # Vizora - Lessons Learned
 
+## Session: 2026-05-31 - Autonomous Builder Correction
+
+### Session Coordination
+- When the operator says there is no other session, treat Codex as the sole builder and use local subagents only as review/research workers. Do not preserve stale "other session" coordination language from an old prompt.
+
+### Worktree Editing
+- In this environment `apply_patch` defaults to the primary checkout path from the initial context, not necessarily the shell command workdir. For isolated worktree tasks, use absolute paths in `apply_patch` and verify `git status` in both the primary checkout and worktree after the first edit.
+
 ## Session: 2026-02-09 - Pilot Readiness Fix Sprint
 
 ### Team Orchestration

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,8 +1,75 @@
 # Vizora - Task Tracker
 
-## In Progress: Display Delivery Reliability Follow-up (2026-05-31)
+## In Progress: Customer Dashboard Quality + Performance Pass (2026-05-31)
+
+**Branch:** `feat/customer-dashboard-quality-pass`
+
+**Why now:** After PR #120 closed the display-delivery reliability slice, the next customer-facing gaps are dashboard quality and middleware/display performance bottlenecks that are repo-side, testable, and do not need production secrets or hardware.
+
+**New primitives introduced:** small web formatting/pagination helpers only. Prefer existing Next dashboard components/API clients, NestJS modules/services/DTOs, Prisma query patterns, and the existing `/api/v1` response envelope.
+
+**Hermes-first analysis:** not applicable unless the selected fix involves business agents, MCP tools, or AI/provider spend. This pass is dashboard UX, middleware performance, content upload/pairing/streaming, and critical-path reliability.
+**Plan/design:** `docs/plans/2026-05-31-customer-dashboard-quality-performance-pass.md`
+
+**Plan**
+- [x] Merge PR #120 after CI green.
+- [x] Re-check deploy gate after merge.
+- [x] Run parallel customer-dashboard, middleware-performance, and customer-1 readiness analyses.
+- [x] Select the highest-value buildable repo-side fixes with file/line evidence.
+- [x] Write/update a short plan/design before code.
+- [x] Implement fixes with focused tests.
+- [x] Run multi-subagent review before broader tests.
+- [x] Run focused and broader verification.
+- [ ] Open PR, wait for CI, merge if clean.
+
+**First scoped bundle selected from subagent reviews**
+- [x] SMTP env parity: `MailService` must accept `SMTP_PASS` as documented/health-checked.
+- [x] Display layout zones: emit/read `resolvedPlaylist` / `resolvedContent` so layout content renders.
+- [x] Realtime command replay: preserve FIFO order for queued offline commands.
+- [x] Fleet push content: map Prisma `Content.name` / `thumbnail`, not non-existent `title` / `thumbnailUrl`.
+- [x] Fleet UI command results: report delivered/queued/failed honestly.
+- [x] Health dashboard: remove random/fabricated metrics and derive stable health from real display status/heartbeat.
+- [x] Content library: clear tag filters with Clear all and stop duplicate post-upload thumbnail generation.
+- [x] Pairing clients: slow polling enough to respect the current status endpoint throttle, with basic 429 handling where feasible.
+- [x] Dashboard list/picker pagination: fetch all pages for content, devices, playlists, schedules, health, status context, overview stats, and emergency override picker instead of truncating at the backend default page.
+
+**Focused verification**
+- [x] `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="mail.service|fleet.service|content.service"` - pass, 3 suites / 126 tests.
+- [x] `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern="redis.service|device.gateway"` - pass, 3 suites / 107 tests.
+- [x] `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="dashboard/health|FleetCommandDropdown|EmergencyOverrideModal|content-page|usePairing|DeviceHealthMonitor"` - pass, 6 suites / 49 tests; existing React `act(...)` warnings remain in `EmergencyOverrideModal` tests.
+- [x] `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="pagination|dashboard/content|dashboard/devices|dashboard/playlists|dashboard/schedules|dashboard/health|dashboard/__tests__|EmergencyOverrideModal|FleetCommandDropdown|usePairing|DeviceHealthMonitor"` - pass, 11 suites / 93 tests; existing React `act(...)` warnings remain in schedule, emergency modal, and upgrade banner tests.
+- [x] Review follow-up `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="pagination|dashboard/__tests__|dashboard/health"` - pass, 3 suites / 25 tests; existing React `act(...)` warnings remain in dashboard/upgrade banner tests.
+- [x] Review follow-up `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="pagination|dashboard/content|dashboard/devices|dashboard/playlists|dashboard/schedules|dashboard/health|dashboard/__tests__|EmergencyOverrideModal|FleetCommandDropdown|commandResultMessage|useDeviceConnection|usePlaylistPlayer|usePairing|DeviceHealthMonitor"` - pass, 14 suites / 106 tests; existing React `act(...)` warnings and intentional negative-path console errors remain.
+- [x] `git diff --check` - pass; line-ending warnings only.
+
+**Broad verification**
+- [x] `pnpm --filter @vizora/middleware test -- --runInBand` - pass, 141 suites / 2763 tests.
+- [x] `pnpm --filter @vizora/realtime test -- --runInBand` - pass, 11 suites / 245 tests.
+- [x] `pnpm --filter @vizora/display test -- --runInBand` - pass, 5 suites / 115 tests; known MaxListeners warning and expected negative-path logs remain.
+- [x] `pnpm --filter @vizora/web test -- --runInBand` - pass, 86 suites / 905 tests; existing React `act(...)` warnings and expected negative-path logs remain.
+- [x] `npx nx build @vizora/middleware` - pass with existing webpack warnings.
+- [x] `npx nx build @vizora/realtime` - pass with existing source-map / optional `ws` warnings.
+- [x] `pnpm --filter @vizora/display build` - pass.
+- [x] `NODE_OPTIONS=--max-old-space-size=4096 npx nx build @vizora/web` - pass with existing Next middleware/proxy and missing production API URL warnings.
+- [x] Direct ESLint equivalent (`ESLINT_USE_FLAT_CONFIG=false eslint "middleware/src/**/*.ts" "realtime/src/**/*.ts"`) - exit 0, 187 warnings, no errors. Local `pnpm lint` wrapper is Windows-incompatible because the script uses Unix-style env assignment.
+- [x] Final `git diff --check` - pass; line-ending warnings only.
+
+**Review gate**
+- [x] Backend/realtime reviewer: initial high/medium findings fixed; final re-review CLEAN.
+- [x] Frontend/customer UX reviewer: initial and follow-up findings fixed; final re-review CLEAN.
+- [x] Performance/readiness reviewer: initial and follow-up findings fixed; final re-review CLEAN.
+
+**Current deployment gate**
+- GitHub main: `70285350105ba46e457fdf702ea9fe33279efc19` after PR #120.
+- Production runtime health: `/api/v1/health` returned `success: true`, database connected at 2026-05-31T06:11:55Z.
+- Production deploy is blocked: `/opt/vizora/app` is dirty, local `HEAD=bb76aa1838740bff5b58623dfef7a906d44f46a6`, and after fetch is `ahead 17, behind 36` relative to `origin/main=70285350105ba46e457fdf702ea9fe33279efc19`. Do not pull/reset/stash/restart services until prod-local work is reconciled.
+
+---
+
+## Completed: Display Delivery Reliability Follow-up (2026-05-31)
 
 **Branch:** `feat/customer-performance-hardening-2`
+**PR / merge commit:** #120 / `70285350105ba46e457fdf702ea9fe33279efc19`
 
 **Plan/design:** `docs/plans/2026-05-31-display-delivery-reliability-follow-up.md`
 
@@ -20,7 +87,7 @@
 - [x] Run focused realtime/display/middleware tests.
 - [x] Run multi-review on the diff before broader tests.
 - [x] Run broader package tests/builds proportional to touched packages.
-- [ ] Open PR, wait for CI, merge if clean.
+- [x] Open PR, wait for CI, merge if clean.
 
 **Verification so far**
 - `NODE_OPTIONS=--use-system-ca pnpm --dir packages/database exec prisma generate` - pass; needed in fresh worktree before realtime tests could import `@vizora/database`.
@@ -38,6 +105,8 @@
 - `npx nx build @vizora/realtime` - pass with existing source-map/optional `ws` warnings.
 - `pnpm --filter @vizora/display build` - pass.
 - `NODE_OPTIONS=--max-old-space-size=4096 npx nx build @vizora/web` - pass with existing Next middleware/proxy and missing production API URL warnings.
+- PR #120 CI - pass: audit, build, lint, security, test, and e2e.
+- Deploy status - not deployed; blocked by dirty/diverged production checkout.
 
 **Review inputs**
 - Realtime/display reviewer: high findings on negative-ACK replay, broadcast bypassing ACK/queue path, Electron protected media URLs, and middleware single-device command DTO drift.

--- a/web/src/app/dashboard/__tests__/dashboard-page.test.tsx
+++ b/web/src/app/dashboard/__tests__/dashboard-page.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import DashboardClient from '../page-client';
+import { apiClient } from '@/lib/api';
 
 const mockPush = jest.fn();
 
@@ -81,5 +82,53 @@ describe('DashboardClient', () => {
   it('shows getting started guide when no devices', () => {
     render(<DashboardClient initialContent={[]} initialPlaylists={[]} />);
     expect(screen.getByText('Getting Started')).toBeInTheDocument();
+  });
+
+  it('refreshes overview counts from all paginated pages on mount', async () => {
+    (apiClient.getContent as jest.Mock)
+      .mockResolvedValueOnce({
+        data: [{ id: 'c1' }],
+        meta: { page: 1, limit: 100, total: 2, totalPages: 2 },
+      })
+      .mockResolvedValueOnce({
+        data: [{ id: 'c2', status: 'processing' }],
+        meta: { page: 2, limit: 100, total: 2, totalPages: 2 },
+      });
+    (apiClient.getPlaylists as jest.Mock).mockResolvedValue({
+      data: [{ id: 'p1', isActive: true }],
+      meta: { page: 1, limit: 100, total: 1, totalPages: 1 },
+    });
+
+    render(<DashboardClient initialContent={[]} initialPlaylists={[]} />);
+
+    await waitFor(() => {
+      expect(apiClient.getContent).toHaveBeenNthCalledWith(1, { page: 1, limit: 100 });
+      expect(apiClient.getContent).toHaveBeenNthCalledWith(2, { page: 2, limit: 100 });
+      expect(apiClient.getPlaylists).toHaveBeenCalledWith({ page: 1, limit: 100 });
+    });
+    expect(screen.getByText('Content Items').parentElement?.parentElement).toHaveTextContent('2');
+    expect(screen.getByText('Playlists').parentElement?.parentElement).toHaveTextContent('1');
+  });
+
+  it('preserves initial overview counts when all-page refresh partially fails', async () => {
+    (apiClient.getContent as jest.Mock).mockRejectedValueOnce(new Error('content unavailable'));
+    (apiClient.getPlaylists as jest.Mock).mockResolvedValueOnce({
+      data: [{ id: 'p1', isActive: true }],
+      meta: { page: 1, limit: 100, total: 1, totalPages: 1 },
+    });
+
+    render(
+      <DashboardClient
+        initialContent={[{ id: 'c1' }, { id: 'c2' }]}
+        initialPlaylists={[{ id: 'p1', isActive: true }]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(apiClient.getContent).toHaveBeenCalledWith({ page: 1, limit: 100 });
+      expect(screen.getByText('Some dashboard data could not refresh')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Content Items').parentElement?.parentElement).toHaveTextContent('2');
+    expect(screen.getByText('Playlists').parentElement?.parentElement).toHaveTextContent('1');
   });
 });

--- a/web/src/app/dashboard/content/__tests__/content-page.test.tsx
+++ b/web/src/app/dashboard/content/__tests__/content-page.test.tsx
@@ -102,7 +102,16 @@ jest.mock('@/components/SearchFilter', () => {
 });
 
 jest.mock('@/components/ContentTagger', () => {
-  return function MockTagger() { return null; };
+  return function MockTagger({ selectedTags, onChange }: any) {
+    return (
+      <div data-testid="content-tagger">
+        <button type="button" onClick={() => onChange(['1'])}>
+          Select Marketing Tag
+        </button>
+        <span data-testid="selected-tags">{selectedTags.join(',')}</span>
+      </div>
+    );
+  };
 });
 
 jest.mock('@/components/FolderTree', () => {
@@ -141,6 +150,7 @@ const sampleContent = [
     url: '/uploads/banner.png',
     thumbnailUrl: '/thumbs/banner.png',
     fileSize: 1024000,
+    metadata: { tags: ['Marketing'] },
     createdAt: '2026-01-15T10:00:00Z',
     updatedAt: '2026-01-15T10:00:00Z',
   },
@@ -272,6 +282,28 @@ describe('ContentClient', () => {
     expect(screen.getByText('Menu PDF')).toBeInTheDocument();
   });
 
+  it('renders content from every paginated page', async () => {
+    mockGetContent
+      .mockResolvedValueOnce({
+        data: [sampleContent[0]],
+        meta: { page: 1, limit: 100, total: 2, totalPages: 2 },
+      })
+      .mockResolvedValueOnce({
+        data: [sampleContent[1]],
+        meta: { page: 2, limit: 100, total: 2, totalPages: 2 },
+      });
+
+    render(<ContentClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+      expect(screen.getByText('Promo Video')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+    expect(mockGetContent).toHaveBeenNthCalledWith(1, { page: 1, limit: 100 });
+    expect(mockGetContent).toHaveBeenNthCalledWith(2, { page: 2, limit: 100 });
+  });
+
   it('shows error toast on fetch failure', async () => {
     mockGetContent.mockRejectedValue(new Error('Network error'));
     render(<ContentClient />);
@@ -326,6 +358,33 @@ describe('ContentClient', () => {
     await waitForAuxiliaryRequestsToSettle();
 
     expect(mockGenerateThumbnail).not.toHaveBeenCalled();
+  });
+
+  it('clears selected tag filters when Clear all is clicked', async () => {
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+      expect(screen.getByText('Promo Video')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    fireEvent.click(screen.getByText(/Tags/));
+    fireEvent.click(screen.getByText('Select Marketing Tag'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+      expect(screen.queryByText('Promo Video')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Clear all'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+      expect(screen.getByText('Promo Video')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('selected-tags')).toHaveTextContent('');
   });
 
   it('also fetches displays and playlists for push/add features', async () => {

--- a/web/src/app/dashboard/content/page-client.tsx
+++ b/web/src/app/dashboard/content/page-client.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { apiClient } from '@/lib/api';
+import { fetchAllPaginated } from '@/lib/api/pagination';
 import { Content, Display, Playlist, ContentFolder } from '@/lib/types';
 import FolderTree from '@/components/FolderTree';
 import FolderBreadcrumb from '@/components/FolderBreadcrumb';
@@ -182,16 +183,15 @@ export default function ContentClient() {
  const folderId = selectedFolderId;
  try {
  setLoading(true);
- let response;
+ let items: Content[];
  if (folderId) {
- response = await apiClient.getFolderContent(folderId);
+ items = await fetchAllPaginated((params) => apiClient.getFolderContent(folderId, params));
  } else {
- response = await apiClient.getContent();
+ items = await fetchAllPaginated((params) => apiClient.getContent(params));
  }
  if (requestId !== loadContentRequestRef.current) {
  return;
  }
- const items = response.data || response || [];
  setContent(items);
  } catch (error: any) {
  if (requestId !== loadContentRequestRef.current) {
@@ -262,8 +262,8 @@ export default function ContentClient() {
 
  const loadDevices = async () => {
  try {
- const response = await apiClient.getDisplays();
- setDevices(response.data || response || []);
+ const devicesList = await fetchAllPaginated((params) => apiClient.getDisplays(params));
+ setDevices(devicesList);
  } catch (error: any) {
  if (process.env.NODE_ENV === 'development') {
   console.error('[ContentPage] Failed to load devices:', error);
@@ -277,8 +277,8 @@ export default function ContentClient() {
 
  const loadPlaylists = async () => {
  try {
- const response = await apiClient.getPlaylists();
- setPlaylists(response.data || response || []);
+ const playlistList = await fetchAllPaginated((params) => apiClient.getPlaylists(params));
+ setPlaylists(playlistList);
  } catch (error: any) {
  if (process.env.NODE_ENV === 'development') {
   console.error('[ContentPage] Failed to load playlists:', error);
@@ -317,15 +317,6 @@ export default function ContentClient() {
  type: uploadForm.type,
  file: item.file, // Pass file object instead of blob URL
  });
-
- // Generate thumbnail for images
- if (uploadForm.type === 'image' && newContent.id) {
- try {
- await apiClient.generateThumbnail(newContent.id);
- } catch (thumbnailError) {
- console.warn('Thumbnail generation failed:', thumbnailError);
- }
- }
 
  // Mark as success
  setUploadQueue(prev => prev.map((q, idx) =>
@@ -790,9 +781,10 @@ export default function ContentClient() {
  setFilterStatus('all');
  setFilterDateRange('all');
  setSearchQuery('');
+ setSelectedTags([]);
  };
 
- const hasActiveFilters = filterType !== 'all' || filterStatus !== 'all' || filterDateRange !== 'all' || searchQuery !== '';
+ const hasActiveFilters = filterType !== 'all' || filterStatus !== 'all' || filterDateRange !== 'all' || searchQuery !== '' || selectedTags.length > 0;
 
  return (
  <div className="flex h-full">

--- a/web/src/app/dashboard/devices/page-client.tsx
+++ b/web/src/app/dashboard/devices/page-client.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { apiClient } from '@/lib/api';
+import { fetchAllPaginated } from '@/lib/api/pagination';
 import { Display, Playlist, DisplayGroup } from '@/lib/types';
 import Modal from '@/components/Modal';
 import ConfirmDialog from '@/components/ConfirmDialog';
@@ -114,23 +115,18 @@ export default function DevicesClient({ initialDevices, initialPlaylists }: Devi
  });
 
  useEffect(() => {
- if (initialDevices.length === 0) {
- loadDevices();
- }
- if (initialPlaylists.length === 0) {
+ loadDevices(initialDevices.length === 0);
  loadPlaylists();
- }
  loadGroups();
  }, []);
 
- const loadDevices = async () => {
+ const loadDevices = async (showLoading = true) => {
  try {
- setLoading(true);
+ if (showLoading) setLoading(true);
  await retry(
  'loadDevices',
  async () => {
- const response = await apiClient.getDisplays();
- const devicesList = response.data || response || [];
+ const devicesList = await fetchAllPaginated((params) => apiClient.getDisplays(params));
  setDevices(devicesList);
  clearError('loadDevices');
  return devicesList;
@@ -143,14 +139,14 @@ export default function DevicesClient({ initialDevices, initialPlaylists }: Devi
  } catch (error: any) {
  recordError('loadDevices', error, 'warning');
  } finally {
- setLoading(false);
+ if (showLoading) setLoading(false);
  }
  };
 
  const loadPlaylists = async () => {
  try {
- const response = await apiClient.getPlaylists();
- setPlaylists(response.data || response || []);
+ const playlistList = await fetchAllPaginated((params) => apiClient.getPlaylists(params));
+ setPlaylists(playlistList);
  } catch (error) {
  toast.error('Failed to load playlists');
  }
@@ -158,8 +154,7 @@ export default function DevicesClient({ initialDevices, initialPlaylists }: Devi
 
  const loadGroups = async () => {
  try {
- const response = await apiClient.getDisplayGroups();
- const groups = response.data || [];
+ const groups = await fetchAllPaginated((params) => apiClient.getDisplayGroups(params));
  setDeviceGroups(groups.map((g: any) => ({
  id: g.id,
  name: g.name,

--- a/web/src/app/dashboard/devices/page.tsx
+++ b/web/src/app/dashboard/devices/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { serverFetch } from '@/lib/server-api';
+import { unwrapPaginatedData } from '@/lib/api/pagination';
 import type { Display, Playlist } from '@/lib/types';
 import DevicesClient from './page-client';
 
@@ -13,17 +14,15 @@ export default async function DevicesPage() {
 
  try {
  const results = await Promise.allSettled([
- serverFetch<any>('/displays'),
- serverFetch<any>('/playlists'),
+ serverFetch<any>('/displays?limit=100'),
+ serverFetch<any>('/playlists?limit=100'),
  ]);
 
  if (results[0].status === 'fulfilled') {
- const val = results[0].value;
- devices = val?.data || val || [];
+ devices = unwrapPaginatedData<Display>(results[0].value);
  }
  if (results[1].status === 'fulfilled') {
- const val = results[1].value;
- playlists = val?.data || val || [];
+ playlists = unwrapPaginatedData<Playlist>(results[1].value);
  }
  } catch {
  // Client handles empty state gracefully

--- a/web/src/app/dashboard/health/__tests__/health-page.test.tsx
+++ b/web/src/app/dashboard/health/__tests__/health-page.test.tsx
@@ -67,7 +67,7 @@ jest.mock('@/components/DeviceHealthMonitor', () => {
   };
 });
 
-import HealthMonitoringClient from '../page-client';
+import HealthMonitoringClient, { deriveDeviceHealthFromDisplay } from '../page-client';
 import { apiClient } from '@/lib/api';
 
 const mockDevices = [
@@ -155,6 +155,25 @@ describe('HealthMonitoringClient', () => {
     await waitFor(() => {
       expect(screen.getByText('Sort by Health')).toBeInTheDocument();
     });
+    expect(screen.getByText('Sort by Status')).toBeInTheDocument();
+    expect(screen.queryByText('Sort by CPU')).not.toBeInTheDocument();
+    expect(screen.queryByText('Sort by Memory')).not.toBeInTheDocument();
+  });
+
+  it('uses a slower background refresh cadence for all-page health polling', async () => {
+    render(<HealthMonitoringClient />);
+
+    await waitFor(() => {
+      expect(apiClient.getDisplays).toHaveBeenCalledTimes(1);
+    });
+
+    jest.advanceTimersByTime(10000);
+    expect(apiClient.getDisplays).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(20000);
+    await waitFor(() => {
+      expect(apiClient.getDisplays).toHaveBeenCalledTimes(2);
+    });
   });
 
   it('shows empty state when no devices', async () => {
@@ -185,5 +204,37 @@ describe('HealthMonitoringClient', () => {
       expect(screen.getByText('Lobby Screen')).toBeInTheDocument();
       expect(screen.getByText('Meeting Room')).toBeInTheDocument();
     });
+  });
+
+  it('derives stable health from real display status and heartbeat data', () => {
+    const device = {
+      ...mockDevices[0],
+      status: 'online',
+      lastHeartbeat: '2026-05-31T12:00:00.000Z',
+    };
+
+    const first = deriveDeviceHealthFromDisplay(device as any, Date.parse('2026-05-31T12:00:30.000Z'));
+    const second = deriveDeviceHealthFromDisplay(device as any, Date.parse('2026-05-31T12:00:30.000Z'));
+
+    expect(first).toEqual(second);
+    expect(first.score).toBe(100);
+    expect(first.lastHeartbeat?.toISOString()).toBe('2026-05-31T12:00:00.000Z');
+    expect(first.cpuUsage).toBeNull();
+    expect(first.memoryUsage).toBeNull();
+    expect(first.storageUsage).toBeNull();
+    expect(first.temperature).toBeNull();
+    expect(first.uptime).toBeNull();
+  });
+
+  it('marks stale offline devices as critical instead of random healthy', () => {
+    const device = {
+      ...mockDevices[1],
+      status: 'offline',
+      lastHeartbeat: '2026-05-31T11:00:00.000Z',
+    };
+
+    const health = deriveDeviceHealthFromDisplay(device as any, Date.parse('2026-05-31T12:00:00.000Z'));
+
+    expect(health.score).toBe(25);
   });
 });

--- a/web/src/app/dashboard/health/page-client.tsx
+++ b/web/src/app/dashboard/health/page-client.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { apiClient } from '@/lib/api';
+import { fetchAllPaginated } from '@/lib/api/pagination';
 import { Display } from '@/lib/types';
 import DeviceHealthMonitor, { DeviceHealth } from '@/components/DeviceHealthMonitor';
 import LoadingSpinner from '@/components/LoadingSpinner';
@@ -12,18 +13,48 @@ import { useDebounce } from '@/lib/hooks/useDebounce';
 import { useRealtimeEvents } from '@/lib/hooks';
 import { Icon } from '@/theme/icons';
 
-// Mock device health data generator
-const generateMockDeviceHealth = (deviceId: string, _deviceName: string): DeviceHealth => {
- const baseScore = Math.random() * 40 + 60; // 60-100
+const parseDisplayHeartbeat = (device: Display): Date | null => {
+ const raw = device.lastHeartbeat ?? device.lastSeen ?? null;
+ if (!raw) return null;
+ const parsed = new Date(raw);
+ return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+const HEALTH_REFRESH_INTERVAL_MS = 30000;
+
+export const deriveDeviceHealthFromDisplay = (
+ device: Display,
+ nowMs: number = Date.now(),
+): DeviceHealth => {
+ const lastHeartbeat = parseDisplayHeartbeat(device);
+ const ageMs = lastHeartbeat ? Math.max(0, nowMs - lastHeartbeat.getTime()) : null;
+ const ageMinutes = ageMs == null ? null : ageMs / 60000;
+ const status = String(device.status ?? 'offline').toLowerCase();
+
+ let score = 25;
+ if (status === 'online') {
+ if (ageMinutes == null) score = 70;
+ else if (ageMinutes <= 2) score = 100;
+ else if (ageMinutes <= 5) score = 85;
+ else if (ageMinutes <= 15) score = 70;
+ else score = 55;
+ } else if (status === 'pairing') {
+ score = 65;
+ } else if (status === 'error') {
+ score = 35;
+ } else {
+ score = ageMinutes != null && ageMinutes <= 15 ? 45 : 25;
+ }
+
  return {
- deviceId,
- cpuUsage: Math.floor(Math.random() * 80),
- memoryUsage: Math.floor(Math.random() * 75),
- storageUsage: Math.floor(Math.random() * 60),
- temperature: Math.floor(Math.random() * 30 + 35),
- uptime: Math.floor(Math.random() * 720), // Up to 30 days
- lastHeartbeat: new Date(Date.now() - Math.random() * 300000),
- score: Math.floor(baseScore),
+ deviceId: device.id,
+ cpuUsage: null,
+ memoryUsage: null,
+ storageUsage: null,
+ temperature: null,
+ uptime: null,
+ lastHeartbeat,
+ score,
  };
 };
 
@@ -32,9 +63,10 @@ export default function HealthMonitoringClient() {
  const [devices, setDevices] = useState<Display[]>([]);
  const [deviceHealthData, setDeviceHealthData] = useState<Record<string, DeviceHealth>>({});
  const [loading, setLoading] = useState(true);
+ const refreshInFlightRef = useRef(false);
  const [searchQuery, setSearchQuery] = useState('');
  const debouncedSearch = useDebounce(searchQuery, 300);
- const [sortBy, setSortBy] = useState<'name' | 'health' | 'cpu' | 'memory'>('health');
+ const [sortBy, setSortBy] = useState<'name' | 'health' | 'status'>('health');
  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
  const [realtimeStatus, setRealtimeStatus] = useState<'connected' | 'offline' | 'error'>('offline');
  const [activeAlerts, setActiveAlerts] = useState<Record<string, any>>({});
@@ -51,31 +83,32 @@ export default function HealthMonitoringClient() {
  loadDevicesAndHealth();
  }, []);
 
- // Auto-refresh health data every 10 seconds
+ // Auto-refresh health data without replacing the page with a loading spinner.
  useEffect(() => {
  const interval = setInterval(() => {
- loadDevicesAndHealth();
- }, 10000);
+ loadDevicesAndHealth(false);
+ }, HEALTH_REFRESH_INTERVAL_MS);
  return () => clearInterval(interval);
  }, []);
 
- const loadDevicesAndHealth = async () => {
+ const loadDevicesAndHealth = async (showLoading = true) => {
+ if (refreshInFlightRef.current) return;
+ refreshInFlightRef.current = true;
  try {
- setLoading(true);
- const response = await apiClient.getDisplays();
- const displayDevices = response.data || response || [];
+ if (showLoading) setLoading(true);
+ const displayDevices = await fetchAllPaginated((params) => apiClient.getDisplays(params), undefined, 100, 5);
  setDevices(displayDevices);
 
- // Generate mock health data for each device
  const healthData: Record<string, DeviceHealth> = {};
  displayDevices.forEach((device: Display) => {
- healthData[device.id] = generateMockDeviceHealth(device.id, device.nickname);
+ healthData[device.id] = deriveDeviceHealthFromDisplay(device);
  });
  setDeviceHealthData(healthData);
  } catch (error: any) {
  toast.error(error.message || 'Failed to load device health');
  } finally {
- setLoading(false);
+ if (showLoading) setLoading(false);
+ refreshInFlightRef.current = false;
  }
  };
 
@@ -110,14 +143,11 @@ export default function HealthMonitoringClient() {
  case 'name':
  compareValue = (a.nickname || '').localeCompare(b.nickname || '');
  break;
+ case 'status':
+ compareValue = String(a.status || '').localeCompare(String(b.status || ''));
+ break;
  case 'health':
  compareValue = (healthA?.score || 0) - (healthB?.score || 0);
- break;
- case 'cpu':
- compareValue = (healthA?.cpuUsage || 0) - (healthB?.cpuUsage || 0);
- break;
- case 'memory':
- compareValue = (healthA?.memoryUsage || 0) - (healthB?.memoryUsage || 0);
  break;
  default:
  compareValue = 0;
@@ -161,7 +191,7 @@ export default function HealthMonitoringClient() {
  </p>
  </div>
  <button
- onClick={loadDevicesAndHealth}
+ onClick={() => loadDevicesAndHealth()}
  className="bg-[#00E5A0] text-[#061A21] px-6 py-3 rounded-lg hover:bg-[#00CC8E] transition font-semibold shadow-md hover:shadow-lg flex items-center gap-2"
  >
  <Icon name="download" size="lg" className="text-white" />
@@ -237,8 +267,7 @@ export default function HealthMonitoringClient() {
  >
  <option value="health">Sort by Health</option>
  <option value="name">Sort by Name</option>
- <option value="cpu">Sort by CPU</option>
- <option value="memory">Sort by Memory</option>
+ <option value="status">Sort by Status</option>
  </select>
  <button
  onClick={() => setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc')}
@@ -309,19 +338,19 @@ export default function HealthMonitoringClient() {
  <div className="bg-[var(--surface)]/50/50 p-2 rounded">
  <p className="text-[var(--foreground-secondary)] text-xs">Uptime</p>
  <p className="font-medium text-[var(--foreground)]">
- {Math.floor(health.uptime / 24)}d {health.uptime % 24}h
+ {typeof health.uptime === 'number' ? `${Math.floor(health.uptime / 24)}d ${health.uptime % 24}h` : 'Not reported'}
  </p>
  </div>
  <div className="bg-[var(--surface)]/50/50 p-2 rounded">
  <p className="text-[var(--foreground-secondary)] text-xs">Temp</p>
  <p className="font-medium text-[var(--foreground)]">
- {health.temperature}°C
+ {typeof health.temperature === 'number' ? `${health.temperature}°C` : 'Not reported'}
  </p>
  </div>
  <div className="bg-[var(--surface)]/50/50 p-2 rounded col-span-2">
  <p className="text-[var(--foreground-secondary)] text-xs mb-1">Last Heartbeat</p>
  <p className="font-medium text-[var(--foreground)] text-xs">
- {Math.round((Date.now() - health.lastHeartbeat.getTime()) / 1000)}s ago
+ {health.lastHeartbeat ? `${Math.round((Date.now() - health.lastHeartbeat.getTime()) / 1000)}s ago` : 'Never'}
  </p>
  </div>
  </div>

--- a/web/src/app/dashboard/page-client.tsx
+++ b/web/src/app/dashboard/page-client.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { apiClient } from '@/lib/api';
+import { fetchAllPaginated } from '@/lib/api/pagination';
 import { useDeviceStatus } from '@/lib/context/DeviceStatusContext';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import UpgradeBanner from '@/components/UpgradeBanner';
@@ -53,6 +54,10 @@ export default function DashboardClient({ initialContent, initialPlaylists }: Da
 
  buildRecentActivity(content, playlists);
  }, [initialContent, initialPlaylists]);
+
+ useEffect(() => {
+ loadStats(false);
+ }, []);
 
  // Update device stats from context (real-time)
  useEffect(() => {
@@ -106,24 +111,16 @@ export default function DashboardClient({ initialContent, initialPlaylists }: Da
  setRecentActivity(activity);
  };
 
- const loadStats = async () => {
+ const loadStats = async (showLoading = true) => {
  try {
- setLoading(true);
+ if (showLoading) setLoading(true);
  const results = await Promise.allSettled([
- apiClient.getContent(),
- apiClient.getPlaylists(),
+ fetchAllPaginated((params) => apiClient.getContent(params)),
+ fetchAllPaginated((params) => apiClient.getPlaylists(params)),
  ]);
 
- const content = results[0].status === 'fulfilled'
- ? Array.isArray(results[0].value?.data) ? results[0].value.data
- : Array.isArray(results[0].value) ? results[0].value
- : []
- : [];
- const playlists = results[1].status === 'fulfilled'
- ? Array.isArray(results[1].value?.data) ? results[1].value.data
- : Array.isArray(results[1].value) ? results[1].value
- : []
- : [];
+ const content = results[0].status === 'fulfilled' ? results[0].value : null;
+ const playlists = results[1].status === 'fulfilled' ? results[1].value : null;
 
  results.forEach((result, index) => {
  if (result.status === 'rejected') {
@@ -135,25 +132,37 @@ export default function DashboardClient({ initialContent, initialPlaylists }: Da
 
  setStats(prev => ({
  ...prev,
+ ...(content
+ ? {
  content: {
  total: content.length,
  processing: content.filter((c: any) => c?.status === 'processing').length,
  },
+ }
+ : {}),
+ ...(playlists
+ ? {
  playlists: {
  total: playlists.length,
  active: playlists.filter((p: any) => p?.isActive === true).length,
  },
+ }
+ : {}),
  }));
 
+ if (content && playlists) {
  buildRecentActivity(content, playlists);
  setError(null);
+ } else {
+ setError('Some dashboard data could not refresh');
+ }
  } catch (error) {
  if (process.env.NODE_ENV === 'development') {
   console.error('Failed to load stats:', error);
  }
  setError(error instanceof Error ? error.message : 'Failed to load dashboard data');
  } finally {
- setLoading(false);
+ if (showLoading) setLoading(false);
  }
  };
 
@@ -210,7 +219,7 @@ export default function DashboardClient({ initialContent, initialPlaylists }: Da
  </h3>
  <p className="text-sm text-red-700 dark:text-red-300 mt-1">{error}</p>
  <button
- onClick={loadStats}
+ onClick={() => loadStats()}
  className="mt-3 text-sm font-medium text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 underline"
  >
  Try again

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { serverFetch } from '@/lib/server-api';
+import { unwrapPaginatedData } from '@/lib/api/pagination';
 import DashboardClient from './page-client';
 
 export const metadata: Metadata = {
@@ -12,17 +13,15 @@ export default async function DashboardPage() {
 
  try {
  const results = await Promise.allSettled([
- serverFetch<any>('/content'),
- serverFetch<any>('/playlists'),
+ serverFetch<any>('/content?limit=100'),
+ serverFetch<any>('/playlists?limit=100'),
  ]);
 
  if (results[0].status === 'fulfilled') {
- const val = results[0].value;
- content = Array.isArray(val?.data) ? val.data : Array.isArray(val) ? val : [];
+ content = unwrapPaginatedData(results[0].value);
  }
  if (results[1].status === 'fulfilled') {
- const val = results[1].value;
- playlists = Array.isArray(val?.data) ? val.data : Array.isArray(val) ? val : [];
+ playlists = unwrapPaginatedData(results[1].value);
  }
  } catch {
  // Client handles empty state gracefully

--- a/web/src/app/dashboard/playlists/page-client.tsx
+++ b/web/src/app/dashboard/playlists/page-client.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { apiClient } from '@/lib/api';
+import { fetchAllPaginated } from '@/lib/api/pagination';
 import { Playlist, Content, Display } from '@/lib/types';
 import Modal from '@/components/Modal';
 import ConfirmDialog from '@/components/ConfirmDialog';
@@ -196,8 +197,8 @@ export default function PlaylistsClient() {
  const loadPlaylists = async () => {
  try {
  setLoading(true);
- const response = await apiClient.getPlaylists();
- setPlaylists(response.data || response || []);
+ const playlistList = await fetchAllPaginated((params) => apiClient.getPlaylists(params));
+ setPlaylists(playlistList);
  } catch (error: any) {
  toast.error(error.message || 'Failed to load playlists');
  } finally {
@@ -207,8 +208,8 @@ export default function PlaylistsClient() {
 
  const loadContent = async () => {
  try {
- const response = await apiClient.getContent();
- setContent(response.data || response || []);
+ const contentList = await fetchAllPaginated((params) => apiClient.getContent(params));
+ setContent(contentList);
  } catch (error) {
  toast.error('Failed to load content');
  }
@@ -216,8 +217,8 @@ export default function PlaylistsClient() {
 
  const loadDevices = async () => {
  try {
- const response = await apiClient.getDisplays();
- setDevices(response.data || response || []);
+ const devicesList = await fetchAllPaginated((params) => apiClient.getDisplays(params));
+ setDevices(devicesList);
  } catch (error) {
  toast.error('Failed to load devices');
  }

--- a/web/src/app/dashboard/schedules/page-client.tsx
+++ b/web/src/app/dashboard/schedules/page-client.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { apiClient } from '@/lib/api';
+import { fetchAllPaginated } from '@/lib/api/pagination';
 import { Display, Playlist } from '@/lib/types';
 import Modal from '@/components/Modal';
 import ConfirmDialog from '@/components/ConfirmDialog';
@@ -130,14 +131,16 @@ export default function SchedulesClient() {
  try {
  setLoading(true);
  const [schedulesRes, devicesRes, playlistsRes, groupsRes] = await Promise.allSettled([
- apiClient.getSchedules(),
- apiClient.getDisplays(),
- apiClient.getPlaylists(),
- apiClient.getDisplayGroups?.() ?? Promise.resolve({ data: [] }),
+ fetchAllPaginated((params) => apiClient.getSchedules(params)),
+ fetchAllPaginated((params) => apiClient.getDisplays(params)),
+ fetchAllPaginated((params) => apiClient.getPlaylists(params)),
+ apiClient.getDisplayGroups
+ ? fetchAllPaginated((params) => apiClient.getDisplayGroups(params))
+ : Promise.resolve([]),
  ]);
 
  if (schedulesRes.status === 'fulfilled') {
- const scheduleData = schedulesRes.value.data || schedulesRes.value || [];
+ const scheduleData = schedulesRes.value || [];
  // Transform backend data to UI format
  const transformedSchedules = (scheduleData as any[]).map((s: any) => ({
  ...s,
@@ -155,15 +158,15 @@ export default function SchedulesClient() {
  setSchedules(transformedSchedules as Schedule[]);
  }
  if (devicesRes.status === 'fulfilled') {
- const deviceData = devicesRes.value.data || devicesRes.value || [];
+ const deviceData = devicesRes.value || [];
  setDevices(deviceData as unknown as Display[]);
  }
  if (playlistsRes.status === 'fulfilled') {
- const playlistData = playlistsRes.value.data || playlistsRes.value || [];
+ const playlistData = playlistsRes.value || [];
  setPlaylists(playlistData as unknown as Playlist[]);
  }
  if (groupsRes?.status === 'fulfilled') {
- setDisplayGroups((groupsRes.value as any)?.data || []);
+ setDisplayGroups(groupsRes.value || []);
  }
  } catch (error: any) {
  toast.error(error.message || 'Failed to load data');

--- a/web/src/app/display/hooks/__tests__/useDeviceConnection.test.tsx
+++ b/web/src/app/display/hooks/__tests__/useDeviceConnection.test.tsx
@@ -101,6 +101,28 @@ describe('useDeviceConnection', () => {
     expect(ack).toHaveBeenCalledWith({ ok: true });
   });
 
+  it('passes push_content duration through as minutes with a 5 minute default', () => {
+    const socket = createSocket();
+    (io as jest.Mock).mockReturnValue(socket);
+    const onContentPush = jest.fn();
+
+    renderConnection({ onContentPush });
+    const commandHandler = socket.on.mock.calls.find(
+      (call: any[]) => call[0] === 'command',
+    )?.[1];
+    const ack = jest.fn();
+    const content = { id: 'content-1', name: 'Emergency', type: 'image', url: '/emergency.png' };
+
+    act(() => {
+      commandHandler({ type: 'push_content', payload: { content, duration: 60 } }, ack);
+      commandHandler({ type: 'push_content', payload: { content } }, ack);
+    });
+
+    expect(onContentPush).toHaveBeenNthCalledWith(1, content, 60);
+    expect(onContentPush).toHaveBeenNthCalledWith(2, content, 5);
+    expect(ack).toHaveBeenCalledWith({ ok: true });
+  });
+
   it('negative-acknowledges commands when applying them fails', () => {
     const socket = createSocket();
     (io as jest.Mock).mockReturnValue(socket);

--- a/web/src/app/display/hooks/__tests__/usePairing.test.tsx
+++ b/web/src/app/display/hooks/__tests__/usePairing.test.tsx
@@ -1,0 +1,92 @@
+import { act, renderHook } from '@testing-library/react';
+import { usePairing } from '../usePairing';
+
+jest.mock('../../lib/device-identifier', () => ({
+  getDeviceIdentifier: jest.fn(() => 'browser-display-1'),
+  getDeviceMetadata: jest.fn(() => ({ userAgent: 'jest' })),
+}));
+
+describe('usePairing', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    localStorage.clear();
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: {
+            code: 'ABC123',
+            expiresInSeconds: 300,
+          },
+        }),
+      })
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: { status: 'pending' } }),
+      }) as jest.Mock;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('polls pairing status slowly enough to stay under the endpoint throttle', async () => {
+    const { result } = renderHook(() => usePairing());
+
+    await act(async () => {
+      await result.current.requestPairingCode();
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(6000);
+      await Promise.resolve();
+    });
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch).toHaveBeenLastCalledWith('/api/v1/devices/pairing/status/ABC123');
+  });
+
+  it('backs off instead of hammering after a 429 status response', async () => {
+    (fetch as jest.Mock)
+      .mockReset()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: { code: 'ABC123', expiresInSeconds: 300 } }),
+      })
+      .mockResolvedValueOnce({ ok: false, status: 429 })
+      .mockResolvedValue({ ok: true, status: 200, json: async () => ({ data: { status: 'pending' } }) });
+
+    const { result } = renderHook(() => usePairing());
+
+    await act(async () => {
+      await result.current.requestPairingCode();
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(8000);
+      await Promise.resolve();
+    });
+    expect(fetch).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      jest.advanceTimersByTime(8000);
+      await Promise.resolve();
+    });
+    expect(fetch).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      jest.advanceTimersByTime(8000);
+      await Promise.resolve();
+    });
+    expect(fetch).toHaveBeenCalledTimes(3);
+  });
+});

--- a/web/src/app/display/hooks/__tests__/usePlaylistPlayer.test.tsx
+++ b/web/src/app/display/hooks/__tests__/usePlaylistPlayer.test.tsx
@@ -1,0 +1,60 @@
+import { act, renderHook } from '@testing-library/react';
+import { usePlaylistPlayer } from '../usePlaylistPlayer';
+
+describe('usePlaylistPlayer', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('treats pushed-content duration as minutes', () => {
+    const playlist = {
+      id: 'playlist-1',
+      name: 'Default Loop',
+      loopPlaylist: true,
+      items: [
+        {
+          id: 'item-1',
+          contentId: 'content-1',
+          duration: 10,
+          order: 0,
+          content: {
+            id: 'content-1',
+            name: 'Default',
+            type: 'image' as const,
+            url: '/default.png',
+          },
+        },
+      ],
+    };
+    const pushedContent = {
+      id: 'emergency-1',
+      name: 'Emergency',
+      type: 'image' as const,
+      url: '/emergency.png',
+    };
+
+    const { result } = renderHook(() => usePlaylistPlayer());
+
+    act(() => {
+      result.current.updatePlaylist(playlist);
+      result.current.pushContent(pushedContent, 1);
+    });
+
+    expect(result.current.temporaryContent?.id).toBe('emergency-1');
+
+    act(() => {
+      jest.advanceTimersByTime(59000);
+    });
+    expect(result.current.temporaryContent?.id).toBe('emergency-1');
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(result.current.temporaryContent).toBeNull();
+    expect(result.current.currentContentId).toBe('content-1');
+  });
+});

--- a/web/src/app/display/hooks/useDeviceConnection.ts
+++ b/web/src/app/display/hooks/useDeviceConnection.ts
@@ -162,7 +162,7 @@ export function useDeviceConnection({
       try {
         if (command.type === 'push_content' && command.payload && onContentPush) {
           const content = command.payload.content as unknown as PushContent;
-          const duration = (command.payload.duration as number) || 30;
+          const duration = (command.payload.duration as number) || 5;
           onContentPush(content, duration);
         } else {
           onCommand(command);

--- a/web/src/app/display/hooks/usePairing.ts
+++ b/web/src/app/display/hooks/usePairing.ts
@@ -5,6 +5,8 @@ import { getDeviceIdentifier, getDeviceMetadata } from '../lib/device-identifier
 import type { DeviceCredentials, PairingResponse, PairingStatusResponse } from '../lib/types';
 
 const CREDENTIALS_KEY = 'vizora_display_credentials';
+const PAIRING_STATUS_POLL_MS = 8000;
+const PAIRING_STATUS_RATE_LIMIT_BACKOFF_MS = 16000;
 
 function getStoredCredentials(): DeviceCredentials | null {
   if (typeof window === 'undefined') return null;
@@ -34,6 +36,7 @@ export function usePairing() {
   const [isPairing, setIsPairing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pausedUntilRef = useRef(0);
   const mountedRef = useRef(true);
 
   // Check for stored credentials on mount
@@ -88,15 +91,23 @@ export function usePairing() {
 
   const startPolling = useCallback((code: string) => {
     if (pollRef.current) clearInterval(pollRef.current);
+    pausedUntilRef.current = 0;
 
     pollRef.current = setInterval(async () => {
       try {
+        if (Date.now() < pausedUntilRef.current) return;
+
         const res = await fetch(`/api/v1/devices/pairing/status/${code}`);
 
         if (res.status === 404) {
           // Code expired, request a new one
           if (pollRef.current) clearInterval(pollRef.current);
           if (mountedRef.current) requestPairingCode();
+          return;
+        }
+
+        if (res.status === 429) {
+          pausedUntilRef.current = Date.now() + PAIRING_STATUS_RATE_LIMIT_BACKOFF_MS;
           return;
         }
 
@@ -123,11 +134,12 @@ export function usePairing() {
       } catch {
         // Silently retry on next interval
       }
-    }, 2000);
+    }, PAIRING_STATUS_POLL_MS);
   }, [requestPairingCode]);
 
   const resetPairing = useCallback(() => {
     if (pollRef.current) clearInterval(pollRef.current);
+    pausedUntilRef.current = 0;
     clearCredentials();
     setCredentials(null);
     setPairingCode(null);

--- a/web/src/app/display/hooks/usePlaylistPlayer.ts
+++ b/web/src/app/display/hooks/usePlaylistPlayer.ts
@@ -110,7 +110,7 @@ export function usePlaylistPlayer({ onImpression }: UsePlaylistPlayerOptions = {
     }
   }, [clearTimer, advanceToNext]);
 
-  const pushContent = useCallback((content: PushContent, duration: number) => {
+  const pushContent = useCallback((content: PushContent, durationMinutes: number) => {
     // Save current state
     if (playlistRef.current && !temporaryContent) {
       savedStateRef.current = {
@@ -123,7 +123,8 @@ export function usePlaylistPlayer({ onImpression }: UsePlaylistPlayerOptions = {
     setTemporaryContent(content);
     contentStartRef.current = Date.now();
 
-    // Resume after duration
+    // Resume after the push-content duration. Fleet/display command durations are minutes.
+    const durationMs = Math.max(1, durationMinutes || 5) * 60 * 1000;
     timerRef.current = setTimeout(() => {
       setTemporaryContent(null);
       if (savedStateRef.current) {
@@ -142,7 +143,7 @@ export function usePlaylistPlayer({ onImpression }: UsePlaylistPlayerOptions = {
           timerRef.current = setTimeout(advanceToNext, dur);
         }
       }
-    }, duration * 1000);
+    }, durationMs);
   }, [clearTimer, advanceToNext, temporaryContent]);
 
   // Cleanup on unmount

--- a/web/src/components/DeviceHealthMonitor.tsx
+++ b/web/src/components/DeviceHealthMonitor.tsx
@@ -4,12 +4,12 @@ import { Icon } from '@/theme/icons';
 
 export interface DeviceHealth {
   deviceId: string;
-  cpuUsage: number;       // 0-100%
-  memoryUsage: number;    // 0-100%
-  storageUsage: number;   // 0-100%
-  temperature: number;    // °C
-  uptime: number;         // hours
-  lastHeartbeat: Date;
+  cpuUsage: number | null;       // 0-100%, null when device telemetry is unavailable
+  memoryUsage: number | null;    // 0-100%, null when device telemetry is unavailable
+  storageUsage: number | null;   // 0-100%, null when device telemetry is unavailable
+  temperature: number | null;    // °C, null when device telemetry is unavailable
+  uptime: number | null;         // hours, null when device telemetry is unavailable
+  lastHeartbeat: Date | null;
   score: number;          // 0-100 health score
 }
 
@@ -39,13 +39,13 @@ const MetricBar = ({ label, value, unit, thresholds }: any) => (
     <div className="flex justify-between text-xs">
       <span className="font-medium text-[var(--foreground-secondary)]">{label}</span>
       <span className="text-[var(--foreground-secondary)]">
-        {value.toFixed(1)}{unit}
+        {typeof value === 'number' ? `${value.toFixed(1)}${unit}` : 'Not reported'}
       </span>
     </div>
     <div className="w-full h-2 bg-[var(--background-tertiary)] rounded-full overflow-hidden">
       <div
-        className={`h-full ${getMetricStatus(value, thresholds)} transition-all`}
-        style={{ width: `${Math.min(value, 100)}%` }}
+        className={`h-full ${typeof value === 'number' ? getMetricStatus(value, thresholds) : 'bg-[var(--foreground-tertiary)]/30'} transition-all`}
+        style={{ width: `${typeof value === 'number' ? Math.min(value, 100) : 0}%` }}
       />
     </div>
   </div>
@@ -78,7 +78,9 @@ export default function DeviceHealthMonitor({
       <div className="flex items-start justify-between">
         <div>
           <h3 className="text-sm font-semibold text-[var(--foreground)]">Device Health</h3>
-          <p className="text-xs text-[var(--foreground-tertiary)] mt-1">Updated {new Date(health.lastHeartbeat).toLocaleTimeString()}</p>
+          <p className="text-xs text-[var(--foreground-tertiary)] mt-1">
+            {health.lastHeartbeat ? `Updated ${new Date(health.lastHeartbeat).toLocaleTimeString()}` : 'No heartbeat reported'}
+          </p>
         </div>
         <div className={`text-right ${healthStatus.color}`}>
           <div className="text-2xl font-bold">{health.score}%</div>
@@ -137,7 +139,9 @@ export default function DeviceHealthMonitor({
           <div className="flex items-center justify-between text-sm">
             <span className="text-[var(--foreground-secondary)]">Uptime</span>
             <span className="font-semibold text-[var(--foreground)]">
-              {health.uptime >= 24
+              {typeof health.uptime !== 'number'
+                ? 'Not reported'
+                : health.uptime >= 24
                 ? `${(health.uptime / 24).toFixed(1)} days`
                 : `${health.uptime.toFixed(1)} hours`}
             </span>

--- a/web/src/components/fleet/EmergencyOverrideModal.tsx
+++ b/web/src/components/fleet/EmergencyOverrideModal.tsx
@@ -2,8 +2,10 @@
 
 import { useState, useEffect } from 'react';
 import { apiClient } from '@/lib/api';
+import { fetchAllPaginated } from '@/lib/api/pagination';
 import { useToast } from '@/lib/hooks/useToast';
 import Modal from '@/components/Modal';
+import { toastFleetCommandResult } from './commandResultMessage';
 
 interface EmergencyOverrideModalProps {
   isOpen: boolean;
@@ -13,7 +15,8 @@ interface EmergencyOverrideModalProps {
 
 interface ContentItem {
   id: string;
-  name: string;
+  name?: string;
+  title?: string;
   type: string;
 }
 
@@ -55,16 +58,13 @@ export default function EmergencyOverrideModal({ isOpen, onClose, organizationId
   const loadData = async () => {
     try {
       const [contentRes, displaysRes, groupsRes] = await Promise.all([
-        apiClient.getContent(),
-        apiClient.getDisplays(),
-        apiClient.getDisplayGroups(),
+        fetchAllPaginated((params) => apiClient.getContent(params)),
+        fetchAllPaginated((params) => apiClient.getDisplays(params)),
+        fetchAllPaginated((params) => apiClient.getDisplayGroups(params)),
       ]);
-      const cData = (contentRes as any)?.data ?? contentRes ?? [];
-      const dData = (displaysRes as any)?.data ?? displaysRes ?? [];
-      const gData = (groupsRes as any)?.data ?? groupsRes ?? [];
-      setContentList(cData as ContentItem[]);
-      setDisplays(dData as DisplayItem[]);
-      setGroups(gData as GroupItem[]);
+      setContentList(contentRes);
+      setDisplays(displaysRes as DisplayItem[]);
+      setGroups(groupsRes as GroupItem[]);
     } catch (error: any) {
       toast.error('Failed to load data');
     }
@@ -90,11 +90,11 @@ export default function EmergencyOverrideModal({ isOpen, onClose, organizationId
         },
       });
 
-      toast.success(
-        `Emergency content pushed to ${result.devicesTargeted} devices (${result.devicesOnline} online, ${result.devicesQueued} queued)`
-      );
-      onClose();
-      resetForm();
+      const message = toastFleetCommandResult(toast, 'Emergency content', result);
+      if (message.kind !== 'error') {
+        onClose();
+        resetForm();
+      }
     } catch (error: any) {
       toast.error(error.message || 'Failed to push emergency content');
     } finally {
@@ -117,10 +117,11 @@ export default function EmergencyOverrideModal({ isOpen, onClose, organizationId
       <div className="space-y-6">
         {/* Content Picker */}
         <div>
-          <label className="block text-sm font-medium text-[var(--foreground-secondary)] mb-2">
+          <label htmlFor="emergency-content-id" className="block text-sm font-medium text-[var(--foreground-secondary)] mb-2">
             Content to Push
           </label>
           <select
+            id="emergency-content-id"
             value={selectedContentId}
             onChange={(e) => setSelectedContentId(e.target.value)}
             className="eh-select w-full"
@@ -128,7 +129,7 @@ export default function EmergencyOverrideModal({ isOpen, onClose, organizationId
             <option value="">Select content...</option>
             {contentList.map((c) => (
               <option key={c.id} value={c.id}>
-                {c.name} ({c.type})
+                {c.name || c.title || 'Untitled'} ({c.type})
               </option>
             ))}
           </select>

--- a/web/src/components/fleet/FleetCommandDropdown.tsx
+++ b/web/src/components/fleet/FleetCommandDropdown.tsx
@@ -5,6 +5,7 @@ import { apiClient } from '@/lib/api';
 import { useToast } from '@/lib/hooks/useToast';
 import ConfirmDialog from '@/components/ConfirmDialog';
 import { Icon } from '@/theme/icons';
+import { toastFleetCommandResult } from './commandResultMessage';
 
 interface FleetCommandDropdownProps {
   organizationId: string;
@@ -42,9 +43,7 @@ export default function FleetCommandDropdown({ organizationId }: FleetCommandDro
         command: confirmCommand.command,
         target: { type: 'organization', id: organizationId },
       });
-      toast.success(
-        `Command sent to ${result.devicesTargeted} devices (${result.devicesOnline} online, ${result.devicesQueued} queued)`
-      );
+      toastFleetCommandResult(toast, confirmCommand.label, result);
     } catch (error: any) {
       toast.error(error.message || 'Failed to send command');
     } finally {

--- a/web/src/components/fleet/__tests__/EmergencyOverrideModal.test.tsx
+++ b/web/src/components/fleet/__tests__/EmergencyOverrideModal.test.tsx
@@ -1,5 +1,15 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import EmergencyOverrideModal from '../EmergencyOverrideModal';
+import { apiClient } from '@/lib/api';
+
+const mockSendFleetCommand = jest.fn();
+const mockToast = {
+  success: jest.fn(),
+  warning: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  ToastContainer: () => null,
+};
 
 jest.mock('@/theme/icons', () => ({
   Icon: ({ name }: { name: string }) => <span data-testid={`icon-${name}`}>{name}</span>,
@@ -7,20 +17,17 @@ jest.mock('@/theme/icons', () => ({
 
 jest.mock('@/lib/api', () => ({
   apiClient: {
-    getContent: jest.fn().mockResolvedValue({ data: [] }),
+    getContent: jest.fn().mockResolvedValue({
+      data: [{ id: 'content-1', name: 'Emergency Notice', type: 'image' }],
+    }),
     getDisplays: jest.fn().mockResolvedValue({ data: [] }),
     getDisplayGroups: jest.fn().mockResolvedValue({ data: [] }),
-    sendFleetCommand: jest.fn(),
+    sendFleetCommand: (...args: any[]) => mockSendFleetCommand(...args),
   },
 }));
 
 jest.mock('@/lib/hooks/useToast', () => ({
-  useToast: () => ({
-    success: jest.fn(),
-    error: jest.fn(),
-    info: jest.fn(),
-    ToastContainer: () => null,
-  }),
+  useToast: () => mockToast,
 }));
 
 describe('EmergencyOverrideModal', () => {
@@ -32,6 +39,19 @@ describe('EmergencyOverrideModal', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (apiClient.getContent as jest.Mock).mockResolvedValue({
+      data: [{ id: 'content-1', name: 'Emergency Notice', type: 'image' }],
+    });
+    (apiClient.getDisplays as jest.Mock).mockResolvedValue({ data: [] });
+    (apiClient.getDisplayGroups as jest.Mock).mockResolvedValue({ data: [] });
+    mockSendFleetCommand.mockResolvedValue({
+      commandId: 'cmd-1',
+      devicesTargeted: 3,
+      devicesOnline: 2,
+      devicesQueued: 1,
+      devicesDelivered: 2,
+      devicesFailed: 0,
+    });
   });
 
   it('renders when isOpen=true', () => {
@@ -70,5 +90,101 @@ describe('EmergencyOverrideModal', () => {
     expect(screen.getByText('1h')).toBeInTheDocument();
     expect(screen.getByText('2h')).toBeInTheDocument();
     expect(screen.getByText('4h')).toBeInTheDocument();
+  });
+
+  it('uses delivered and queued counts in emergency override success messaging', async () => {
+    render(<EmergencyOverrideModal {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Emergency Notice (image)' })).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('Content to Push'), {
+      target: { value: 'content-1' },
+    });
+    fireEvent.click(screen.getByText('Push Emergency Content'));
+
+    await waitFor(() => {
+      expect(mockToast.success).toHaveBeenCalledWith(
+        'Emergency content delivered to 2 devices; 1 queued for offline devices',
+      );
+    });
+  });
+
+  it('loads all paginated content options for emergency override', async () => {
+    (apiClient.getContent as jest.Mock)
+      .mockResolvedValueOnce({
+        data: [{ id: 'content-1', name: 'Emergency Notice', type: 'image' }],
+        meta: { page: 1, limit: 100, total: 2, totalPages: 2 },
+      })
+      .mockResolvedValueOnce({
+        data: [{ id: 'content-2', name: 'Safety Instructions', type: 'html' }],
+        meta: { page: 2, limit: 100, total: 2, totalPages: 2 },
+      });
+
+    render(<EmergencyOverrideModal {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Emergency Notice (image)' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'Safety Instructions (html)' })).toBeInTheDocument();
+    });
+    expect(apiClient.getContent).toHaveBeenNthCalledWith(1, { page: 1, limit: 100 });
+    expect(apiClient.getContent).toHaveBeenNthCalledWith(2, { page: 2, limit: 100 });
+  });
+
+  it('does not close the modal when no devices match the emergency target', async () => {
+    const onClose = jest.fn();
+    mockSendFleetCommand.mockResolvedValue({
+      commandId: 'cmd-1',
+      devicesTargeted: 0,
+      devicesOnline: 0,
+      devicesQueued: 0,
+      devicesDelivered: 0,
+      devicesFailed: 0,
+    });
+
+    render(<EmergencyOverrideModal {...defaultProps} onClose={onClose} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Emergency Notice (image)' })).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('Content to Push'), {
+      target: { value: 'content-1' },
+    });
+    fireEvent.click(screen.getByText('Push Emergency Content'));
+
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith('Emergency content did not match any devices');
+    });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('warns when emergency override delivery partially fails', async () => {
+    mockSendFleetCommand.mockResolvedValue({
+      commandId: 'cmd-1',
+      devicesTargeted: 3,
+      devicesOnline: 2,
+      devicesQueued: 0,
+      devicesDelivered: 1,
+      devicesFailed: 2,
+    });
+
+    render(<EmergencyOverrideModal {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Emergency Notice (image)' })).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('Content to Push'), {
+      target: { value: 'content-1' },
+    });
+    fireEvent.click(screen.getByText('Push Emergency Content'));
+
+    await waitFor(() => {
+      expect(mockToast.warning).toHaveBeenCalledWith(
+        'Emergency content reached 1 of 3 devices; 2 failed',
+      );
+    });
   });
 });

--- a/web/src/components/fleet/__tests__/FleetCommandDropdown.test.tsx
+++ b/web/src/components/fleet/__tests__/FleetCommandDropdown.test.tsx
@@ -6,6 +6,13 @@ jest.mock('@/theme/icons', () => ({
 }));
 
 const mockSendFleetCommand = jest.fn();
+const mockToast = {
+  success: jest.fn(),
+  warning: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  ToastContainer: () => null,
+};
 
 jest.mock('@/lib/api', () => ({
   apiClient: {
@@ -14,12 +21,7 @@ jest.mock('@/lib/api', () => ({
 }));
 
 jest.mock('@/lib/hooks/useToast', () => ({
-  useToast: () => ({
-    success: jest.fn(),
-    error: jest.fn(),
-    info: jest.fn(),
-    ToastContainer: () => null,
-  }),
+  useToast: () => mockToast,
 }));
 
 describe('FleetCommandDropdown', () => {
@@ -55,6 +57,8 @@ describe('FleetCommandDropdown', () => {
       devicesTargeted: 5,
       devicesOnline: 3,
       devicesQueued: 2,
+      devicesDelivered: 3,
+      devicesFailed: 0,
     });
 
     render(<FleetCommandDropdown organizationId="org-1" />);
@@ -67,6 +71,57 @@ describe('FleetCommandDropdown', () => {
         command: 'reload',
         target: { type: 'organization', id: 'org-1' },
       });
+    });
+    expect(mockToast.success).toHaveBeenCalledWith(
+      'Reload All Devices delivered to 3 devices; 2 queued for offline devices',
+    );
+  });
+
+  it('warns when a fleet command partially fails', async () => {
+    mockSendFleetCommand.mockResolvedValue({
+      commandId: 'cmd-1',
+      command: 'reload',
+      target: { type: 'organization', id: 'org-1' },
+      devicesTargeted: 5,
+      devicesOnline: 4,
+      devicesQueued: 0,
+      devicesDelivered: 3,
+      devicesFailed: 2,
+    });
+
+    render(<FleetCommandDropdown organizationId="org-1" />);
+    fireEvent.click(screen.getByText('Fleet Commands'));
+    fireEvent.click(screen.getByText('Reload All Devices'));
+    fireEvent.click(screen.getByText('Send Command'));
+
+    await waitFor(() => {
+      expect(mockToast.warning).toHaveBeenCalledWith(
+        'Reload All Devices reached 3 of 5 devices; 2 failed',
+      );
+    });
+  });
+
+  it('errors when a fleet command fails for every targeted device', async () => {
+    mockSendFleetCommand.mockResolvedValue({
+      commandId: 'cmd-1',
+      command: 'reload',
+      target: { type: 'organization', id: 'org-1' },
+      devicesTargeted: 2,
+      devicesOnline: 0,
+      devicesQueued: 0,
+      devicesDelivered: 0,
+      devicesFailed: 2,
+    });
+
+    render(<FleetCommandDropdown organizationId="org-1" />);
+    fireEvent.click(screen.getByText('Fleet Commands'));
+    fireEvent.click(screen.getByText('Reload All Devices'));
+    fireEvent.click(screen.getByText('Send Command'));
+
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith(
+        'Reload All Devices failed for all 2 targeted devices',
+      );
     });
   });
 });

--- a/web/src/components/fleet/__tests__/commandResultMessage.test.ts
+++ b/web/src/components/fleet/__tests__/commandResultMessage.test.ts
@@ -1,0 +1,15 @@
+import { formatFleetCommandResult } from '../commandResultMessage';
+
+describe('formatFleetCommandResult', () => {
+  it('treats zero-target commands as errors instead of successful no-ops', () => {
+    expect(formatFleetCommandResult('Emergency content', {
+      devicesTargeted: 0,
+      devicesDelivered: 0,
+      devicesQueued: 0,
+      devicesFailed: 0,
+    })).toEqual({
+      kind: 'error',
+      message: 'Emergency content did not match any devices',
+    });
+  });
+});

--- a/web/src/components/fleet/commandResultMessage.ts
+++ b/web/src/components/fleet/commandResultMessage.ts
@@ -1,0 +1,89 @@
+interface FleetCommandResult {
+  devicesTargeted: number;
+  devicesOnline?: number;
+  devicesQueued?: number;
+  devicesDelivered?: number;
+  devicesFailed?: number;
+}
+
+export type FleetCommandMessageKind = 'success' | 'warning' | 'error';
+
+export interface FleetCommandMessage {
+  kind: FleetCommandMessageKind;
+  message: string;
+}
+
+const plural = (count: number, singular: string, pluralText = `${singular}s`) =>
+  `${count} ${count === 1 ? singular : pluralText}`;
+
+export function formatFleetCommandResult(
+  actionLabel: string,
+  result: FleetCommandResult,
+): FleetCommandMessage {
+  const targeted = result.devicesTargeted ?? 0;
+  const delivered = result.devicesDelivered ?? result.devicesOnline ?? 0;
+  const queued = result.devicesQueued ?? Math.max(targeted - delivered, 0);
+  const failed = result.devicesFailed ?? 0;
+
+  if (targeted === 0) {
+    return {
+      kind: 'error',
+      message: `${actionLabel} did not match any devices`,
+    };
+  }
+
+  if (targeted > 0 && failed >= targeted && delivered === 0 && queued === 0) {
+    return {
+      kind: 'error',
+      message: `${actionLabel} failed for all ${plural(targeted, 'targeted device')}`,
+    };
+  }
+
+  if (failed > 0) {
+    return {
+      kind: 'warning',
+      message: `${actionLabel} reached ${delivered} of ${targeted} devices; ${failed} failed`,
+    };
+  }
+
+  if (queued > 0 && delivered === 0) {
+    return {
+      kind: 'success',
+      message: `${actionLabel} queued for ${plural(queued, 'offline device')}`,
+    };
+  }
+
+  if (queued > 0) {
+    return {
+      kind: 'success',
+      message: `${actionLabel} delivered to ${plural(delivered, 'device')}; ${queued} queued for offline devices`,
+    };
+  }
+
+  return {
+    kind: 'success',
+    message: `${actionLabel} delivered to ${plural(delivered, 'device')}`,
+  };
+}
+
+export function toastFleetCommandResult(
+  toast: {
+    success: (message: string) => void;
+    warning?: (message: string) => void;
+    error: (message: string) => void;
+  },
+  actionLabel: string,
+  result: FleetCommandResult,
+): FleetCommandMessage {
+  const formatted = formatFleetCommandResult(actionLabel, result);
+  if (formatted.kind === 'error') {
+    toast.error(formatted.message);
+    return formatted;
+  }
+  if (formatted.kind === 'warning') {
+    (toast.warning ?? toast.error)(formatted.message);
+    return formatted;
+  }
+  toast.success(formatted.message);
+  return formatted;
+}

--- a/web/src/lib/api/__tests__/pagination.test.ts
+++ b/web/src/lib/api/__tests__/pagination.test.ts
@@ -1,0 +1,68 @@
+import { fetchAllPaginated, unwrapPaginatedData } from '../pagination';
+
+describe('fetchAllPaginated', () => {
+  it('loads every page when the API response includes totalPages', async () => {
+    const fetchPage = jest.fn()
+      .mockResolvedValueOnce({
+        data: ['a', 'b'],
+        meta: { page: 1, limit: 2, total: 3, totalPages: 2 },
+      })
+      .mockResolvedValueOnce({
+        data: ['c'],
+        meta: { page: 2, limit: 2, total: 3, totalPages: 2 },
+      });
+
+    await expect(fetchAllPaginated<string>(fetchPage, undefined, 2)).resolves.toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+    expect(fetchPage).toHaveBeenNthCalledWith(1, { page: 1, limit: 2 });
+    expect(fetchPage).toHaveBeenNthCalledWith(2, { page: 2, limit: 2 });
+  });
+
+  it('passes through additional query params on every page', async () => {
+    const fetchPage = jest.fn().mockResolvedValue({
+      data: ['image-1'],
+      meta: { page: 1, limit: 100, total: 1, totalPages: 1 },
+    });
+
+    await fetchAllPaginated<string, { type: string }>(fetchPage, { type: 'image' });
+
+    expect(fetchPage).toHaveBeenCalledWith({
+      type: 'image',
+      page: 1,
+      limit: 100,
+    });
+  });
+
+  it('treats non-paginated array responses as complete', async () => {
+    const fetchPage = jest.fn().mockResolvedValue(['one', 'two']);
+
+    await expect(fetchAllPaginated<string>(fetchPage)).resolves.toEqual(['one', 'two']);
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails visibly when the response exceeds maxPages', async () => {
+    const fetchPage = jest.fn().mockResolvedValue({
+      data: ['page-item'],
+      meta: { page: 1, limit: 100, total: 5000, totalPages: 50 },
+    });
+
+    await expect(fetchAllPaginated<string>(fetchPage, undefined, 100, 3))
+      .rejects.toThrow('Paginated response exceeded the 3-page safety cap');
+
+    expect(fetchPage).toHaveBeenCalledTimes(3);
+    expect(fetchPage).toHaveBeenLastCalledWith({ page: 3, limit: 100 });
+  });
+
+  it('unwraps raw and enveloped paginated responses', () => {
+    expect(unwrapPaginatedData<string>({ data: ['raw'], meta: {} })).toEqual(['raw']);
+    expect(unwrapPaginatedData<string>({
+      success: true,
+      data: { data: ['enveloped'], meta: {} },
+    })).toEqual(['enveloped']);
+    expect(unwrapPaginatedData<string>(['array'])).toEqual(['array']);
+    expect(unwrapPaginatedData<string>({ success: true, data: { notData: [] } })).toEqual([]);
+  });
+});

--- a/web/src/lib/api/pagination.ts
+++ b/web/src/lib/api/pagination.ts
@@ -1,0 +1,58 @@
+import type { PaginatedResponse } from '../types';
+
+const DEFAULT_PAGE_SIZE = 100;
+const DEFAULT_MAX_PAGES = 10;
+
+type PageFetcher<T, P extends object> = (
+  params: P & { page: number; limit: number },
+) => Promise<PaginatedResponse<T> | T[]>;
+
+export async function fetchAllPaginated<T, P extends object = object>(
+  fetchPage: PageFetcher<T, P>,
+  params?: P,
+  pageSize = DEFAULT_PAGE_SIZE,
+  maxPages = DEFAULT_MAX_PAGES,
+): Promise<T[]> {
+  const all: T[] = [];
+  let page = 1;
+  let totalPages = 1;
+
+  do {
+    const response = await fetchPage({
+      ...(params ?? ({} as P)),
+      page,
+      limit: pageSize,
+    });
+    const data = Array.isArray(response) ? response : (response.data ?? []);
+    all.push(...data);
+
+    if (Array.isArray(response) || !response.meta) {
+      return all;
+    }
+
+    totalPages = response.meta.totalPages ?? Math.ceil((response.meta.total ?? all.length) / pageSize);
+    page += 1;
+  } while (page <= totalPages && page <= maxPages);
+
+  if (page <= totalPages) {
+    throw new Error(`Paginated response exceeded the ${maxPages}-page safety cap`);
+  }
+
+  return all;
+}
+
+export function unwrapPaginatedData<T>(response: unknown): T[] {
+  const body = response && typeof response === 'object' && 'success' in response && 'data' in response
+    ? (response as { data?: unknown }).data
+    : response;
+
+  if (Array.isArray(body)) {
+    return body as T[];
+  }
+
+  if (body && typeof body === 'object' && Array.isArray((body as { data?: unknown }).data)) {
+    return (body as { data: T[] }).data;
+  }
+
+  return [];
+}

--- a/web/src/lib/context/DeviceStatusContext.tsx
+++ b/web/src/lib/context/DeviceStatusContext.tsx
@@ -3,6 +3,7 @@
 import React, { createContext, useContext, useEffect, useRef, useState, useCallback, ReactNode } from 'react';
 import { useSocket } from '@/lib/hooks/useSocket';
 import { apiClient } from '@/lib/api';
+import { fetchAllPaginated } from '@/lib/api/pagination';
 
 export type DeviceStatus = 'online' | 'offline' | 'idle' | 'error';
 
@@ -54,8 +55,7 @@ export function DeviceStatusProvider({ children, user }: DeviceStatusProviderPro
     const initializeFromAPI = async () => {
       try {
         setIsInitializing(true);
-        const response = await apiClient.getDisplays();
-        const devices = response.data || response || [];
+        const devices = await fetchAllPaginated((params) => apiClient.getDisplays(params));
 
         // Convert API Display objects to DeviceStatusUpdate
         const updates = devices.map((device: any) => ({


### PR DESCRIPTION
## Summary
- hardens customer dashboard readiness paths: full-page pagination, safer dashboard refresh behavior, deterministic health display, honest fleet command toasts, and clearer emergency override failures
- fixes display delivery reliability gaps: FIFO queued commands, org-scoped realtime layout resolution, resolved layout content metadata, browser push-content duration units, and slower pairing polling with 429 backoff
- closes repo-side launch gaps around SMTP env aliasing, content picker/title handling, duplicate thumbnail generation, and selected tag clearing

## Reviews
- Backend/realtime/security reviewer: CLEAN after fixes
- Frontend/customer UX reviewer: CLEAN after fixes
- Performance/readiness reviewer: CLEAN after fixes

## Verification
- pnpm --filter @vizora/middleware test -- --runInBand
- pnpm --filter @vizora/realtime test -- --runInBand
- pnpm --filter @vizora/display test -- --runInBand
- pnpm --filter @vizora/web test -- --runInBand
- npx nx build @vizora/middleware
- npx nx build @vizora/realtime
- pnpm --filter @vizora/display build
- $env:NODE_OPTIONS='--max-old-space-size=4096'; npx nx build @vizora/web
- git diff --check
- direct ESLint equivalent on Windows: $env:ESLINT_USE_FLAT_CONFIG='false'; pnpm exec eslint middleware/src/**/*.ts realtime/src/**/*.ts (0 errors, existing warnings only)

## Deployment note
Production deploy is not part of this PR merge gate. The prod checkout must be freshly re-checked before any deploy; earlier runtime evidence showed a dirty/diverged prod checkout, which blocks safe deployment until reconciled.