### PR TITLE
fix: port readiness audit residuals

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,11 @@ MIDDLEWARE_PORT=3000
 WEB_PORT=3001
 REALTIME_PORT=3002
 
+# Number of trusted reverse proxy hops before middleware.
+# Default 1 = host nginx -> middleware. Increase only when the actual
+# topology includes additional trusted proxies such as CDN -> nginx -> app.
+TRUST_PROXY_HOPS=1
+
 # =============================================================================
 # CORS Origins
 # =============================================================================

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ env:
   MINIO_ACCESS_KEY: minioadmin
   MINIO_SECRET_KEY: minioadmin
   MINIO_BUCKET: test-bucket
+  NEXT_PUBLIC_API_URL: http://localhost:3000
+  NEXT_PUBLIC_SOCKET_URL: http://localhost:3002
+  BACKEND_URL: http://localhost:3000
 
 jobs:
   lint:
@@ -94,6 +97,9 @@ jobs:
       - name: Run realtime unit tests
         working-directory: realtime
         run: pnpm test --passWithNoTests
+
+      - name: Run ops unit tests
+        run: pnpm test:ops
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,7 @@ DATABASE_URL            # PostgreSQL connection string
 REDIS_URL               # Redis connection URL
 NODE_ENV                # development | production
 PORT, MIDDLEWARE_PORT, WEB_PORT, REALTIME_PORT  # Service ports (3000 / 3001 / 3002 / 3002)
+TRUST_PROXY_HOPS        # Trusted reverse-proxy hop count for Express req.ip/rate-limit keys (default 1)
 CORS_ORIGIN             # Comma-separated allowed origins
 ```
 

--- a/docs/plans/2026-05-31-pr34-readiness-residuals.md
+++ b/docs/plans/2026-05-31-pr34-readiness-residuals.md
@@ -1,0 +1,60 @@
+# PR #34 Readiness Residuals Plan
+
+**Goal:** Resolve the still-relevant production-readiness fixes from stale PR #34 on top of current `origin/main`, without replaying obsolete or conflicting changes.
+
+**New primitives introduced:** none. This ports existing security/ops behavior onto current Vizora-native modules and scripts.
+
+**Hermes-first analysis:**
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Web security headers | none applicable | Build in existing `web/next.config.js`; no agent/runtime skill surface. |
+| Realtime notification cleanup | none applicable | Build in existing realtime notification service. |
+| Ops content lifecycle archiving | none applicable | Build in existing PM2 ops script and `OpsApiClient`. |
+
+Awesome-Hermes-agent ecosystem check: not applicable; this is repository runtime hardening, not a business-agent workflow or AI/provider spend path.
+
+## Drift Check
+
+- `middleware/src/main.ts` already has env-driven `TRUST_PROXY_HOPS`; residual gaps are Sentry capture for unhandled rejections and clearer port bind diagnostics.
+- `web/next.config.js` still injects raw `BACKEND_URL` / `NEXT_PUBLIC_SOCKET_URL` into browser CSP and still emits deprecated `X-XSS-Protection`.
+- `realtime/src/services/notification.service.ts` still logs and retries orphaned Redis offline notification keys forever after organization FK failures.
+- `scripts/ops/content-lifecycle.ts` still calls `PATCH /content/:id { status: "archived" }` even though the production endpoint is `POST /content/:id/archive`.
+
+## Plan
+
+- [x] Harden `web/next.config.js` CSP inputs, headers, `/pricing` redirect, and production socket URL guard.
+- [x] Add CI-safe public URL env defaults for web builds.
+- [x] Preserve current `TRUST_PROXY_HOPS` behavior while adding Sentry capture for unhandled rejections and clearer bind errors.
+- [x] Drop only organization-FK orphaned realtime notification keys, with tests.
+- [x] Switch content lifecycle archive calls to `POST /content/:id/archive`, classify 409/404/405 failures, keep inline alerts, and surface storage-check failures as incidents.
+- [x] Update `.env.example`, `CLAUDE.md`, and `tasks/todo.md` evidence.
+- [x] Run focused tests/builds, reviewer pass, PR, CI, merge.
+
+## Merge Gate
+
+- [x] Focused realtime notification tests pass.
+- [x] Middleware/realtime/web builds pass.
+- [x] Web build verifies production CSP guard with CI-safe env.
+- [ ] Stale PR #34 is either closed or superseded by the new merged PR.
+
+## Verification Evidence
+
+- `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern=notification.service` - pass, 24 tests.
+- `pnpm --filter @vizora/web test -- --runInBand --testPathPattern=next.config.security` - pass, 4 tests.
+- `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="ContentRenderer|next.config.security"` - pass, 2 suites / 5 tests.
+- `pnpm test:ops` - pass, 5 tests.
+- `pnpm --filter @vizora/realtime test -- --runInBand` - pass, 11 suites / 248 tests.
+- `pnpm --filter @vizora/web test -- --runInBand` - pass, 88 suites / 910 tests.
+- `pnpm --filter @vizora/middleware test -- --runInBand` - pass, 141 suites / 2763 tests.
+- `npx nx build @vizora/middleware` - pass with existing webpack warnings.
+- `npx nx build @vizora/realtime` - pass with existing source-map / optional `ws` warnings.
+- `NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_API_URL=http://localhost:3000 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 BACKEND_URL=http://localhost:3000 npx nx build @vizora/web` - pass with existing Next middleware/proxy deprecation and TypeScript reference warnings.
+- Direct ESLint equivalent (`ESLINT_USE_FLAT_CONFIG=false eslint "middleware/src/**/*.ts" "realtime/src/**/*.ts"`) - exit 0, 186 warnings, no errors. Local `pnpm lint` wrapper is Windows-incompatible because the script uses Unix-style env assignment.
+- Ops TypeScript check (`tsc --noEmit --target ES2022 --module ESNext --moduleResolution Bundler --types node scripts/ops/content-lifecycle.ts scripts/ops/lib/archive-error.ts`) - pass.
+- `git diff --check` - pass; line-ending warnings only.
+
+## Review Evidence
+
+- Security/runtime reviewer: initial CSP and external image findings fixed; final re-review CLEAN.
+- Ops/realtime reviewer: initial lock-scope, CI wiring, overlap, and archive-error findings fixed; final re-review CLEAN.

--- a/middleware/src/main.ts
+++ b/middleware/src/main.ts
@@ -24,6 +24,7 @@ import { join } from 'path';
 import helmet from 'helmet';
 import compression from 'compression';
 import cookieParser from 'cookie-parser';
+import * as Sentry from '@sentry/nestjs';
 import { AppModule } from './app/app.module';
 import { SanitizeInterceptor } from './modules/common/interceptors/sanitize.interceptor';
 import { LoggingInterceptor } from './modules/common/interceptors/logging.interceptor';
@@ -225,9 +226,16 @@ async function bootstrap() {
       }
     }
   } catch (error) {
-    Logger.error(`❌ FATAL: Cannot bind to port ${port}`);
-    Logger.error(`Another process is using port ${port}. Stop it first.`);
-    Logger.error(`Run: netstat -ano | findstr :${port}`);
+    const code = (error as NodeJS.ErrnoException)?.code;
+    Logger.error(`❌ FATAL: Cannot bind to port ${port} (code=${code || 'unknown'})`);
+    if (code === 'EADDRINUSE') {
+      Logger.error(`Another process is using port ${port}. Stop it first.`);
+      Logger.error(`Run: netstat -ano | findstr :${port}`);
+    } else if (code === 'EACCES') {
+      Logger.error(`Permission denied binding to port ${port}. Ports below 1024 require elevated privileges.`);
+    } else {
+      Logger.error(`Underlying error: ${(error as Error)?.message || error}`);
+    }
     process.exit(1);
   }
 }
@@ -237,9 +245,10 @@ bootstrap().catch((err) => {
   process.exit(1);
 });
 
-// Catch unhandled rejections — log but don't exit; let PM2 handle restarts if needed
+// Catch unhandled rejections: log and capture for alerting, but don't exit.
 process.on('unhandledRejection', (reason, promise) => {
   Logger.error('🚨 Unhandled Rejection at:', promise, 'reason:', reason);
+  Sentry.captureException(reason instanceof Error ? reason : new Error(String(reason)));
 });
 
 // Catch uncaught exceptions

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:realtime": "nx build @vizora/realtime",
     "dev": "nx run-many --target=serve --all --parallel",
     "test": "nx run-many --target=test --all",
+    "test:ops": "node --import tsx --test \"scripts/ops/**/*.test.ts\"",
     "test:e2e": "pnpm --filter @vizora/middleware test:e2e",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint --ext .ts,.tsx middleware/src realtime/src",
     "lint:web": "pnpm --filter @vizora/web exec next lint"

--- a/realtime/src/services/notification.service.spec.ts
+++ b/realtime/src/services/notification.service.spec.ts
@@ -90,7 +90,6 @@ describe('NotificationService', () => {
     });
 
     it('should schedule notification for 2 minutes in the future', async () => {
-      const before = Date.now();
       await service.scheduleOfflineNotification('device-1', 'Test', 'org-1');
 
       const storedData = JSON.parse(mockRedisService.set.mock.calls[0][1]);
@@ -234,6 +233,69 @@ describe('NotificationService', () => {
       mockRedisService.get.mockResolvedValueOnce('invalid json{{{');
 
       await expect(service.checkPendingNotifications()).resolves.not.toThrow();
+    });
+
+    it('should delete an orphaned pending notification when the organization FK is gone', async () => {
+      const data = {
+        deviceId: 'device-1',
+        deviceName: 'Test Device',
+        organizationId: 'deleted-org',
+        scheduledFor: Date.now() - 1000,
+        disconnectedAt: Date.now() - 121000,
+      };
+      mockRedisService.getRedis.mockReturnValue({
+        scan: jest.fn().mockResolvedValue(['0', ['notify:offline:device-1']]),
+      });
+      mockRedisService.get.mockResolvedValueOnce(JSON.stringify(data));
+      mockDatabaseService.notification.create.mockRejectedValueOnce({
+        code: 'P2003',
+        meta: { field_name: 'Notification_organizationId_fkey' },
+      });
+
+      await expect(service.checkPendingNotifications()).resolves.not.toThrow();
+
+      expect(mockRedisService.delete).toHaveBeenCalledWith('notify:offline:device-1');
+    });
+
+    it('should not delete pending notifications for non-organization FK failures', async () => {
+      const data = {
+        deviceId: 'device-1',
+        deviceName: 'Test Device',
+        organizationId: 'org-1',
+        scheduledFor: Date.now() - 1000,
+        disconnectedAt: Date.now() - 121000,
+      };
+      mockRedisService.getRedis.mockReturnValue({
+        scan: jest.fn().mockResolvedValue(['0', ['notify:offline:device-1']]),
+      });
+      mockRedisService.get.mockResolvedValueOnce(JSON.stringify(data));
+      mockDatabaseService.notification.create.mockRejectedValueOnce({
+        code: 'P2003',
+        meta: { field_name: 'Notification_deviceId_fkey' },
+      });
+
+      await expect(service.checkPendingNotifications()).resolves.not.toThrow();
+
+      expect(mockRedisService.delete).not.toHaveBeenCalled();
+    });
+
+    it('should skip overlapping pending-notification sweeps', async () => {
+      let finishScan!: () => void;
+      const scan = jest.fn().mockImplementation(
+        () => new Promise(resolve => {
+          finishScan = () => resolve(['0', []]);
+        }),
+      );
+      mockRedisService.getRedis.mockReturnValue({ scan });
+
+      const firstSweep = service.checkPendingNotifications();
+      const secondSweep = service.checkPendingNotifications();
+
+      await secondSweep;
+      expect(scan).toHaveBeenCalledTimes(1);
+
+      finishScan();
+      await firstSweep;
     });
   });
 

--- a/realtime/src/services/notification.service.ts
+++ b/realtime/src/services/notification.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
 import { RedisService } from './redis.service';
 import { DatabaseService } from '../database/database.service';
 
@@ -17,6 +16,7 @@ export class NotificationService implements OnModuleInit, OnModuleDestroy {
   private readonly OFFLINE_DELAY_MS = 120000; // 2 minutes
   private readonly REDIS_KEY_PREFIX = 'notify:offline:';
   private intervalId: NodeJS.Timeout | null = null;
+  private isCheckingPendingNotifications = false;
 
   constructor(
     private readonly redisService: RedisService,
@@ -115,6 +115,12 @@ export class NotificationService implements OnModuleInit, OnModuleDestroy {
    * Periodically check for pending offline notifications and create them
    */
   async checkPendingNotifications(): Promise<void> {
+    if (this.isCheckingPendingNotifications) {
+      this.logger.warn('Skipping overlapping pending notification check');
+      return;
+    }
+
+    this.isCheckingPendingNotifications = true;
     const now = Date.now();
 
     // Scan for all pending offline notification keys
@@ -145,11 +151,41 @@ export class NotificationService implements OnModuleInit, OnModuleDestroy {
             );
           }
         } catch (error) {
-          this.logger.error(`Error processing notification key ${key}:`, error);
+          const err = error as {
+            code?: string;
+            meta?: { field_name?: string; constraint?: string; modelName?: string };
+          };
+          const fieldName = err?.meta?.field_name ?? '';
+          const constraint = err?.meta?.constraint ?? '';
+          const isOrgFkViolation =
+            err?.code === 'P2003' &&
+            (fieldName.toLowerCase().includes('organization') ||
+              constraint.toLowerCase().includes('organization'));
+
+          if (isOrgFkViolation) {
+            try {
+              await this.redisService.delete(key);
+              this.logger.warn(
+                `Dropped orphaned notification key ${key} (P2003 on ${fieldName || constraint || 'organizationId'}; referenced org deleted)`,
+              );
+            } catch (deleteError) {
+              this.logger.error(
+                `Failed to delete orphan notification key ${key} after organization P2003:`,
+                deleteError,
+              );
+            }
+          } else {
+            this.logger.error(
+              `Error processing notification key ${key} (code=${err?.code ?? 'none'}, field=${fieldName || 'none'}):`,
+              error,
+            );
+          }
         }
       }
     } catch (error) {
       this.logger.error('Error scanning for pending notifications:', error);
+    } finally {
+      this.isCheckingPendingNotifications = false;
     }
   }
 

--- a/scripts/ops/content-lifecycle.ts
+++ b/scripts/ops/content-lifecycle.ts
@@ -28,6 +28,7 @@ import {
 } from './lib/state.js';
 import { login, OpsApiClient } from './lib/api-client.js';
 import { log, sendInlineAlert } from './lib/alerting.js';
+import { classifyArchiveError } from './lib/archive-error.js';
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -59,17 +60,24 @@ interface Playlist {
   items?: { contentId: string }[];
 }
 
+type ContentLifecycleCounters = {
+  issuesFound: number;
+  issuesFixed: number;
+  issuesEscalated: number;
+  fatalDetected: boolean;
+};
+
 // ─── Check: Expired Content ──────────────────────────────────────────────────
 
 /**
  * Find active content with an expiresAt date in the past.
- * Auto-fix: archive each expired item via PATCH.
+ * Auto-fix: archive each expired item via POST /content/:id/archive.
  */
 async function checkExpiredContent(
   api: OpsApiClient,
   content: ContentItem[],
   incidents: Incident[],
-  state: { issuesFound: number; issuesFixed: number },
+  state: ContentLifecycleCounters,
 ): Promise<void> {
   const now = new Date();
   const expired = content.filter(c => {
@@ -93,7 +101,7 @@ async function checkExpiredContent(
     log(AGENT, `Archiving expired content: ${label} (expired ${item.expiresAt})`);
 
     try {
-      await api.patch(`/content/${item.id}`, { status: 'archived' }, {
+      await api.post(`/content/${item.id}/archive`, {}, {
         target: 'content',
         targetId: item.id,
         action: `Archive expired content "${label}"`,
@@ -109,7 +117,7 @@ async function checkExpiredContent(
         targetId: item.id,
         detected: new Date().toISOString(),
         message: `Content "${label}" expired on ${item.expiresAt} — auto-archived`,
-        remediation: `PATCH /content/${item.id} { status: "archived" }`,
+        remediation: `POST /content/${item.id}/archive`,
         status: 'resolved',
         attempts: 1,
         resolvedAt: new Date().toISOString(),
@@ -127,22 +135,48 @@ async function checkExpiredContent(
         `Content id ${item.id} reached its expiresAt (${item.expiresAt}) and was archived. If still needed, restore via the content library and update the expiry date.`,
       );
     } catch (err) {
-      const errorMsg = err instanceof Error ? err.message : String(err);
-      log(AGENT, `Failed to archive expired content ${label}: ${errorMsg}`);
+      const classified = classifyArchiveError(err);
+
+      if (classified.kind === 'already_archived' || classified.kind === 'not_found') {
+        incidents.push({
+          id: incidentId,
+          agent: AGENT,
+          type: 'expired_content',
+          severity: 'warning',
+          target: 'content',
+          targetId: item.id,
+          detected: new Date().toISOString(),
+          message: `Content "${label}" expired - ${classified.kind === 'not_found' ? 'no longer found' : 'already archived'}`,
+          remediation: `POST /content/${item.id}/archive`,
+          status: 'resolved',
+          attempts: 1,
+          resolvedAt: new Date().toISOString(),
+        });
+        state.issuesFixed++;
+        log(AGENT, `Expired content ${classified.kind === 'not_found' ? 'no longer found' : 'already archived'}: ${label}`);
+        continue;
+      }
+
+      if (classified.kind === 'fatal') {
+        state.fatalDetected = true;
+        log(AGENT, `FATAL: archive endpoint returned ${classified.status} for ${label}: ${classified.message}`);
+      } else {
+        log(AGENT, `Failed to archive expired content ${label}: ${classified.message}`);
+      }
 
       incidents.push({
         id: incidentId,
         agent: AGENT,
         type: 'expired_content',
-        severity: 'warning',
+        severity: classified.kind === 'fatal' ? 'critical' : 'warning',
         target: 'content',
         targetId: item.id,
         detected: new Date().toISOString(),
-        message: `Content "${label}" expired on ${item.expiresAt} — archive failed`,
-        remediation: `PATCH /content/${item.id} { status: "archived" }`,
+        message: `Content "${label}" expired on ${item.expiresAt} - archive failed (${classified.kind})`,
+        remediation: `POST /content/${item.id}/archive`,
         status: 'open',
         attempts: 1,
-        error: errorMsg,
+        error: classified.message,
       });
     }
   }
@@ -153,14 +187,14 @@ async function checkExpiredContent(
 /**
  * Find content that is not referenced by any playlist, is older than
  * ORPHAN_AGE_DAYS, and is not of type "layout" (layouts are structural).
- * Auto-fix: archive each orphaned item via PATCH.
+ * Auto-fix: archive each orphaned item via POST /content/:id/archive.
  */
 async function checkOrphanedContent(
   api: OpsApiClient,
   content: ContentItem[],
   playlists: Playlist[],
   incidents: Incident[],
-  state: { issuesFound: number; issuesFixed: number },
+  state: ContentLifecycleCounters,
 ): Promise<void> {
   // Build a set of all content IDs referenced by any playlist
   const referencedIds = new Set<string>();
@@ -204,7 +238,7 @@ async function checkOrphanedContent(
     log(AGENT, `Archiving orphaned content: ${label} (created ${item.createdAt})`);
 
     try {
-      await api.patch(`/content/${item.id}`, { status: 'archived' }, {
+      await api.post(`/content/${item.id}/archive`, {}, {
         target: 'content',
         targetId: item.id,
         action: `Archive orphaned content "${label}"`,
@@ -220,7 +254,7 @@ async function checkOrphanedContent(
         targetId: item.id,
         detected: new Date().toISOString(),
         message: `Content "${label}" not in any playlist and older than ${ORPHAN_AGE_DAYS} days — auto-archived`,
-        remediation: `PATCH /content/${item.id} { status: "archived" }`,
+        remediation: `POST /content/${item.id}/archive`,
         status: 'resolved',
         attempts: 1,
         resolvedAt: new Date().toISOString(),
@@ -239,22 +273,48 @@ async function checkOrphanedContent(
         `Content id ${item.id} was not referenced by any playlist and was older than ${ORPHAN_AGE_DAYS} days. Archived automatically. Restore via the content library if you still need it.`,
       );
     } catch (err) {
-      const errorMsg = err instanceof Error ? err.message : String(err);
-      log(AGENT, `Failed to archive orphaned content ${label}: ${errorMsg}`);
+      const classified = classifyArchiveError(err);
+
+      if (classified.kind === 'already_archived' || classified.kind === 'not_found') {
+        incidents.push({
+          id: incidentId,
+          agent: AGENT,
+          type: 'orphaned_content',
+          severity: 'info',
+          target: 'content',
+          targetId: item.id,
+          detected: new Date().toISOString(),
+          message: `Content "${label}" is orphaned - ${classified.kind === 'not_found' ? 'no longer found' : 'already archived'}`,
+          remediation: `POST /content/${item.id}/archive`,
+          status: 'resolved',
+          attempts: 1,
+          resolvedAt: new Date().toISOString(),
+        });
+        state.issuesFixed++;
+        log(AGENT, `Orphaned content ${classified.kind === 'not_found' ? 'no longer found' : 'already archived'}: ${label}`);
+        continue;
+      }
+
+      if (classified.kind === 'fatal') {
+        state.fatalDetected = true;
+        log(AGENT, `FATAL: archive endpoint returned ${classified.status} for ${label}: ${classified.message}`);
+      } else {
+        log(AGENT, `Failed to archive orphaned content ${label}: ${classified.message}`);
+      }
 
       incidents.push({
         id: incidentId,
         agent: AGENT,
         type: 'orphaned_content',
-        severity: 'info',
+        severity: classified.kind === 'fatal' ? 'critical' : 'info',
         target: 'content',
         targetId: item.id,
         detected: new Date().toISOString(),
-        message: `Content "${label}" is orphaned — archive failed`,
-        remediation: `PATCH /content/${item.id} { status: "archived" }`,
+        message: `Content "${label}" is orphaned - archive failed (${classified.kind})`,
+        remediation: `POST /content/${item.id}/archive`,
         status: 'open',
         attempts: 1,
-        error: errorMsg,
+        error: classified.message,
       });
     }
   }
@@ -272,7 +332,7 @@ async function checkOrphanedContent(
 async function checkStorageUsage(
   api: OpsApiClient,
   incidents: Incident[],
-  state: { issuesFound: number; issuesEscalated: number },
+  state: ContentLifecycleCounters,
 ): Promise<void> {
   try {
     const health = await api.get<Record<string, unknown>>('/health');
@@ -348,9 +408,23 @@ async function checkStorageUsage(
       log(AGENT, `Storage usage healthy: ${usagePct.toFixed(1)}%`);
     }
   } catch (err) {
-    // Gracefully handle — storage monitoring is best-effort
     const errorMsg = err instanceof Error ? err.message : String(err);
-    log(AGENT, `Storage check failed (non-fatal): ${errorMsg}`);
+    log(AGENT, `Storage check failed: ${errorMsg}`);
+    state.issuesFound++;
+    incidents.push({
+      id: makeIncidentId(AGENT, 'storage_check_failed', 'system'),
+      agent: AGENT,
+      type: 'storage_check_failed',
+      severity: 'warning',
+      target: 'storage',
+      targetId: 'system',
+      detected: new Date().toISOString(),
+      message: `Storage monitoring could not run - ${errorMsg}`,
+      remediation: 'Check /health endpoint and storage subsystem',
+      status: 'open',
+      attempts: 1,
+      error: errorMsg,
+    });
   }
 }
 
@@ -404,9 +478,13 @@ async function main(): Promise<void> {
 
   // ─── 3. Run Checks ───────────────────────────────────────────────────────
 
-  const opsState = readOpsState();
   const incidents: Incident[] = [];
-  const counters = { issuesFound: 0, issuesFixed: 0, issuesEscalated: 0 };
+  const counters: ContentLifecycleCounters = {
+    issuesFound: 0,
+    issuesFixed: 0,
+    issuesEscalated: 0,
+    fatalDetected: false,
+  };
 
   // 3a. Expired content
   await checkExpiredContent(api, content, incidents, counters);
@@ -431,19 +509,24 @@ async function main(): Promise<void> {
     incidents,
   };
 
-  recordAgentRun(opsState, result);
+  const opsState = readOpsState();
+  try {
+    recordAgentRun(opsState, result);
 
-  for (const r of api.auditLog) {
-    addRemediation(opsState, r);
+    for (const r of api.auditLog) {
+      addRemediation(opsState, r);
+    }
+  } finally {
+    writeOpsState(opsState);
   }
-
-  writeOpsState(opsState);
 
   // ─── 5. Summary ───────────────────────────────────────────────────────────
 
-  log(AGENT, `Cycle complete in ${durationMs}ms — found: ${counters.issuesFound}, fixed: ${counters.issuesFixed}, escalated: ${counters.issuesEscalated}`);
+  log(AGENT, `Cycle complete in ${durationMs}ms — found: ${counters.issuesFound}, fixed: ${counters.issuesFixed}, escalated: ${counters.issuesEscalated}${counters.fatalDetected ? ', FATAL API drift detected' : ''}`);
 
-  if (counters.issuesFound > 0 && counters.issuesFixed < counters.issuesFound) {
+  if (counters.fatalDetected) {
+    process.exitCode = 2;
+  } else if (counters.issuesFound > 0 && counters.issuesFixed < counters.issuesFound) {
     process.exitCode = 1;
   } else {
     process.exitCode = 0;

--- a/scripts/ops/lib/archive-error.test.ts
+++ b/scripts/ops/lib/archive-error.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { classifyArchiveError } from './archive-error.js';
+
+test('classifyArchiveError treats duplicate archive attempts as idempotent success', () => {
+  assert.deepEqual(
+    classifyArchiveError(new Error('API 409: Conflict - already archived')),
+    { kind: 'already_archived' },
+  );
+});
+
+test('classifyArchiveError treats missing archive endpoints as fatal contract drift', () => {
+  assert.deepEqual(
+    classifyArchiveError(new Error('API 405: Method Not Allowed - /content/abc/archive')),
+    {
+      kind: 'fatal',
+      status: 405,
+      message: 'API 405: Method Not Allowed - /content/abc/archive',
+    },
+  );
+});
+
+test('classifyArchiveError treats not-found archive attempts as benign races', () => {
+  assert.deepEqual(
+    classifyArchiveError(new Error('API 404: Not Found - content was deleted')),
+    { kind: 'not_found' },
+  );
+});
+
+test('classifyArchiveError treats missing archive routes as fatal contract drift', () => {
+  assert.deepEqual(
+    classifyArchiveError(
+      new Error('API 404: Not Found - /content/abc/archive: {"message":"Cannot POST /api/v1/content/abc/archive"}'),
+    ),
+    {
+      kind: 'fatal',
+      status: 404,
+      message: 'API 404: Not Found - /content/abc/archive: {"message":"Cannot POST /api/v1/content/abc/archive"}',
+    },
+  );
+});
+
+test('classifyArchiveError treats server errors as transient', () => {
+  assert.deepEqual(
+    classifyArchiveError(new Error('API 503: Service Unavailable')),
+    {
+      kind: 'transient',
+      status: 503,
+      message: 'API 503: Service Unavailable',
+    },
+  );
+});

--- a/scripts/ops/lib/archive-error.ts
+++ b/scripts/ops/lib/archive-error.ts
@@ -1,0 +1,24 @@
+export type ArchiveResult =
+  | { kind: 'already_archived' }
+  | { kind: 'not_found' }
+  | { kind: 'fatal'; status: number; message: string }
+  | { kind: 'transient'; status: number | null; message: string };
+
+export function classifyArchiveError(err: unknown): ArchiveResult {
+  const message = err instanceof Error ? err.message : String(err);
+  const statusMatch = message.match(/^API (\d+):/);
+  const status = statusMatch ? Number(statusMatch[1]) : null;
+
+  if (status === 409) return { kind: 'already_archived' };
+  if (status === 404) {
+    if (/cannot\s+post/i.test(message)) {
+      return { kind: 'fatal', status, message };
+    }
+    return { kind: 'not_found' };
+  }
+  if (status === 405) {
+    return { kind: 'fatal', status, message };
+  }
+
+  return { kind: 'transient', status, message };
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,47 @@
 # Vizora - Task Tracker
 
+## In Progress: PR #34 Readiness Residuals (2026-05-31)
+
+**Branch:** `fix/readiness-pr34-residual`
+
+**Why now:** PR #34 is the only remaining open PR, but it is stale, dirty against main, and has failing April checks. Current main already absorbed part of it (`TRUST_PROXY_HOPS`), while web CSP hardening, realtime orphan notification cleanup, and content lifecycle archive endpoint fixes still have residual gaps.
+
+**New primitives introduced:** none. This ports stale PR behavior into existing Vizora modules/scripts.
+
+**Hermes-first analysis:** not applicable. This task is repository runtime hardening in existing web/middleware/realtime/ops paths, not a business-agent workflow, MCP tool, or AI/provider spend path.
+
+**Plan/design:** `docs/plans/2026-05-31-pr34-readiness-residuals.md`
+
+**Plan**
+- [x] Classify PR #34 diff against current `origin/main`.
+- [x] Port only residual web security header/CSP fixes.
+- [x] Port middleware unhandled-rejection and bind-error diagnostics without replacing current `TRUST_PROXY_HOPS`.
+- [x] Port realtime orphan Redis notification cleanup with tests.
+- [x] Port content-lifecycle archive endpoint and failure-classification fixes while preserving current inline operator alerts.
+- [x] Update env/docs for `TRUST_PROXY_HOPS` and CI web build env.
+- [x] Run focused tests/builds, review, PR, CI, merge.
+- [ ] Close or supersede stale PR #34 after replacement is merged.
+
+**Evidence**
+- Replacement PR branch: `fix/readiness-pr34-residual`; stale PR #34 is not mergeable on current main and is superseded by this branch.
+- Security/runtime reviewer: initial CSP and external image findings fixed; final re-review CLEAN.
+- Ops/realtime reviewer: initial lock-scope, CI wiring, overlap, and archive-error findings fixed; final re-review CLEAN.
+- `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern=notification.service` - pass, 24 tests.
+- `pnpm --filter @vizora/web test -- --runInBand --testPathPattern=next.config.security` - pass, 4 tests.
+- `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="ContentRenderer|next.config.security"` - pass, 2 suites / 5 tests.
+- `pnpm test:ops` - pass, 5 tests.
+- `pnpm --filter @vizora/realtime test -- --runInBand` - pass, 11 suites / 248 tests.
+- `pnpm --filter @vizora/web test -- --runInBand` - pass, 88 suites / 910 tests.
+- `pnpm --filter @vizora/middleware test -- --runInBand` - pass, 141 suites / 2763 tests.
+- `npx nx build @vizora/middleware` - pass with existing webpack warnings.
+- `npx nx build @vizora/realtime` - pass with existing source-map / optional `ws` warnings.
+- `NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_API_URL=http://localhost:3000 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 BACKEND_URL=http://localhost:3000 npx nx build @vizora/web` - pass with existing Next middleware/proxy deprecation and TypeScript reference warnings.
+- Direct ESLint equivalent (`ESLINT_USE_FLAT_CONFIG=false eslint "middleware/src/**/*.ts" "realtime/src/**/*.ts"`) - exit 0, 186 warnings, no errors. Local `pnpm lint` wrapper is Windows-incompatible because the script uses Unix-style env assignment.
+- Ops TypeScript check (`tsc --noEmit --target ES2022 --module ESNext --moduleResolution Bundler --types node scripts/ops/content-lifecycle.ts scripts/ops/lib/archive-error.ts`) - pass.
+- `git diff --check` - pass; line-ending warnings only.
+
+---
+
 ## In Progress: Customer Dashboard Quality + Performance Pass (2026-05-31)
 
 **Branch:** `feat/customer-dashboard-quality-pass`

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -6,6 +6,12 @@ const { composePlugins, withNx } = require('@nx/next');
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 });
+const {
+  buildSecurityHeaderRoutes,
+  parseOriginSafe,
+} = require('./next.config.security');
+
+const apiOrigin = parseOriginSafe('NEXT_PUBLIC_API_URL');
 
 /**
  * @type {import('@nx/next/plugins/with-nx').WithNxOptions}
@@ -18,10 +24,11 @@ const nextConfig = {
     ignoreBuildErrors: false,
   },
   productionBrowserSourceMaps: false,
+  poweredByHeader: false,
   // Allow Server Actions from production and dev origins.
   // The actual fix for "Failed to find Server Action" errors on rebuild
   // is the NEXT_SERVER_ACTIONS_ENCRYPTION_KEY env var (read automatically
-  // by Next.js at build time) — set it to a stable value in production .env.
+  // by Next.js at build time) - set it to a stable value in production .env.
   experimental: {
     turbopackUseSystemTlsCerts: true,
     serverActions: {
@@ -42,21 +49,30 @@ const nextConfig = {
         port: '3000',
         pathname: '/uploads/**',
       },
-      // Production: parse hostname from NEXT_PUBLIC_API_URL
-      ...(process.env.NEXT_PUBLIC_API_URL ? [{
-        protocol: new URL(process.env.NEXT_PUBLIC_API_URL).protocol.replace(':', ''),
-        hostname: new URL(process.env.NEXT_PUBLIC_API_URL).hostname,
-        pathname: '/static/**',
-      }, {
-        protocol: new URL(process.env.NEXT_PUBLIC_API_URL).protocol.replace(':', ''),
-        hostname: new URL(process.env.NEXT_PUBLIC_API_URL).hostname,
-        pathname: '/api/**',
-      }] : []),
+      ...(apiOrigin
+        ? [
+            {
+              protocol: new URL(apiOrigin).protocol.replace(':', ''),
+              hostname: new URL(apiOrigin).hostname,
+              pathname: '/static/**',
+            },
+            {
+              protocol: new URL(apiOrigin).protocol.replace(':', ''),
+              hostname: new URL(apiOrigin).hostname,
+              pathname: '/api/**',
+            },
+          ]
+        : []),
     ],
   },
   webpack: (config) => {
     config.devtool = false;
     return config;
+  },
+  async redirects() {
+    return [
+      { source: '/pricing', destination: '/#pricing', permanent: false },
+    ];
   },
   // Proxy API requests through Next.js to the backend.
   // This makes cookies same-origin (both on port 3001) so httpOnly auth
@@ -90,59 +106,8 @@ const nextConfig = {
       },
     ];
   },
-  // Security headers
   async headers() {
-    const cspBackendUrl = process.env.BACKEND_URL || 'http://localhost:3000';
-    const realtimeUrl = process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:3002';
-    return [
-      // Relaxed CSP for /display route — needs iframes, external media, WebSocket
-      {
-        source: '/display',
-        headers: [
-          {
-            key: 'Content-Security-Policy',
-            value: `default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: ${cspBackendUrl} https: http:; font-src 'self' data:; connect-src 'self' ${cspBackendUrl} ${realtimeUrl} ws: wss: https: http:; media-src 'self' blob: ${cspBackendUrl} https: http:; frame-src 'self' https: http:;`,
-          },
-          {
-            key: 'X-Content-Type-Options',
-            value: 'nosniff',
-          },
-          {
-            key: 'X-XSS-Protection',
-            value: '1; mode=block',
-          },
-          {
-            key: 'Referrer-Policy',
-            value: 'strict-origin-when-cross-origin',
-          },
-        ],
-      },
-      {
-        source: '/((?!display).*)',
-        headers: [
-          {
-            key: 'Content-Security-Policy',
-            value: `default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com https://apis.google.com; style-src 'self' 'unsafe-inline' https://accounts.google.com; img-src 'self' data: ${cspBackendUrl} https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' ${cspBackendUrl} https://accounts.google.com ws: wss: https:; frame-src 'self' https://accounts.google.com; media-src 'self' ${cspBackendUrl};`,
-          },
-          {
-            key: 'X-Content-Type-Options',
-            value: 'nosniff',
-          },
-          {
-            key: 'X-Frame-Options',
-            value: 'SAMEORIGIN',
-          },
-          {
-            key: 'X-XSS-Protection',
-            value: '1; mode=block',
-          },
-          {
-            key: 'Referrer-Policy',
-            value: 'strict-origin-when-cross-origin',
-          },
-        ],
-      },
-    ];
+    return buildSecurityHeaderRoutes();
   },
 };
 

--- a/web/next.config.security.js
+++ b/web/next.config.security.js
@@ -1,0 +1,130 @@
+function parseOriginSafe(envVar, value = process.env[envVar]) {
+  if (!value) return null;
+
+  try {
+    if (/\s/.test(value)) {
+      throw new Error('URL contains whitespace');
+    }
+
+    const parsed = new URL(value);
+    if (!['http:', 'https:', 'ws:', 'wss:'].includes(parsed.protocol) || parsed.origin === 'null') {
+      throw new Error(`unsupported protocol ${parsed.protocol}`);
+    }
+
+    return parsed.origin;
+  } catch {
+    throw new Error(
+      `Invalid ${envVar}: "${value}" is not a valid URL. Refusing to build because it would inject unvalidated text into CSP headers.`,
+    );
+  }
+}
+
+function toWebSocketOrigin(origin) {
+  if (!origin) return null;
+  if (origin.startsWith('https://')) return origin.replace(/^https:\/\//, 'wss://');
+  if (origin.startsWith('http://')) return origin.replace(/^http:\/\//, 'ws://');
+  return origin.startsWith('ws://') || origin.startsWith('wss://') ? origin : null;
+}
+
+function joinCsp(directives) {
+  return directives
+    .map(part => part.replace(/\s+/g, ' ').trim())
+    .filter(Boolean)
+    .join('; ');
+}
+
+function buildSecurityHeaderRoutes(env = process.env) {
+  const nodeEnv = env.nodeEnv ?? env.NODE_ENV;
+  const isProd = nodeEnv === 'production';
+  const isDev = nodeEnv === 'development';
+  const socketOrigin = parseOriginSafe('NEXT_PUBLIC_SOCKET_URL', env.socketUrl ?? env.NEXT_PUBLIC_SOCKET_URL);
+  const apiOrigin = parseOriginSafe('NEXT_PUBLIC_API_URL', env.apiUrl ?? env.NEXT_PUBLIC_API_URL);
+
+  if (isProd && !socketOrigin) {
+    throw new Error(
+      'NEXT_PUBLIC_SOCKET_URL must be set in production so web CSP connect-src is not permissive or broken.',
+    );
+  }
+
+  const socketWsOrigin = toWebSocketOrigin(socketOrigin);
+  const devSources = isDev
+    ? 'http://localhost:3000 http://localhost:3002 ws://localhost:3002'
+    : '';
+  const connectSources = ["'self'"];
+
+  if (socketOrigin) connectSources.push(socketOrigin);
+  if (socketWsOrigin && socketWsOrigin !== socketOrigin) connectSources.push(socketWsOrigin);
+  if (apiOrigin && !connectSources.includes(apiOrigin)) connectSources.push(apiOrigin);
+  if (devSources) connectSources.push(devSources);
+
+  const baseSecurityHeaders = [
+    { key: 'X-Content-Type-Options', value: 'nosniff' },
+    { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+    {
+      key: 'Permissions-Policy',
+      value:
+        'camera=(), microphone=(), geolocation=(), interest-cohort=(), payment=(), usb=(), display-capture=()',
+    },
+  ];
+  const commonSecurityHeaders = isProd
+    ? [
+        ...baseSecurityHeaders,
+        {
+          key: 'Strict-Transport-Security',
+          value: 'max-age=63072000; includeSubDomains; preload',
+        },
+      ]
+    : baseSecurityHeaders;
+
+  const displayCsp = joinCsp([
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    `img-src 'self' data: blob: https: ${apiOrigin ?? ''} ${devSources}`,
+    "font-src 'self' data:",
+    `connect-src ${connectSources.join(' ')}`,
+    `media-src 'self' blob: https: ${apiOrigin ?? ''} ${devSources}`,
+    "frame-src 'self' https:",
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'none'",
+  ]);
+
+  const dashboardCsp = joinCsp([
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline' https://accounts.google.com https://apis.google.com",
+    "style-src 'self' 'unsafe-inline' https://accounts.google.com https://fonts.googleapis.com",
+    `img-src 'self' data: blob: https: ${apiOrigin ?? ''} ${devSources}`,
+    "font-src 'self' data: https://fonts.gstatic.com",
+    `connect-src ${[...connectSources, 'https://accounts.google.com'].join(' ')}`,
+    "frame-src 'self' https://accounts.google.com",
+    `media-src 'self' blob: https: ${apiOrigin ?? ''} ${devSources}`,
+    "frame-ancestors 'self'",
+    "base-uri 'self'",
+    "form-action 'self'",
+  ]);
+
+  return [
+    {
+      source: '/display/:path*',
+      headers: [
+        { key: 'Content-Security-Policy', value: displayCsp },
+        ...commonSecurityHeaders,
+      ],
+    },
+    {
+      source: '/((?!display).*)',
+      headers: [
+        { key: 'Content-Security-Policy', value: dashboardCsp },
+        { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+        ...commonSecurityHeaders,
+      ],
+    },
+  ];
+}
+
+module.exports = {
+  buildSecurityHeaderRoutes,
+  parseOriginSafe,
+  toWebSocketOrigin,
+};

--- a/web/next.config.security.test.js
+++ b/web/next.config.security.test.js
@@ -1,0 +1,50 @@
+const {
+  buildSecurityHeaderRoutes,
+  parseOriginSafe,
+} = require('./next.config.security');
+
+describe('next.config security headers', () => {
+  it('rejects malformed public URL values before they reach CSP headers', () => {
+    expect(() => parseOriginSafe('NEXT_PUBLIC_SOCKET_URL', 'https://vizora.cloud\nbad')).toThrow(
+      /Invalid NEXT_PUBLIC_SOCKET_URL/,
+    );
+  });
+
+  it('builds production CSP without localhost, raw backend URLs, or deprecated XSS headers', () => {
+    const routes = buildSecurityHeaderRoutes({
+      nodeEnv: 'production',
+      socketUrl: 'https://rt.vizora.example',
+    });
+
+    const allHeaders = routes.flatMap(route => route.headers);
+    const headerText = allHeaders.map(header => `${header.key}: ${header.value}`).join('\n');
+
+    expect(headerText).toContain('Strict-Transport-Security');
+    expect(headerText).toContain('Permissions-Policy');
+    expect(headerText).toContain('wss://rt.vizora.example');
+    expect(headerText).not.toContain('localhost');
+    expect(headerText).not.toContain('http://localhost:3000');
+    expect(headerText).not.toContain('X-XSS-Protection');
+  });
+
+  it('requires an explicit realtime origin for production builds', () => {
+    expect(() => buildSecurityHeaderRoutes({ nodeEnv: 'production' })).toThrow(
+      /NEXT_PUBLIC_SOCKET_URL must be set in production/,
+    );
+  });
+
+  it('allows display clients to fetch protected content from the public API origin', () => {
+    const routes = buildSecurityHeaderRoutes({
+      nodeEnv: 'production',
+      socketUrl: 'https://rt.vizora.example',
+      apiUrl: 'https://api.vizora.example',
+    });
+
+    const displayRoute = routes.find(route => route.source === '/display/:path*');
+    const displayCsp = displayRoute.headers.find(header => header.key === 'Content-Security-Policy').value;
+
+    expect(displayCsp).toContain('connect-src');
+    expect(displayCsp).toContain('media-src');
+    expect(displayCsp).toContain('https://api.vizora.example');
+  });
+});

--- a/web/src/app/display/components/ContentRenderer.tsx
+++ b/web/src/app/display/components/ContentRenderer.tsx
@@ -57,10 +57,15 @@ function useBlobUrl(url: string, enabled: boolean) {
   return { blobUrl, error };
 }
 
+function shouldFetchImageAsBlob(url: string): boolean {
+  return url.includes('/device-content/') && url.includes('/file');
+}
+
 export function ContentRenderer({ type, url, name, metadata, onEnded, onError }: ContentRendererProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const isImage = type === 'image';
-  const { blobUrl, error: fetchError } = useBlobUrl(url, isImage);
+  const shouldFetchBlob = isImage && shouldFetchImageAsBlob(url);
+  const { blobUrl, error: fetchError } = useBlobUrl(url, shouldFetchBlob);
 
   // Attempt autoplay when video mounts
   useEffect(() => {
@@ -84,6 +89,19 @@ export function ContentRenderer({ type, url, name, metadata, onEnded, onError }:
 
   switch (type) {
     case 'image':
+      if (!shouldFetchBlob) {
+        return (
+          <img
+            src={url}
+            alt={name || 'Display content'}
+            style={styles.image}
+            onError={() => {
+              onError?.('load_error', `Image failed to load: ${url}`);
+              onEnded?.();
+            }}
+          />
+        );
+      }
       if (fetchError) {
         return (
           <div style={{ ...styles.image, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#ff6b6b', fontSize: '14px', padding: '20px', textAlign: 'center' as const }}>

--- a/web/src/app/display/components/__tests__/ContentRenderer.test.tsx
+++ b/web/src/app/display/components/__tests__/ContentRenderer.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { ContentRenderer } from '../ContentRenderer';
+
+describe('ContentRenderer', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('renders external HTTPS images directly instead of fetching them as blobs', () => {
+    render(
+      <ContentRenderer
+        type="image"
+        url="https://cdn.example.com/menu.png"
+        name="Menu"
+      />,
+    );
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(screen.getByRole('img', { name: 'Menu' })).toHaveAttribute(
+      'src',
+      'https://cdn.example.com/menu.png',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- supersedes stale PR #34 by porting only still-relevant readiness residuals onto current main
- hardens web security header generation with validated CSP origins, production socket URL guard, CI-safe build env, and display protected-content handling
- adds middleware rejection capture/bind diagnostics, realtime orphan offline-notification cleanup, and ops archive endpoint/failure classification fixes

## Verification
- pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern=notification.service
- pnpm --filter @vizora/web test -- --runInBand --testPathPattern=next.config.security
- pnpm --filter @vizora/web test -- --runInBand --testPathPattern=ContentRenderer|next.config.security
- pnpm test:ops
- pnpm --filter @vizora/realtime test -- --runInBand
- pnpm --filter @vizora/web test -- --runInBand
- pnpm --filter @vizora/middleware test -- --runInBand
- npx nx build @vizora/middleware
- npx nx build @vizora/realtime
- NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_API_URL=http://localhost:3000 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 BACKEND_URL=http://localhost:3000 npx nx build @vizora/web
- direct ESLint equivalent for middleware/realtime: exit 0, warnings only
- ops TypeScript check for content-lifecycle/archive-error: pass
- git diff --check: pass, line-ending warnings only

## Review
- Security/runtime reviewer: CLEAN after CSP/external-image fixes
- Ops/realtime reviewer: CLEAN after lock-scope, CI wiring, overlap, and archive-error fixes

## Notes
- Stale PR #34 is dirty/failing against current main and should be closed after this replacement merges.
- No production deployment is included in this PR.