### PR TITLE
Harden customer readiness hot paths

### DIFF
--- a/display/src/electron/device-client.spec.ts
+++ b/display/src/electron/device-client.spec.ts
@@ -128,7 +128,9 @@ describe('DeviceClient', () => {
         destroy: jest.fn(),
       };
 
-      (http.request as jest.Mock).mockImplementation((_url: any, _opts: any, cb: Function) => {
+      let requestedUrl = '';
+      (http.request as jest.Mock).mockImplementation((url: any, _opts: any, cb: Function) => {
+        requestedUrl = url.toString();
         cb(mockResponse);
         // Simulate async data
         Promise.resolve().then(() => {
@@ -141,6 +143,7 @@ describe('DeviceClient', () => {
       const result = await client.requestPairingCode();
 
       expect(result).toEqual({ code: 'ABC123', qrCode: 'data:image/png;base64,...' });
+      expect(requestedUrl).toContain('/api/v1/devices/pairing/request');
       expect(mockReq.write).toHaveBeenCalled();
       expect(mockReq.end).toHaveBeenCalled();
     });
@@ -167,7 +170,9 @@ describe('DeviceClient', () => {
         destroy: jest.fn(),
       };
 
-      (http.request as jest.Mock).mockImplementation((_url: any, _opts: any, cb: Function) => {
+      let requestedUrl = '';
+      (http.request as jest.Mock).mockImplementation((url: any, _opts: any, cb: Function) => {
+        requestedUrl = url.toString();
         cb(mockResponse);
         Promise.resolve().then(() => {
           dataCallback('Internal Server Error');
@@ -227,7 +232,9 @@ describe('DeviceClient', () => {
         destroy: jest.fn(),
       };
 
-      (http.request as jest.Mock).mockImplementation((_url: any, _opts: any, cb: Function) => {
+      let requestedUrl = '';
+      (http.request as jest.Mock).mockImplementation((url: any, _opts: any, cb: Function) => {
+        requestedUrl = url.toString();
         cb(mockResponse);
         Promise.resolve().then(() => {
           dataCallback(JSON.stringify({ status: 'paired', deviceToken: 'jwt-token-123' }));
@@ -240,6 +247,7 @@ describe('DeviceClient', () => {
 
       expect(result.status).toBe('paired');
       expect(result.deviceToken).toBe('jwt-token-123');
+      expect(requestedUrl).toContain('/api/v1/devices/pairing/status/ABC123');
       expect(mockConfig.onPaired).toHaveBeenCalledWith('jwt-token-123');
       expect(io).toHaveBeenCalled();
     });
@@ -533,14 +541,14 @@ describe('DeviceClient', () => {
       expect(mockSocket.connect).toHaveBeenCalled();
     });
 
-    it('should acknowledge commands after applying them', async () => {
+    it('should acknowledge renderer-owned commands after applying them', async () => {
       client.connect('test-token');
 
       const commandCall = mockSocket.on.mock.calls.find(
         (call: any[]) => call[0] === 'command',
       );
       const ack = jest.fn();
-      const command = { type: 'clear_cache' };
+      const command = { type: 'unknown_command' };
 
       await commandCall![1](command, ack);
 
@@ -655,6 +663,42 @@ describe('DeviceClient', () => {
       } finally {
         logSpy.mockRestore();
       }
+    });
+
+    it('should clear overrides in the main process even when the renderer command path is unavailable', async () => {
+      const electron = require('electron');
+      const mockWindow = {
+        webContents: {
+          getURL: jest.fn().mockReturnValue('file:///display/index.html'),
+        },
+        loadURL: jest.fn().mockResolvedValue(undefined),
+      };
+      electron.BrowserWindow.getAllWindows.mockReturnValue([mockWindow]);
+      mockConfig.onCommand.mockRejectedValue(new Error('renderer unavailable'));
+      client.connect('device-token-123');
+
+      const commandCall = mockSocket.on.mock.calls.find(
+        (call: any[]) => call[0] === 'command',
+      );
+
+      await commandCall![1]({
+        type: 'push_content',
+        payload: {
+          content: {
+            id: 'content-1',
+            url: 'http://localhost:3000/api/v1/device-content/content-1/file',
+          },
+          duration: 1,
+        },
+      }, jest.fn());
+      mockWindow.loadURL.mockClear();
+
+      const ack = jest.fn();
+      await commandCall![1]({ type: 'clear_override' }, ack);
+
+      expect(mockConfig.onCommand).not.toHaveBeenCalled();
+      expect(mockWindow.loadURL).toHaveBeenCalledWith('file:///display/index.html');
+      expect(ack).toHaveBeenCalledWith({ ok: true });
     });
 
     it('should start heartbeat on connect event', () => {

--- a/display/src/electron/device-client.ts
+++ b/display/src/electron/device-client.ts
@@ -91,12 +91,12 @@ export class DeviceClient {
           metadata: this.getDeviceMetadata(),
         });
 
-        console.log('[DeviceClient] Requesting pairing code from:', `${this.apiUrl}/api/devices/pairing/request`);
+        console.log('[DeviceClient] Requesting pairing code from:', `${this.apiUrl}/api/v1/devices/pairing/request`);
         console.log('[DeviceClient] Device Identifier:', deviceIdentifier);
         console.log('[DeviceClient] Nickname:', os.hostname());
 
         // Fix localhost resolution to IPv4 instead of IPv6
-        const urlStr = `${this.apiUrl}/api/devices/pairing/request`.replace(/localhost/g, '127.0.0.1');
+        const urlStr = `${this.apiUrl}/api/v1/devices/pairing/request`.replace(/localhost/g, '127.0.0.1');
         const url = new URL(urlStr);
         const options = {
           method: 'POST',
@@ -173,7 +173,7 @@ export class DeviceClient {
     return new Promise((resolve, reject) => {
       try {
         // Fix localhost resolution to IPv4 instead of IPv6
-        const urlStr = `${this.apiUrl}/api/devices/pairing/status/${code}`.replace(/localhost/g, '127.0.0.1');
+        const urlStr = `${this.apiUrl}/api/v1/devices/pairing/status/${code}`.replace(/localhost/g, '127.0.0.1');
         const url = new URL(urlStr);
         const options = {
           method: 'GET',
@@ -351,6 +351,14 @@ export class DeviceClient {
           return;
         }
 
+        if (this.isMainProcessOwnedCommand(command)) {
+          await this.handleCommand(command);
+          if (!ackSent) {
+            sendAck({ ok: true });
+          }
+          return;
+        }
+
         await this.config.onCommand(command);
         await this.handleCommand(command);
         if (!ackSent) {
@@ -467,6 +475,10 @@ export class DeviceClient {
 
   private shouldAckBeforeCommandExecution(command: any): boolean {
     return command?.type === 'restart' || command?.type === 'reboot';
+  }
+
+  private isMainProcessOwnedCommand(command: any): boolean {
+    return ['push_content', 'clear_override', 'clear_cache'].includes(command?.type);
   }
 
   private async waitForSelfTerminatingCommandAckFlush(): Promise<void> {
@@ -825,7 +837,7 @@ export class DeviceClient {
     return new Promise((resolve, reject) => {
       try {
         const deviceIdentifier = this.getDeviceIdentifier();
-        const urlStr = `${this.apiUrl}/api/devices/pairing/unpair`.replace(/localhost/g, '127.0.0.1');
+        const urlStr = `${this.apiUrl}/api/v1/devices/pairing/unpair`.replace(/localhost/g, '127.0.0.1');
         const url = new URL(urlStr);
         const payload = JSON.stringify({ deviceIdentifier });
 

--- a/docs/plans/2026-05-31-customer-performance-readiness-3.md
+++ b/docs/plans/2026-05-31-customer-performance-readiness-3.md
@@ -75,6 +75,7 @@ Awesome-Hermes-agent ecosystem check: not applicable; this pass does not introdu
 - `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` - pass.
 - `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vizora pnpm --filter @vizora/database exec prisma validate` - pass.
 - `pnpm --filter @vizora/realtime test -- --runInBand` - pass, 11 suites / 256 tests.
+- Post-PR E2E fixture follow-up: `pnpm --filter @vizora/realtime test -- device.gateway.spec.ts --runInBand` - pass, 1 suite / 85 tests. Local realtime E2E is blocked in this worktree by generated `realtime/dist/package.json` Jest haste collision plus missing local E2E `DATABASE_URL`/Redis setup; GitHub CI is the authoritative E2E verifier.
 - `pnpm --filter @vizora/web test -- --runInBand` - pass, 89 suites / 925 tests; existing React `act(...)` and jsdom navigation warnings remain.
 - `pnpm --filter @vizora/display test -- --runInBand` - pass, 5 suites / 116 tests; expected negative-path logs and existing MaxListeners warning remain.
 - `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` - pass.

--- a/docs/plans/2026-05-31-customer-performance-readiness-3.md
+++ b/docs/plans/2026-05-31-customer-performance-readiness-3.md
@@ -1,0 +1,88 @@
+# Customer Performance Readiness Pass 3
+
+**Goal:** Review Vizora as a paying customer would experience it, identify remaining repo-side production-readiness and performance gaps, fix the highest-value buildable issues, and leave merged evidence without touching operator-gated production state.
+
+**New primitives introduced:** none planned. Prefer existing Next dashboard pages/components, NestJS services/controllers/DTOs, Prisma models/indexes, realtime gateway/Socket.IO paths, display clients, ops scripts, and the existing response envelope.
+
+**Hermes-first analysis:**
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Dashboard UX and API correctness | none applicable | Build in existing dashboard/API client/middleware paths. |
+| Content upload/list/streaming performance | none applicable | Build in existing content/storage/database paths. |
+| Pairing/realtime/display delivery reliability | none applicable | Build in existing pairing/realtime/display-client paths. |
+| Code review and production readiness | none applicable | Build/test repo-side fixes; keep prod actions operator-gated. |
+
+Awesome-Hermes-agent ecosystem check: not applicable; this pass does not introduce business-agent workflows, MCP tools, AI provider calls, or spend paths.
+
+## Drift Check
+
+- PR #120 merged display delivery reliability fixes.
+- PR #121 merged customer dashboard readiness fixes.
+- PR #122 merged stale PR #34 readiness residuals and closed PR #34.
+- Current `origin/main` is `48affb3e0ff6163ae5babf6bbe74d702c67e5348`.
+- Production deploy remains blocked by dirty/diverged `/opt/vizora/app`; do not pull/reset/stash/restart services until prod-local work is reconciled.
+
+## Analysis Plan
+
+- [x] Run independent dashboard/customer UX analysis.
+- [x] Run independent middleware/content performance analysis.
+- [x] Run independent pairing/realtime/display reliability analysis.
+- [x] Run independent code-review/security/readiness analysis.
+- [x] Synthesize a ranked customer-facing issue list with file/line evidence.
+- [x] Select a scoped buildable bundle that is repo-side, testable, and does not require production secrets, DNS, SMTP, live payments, or real hardware.
+
+## Selected Fix Bundle
+
+- **Device-token enforcement:** reject disabled/deleted displays in realtime connection auth and device-content file serving; make protected media responses revocation-friendly.
+- **Delivery correctness:** count only active device sockets, not dashboard observers, when delivering commands/playlists and reporting fleet delivery state.
+- **Display client reliability:** handle browser display `token:refresh`, prevent web display JWT leakage to attacker-origin device-content lookalikes, move Electron pairing to `/api/v1`, and execute main-process override commands even if the renderer is unavailable after a pushed page load.
+- **Notification recovery:** keep a separate fired-offline marker so long outages emit both offline and back-online notifications.
+- **Upload/storage integrity:** reserve upload quota atomically, release reservations on upload/DB failure, fail closed in production when MinIO upload is unavailable, and avoid deleting DB rows when storage deletion fails.
+- **Query performance:** add composite indexes for customer hot list paths and active schedule lookup.
+- **Dashboard correctness:** align visible API-key scopes with backend validation, make device-group filtering actually filter, fix schedule group round-tripping / multi-device targeting, avoid fake playlist active counts, and stop customization saves from reporting success before the durable API call succeeds.
+- **Smoke coverage:** add upload/device-content range smoke coverage if it can be done without secrets or real hardware.
+
+## Implementation Plan
+
+- [x] Add focused regression tests before fixes where practical.
+- [x] Implement the selected bundle using Vizora-native modules and patterns.
+- [x] Run multi-subagent review before broad tests.
+- [x] Run focused and broad tests proportional to touched surfaces.
+- [ ] Open PR, wait for CI, merge if clean.
+- [ ] Re-check production deployment gate; deploy only if prod checkout is clean and safe.
+
+## Implementation Evidence
+
+- Device-token enforcement now rejects disabled/deleted displays in realtime and device-content file serving, and protected device-content file responses use revocation-friendly `private, no-store` cache headers.
+- Delivery correctness now counts and targets active device sockets instead of dashboard sockets that share `device:{id}` observer rooms.
+- Browser and Electron display clients persist refreshed device tokens, authenticate protected `/api/v1/device-content/:id/file` URLs only for trusted origins, move Electron pairing to `/api/v1`, and execute main-process override commands when renderer dispatch is unavailable.
+- Offline notifications preserve a fired marker so long outages can still emit back-online notifications.
+- Upload and replacement quota accounting now reserves atomically, fails closed in production when MinIO is unavailable, releases reservations only when uploaded-object cleanup succeeds, and keeps DB/accounting state aligned when storage deletes fail.
+- Hot path database indexes were added for display/content/playlist/schedule list and active-schedule queries.
+- Dashboard fixes align API-key scopes with backend validation, load group membership for device filters, round-trip group schedules, create one schedule per selected display, show ready-playlist counts, and persist customization saves through the organization branding API before mutating local state.
+
+## Review Gate
+
+- Backend/runtime reviewer: initial findings fixed for storage quota rollback, failed delete accounting, false offline alerts on intentional disable, multipart `keepBackup=false`, and DB-delete-after-storage-cleanup drift; final re-review CLEAN.
+- Frontend/customer UX reviewer: initial findings fixed for nullable schedule target types, durable customization save ordering, layout tokenization, corrupt localStorage token refresh, and group schedule labels; final re-review CLEAN.
+
+## Local Verification
+
+- `git diff --check` - pass; line-ending warnings only.
+- `pnpm --filter @vizora/middleware test -- content.service.spec.ts --runInBand` - pass, 96 tests.
+- `pnpm --filter @vizora/middleware test -- --runInBand` - pass, 143 suites / 2787 tests.
+- `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` - pass.
+- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vizora pnpm --filter @vizora/database exec prisma validate` - pass.
+- `pnpm --filter @vizora/realtime test -- --runInBand` - pass, 11 suites / 256 tests.
+- `pnpm --filter @vizora/web test -- --runInBand` - pass, 89 suites / 925 tests; existing React `act(...)` and jsdom navigation warnings remain.
+- `pnpm --filter @vizora/display test -- --runInBand` - pass, 5 suites / 116 tests; expected negative-path logs and existing MaxListeners warning remain.
+- `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` - pass.
+- `npx nx build @vizora/middleware` - pass with existing webpack warnings.
+- `npx nx build @vizora/realtime` - pass with existing source-map / optional `ws` warnings.
+- `NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 npx nx build @vizora/web` - pass with existing Next middleware deprecation and TypeScript project-reference warnings.
+
+## Pending Integration
+
+- Branch commit, PR creation, GitHub CI, merge, and post-merge deploy gate re-check remain pending.
+- Production deployment is still expected to be blocked unless `/opt/vizora/app` has been reconciled; earlier runtime evidence showed the production checkout dirty and diverged from `origin/main`.

--- a/middleware/src/modules/content/content.controller.spec.ts
+++ b/middleware/src/modules/content/content.controller.spec.ts
@@ -86,6 +86,7 @@ describe('ContentController', () => {
     mockStorageQuotaService = {
       getStorageInfo: jest.fn(),
       checkQuota: jest.fn(),
+      reserveQuota: jest.fn(),
       incrementUsage: jest.fn(),
       decrementUsage: jest.fn(),
       recalculateUsage: jest.fn(),
@@ -199,6 +200,46 @@ describe('ContentController', () => {
 
       expect(result).toHaveProperty('content');
       expect(result).toHaveProperty('fileHash', 'abc123hash');
+      expect(mockStorageQuotaService.reserveQuota).toHaveBeenCalledWith(organizationId, mockFile.size);
+      expect(mockStorageQuotaService.incrementUsage).not.toHaveBeenCalled();
+    });
+
+    it('should release reserved quota when content creation fails', async () => {
+      mockContentService.create.mockRejectedValueOnce(new Error('db write failed'));
+
+      await expect(controller.uploadFile(organizationId, mockFile)).rejects.toThrow('db write failed');
+
+      expect(mockStorageQuotaService.reserveQuota).toHaveBeenCalledWith(organizationId, mockFile.size);
+      expect(mockStorageQuotaService.decrementUsage).toHaveBeenCalledWith(organizationId, mockFile.size);
+    });
+
+    it('keeps quota reserved when uploaded object cleanup fails after content creation failure', async () => {
+      mockStorageService.isMinioAvailable.mockReturnValueOnce(true);
+      mockStorageService.generateObjectKey.mockReturnValueOnce('org-123/uploads/uploaded.jpg');
+      mockContentService.create.mockRejectedValueOnce(new Error('db write failed'));
+      mockStorageService.deleteFile.mockRejectedValueOnce(new Error('delete failed'));
+
+      await expect(controller.uploadFile(organizationId, mockFile)).rejects.toThrow('db write failed');
+
+      expect(mockStorageQuotaService.reserveQuota).toHaveBeenCalledWith(organizationId, mockFile.size);
+      expect(mockStorageQuotaService.decrementUsage).not.toHaveBeenCalledWith(organizationId, mockFile.size);
+    });
+
+    it('should fail closed in production when object storage is unavailable', async () => {
+      const oldEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+      try {
+        mockStorageService.isMinioAvailable.mockReturnValueOnce(false);
+
+        await expect(controller.uploadFile(organizationId, mockFile)).rejects.toThrow(
+          'Storage service is currently unavailable',
+        );
+
+        expect(mockContentService.create).not.toHaveBeenCalled();
+        expect(mockStorageQuotaService.decrementUsage).toHaveBeenCalledWith(organizationId, mockFile.size);
+      } finally {
+        process.env.NODE_ENV = oldEnv;
+      }
     });
 
     it('should validate file with magic numbers', async () => {
@@ -467,6 +508,31 @@ describe('ContentController', () => {
       );
     });
 
+    it('should not reserve additional quota when replacement validation fails', async () => {
+      mockFileValidationService.validateFile.mockRejectedValueOnce(new BadRequestException('Invalid file'));
+
+      await expect(controller.replaceFile(organizationId, 'content-123', mockFile, {})).rejects.toThrow(
+        BadRequestException,
+      );
+
+      expect(mockStorageQuotaService.reserveQuota).not.toHaveBeenCalled();
+      expect(mockStorageQuotaService.decrementUsage).not.toHaveBeenCalled();
+    });
+
+    it('keeps replacement quota reserved when uploaded replacement cleanup fails after service failure', async () => {
+      mockStorageService.isMinioAvailable.mockReturnValueOnce(true);
+      mockStorageService.generateObjectKey.mockReturnValueOnce('org-123/uploads/replacement.jpg');
+      mockContentService.replaceFile.mockRejectedValueOnce(new Error('db write failed'));
+      mockStorageService.deleteFile.mockRejectedValueOnce(new Error('delete failed'));
+
+      await expect(controller.replaceFile(organizationId, 'content-123', mockFile, {})).rejects.toThrow(
+        'db write failed',
+      );
+
+      expect(mockStorageQuotaService.reserveQuota).toHaveBeenCalledWith(organizationId, 1024);
+      expect(mockStorageQuotaService.decrementUsage).not.toHaveBeenCalledWith(organizationId, 1024);
+    });
+
     it('should sanitize filename', async () => {
       await controller.replaceFile(organizationId, 'content-123', mockFile, {});
 
@@ -476,11 +542,28 @@ describe('ContentController', () => {
     it('should pass keepBackup option to service', async () => {
       await controller.replaceFile(organizationId, 'content-123', mockFile, { keepBackup: true });
 
+      expect(mockStorageQuotaService.reserveQuota).toHaveBeenCalledWith(organizationId, mockFile.size);
       expect(mockContentService.replaceFile).toHaveBeenCalledWith(
         organizationId,
         'content-123',
         expect.any(String),
         expect.objectContaining({ keepBackup: true }),
+      );
+    });
+
+    it('should not decrement quota for smaller keepBackup replacement because the old file is retained', async () => {
+      mockContentService.findOne.mockResolvedValueOnce({
+        id: 'content-123',
+        name: 'old-image.jpg',
+        fileSize: 4096,
+      } as any);
+
+      await controller.replaceFile(organizationId, 'content-123', mockFile, { keepBackup: true });
+
+      expect(mockStorageQuotaService.reserveQuota).toHaveBeenCalledWith(organizationId, mockFile.size);
+      expect(mockStorageQuotaService.decrementUsage).not.toHaveBeenCalledWith(
+        organizationId,
+        expect.any(Number),
       );
     });
 

--- a/middleware/src/modules/content/content.controller.ts
+++ b/middleware/src/modules/content/content.controller.ts
@@ -14,6 +14,7 @@ import {
   UseGuards,
   BadRequestException,
   NotFoundException,
+  ServiceUnavailableException,
   Logger,
 } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
@@ -89,9 +90,6 @@ export class ContentController {
       throw new BadRequestException('No file provided');
     }
 
-    // Check storage quota before processing
-    await this.storageQuotaService.checkQuota(organizationId, file.size);
-
     // Validate file using magic numbers, size, etc.
     const validation = await this.fileValidationService.validateFile(
       file.buffer,
@@ -106,65 +104,79 @@ export class ContentController {
 
     let fileUrl: string;
     const filename = `${validation.hash}-${safeFilename}`;
+    let uploadedObjectKey: string | null = null;
 
-    // Try MinIO first, fall back to local storage
-    if (this.storageService.isMinioAvailable()) {
-      try {
+    await this.storageQuotaService.reserveQuota(organizationId, file.size);
+    try {
+      // Try MinIO first. In production, fail closed instead of creating
+      // unreachable /uploads content when object storage is unhealthy.
+      if (this.storageService.isMinioAvailable()) {
         const objectKey = this.storageService.generateObjectKey(
           organizationId,
           validation.hash,
           safeFilename,
         );
         await this.storageService.uploadFile(file.buffer, objectKey, file.mimetype);
+        uploadedObjectKey = objectKey;
         // Store with minio:// prefix to identify MinIO-stored content
         fileUrl = `${MINIO_URL_PREFIX}${objectKey}`;
         this.logger.debug(`File uploaded to MinIO: ${objectKey}`);
-      } catch (error) {
-        this.logger.warn(`MinIO upload failed, falling back to local storage: ${error}`);
-        // Fall back to local storage
+      } else if (process.env.NODE_ENV === 'production') {
+        throw new ServiceUnavailableException('Storage service is currently unavailable');
+      } else {
+        // Development fallback only; production middleware no longer serves
+        // /uploads, so accepting this path there would create dead content.
         fileUrl = await this.saveFileLocally(organizationId, filename, file.buffer);
       }
-    } else {
-      // MinIO not available, use local storage
-      fileUrl = await this.saveFileLocally(organizationId, filename, file.buffer);
+
+      // Determine the content type from the file mimetype
+      const contentType = type || (file.mimetype.startsWith('video/') ? 'video' :
+                                   file.mimetype.startsWith('image/') ? 'image' :
+                                   file.mimetype === 'application/pdf' ? 'pdf' : 'url');
+
+      // Create content record (fileHash stored in metadata since not in schema)
+      const content = await this.contentService.create(organizationId, {
+        name: name || safeFilename,
+        type: contentType,
+        url: fileUrl,
+        fileSize: file.size,
+        mimeType: file.mimetype,
+        metadata: { fileHash: validation.hash },
+      } as CreateContentDto);
+
+      // Generate thumbnail in background (fire-and-forget to avoid blocking upload response)
+      if (contentType === 'image') {
+        this.thumbnailService.generateThumbnail(
+          content.id,
+          file.buffer,
+          file.mimetype,
+        ).then(async (thumbnailUrl) => {
+          await this.contentService.update(organizationId, content.id, { thumbnail: thumbnailUrl });
+          this.logger.debug(`Thumbnail generated in background: ${thumbnailUrl}`);
+        }).catch((error) => {
+          this.logger.warn(`Background thumbnail generation failed: ${error}`);
+        });
+      }
+
+      return {
+        content,
+        fileHash: validation.hash,
+      };
+    } catch (error) {
+      let canReleaseQuota = true;
+      if (uploadedObjectKey) {
+        try {
+          await this.storageService.deleteFile(uploadedObjectKey);
+        } catch (deleteError) {
+          canReleaseQuota = false;
+          this.logger.warn(`Failed to clean up uploaded object after upload failure: ${deleteError}`);
+        }
+      }
+      if (canReleaseQuota) {
+        await this.releaseQuotaReservation(organizationId, file.size);
+      }
+      throw error;
     }
-
-    // Determine the content type from the file mimetype
-    const contentType = type || (file.mimetype.startsWith('video/') ? 'video' :
-                                 file.mimetype.startsWith('image/') ? 'image' :
-                                 file.mimetype === 'application/pdf' ? 'pdf' : 'url');
-
-    // Create content record (fileHash stored in metadata since not in schema)
-    const content = await this.contentService.create(organizationId, {
-      name: name || safeFilename,
-      type: contentType,
-      url: fileUrl,
-      fileSize: file.size,
-      mimeType: file.mimetype,
-      metadata: { fileHash: validation.hash },
-    } as CreateContentDto);
-
-    // Track storage usage after successful upload
-    await this.storageQuotaService.incrementUsage(organizationId, file.size);
-
-    // Generate thumbnail in background (fire-and-forget to avoid blocking upload response)
-    if (contentType === 'image') {
-      this.thumbnailService.generateThumbnail(
-        content.id,
-        file.buffer,
-        file.mimetype,
-      ).then(async (thumbnailUrl) => {
-        await this.contentService.update(organizationId, content.id, { thumbnail: thumbnailUrl });
-        this.logger.debug(`Thumbnail generated in background: ${thumbnailUrl}`);
-      }).catch((error) => {
-        this.logger.warn(`Background thumbnail generation failed: ${error}`);
-      });
-    }
-
-    return {
-      content,
-      fileHash: validation.hash,
-    };
   }
 
   /**
@@ -432,11 +444,7 @@ export class ContentController {
     const existingContent = await this.contentService.findOne(organizationId, id);
     const oldFileSize = existingContent.fileSize || 0;
     const netIncrease = file.size - oldFileSize;
-
-    // Check storage quota only if net storage increases
-    if (netIncrease > 0) {
-      await this.storageQuotaService.checkQuota(organizationId, netIncrease);
-    }
+    const keepBackup = replaceFileDto.keepBackup === true;
 
     // Validate file
     const validation = await this.fileValidationService.validateFile(
@@ -452,68 +460,98 @@ export class ContentController {
 
     let fileUrl: string;
     const filename = `${validation.hash}-${safeFilename}`;
+    let uploadedObjectKey: string | null = null;
 
-    // Try MinIO first, fall back to local storage
-    if (this.storageService.isMinioAvailable()) {
-      try {
+    // Reserve quota only after validation succeeds so rejected files cannot
+    // leave behind accounting reservations. Backup replacements retain the
+    // previous file, so the quota increase is the full new file size.
+    const quotaReservation = keepBackup ? file.size : Math.max(0, netIncrease);
+    if (quotaReservation > 0) {
+      await this.storageQuotaService.reserveQuota(organizationId, quotaReservation);
+    }
+
+    try {
+      // Try MinIO first. In production, fail closed instead of creating
+      // unreachable /uploads content when object storage is unhealthy.
+      if (this.storageService.isMinioAvailable()) {
         const objectKey = this.storageService.generateObjectKey(
           organizationId,
           validation.hash,
           safeFilename,
         );
         await this.storageService.uploadFile(file.buffer, objectKey, file.mimetype);
+        uploadedObjectKey = objectKey;
         fileUrl = `${MINIO_URL_PREFIX}${objectKey}`;
         this.logger.debug(`Replacement file uploaded to MinIO: ${objectKey}`);
-      } catch (error) {
-        this.logger.warn(`MinIO upload failed for replacement, falling back to local: ${error}`);
+      } else if (process.env.NODE_ENV === 'production') {
+        throw new ServiceUnavailableException('Storage service is currently unavailable');
+      } else {
         fileUrl = await this.saveFileLocally(organizationId, filename, file.buffer);
       }
-    } else {
-      fileUrl = await this.saveFileLocally(organizationId, filename, file.buffer);
-    }
 
-    // Determine thumbnail for images
-    const contentType = file.mimetype.startsWith('video/') ? 'video' :
-                       file.mimetype.startsWith('image/') ? 'image' :
-                       file.mimetype === 'application/pdf' ? 'pdf' : 'url';
+      // Determine thumbnail for images
+      const contentType = file.mimetype.startsWith('video/') ? 'video' :
+                         file.mimetype.startsWith('image/') ? 'image' :
+                         file.mimetype === 'application/pdf' ? 'pdf' : 'url';
 
-    const content = await this.contentService.replaceFile(
-      organizationId,
-      id,
-      fileUrl,
-      {
-        name: replaceFileDto.name,
-        keepBackup: replaceFileDto.keepBackup,
-        fileSize: file.size,
-        mimeType: file.mimetype,
-      },
-    );
-
-    // Update storage usage: adjust for the net difference
-    if (netIncrease > 0) {
-      await this.storageQuotaService.incrementUsage(organizationId, netIncrease);
-    } else if (netIncrease < 0) {
-      await this.storageQuotaService.decrementUsage(organizationId, Math.abs(netIncrease));
-    }
-
-    // Generate thumbnail in background (fire-and-forget)
-    if (contentType === 'image') {
-      this.thumbnailService.generateThumbnail(
+      const content = await this.contentService.replaceFile(
+        organizationId,
         id,
-        file.buffer,
-        file.mimetype,
-      ).then(async (thumbnailUrl) => {
-        await this.contentService.update(organizationId, id, { thumbnail: thumbnailUrl });
-        this.logger.debug(`Replacement thumbnail generated in background: ${thumbnailUrl}`);
-      }).catch((error) => {
-        this.logger.warn(`Background thumbnail generation failed during replace: ${error}`);
-      });
-    }
+        fileUrl,
+        {
+          name: replaceFileDto.name,
+          keepBackup,
+          fileSize: file.size,
+          mimeType: file.mimetype,
+        },
+      );
 
-    return {
-      content,
-      fileHash: validation.hash,
-    };
+      // Update storage usage: adjust for the net difference
+      if (!keepBackup && netIncrease < 0) {
+        await this.storageQuotaService.decrementUsage(organizationId, Math.abs(netIncrease));
+      }
+
+      // Generate thumbnail in background (fire-and-forget)
+      if (contentType === 'image') {
+        this.thumbnailService.generateThumbnail(
+          id,
+          file.buffer,
+          file.mimetype,
+        ).then(async (thumbnailUrl) => {
+          await this.contentService.update(organizationId, id, { thumbnail: thumbnailUrl });
+          this.logger.debug(`Replacement thumbnail generated in background: ${thumbnailUrl}`);
+        }).catch((error) => {
+          this.logger.warn(`Background thumbnail generation failed during replace: ${error}`);
+        });
+      }
+
+      return {
+        content,
+        fileHash: validation.hash,
+      };
+    } catch (error) {
+      let canReleaseQuota = true;
+      if (uploadedObjectKey) {
+        try {
+          await this.storageService.deleteFile(uploadedObjectKey);
+        } catch (deleteError) {
+          canReleaseQuota = false;
+          this.logger.warn(`Failed to clean up replacement object after failure: ${deleteError}`);
+        }
+      }
+      if (canReleaseQuota && quotaReservation > 0) {
+        await this.releaseQuotaReservation(organizationId, quotaReservation);
+      }
+      throw error;
+    }
+  }
+
+  private async releaseQuotaReservation(organizationId: string, bytes: number): Promise<void> {
+    try {
+      await this.storageQuotaService.decrementUsage(organizationId, bytes);
+    } catch (error) {
+      this.logger.error(`Failed to release reserved storage quota for ${organizationId}: ${error}`);
+    }
   }
 
   @Get(':id/versions')

--- a/middleware/src/modules/content/content.service.spec.ts
+++ b/middleware/src/modules/content/content.service.spec.ts
@@ -369,6 +369,39 @@ describe('ContentService', () => {
 
       await expect(service.remove('org-123', 'invalid-id')).rejects.toThrow(NotFoundException);
     });
+
+    it('should retain DB row and quota when MinIO delete fails', async () => {
+      mockDatabaseService.content.findFirst.mockResolvedValue({
+        ...mockContent,
+        url: 'minio://org-123/uploads/file.jpg',
+        fileSize: 1000,
+      });
+      mockStorageService.deleteFile.mockRejectedValueOnce(new Error('MinIO unavailable'));
+
+      await expect(service.remove('org-123', 'content-123')).rejects.toThrow(
+        'Content file could not be deleted from storage',
+      );
+
+      expect(mockDatabaseService.content.deleteMany).not.toHaveBeenCalled();
+      expect(mockStorageQuotaService.decrementUsage).not.toHaveBeenCalled();
+    });
+
+    it('should not decrement quota when a concurrent delete already removed the row', async () => {
+      mockDatabaseService.content.findFirst.mockResolvedValue({
+        ...mockContent,
+        fileSize: 1000,
+      });
+      mockDatabaseService.content.deleteMany.mockResolvedValue({ count: 0 });
+
+      const result = await service.remove('org-123', 'content-123');
+
+      expect(result).toEqual({ count: 0 });
+      expect(mockStorageQuotaService.decrementUsage).not.toHaveBeenCalled();
+      expect(mockEventEmitter.emit).not.toHaveBeenCalledWith(
+        'content.deleted',
+        expect.anything(),
+      );
+    });
   });
 
   describe('archive', () => {
@@ -871,6 +904,87 @@ describe('ContentService', () => {
           versionNumber: 2,
         }),
       });
+    });
+
+    it('should delete old MinIO object after simple replacement succeeds', async () => {
+      mockDatabaseService.content.findFirst.mockResolvedValue({
+        ...existingContent,
+        url: 'minio://org-123/uploads/old.jpg',
+      });
+      mockDatabaseService.content.updateMany.mockResolvedValue({ count: 1 });
+      mockDatabaseService.content.findUnique.mockResolvedValue({
+        ...existingContent,
+        url: 'minio://org-123/uploads/new.jpg',
+        versionNumber: 2,
+      });
+
+      await service.replaceFile(
+        'org-123',
+        'content-123',
+        'minio://org-123/uploads/new.jpg',
+      );
+
+      expect(mockStorageService.deleteFile).toHaveBeenCalledWith('org-123/uploads/old.jpg');
+    });
+
+    it('should account and mark metadata when old MinIO object cleanup fails', async () => {
+      mockDatabaseService.content.findFirst.mockResolvedValue({
+        ...existingContent,
+        url: 'minio://org-123/uploads/old.jpg',
+        fileSize: 1000,
+        metadata: { fileHash: 'old' },
+      });
+      mockDatabaseService.content.updateMany.mockResolvedValue({ count: 1 });
+      mockDatabaseService.content.findUnique.mockResolvedValue({
+        ...existingContent,
+        url: 'minio://org-123/uploads/new.jpg',
+        versionNumber: 2,
+      });
+      mockStorageService.deleteFile.mockRejectedValueOnce(new Error('delete failed'));
+
+      await service.replaceFile(
+        'org-123',
+        'content-123',
+        'minio://org-123/uploads/new.jpg',
+      );
+
+      expect(mockStorageQuotaService.incrementUsage).toHaveBeenCalledWith('org-123', 1000);
+      expect(mockDatabaseService.content.updateMany).toHaveBeenLastCalledWith({
+        where: { id: 'content-123', organizationId: 'org-123' },
+        data: {
+          metadata: expect.objectContaining({
+            fileHash: 'old',
+            orphanedPreviousFileKey: 'org-123/uploads/old.jpg',
+            orphanedPreviousFileDeleteFailedAt: expect.any(String),
+          }),
+        },
+      });
+    });
+
+    it('should not fail replacement if orphan metadata marking fails after DB pointer update', async () => {
+      mockDatabaseService.content.findFirst.mockResolvedValue({
+        ...existingContent,
+        url: 'minio://org-123/uploads/old.jpg',
+        fileSize: 512,
+      });
+      mockDatabaseService.content.updateMany
+        .mockResolvedValueOnce({ count: 1 })
+        .mockRejectedValueOnce(new Error('metadata write failed'));
+      mockDatabaseService.content.findUnique.mockResolvedValue({
+        ...existingContent,
+        url: 'minio://org-123/uploads/new.jpg',
+        versionNumber: 2,
+      });
+      mockStorageService.deleteFile.mockRejectedValueOnce(new Error('delete failed'));
+
+      const result = await service.replaceFile(
+        'org-123',
+        'content-123',
+        'minio://org-123/uploads/new.jpg',
+      );
+
+      expect(result.url).toBe('minio://org-123/uploads/new.jpg');
+      expect(mockStorageQuotaService.incrementUsage).toHaveBeenCalledWith('org-123', 512);
     });
 
     it('should replace file with backup', async () => {
@@ -1455,7 +1569,7 @@ describe('ContentService', () => {
         { id: 'id-2', fileSize: 2000, fileKey: null, url: null },
         { id: 'id-3', fileSize: 0, fileKey: null, url: null },
       ]);
-      mockDatabaseService.content.deleteMany.mockResolvedValue({ count: 3 });
+      mockDatabaseService.content.deleteMany.mockResolvedValue({ count: 1 });
 
       const result = await service.bulkDelete('org-123', {
         ids: ['id-1', 'id-2', 'id-3'],
@@ -1463,8 +1577,16 @@ describe('ContentService', () => {
 
       expect(result.deleted).toBe(3);
       expect(mockDatabaseService.content.deleteMany).toHaveBeenCalledWith({
-        where: { id: { in: ['id-1', 'id-2', 'id-3'] }, organizationId: 'org-123' },
+        where: { id: 'id-1', organizationId: 'org-123' },
       });
+      expect(mockDatabaseService.content.deleteMany).toHaveBeenCalledWith({
+        where: { id: 'id-2', organizationId: 'org-123' },
+      });
+      expect(mockDatabaseService.content.deleteMany).toHaveBeenCalledWith({
+        where: { id: 'id-3', organizationId: 'org-123' },
+      });
+      expect(mockStorageQuotaService.decrementUsage).toHaveBeenCalledWith('org-123', 1000);
+      expect(mockStorageQuotaService.decrementUsage).toHaveBeenCalledWith('org-123', 2000);
     });
 
     it('should throw error if some content not found', async () => {
@@ -1496,7 +1618,7 @@ describe('ContentService', () => {
 
       // Only the successful id is in the deleteMany WHERE.
       expect(mockDatabaseService.content.deleteMany).toHaveBeenCalledWith({
-        where: { id: { in: ['good-1'] }, organizationId: 'org-123' },
+        where: { id: 'good-1', organizationId: 'org-123' },
       });
       // Result surfaces both counts so the caller can act on failures.
       expect(result.deleted).toBe(1);
@@ -1504,6 +1626,55 @@ describe('ContentService', () => {
       expect(result.failedIds).toEqual(['bad-1']);
       // Quota decrement is for the SUCCESSFUL bytes only (1000), not 3000.
       expect(mockStorageQuotaService.decrementUsage).toHaveBeenCalledWith('org-123', 1000);
+    });
+
+    it('decrements quota only for bulk-delete rows actually removed', async () => {
+      mockDatabaseService.content.findMany.mockResolvedValue([
+        { id: 'id-1', fileSize: 1000, fileKey: null, url: null },
+        { id: 'id-2', fileSize: 2000, fileKey: null, url: null },
+      ]);
+      mockDatabaseService.content.deleteMany
+        .mockResolvedValueOnce({ count: 1 })
+        .mockResolvedValueOnce({ count: 0 });
+
+      const result = await service.bulkDelete('org-123', {
+        ids: ['id-1', 'id-2'],
+      });
+
+      expect(result.deleted).toBe(1);
+      expect(mockStorageQuotaService.decrementUsage).toHaveBeenCalledWith('org-123', 1000);
+    });
+
+    it('continues bulk delete and adjusts quota when a DB delete fails after storage cleanup', async () => {
+      mockDatabaseService.content.findMany.mockResolvedValue([
+        { id: 'id-1', fileSize: 1000, fileKey: null, url: 'minio://o/id-1.png' },
+        { id: 'id-2', fileSize: 2000, fileKey: null, url: 'minio://o/id-2.png' },
+      ]);
+      mockDatabaseService.content.deleteMany
+        .mockRejectedValueOnce(new Error('db temporarily unavailable'))
+        .mockResolvedValueOnce({ count: 1 });
+
+      const result = await service.bulkDelete('org-123', {
+        ids: ['id-1', 'id-2'],
+      });
+
+      expect(result.deleted).toBe(1);
+      expect(result.failed).toBe(1);
+      expect(result.failedIds).toEqual(['id-1']);
+      expect(mockDatabaseService.content.updateMany).toHaveBeenCalledWith({
+        where: { id: 'id-1', organizationId: 'org-123' },
+        data: expect.objectContaining({
+          status: 'archived',
+          metadata: expect.objectContaining({
+            storageObjectRemovedDuringBulkDelete: true,
+          }),
+        }),
+      });
+      expect(mockDatabaseService.playlistItem.deleteMany).toHaveBeenCalledWith({
+        where: { contentId: 'id-1' },
+      });
+      expect(mockStorageQuotaService.decrementUsage).toHaveBeenCalledWith('org-123', 1000);
+      expect(mockStorageQuotaService.decrementUsage).toHaveBeenCalledWith('org-123', 2000);
     });
   });
 

--- a/middleware/src/modules/content/content.service.ts
+++ b/middleware/src/modules/content/content.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException, BadRequestException, Logger } from '@nestjs/common';
+import { Injectable, NotFoundException, BadRequestException, Logger, ServiceUnavailableException } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Prisma } from '@vizora/database';
 import { DatabaseService } from '../database/database.service';
@@ -259,6 +259,7 @@ export class ContentService {
         await this.storageService.deleteFile(content.fileKey);
       } catch (error) {
         this.logger.error(`Failed to delete file ${content.fileKey} from storage: ${error}`);
+        throw new ServiceUnavailableException('Content file could not be deleted from storage; DB row retained for retry');
       }
     } else if (content.url?.startsWith('minio://')) {
       // Fall back to extracting object key from minio:// URL
@@ -267,6 +268,7 @@ export class ContentService {
         await this.storageService.deleteFile(objectKey);
       } catch (error) {
         this.logger.error(`Failed to delete file ${objectKey} from storage: ${error}`);
+        throw new ServiceUnavailableException('Content file could not be deleted from storage; DB row retained for retry');
       }
     }
 
@@ -275,12 +277,15 @@ export class ContentService {
       where: { id, organizationId },
     });
 
-    // Decrement storage usage if the content had a file size
-    if (content.fileSize && content.fileSize > 0) {
+    // Decrement storage usage only if this request actually removed the row.
+    // Concurrent deletes can both read the row before one delete wins.
+    if (deleted.count > 0 && content.fileSize && content.fileSize > 0) {
       await this.storageQuotaService.decrementUsage(organizationId, content.fileSize);
     }
 
-    this.eventEmitter.emit('content.deleted', { action: 'deleted', entityType: 'content', entityId: id, organizationId });
+    if (deleted.count > 0) {
+      this.eventEmitter.emit('content.deleted', { action: 'deleted', entityType: 'content', entityId: id, organizationId });
+    }
     return deleted;
   }
 
@@ -321,6 +326,9 @@ export class ContentService {
     options: { name?: string; keepBackup?: boolean; thumbnail?: string; fileSize?: number; mimeType?: string } = {},
   ) {
     const existingContent = await this.findOne(organizationId, id);
+    const previousObjectKey = existingContent.url?.startsWith('minio://')
+      ? existingContent.url.substring('minio://'.length)
+      : null;
 
     if (options.keepBackup) {
       // Create backup and update original in a transaction to prevent data loss
@@ -383,7 +391,66 @@ export class ContentService {
     }
     const updatedContent = await this.db.content.findUnique({ where: { id } });
 
+    if (previousObjectKey && newUrl !== `minio://${previousObjectKey}`) {
+      await this.cleanupPreviousReplacementObject(
+        organizationId,
+        id,
+        previousObjectKey,
+        existingContent.fileSize,
+        existingContent.metadata,
+      );
+    }
+
     return this.mapContentResponse(updatedContent);
+  }
+
+  private async cleanupPreviousReplacementObject(
+    organizationId: string,
+    contentId: string,
+    previousObjectKey: string,
+    previousFileSize?: number | null,
+    metadata?: unknown,
+  ): Promise<void> {
+    try {
+      await this.storageService.deleteFile(previousObjectKey);
+      return;
+    } catch (error) {
+      this.logger.warn(
+        `Replacement kept previous storage object ${previousObjectKey} after delete failure: ${error}`,
+      );
+    }
+
+    // The DB row already points at the replacement object by this point. Any
+    // accounting/audit cleanup below must not make the controller delete that
+    // replacement object as if the whole replace failed.
+    try {
+      if (previousFileSize && previousFileSize > 0) {
+        await this.storageQuotaService.incrementUsage(organizationId, previousFileSize);
+      }
+    } catch (error) {
+      this.logger.error(`Failed to account retained previous object ${previousObjectKey}: ${error}`);
+    }
+
+    try {
+      const previousMetadata =
+        metadata &&
+        typeof metadata === 'object' &&
+        !Array.isArray(metadata)
+          ? (metadata as Record<string, unknown>)
+          : {};
+      await this.db.content.updateMany({
+        where: { id: contentId, organizationId },
+        data: {
+          metadata: {
+            ...previousMetadata,
+            orphanedPreviousFileKey: previousObjectKey,
+            orphanedPreviousFileDeleteFailedAt: new Date().toISOString(),
+          } as Prisma.InputJsonValue,
+        },
+      });
+    } catch (error) {
+      this.logger.error(`Failed to mark retained previous object ${previousObjectKey}: ${error}`);
+    }
   }
 
   async getVersionHistory(organizationId: string, id: string) {
@@ -642,7 +709,7 @@ export class ContentService {
     // Fetch items with file info for storage cleanup
     const items = await this.db.content.findMany({
       where: { id: { in: uniqueIds }, organizationId },
-      select: { id: true, fileSize: true, url: true },
+      select: { id: true, fileSize: true, url: true, metadata: true },
     });
 
     if (items.length !== uniqueIds.length) {
@@ -686,16 +753,55 @@ export class ContentService {
 
     let deleted = 0;
     if (deletableIds.length > 0) {
-      const result = await this.db.content.deleteMany({
-        where: { id: { in: deletableIds }, organizationId },
-      });
-      deleted = result.count;
-
-      const successfulBytes = items
-        .filter((i) => deletableIds.includes(i.id))
-        .reduce((sum, i) => sum + (i.fileSize || 0), 0);
-      if (successfulBytes > 0) {
-        await this.storageQuotaService.decrementUsage(organizationId, successfulBytes);
+      for (const item of items.filter((i) => deletableIds.includes(i.id))) {
+        const bytes = item.fileSize || 0;
+        try {
+          const result = await this.db.content.deleteMany({
+            where: { id: item.id, organizationId },
+          });
+          if (result.count > 0) {
+            deleted += result.count;
+            if (bytes > 0) {
+              await this.storageQuotaService.decrementUsage(organizationId, bytes);
+            }
+          }
+        } catch (err) {
+          failedIds.push(item.id);
+          this.logger.warn(
+            `Bulk delete: DB delete failed for content ${item.id} after storage cleanup: ${
+              err instanceof Error ? err.message : err
+            }. Row retained but storage quota is adjusted to match removed object.`,
+          );
+          try {
+            const previousMetadata =
+              item.metadata &&
+              typeof item.metadata === 'object' &&
+              !Array.isArray(item.metadata)
+                ? (item.metadata as Record<string, unknown>)
+                : {};
+            await this.db.content.updateMany({
+              where: { id: item.id, organizationId },
+              data: {
+                status: 'archived',
+                metadata: {
+                  ...previousMetadata,
+                  bulkDeleteDbDeleteFailedAt: new Date().toISOString(),
+                  storageObjectRemovedDuringBulkDelete: true,
+                } as Prisma.InputJsonValue,
+              },
+            });
+            await this.db.playlistItem.deleteMany({
+              where: { contentId: item.id },
+            });
+          } catch (markError) {
+            this.logger.error(
+              `Bulk delete: failed to mark retained row or remove playlist assignments for ${item.id} after storage cleanup: ${markError}`,
+            );
+          }
+          if (bytes > 0) {
+            await this.storageQuotaService.decrementUsage(organizationId, bytes);
+          }
+        }
       }
     }
 

--- a/middleware/src/modules/content/device-content.controller.spec.ts
+++ b/middleware/src/modules/content/device-content.controller.spec.ts
@@ -17,6 +17,7 @@ import { JwtService } from '@nestjs/jwt';
 import { DeviceContentController } from './device-content.controller';
 import { ContentService } from './content.service';
 import { StorageService } from '../storage/storage.service';
+import { DatabaseService } from '../database/database.service';
 import { Readable, Writable } from 'node:stream';
 
 describe('DeviceContentController', () => {
@@ -24,6 +25,7 @@ describe('DeviceContentController', () => {
   let mockContentService: jest.Mocked<ContentService>;
   let mockStorageService: jest.Mocked<StorageService>;
   let mockJwtService: jest.Mocked<JwtService>;
+  let mockDatabaseService: any;
 
   const organizationId = 'org-123';
   const deviceId = 'device-456';
@@ -63,12 +65,23 @@ describe('DeviceContentController', () => {
       verify: jest.fn(),
     } as any;
 
+    mockDatabaseService = {
+      display: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: deviceId,
+          organizationId,
+          isDisabled: false,
+        }),
+      },
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [DeviceContentController],
       providers: [
         { provide: ContentService, useValue: mockContentService },
         { provide: StorageService, useValue: mockStorageService },
         { provide: JwtService, useValue: mockJwtService },
+        { provide: DatabaseService, useValue: mockDatabaseService },
       ],
     }).compile();
 
@@ -145,6 +158,22 @@ describe('DeviceContentController', () => {
       expect(mockStorageService.getObject).toHaveBeenCalledWith(objectKey);
       expect(mockStorageService.getObjectRange).not.toHaveBeenCalled();
       expect(res.getBody().toString()).toBe('file-content');
+    });
+
+    it('should reject disabled display tokens before serving content', async () => {
+      const req = createMockRequest('valid-device-token');
+      const res = createMockResponse();
+      mockJwtService.verify.mockReturnValue(validDevicePayload);
+      mockDatabaseService.display.findUnique.mockResolvedValueOnce({
+        id: deviceId,
+        organizationId,
+        isDisabled: true,
+      });
+
+      await expect(controller.serveFile(contentId, req, res)).rejects.toThrow(UnauthorizedException);
+
+      expect(mockContentService.findByIdForDevice).not.toHaveBeenCalled();
+      expect(mockStorageService.getObject).not.toHaveBeenCalled();
     });
 
     it('should serve content file with valid device JWT from query parameter', async () => {
@@ -437,7 +466,7 @@ describe('DeviceContentController', () => {
       );
       expect(res.set).not.toHaveBeenCalledWith(
         expect.objectContaining({
-          'Cache-Control': 'public, max-age=86400',
+          'Cache-Control': 'private, no-store',
         }),
       );
       expect(mockStorageService.getObject).not.toHaveBeenCalled();

--- a/middleware/src/modules/content/device-content.controller.ts
+++ b/middleware/src/modules/content/device-content.controller.ts
@@ -18,6 +18,7 @@ import { SkipEnvelope } from '../common/interceptors/response-envelope.intercept
 import { SkipOutputSanitize } from '../common/interceptors/sanitize.interceptor';
 import { ContentService } from './content.service';
 import { StorageService } from '../storage/storage.service';
+import { DatabaseService } from '../database/database.service';
 import { pipeline } from 'node:stream/promises';
 
 const MINIO_URL_PREFIX = 'minio://';
@@ -53,6 +54,7 @@ export class DeviceContentController {
     private readonly contentService: ContentService,
     private readonly storageService: StorageService,
     private readonly jwtService: JwtService,
+    private readonly databaseService: DatabaseService,
   ) {}
 
   /**
@@ -186,6 +188,14 @@ export class DeviceContentController {
     // IDs for existence via timing or DB error patterns.
     const devicePayload = this.verifyDeviceToken(req);
 
+    const display = await this.databaseService.display.findUnique({
+      where: { id: devicePayload.sub },
+      select: { id: true, organizationId: true, isDisabled: true },
+    });
+    if (!display || display.organizationId !== devicePayload.organizationId || display.isDisabled) {
+      throw new UnauthorizedException('Device is not authorized');
+    }
+
     const content = await this.contentService.findByIdForDevice(
       id,
       devicePayload.organizationId,
@@ -242,7 +252,7 @@ export class DeviceContentController {
           'Accept-Ranges': 'bytes',
           'Content-Length': String(length),
           'Content-Range': `bytes ${range.range.start}-${range.range.end}/${metadata.size}`,
-          'Cache-Control': 'public, max-age=86400',
+          'Cache-Control': 'private, no-store',
           'Cross-Origin-Resource-Policy': 'cross-origin',
         });
         await this.streamToResponse(stream, res);
@@ -254,7 +264,7 @@ export class DeviceContentController {
         'Content-Type': mimeType,
         'Accept-Ranges': 'bytes',
         'Content-Length': String(metadata.size),
-        'Cache-Control': 'public, max-age=86400',
+        'Cache-Control': 'private, no-store',
         'Cross-Origin-Resource-Policy': 'cross-origin',
       });
       await this.streamToResponse(stream, res);

--- a/middleware/src/modules/content/dto/replace-file.dto.spec.ts
+++ b/middleware/src/modules/content/dto/replace-file.dto.spec.ts
@@ -1,0 +1,39 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { ReplaceFileDto } from './replace-file.dto';
+
+describe('ReplaceFileDto', () => {
+  it('parses multipart string false as boolean false', async () => {
+    const dto = plainToInstance(
+      ReplaceFileDto,
+      { keepBackup: 'false' },
+      { enableImplicitConversion: true },
+    );
+
+    expect(dto.keepBackup).toBe(false);
+    await expect(validate(dto)).resolves.toHaveLength(0);
+  });
+
+  it('parses multipart string true as boolean true', async () => {
+    const dto = plainToInstance(
+      ReplaceFileDto,
+      { keepBackup: 'true' },
+      { enableImplicitConversion: true },
+    );
+
+    expect(dto.keepBackup).toBe(true);
+    await expect(validate(dto)).resolves.toHaveLength(0);
+  });
+
+  it('rejects non-boolean keepBackup values', async () => {
+    const dto = plainToInstance(
+      ReplaceFileDto,
+      { keepBackup: 'maybe' },
+      { enableImplicitConversion: true },
+    );
+
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('keepBackup');
+  });
+});

--- a/middleware/src/modules/content/dto/replace-file.dto.ts
+++ b/middleware/src/modules/content/dto/replace-file.dto.ts
@@ -1,5 +1,5 @@
 import { IsOptional, IsBoolean, IsString } from 'class-validator';
-import { Type } from 'class-transformer';
+import { Transform } from 'class-transformer';
 
 export class ReplaceFileDto {
   @IsOptional()
@@ -7,7 +7,15 @@ export class ReplaceFileDto {
   name?: string;
 
   @IsOptional()
-  @Type(() => Boolean)
+  @Transform(({ value }) => {
+    if (value === true || value === false || value == null) return value;
+    if (typeof value === 'string') {
+      const normalized = value.trim().toLowerCase();
+      if (normalized === 'true') return true;
+      if (normalized === 'false') return false;
+    }
+    return value;
+  })
   @IsBoolean()
-  keepBackup?: boolean; // Whether to keep the old file as a previous version
+  keepBackup?: boolean | string; // Whether to keep the old file as a previous version
 }

--- a/middleware/src/modules/display-groups/display-groups.service.spec.ts
+++ b/middleware/src/modules/display-groups/display-groups.service.spec.ts
@@ -156,6 +156,28 @@ describe('DisplayGroupsService', () => {
 
       expect(result.data[0]._count.displays).toBe(3);
     });
+
+    it('should include member display ids for dashboard group filtering', async () => {
+      mockDatabaseService.displayGroup.findMany.mockResolvedValue([
+        {
+          ...mockDisplayGroup,
+          displays: [{ displayId: 'display-1' }],
+          _count: { displays: 1 },
+        },
+      ]);
+      mockDatabaseService.displayGroup.count.mockResolvedValue(1);
+
+      await service.findAll('org-123', { page: 1, limit: 10 });
+
+      expect(mockDatabaseService.displayGroup.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          include: expect.objectContaining({
+            displays: { select: { displayId: true } },
+            _count: { select: { displays: true } },
+          }),
+        }),
+      );
+    });
   });
 
   describe('findOne', () => {

--- a/middleware/src/modules/display-groups/display-groups.service.ts
+++ b/middleware/src/modules/display-groups/display-groups.service.ts
@@ -36,6 +36,11 @@ export class DisplayGroupsService {
         take: limit,
         orderBy: { createdAt: 'desc' },
         include: {
+          displays: {
+            select: {
+              displayId: true,
+            },
+          },
           _count: {
             select: {
               displays: true,

--- a/middleware/src/modules/schedules/schedules.service.spec.ts
+++ b/middleware/src/modules/schedules/schedules.service.spec.ts
@@ -430,6 +430,62 @@ describe('SchedulesService', () => {
 
       expect(databaseService.schedule.update).not.toHaveBeenCalled();
     });
+
+    it('should clear displayGroupId when moving a group schedule to a display', async () => {
+      const updateDto: UpdateScheduleDto = {
+        displayId: mockDisplayId,
+      };
+
+      databaseService.schedule.findFirst.mockResolvedValue(mockScheduleWithRelations);
+      databaseService.display.findFirst.mockResolvedValue({ id: mockDisplayId });
+      databaseService.schedule.update.mockResolvedValue({
+        ...mockSchedule,
+        displayId: mockDisplayId,
+        displayGroupId: null,
+        playlist: {},
+        display: {},
+        displayGroup: null,
+      });
+
+      await service.update(mockOrganizationId, mockScheduleId, updateDto);
+
+      expect(databaseService.schedule.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            displayId: mockDisplayId,
+            displayGroupId: null,
+          }),
+        }),
+      );
+    });
+
+    it('should clear displayId when moving a display schedule to a group', async () => {
+      const updateDto: UpdateScheduleDto = {
+        displayGroupId: 'group-123',
+      };
+
+      databaseService.schedule.findFirst.mockResolvedValue(mockScheduleWithRelations);
+      databaseService.displayGroup.findFirst.mockResolvedValue({ id: 'group-123' });
+      databaseService.schedule.update.mockResolvedValue({
+        ...mockSchedule,
+        displayId: null,
+        displayGroupId: 'group-123',
+        playlist: {},
+        display: null,
+        displayGroup: {},
+      });
+
+      await service.update(mockOrganizationId, mockScheduleId, updateDto);
+
+      expect(databaseService.schedule.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            displayId: null,
+            displayGroupId: 'group-123',
+          }),
+        }),
+      );
+    });
   });
 
   describe('duplicate', () => {

--- a/middleware/src/modules/schedules/schedules.service.ts
+++ b/middleware/src/modules/schedules/schedules.service.ts
@@ -235,10 +235,18 @@ export class SchedulesService {
       }
     }
 
+    const targetUpdate =
+      updateScheduleDto.displayId
+        ? { displayId: updateScheduleDto.displayId, displayGroupId: null }
+        : updateScheduleDto.displayGroupId
+          ? { displayId: null, displayGroupId: updateScheduleDto.displayGroupId }
+          : {};
+
     const updated = await this.db.schedule.update({
       where: { id },
       data: {
         ...updateScheduleDto,
+        ...targetUpdate,
         startDate: updateScheduleDto.startDate ? new Date(updateScheduleDto.startDate) : undefined,
         endDate: updateScheduleDto.endDate ? new Date(updateScheduleDto.endDate) : undefined,
       },

--- a/middleware/src/modules/storage/storage-quota.service.spec.ts
+++ b/middleware/src/modules/storage/storage-quota.service.spec.ts
@@ -1,0 +1,61 @@
+import { PayloadTooLargeException } from '@nestjs/common';
+import { StorageQuotaService } from './storage-quota.service';
+
+describe('StorageQuotaService', () => {
+  let service: StorageQuotaService;
+  let db: any;
+
+  beforeEach(() => {
+    db = {
+      $queryRaw: jest.fn(),
+      $executeRaw: jest.fn(),
+      organization: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+      },
+      content: {
+        aggregate: jest.fn(),
+      },
+    };
+    service = new StorageQuotaService(db);
+  });
+
+  describe('reserveQuota', () => {
+    it('increments usage with one conditional database write', async () => {
+      db.$queryRaw.mockResolvedValueOnce([
+        { storageUsedBytes: 90n, storageQuotaBytes: 100n },
+      ]);
+
+      await service.reserveQuota('org-1', 40);
+
+      expect(db.$queryRaw).toHaveBeenCalledTimes(1);
+      expect(db.organization.update).not.toHaveBeenCalled();
+    });
+
+    it('throws quota exceeded details when the conditional reservation fails', async () => {
+      db.$queryRaw.mockResolvedValueOnce([]);
+      db.organization.findUnique.mockResolvedValueOnce({
+        storageUsedBytes: 80n,
+        storageQuotaBytes: 100n,
+      });
+
+      await expect(service.reserveQuota('org-1', 40)).rejects.toThrow(PayloadTooLargeException);
+    });
+  });
+
+  describe('decrementUsage', () => {
+    it('releases usage with one atomic floor-at-zero database write', async () => {
+      await service.decrementUsage('org-1', 25);
+
+      expect(db.$executeRaw).toHaveBeenCalledTimes(1);
+      expect(db.organization.findUnique).not.toHaveBeenCalled();
+      expect(db.organization.update).not.toHaveBeenCalled();
+    });
+
+    it('does not write for empty releases', async () => {
+      await service.decrementUsage('org-1', 0);
+
+      expect(db.$executeRaw).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/middleware/src/modules/storage/storage-quota.service.ts
+++ b/middleware/src/modules/storage/storage-quota.service.ts
@@ -55,6 +55,47 @@ export class StorageQuotaService {
   }
 
   /**
+   * Atomically reserve storage quota for an upload.
+   *
+   * This increments usage in the same conditional database write that checks
+   * available quota, so concurrent uploads cannot both pass a stale read.
+   * Call `decrementUsage` to release the reservation if later storage or DB
+   * writes fail.
+   */
+  async reserveQuota(organizationId: string, fileSizeBytes: number): Promise<void> {
+    if (fileSizeBytes <= 0) return;
+
+    const requestedBytes = BigInt(fileSizeBytes);
+    const rows = await this.db.$queryRaw<Array<{ storageUsedBytes: bigint; storageQuotaBytes: bigint }>>`
+      UPDATE "organizations"
+      SET "storageUsedBytes" = "storageUsedBytes" + ${requestedBytes}
+      WHERE "id" = ${organizationId}
+        AND "storageUsedBytes" + ${requestedBytes} <= "storageQuotaBytes"
+      RETURNING "storageUsedBytes", "storageQuotaBytes"
+    `;
+
+    if (rows.length > 0) {
+      return;
+    }
+
+    const org = await this.db.organization.findUnique({
+      where: { id: organizationId },
+      select: { storageUsedBytes: true, storageQuotaBytes: true },
+    });
+    if (!org) return;
+
+    const usedBytes = Number(org.storageUsedBytes);
+    const quotaBytes = Number(org.storageQuotaBytes);
+    throw new PayloadTooLargeException({
+      message: 'Storage quota exceeded',
+      usedBytes,
+      quotaBytes,
+      availableBytes: quotaBytes - usedBytes,
+      requestedBytes: fileSizeBytes,
+    });
+  }
+
+  /**
    * Increment storage usage after a successful upload.
    */
   async incrementUsage(organizationId: string, bytes: number): Promise<void> {
@@ -68,18 +109,14 @@ export class StorageQuotaService {
    * Decrement storage usage after a file deletion.
    */
   async decrementUsage(organizationId: string, bytes: number): Promise<void> {
-    // Prevent going below zero
-    const org = await this.db.organization.findUnique({
-      where: { id: organizationId },
-      select: { storageUsedBytes: true },
-    });
-    if (!org) return;
-    const currentUsed = Number(org.storageUsedBytes);
-    const newUsed = Math.max(0, currentUsed - bytes);
-    await this.db.organization.update({
-      where: { id: organizationId },
-      data: { storageUsedBytes: BigInt(newUsed) },
-    });
+    if (bytes <= 0) return;
+
+    const releaseBytes = BigInt(bytes);
+    await this.db.$executeRaw`
+      UPDATE "organizations"
+      SET "storageUsedBytes" = GREATEST("storageUsedBytes" - ${releaseBytes}, ${BigInt(0)})
+      WHERE "id" = ${organizationId}
+    `;
   }
 
   /**

--- a/packages/database/prisma/migrations/20260531090000_customer_hot_path_indexes/migration.sql
+++ b/packages/database/prisma/migrations/20260531090000_customer_hot_path_indexes/migration.sql
@@ -1,0 +1,33 @@
+-- Customer hot-path indexes for dashboard lists, playlist pushes, and active
+-- schedule lookup. These match the query shapes used by the middleware list
+-- endpoints and display schedule resolution paths.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "devices_organizationId_createdAt_idx"
+  ON "devices"("organizationId", "createdAt" DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "devices_organizationId_status_createdAt_idx"
+  ON "devices"("organizationId", "status", "createdAt" DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "devices_organizationId_currentPlaylistId_idx"
+  ON "devices"("organizationId", "currentPlaylistId");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Content_organizationId_createdAt_idx"
+  ON "Content"("organizationId", "createdAt" DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Content_organizationId_status_createdAt_idx"
+  ON "Content"("organizationId", "status", "createdAt" DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Content_organizationId_type_createdAt_idx"
+  ON "Content"("organizationId", "type", "createdAt" DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Content_organizationId_templateOrientation_createdAt_idx"
+  ON "Content"("organizationId", "templateOrientation", "createdAt" DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Playlist_organizationId_createdAt_idx"
+  ON "Playlist"("organizationId", "createdAt" DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Schedule_organizationId_isActive_priority_createdAt_idx"
+  ON "Schedule"("organizationId", "isActive", "priority" DESC, "createdAt" DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Schedule_daysOfWeek_gin_idx"
+  ON "Schedule" USING GIN ("daysOfWeek");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -157,6 +157,9 @@ model Display {
   alertRuleFires       AlertRuleFire[]
 
   @@index([organizationId])
+  @@index([organizationId, createdAt(sort: Desc)])
+  @@index([organizationId, status, createdAt(sort: Desc)])
+  @@index([organizationId, currentPlaylistId])
   @@index([deviceIdentifier])
   @@index([status])
   @@index([pairingCode])
@@ -240,6 +243,10 @@ model Content {
   impressions   ContentImpression[]
 
   @@index([organizationId])
+  @@index([organizationId, createdAt(sort: Desc)])
+  @@index([organizationId, status, createdAt(sort: Desc)])
+  @@index([organizationId, type, createdAt(sort: Desc)])
+  @@index([organizationId, templateOrientation, createdAt(sort: Desc)])
   @@index([type])
   @@index([status])
   @@index([expiresAt])
@@ -267,6 +274,7 @@ model Playlist {
   provisioningTemplates ProvisioningTemplate[]
 
   @@index([organizationId])
+  @@index([organizationId, createdAt(sort: Desc)])
   @@index([organizationId, updatedAt])
 }
 
@@ -349,6 +357,8 @@ model Schedule {
   displayGroup   DisplayGroup? @relation(fields: [displayGroupId], references: [id], onDelete: Cascade)
 
   @@index([organizationId])
+  @@index([organizationId, isActive, priority(sort: Desc), createdAt(sort: Desc)])
+  @@index([daysOfWeek], type: Gin, map: "Schedule_daysOfWeek_gin_idx")
   @@index([playlistId])
   @@index([displayId])
   @@index([displayGroupId])

--- a/realtime/src/app/app.controller.spec.ts
+++ b/realtime/src/app/app.controller.spec.ts
@@ -30,6 +30,8 @@ describe('AppController', () => {
       } as any,
       sendPlaylistUpdate: jest.fn(),
       sendCommand: jest.fn(),
+      hasActiveDeviceSocket: jest.fn((deviceId: string) => mockRooms.has(`device:${deviceId}`)),
+      disconnectDevice: jest.fn(),
     };
 
     mockRedisService = {
@@ -157,6 +159,24 @@ describe('AppController', () => {
         queued: 0,
         failed: 1,
       });
+    });
+  });
+
+  describe('sendCommand', () => {
+    it('disconnects active sockets for disable commands instead of relying on client command handling', async () => {
+      (mockDeviceGateway.disconnectDevice as jest.Mock).mockReturnValue(true);
+
+      const result = await controller.sendCommand({
+        deviceId: 'dev-a',
+        command: { type: 'disable' },
+      });
+
+      expect(result).toEqual({
+        success: true,
+        message: 'Device disconnected after disable',
+      });
+      expect(mockDeviceGateway.disconnectDevice).toHaveBeenCalledWith('dev-a', 'device_disabled');
+      expect(mockDeviceGateway.sendCommand).not.toHaveBeenCalled();
     });
   });
 

--- a/realtime/src/app/app.controller.ts
+++ b/realtime/src/app/app.controller.ts
@@ -219,8 +219,7 @@ export class AppController {
   ) {
     const onlineDevices = new Set(
       data.deviceIds.filter((deviceId) => {
-        const room = this.deviceGateway.server.sockets.adapter.rooms.get(`device:${deviceId}`);
-        return Boolean(room && room.size > 0);
+        return this.deviceGateway.hasActiveDeviceSocket(deviceId);
       }),
     );
 
@@ -277,6 +276,16 @@ export class AppController {
   async sendCommand(
     @Body() data: InternalCommandDto,
   ): Promise<PushResponse> {
+    if (data.command.type === 'disable') {
+      const disconnected = this.deviceGateway.disconnectDevice(data.deviceId, 'device_disabled');
+      return {
+        success: disconnected,
+        message: disconnected
+          ? 'Device disconnected after disable'
+          : 'Device not connected',
+      };
+    }
+
     const result = await this.deviceGateway.sendCommand(data.deviceId, data.command);
     if (!result.delivered) {
       this.logger.warn(`Command delivery failed for device ${data.deviceId}: ${result.reason ?? 'unknown'}`);

--- a/realtime/src/gateways/device.gateway.spec.ts
+++ b/realtime/src/gateways/device.gateway.spec.ts
@@ -93,7 +93,7 @@ describe('DeviceGateway', () => {
   // Mock socket that auto-invokes ack callbacks on emit
   const mockRemoteSocket = {
     id: 'remote-socket-1',
-    data: { deliveryAckCapable: true },
+    data: { deliveryAckCapable: true, deviceId: 'device-1' },
     emit: jest.fn((_event: string, _data: any, ackCb?: () => void) => {
       if (ackCb) ackCb();
     }),
@@ -158,6 +158,7 @@ describe('DeviceGateway', () => {
 
     // Assign mock server
     (gateway as any).server = mockServer;
+    (gateway as any).deviceSockets.set('device-1', 'remote-socket-1');
   });
 
   afterEach(() => {
@@ -354,6 +355,28 @@ describe('DeviceGateway', () => {
       expect(mockRedisService.setDeviceStatus).toHaveBeenCalled();
     });
 
+    it('should reject disabled device connections', async () => {
+      mockJwtService.verify.mockReturnValue({
+        sub: 'device-1',
+        type: 'device',
+        organizationId: 'org-1',
+        deviceIdentifier: 'test-id',
+      });
+      mockDatabaseService.display.findUnique.mockResolvedValue({
+        id: 'device-1',
+        organizationId: 'org-1',
+        isDisabled: true,
+      });
+
+      const client = createMockSocket();
+
+      await gateway.handleConnection(client as any);
+
+      expect(client.emit).toHaveBeenCalledWith('error', { message: 'device_disabled' });
+      expect(client.disconnect).toHaveBeenCalled();
+      expect(client.join).not.toHaveBeenCalledWith('device:device-1');
+    });
+
     it('should reject connections with a revoked token', async () => {
       mockJwtService.verify.mockReturnValue({
         sub: 'device-1',
@@ -481,6 +504,30 @@ describe('DeviceGateway', () => {
       await gateway.handleConnection(client as any);
       expect(client.disconnect).toHaveBeenCalled();
     });
+
+    it('should not rate limit different tokens sharing one proxy IP', async () => {
+      mockJwtService.verify.mockImplementation((token: string) => ({
+        sub: token,
+        type: 'device',
+        organizationId: 'org-1',
+        deviceIdentifier: token,
+      }));
+      mockDatabaseService.display.findUnique.mockImplementation(({ where }: any) =>
+        Promise.resolve({ id: where.id, organizationId: 'org-1', isDisabled: false }),
+      );
+
+      const clients = [];
+      for (let i = 0; i < 12; i++) {
+        const client = createMockSocket({
+          id: `socket-token-${i}`,
+          handshake: { auth: { token: `device-token-${i}` }, address: '10.0.0.1' },
+        });
+        clients.push(client);
+        await gateway.handleConnection(client as any);
+      }
+
+      expect(clients.every((client) => client.disconnect.mock.calls.length === 0)).toBe(true);
+    });
   });
 
   describe('handleDisconnect', () => {
@@ -511,12 +558,48 @@ describe('DeviceGateway', () => {
       expect(mockRedisService.setDeviceStatus).not.toHaveBeenCalled();
     });
 
+    it('does not schedule an offline notification for intentional disable disconnects', async () => {
+      (gateway as any).deviceSockets.set('device-1', 'socket-1');
+
+      const client = createMockSocket({
+        data: {
+          deviceId: 'device-1',
+          organizationId: 'org-1',
+          suppressOfflineNotification: true,
+        },
+      });
+
+      await gateway.handleDisconnect(client as any);
+
+      expect(mockNotificationService.scheduleOfflineNotification).not.toHaveBeenCalled();
+      expect(mockMetricsService.recordConnection).toHaveBeenCalledWith('org-1', 'disconnected');
+    });
+
     it('should handle disconnect for non-device clients gracefully', async () => {
       const client = createMockSocket({
         data: {}, // no deviceId
       });
 
       await expect(gateway.handleDisconnect(client as any)).resolves.not.toThrow();
+    });
+  });
+
+  describe('disconnectDevice', () => {
+    it('emits a reason and disconnects the active device socket', () => {
+      const socket = {
+        id: 'remote-socket-1',
+        emit: jest.fn(),
+        disconnect: jest.fn(),
+      };
+      mockServer.sockets.sockets.set('remote-socket-1', socket);
+      (gateway as any).deviceSockets.set('device-1', 'remote-socket-1');
+
+      const result = gateway.disconnectDevice('device-1', 'device_disabled');
+
+      expect(result).toBe(true);
+      expect(socket.data).toEqual(expect.objectContaining({ suppressOfflineNotification: true }));
+      expect(socket.emit).toHaveBeenCalledWith('error', { message: 'device_disabled' });
+      expect(socket.disconnect).toHaveBeenCalledWith(true);
     });
   });
 
@@ -931,10 +1014,10 @@ describe('DeviceGateway', () => {
     it('should emit playlist:update to device room', async () => {
       const playlist = { id: 'p-1', name: 'Test', items: [] };
 
-      const result = await gateway.sendPlaylistUpdate('device-2', playlist as any);
+      const result = await gateway.sendPlaylistUpdate('device-1', playlist as any);
 
       expect(result).toEqual({ delivered: true });
-      expect(mockServer.in).toHaveBeenCalledWith('device:device-2');
+      expect(mockServer.in).toHaveBeenCalledWith('device:device-1');
       expect(mockRemoteSocket.emit).toHaveBeenCalledWith(
         'playlist:update',
         expect.objectContaining({
@@ -995,6 +1078,9 @@ describe('DeviceGateway', () => {
       await Promise.resolve();
       await Promise.resolve();
 
+      mockServer.in.mockReturnValueOnce({
+        fetchSockets: jest.fn().mockResolvedValue([pendingClient]),
+      });
       const pushResult = await gateway.sendPlaylistUpdate('device-1', newPlaylist as any);
       resolveDisplay({ metadata: {} });
       const replayResult = await replay;
@@ -1023,6 +1109,26 @@ describe('DeviceGateway', () => {
       expect((gateway as any).heartbeatReplayState.has('device-99')).toBe(false);
     });
 
+    it('should queue playlist when only a dashboard socket is in the device room', async () => {
+      const dashboardSocket = {
+        id: 'dashboard-socket',
+        data: { isDashboard: true, organizationId: 'org-1' },
+        emit: jest.fn(),
+      };
+      mockServer.in.mockReturnValueOnce({
+        fetchSockets: jest.fn().mockResolvedValue([dashboardSocket]),
+      });
+
+      const result = await gateway.sendPlaylistUpdate('device-1', { id: 'p-1', name: 'Test', items: [] } as any);
+
+      expect(result).toEqual({ delivered: false, reason: 'no_sockets' });
+      expect(dashboardSocket.emit).not.toHaveBeenCalled();
+      expect(mockRedisService.setPendingPlaylist).toHaveBeenCalledWith(
+        'device-1',
+        expect.objectContaining({ id: 'p-1' }),
+      );
+    });
+
     it('should requeue playlist when the device sends a negative ack', async () => {
       mockRemoteSocket.emit.mockImplementationOnce(
         (_event: string, _data: any, ackCb?: (ack?: { ok: boolean; error?: string }) => void) => {
@@ -1043,9 +1149,10 @@ describe('DeviceGateway', () => {
     it('should treat no-ack legacy sockets as best-effort delivered', async () => {
       const legacySocket = {
         id: 'legacy-socket',
-        data: { deliveryAckCapable: false },
+        data: { deliveryAckCapable: false, deviceId: 'device-1' },
         emit: jest.fn(),
       };
+      (gateway as any).deviceSockets.set('device-1', 'legacy-socket');
       mockServer.in.mockReturnValueOnce({
         fetchSockets: jest.fn().mockResolvedValue([legacySocket]),
       });
@@ -1096,6 +1203,27 @@ describe('DeviceGateway', () => {
       expect((gateway as any).heartbeatReplayState.has('device-99')).toBe(false);
     });
 
+    it('should queue command when only a dashboard socket is in the device room', async () => {
+      const dashboardSocket = {
+        id: 'dashboard-socket',
+        data: { isDashboard: true, organizationId: 'org-1' },
+        emit: jest.fn(),
+      };
+      mockServer.in.mockReturnValueOnce({
+        fetchSockets: jest.fn().mockResolvedValue([dashboardSocket]),
+      });
+      const command = { type: 'reload' as any };
+
+      const result = await gateway.sendCommand('device-1', command);
+
+      expect(result).toEqual({ delivered: false, reason: 'no_sockets' });
+      expect(dashboardSocket.emit).not.toHaveBeenCalled();
+      expect(mockRedisService.addDeviceCommand).toHaveBeenCalledWith(
+        'device-1',
+        expect.objectContaining({ type: 'reload', timestamp: expect.any(String) }),
+      );
+    });
+
     it('should queue command when the device sends a negative ack', async () => {
       mockRemoteSocket.emit.mockImplementationOnce(
         (_event: string, _data: any, ackCb?: (ack?: { ok: boolean; error?: string }) => void) => {
@@ -1116,9 +1244,10 @@ describe('DeviceGateway', () => {
     it('should treat no-ack legacy sockets as best-effort delivered for commands', async () => {
       const legacySocket = {
         id: 'legacy-socket',
-        data: { deliveryAckCapable: false },
+        data: { deliveryAckCapable: false, deviceId: 'device-1' },
         emit: jest.fn(),
       };
+      (gateway as any).deviceSockets.set('device-1', 'legacy-socket');
       mockServer.in.mockReturnValueOnce({
         fetchSockets: jest.fn().mockResolvedValue([legacySocket]),
       });

--- a/realtime/src/gateways/device.gateway.ts
+++ b/realtime/src/gateways/device.gateway.ts
@@ -37,6 +37,7 @@ import {
   BroadcastData,
 } from '../types';
 import * as Sentry from '@sentry/nestjs';
+import { createHash } from 'node:crypto';
 import { WsAllExceptionsFilter } from './filters/ws-exception.filter';
 import { WsAuthGuard, WsDeviceGuard } from './guards/ws-auth.guard';
 
@@ -183,6 +184,47 @@ export class DeviceGateway
 
   private isActiveDeviceSocket(client: { id?: string }, deviceId: string): boolean {
     return this.deviceSockets.get(deviceId) === client.id;
+  }
+
+  private isDeliveryDeviceSocket(client: { id?: string; data?: Record<string, any> }, deviceId: string): boolean {
+    return (
+      client.data?.deviceId === deviceId &&
+      client.data?.isDashboard !== true &&
+      this.isActiveDeviceSocket(client, deviceId)
+    );
+  }
+
+  private filterDeliverySockets<T extends { id?: string; data?: Record<string, any> }>(
+    sockets: T[],
+    deviceId: string,
+  ): T[] {
+    return sockets.filter((socket) => this.isDeliveryDeviceSocket(socket, deviceId));
+  }
+
+  hasActiveDeviceSocket(deviceId: string): boolean {
+    const socketId = this.deviceSockets.get(deviceId);
+    return Boolean(socketId && this.server?.sockets?.sockets?.has(socketId));
+  }
+
+  disconnectDevice(deviceId: string, reason = 'device_disconnected'): boolean {
+    const socketId = this.deviceSockets.get(deviceId);
+    if (!socketId) {
+      return false;
+    }
+
+    const socket = this.server?.sockets?.sockets?.get(socketId);
+    if (!socket) {
+      this.deviceSockets.delete(deviceId);
+      return false;
+    }
+
+    socket.data = {
+      ...(socket.data || {}),
+      suppressOfflineNotification: reason === 'device_disabled',
+    };
+    socket.emit('error', { message: reason });
+    socket.disconnect(true);
+    return true;
   }
 
   private shouldAttemptHeartbeatReplay(deviceId: string): boolean {
@@ -522,21 +564,9 @@ export class DeviceGateway
         return;
       }
 
-      // Device connection flow (unchanged)
+      // Device connection flow
       const deviceId = authResult.payload.sub;
       const orgId = authResult.payload.organizationId;
-
-      // Step 3: Verify device exists in database and belongs to the JWT's org (B.1 + M2)
-      const device = await this.databaseService.display.findUnique({
-        where: { id: deviceId },
-        select: { id: true, organizationId: true },
-      });
-      if (!device || device.organizationId !== orgId) {
-        this.logger.warn(`Connection rejected: Device not found or org mismatch (id: ${deviceId}, jwtOrg: ${orgId}, deviceOrg: ${device?.organizationId})`);
-        client.emit('error', { message: 'device_not_found' });
-        client.disconnect();
-        return;
-      }
 
       // Step 4: Room joins + Redis status
       await this.setupDeviceRooms(client, deviceId, orgId);
@@ -558,25 +588,29 @@ export class DeviceGateway
    * Returns true if the connection is allowed, false if rate-limited.
    */
   private validateConnectionRate(client: Socket): boolean {
+    const token = this.getTokenFromClient(client);
     const clientIp = client.handshake.address;
+    const rateKey = token
+      ? `token:${createHash('sha256').update(token).digest('hex').slice(0, 16)}`
+      : `ip:${clientIp}`;
     const now = Date.now();
-    const rateEntry = this.connectionAttempts.get(clientIp);
+    const rateEntry = this.connectionAttempts.get(rateKey);
 
     if (rateEntry) {
       if (now > rateEntry.resetAt) {
         // Reset window
-        this.connectionAttempts.set(clientIp, { count: 1, resetAt: now + 60000 });
+        this.connectionAttempts.set(rateKey, { count: 1, resetAt: now + 60000 });
       } else {
         rateEntry.count++;
         if (rateEntry.count > 10) {
-          this.logger.warn(`Connection rate limited for IP: ${clientIp}`);
+          this.logger.warn(`Connection rate limited for ${token ? 'token' : 'IP'}: ${token ? rateKey : clientIp}`);
           client.emit('error', { message: 'rate_limited' });
           client.disconnect();
           return false;
         }
       }
     } else {
-      this.connectionAttempts.set(clientIp, { count: 1, resetAt: now + 60000 });
+      this.connectionAttempts.set(rateKey, { count: 1, resetAt: now + 60000 });
     }
 
     return true;
@@ -634,6 +668,24 @@ export class DeviceGateway
         }
 
         const deviceId = payload.sub;
+        const device = await this.databaseService.display.findUnique({
+          where: { id: deviceId },
+          select: { id: true, organizationId: true, isDisabled: true },
+        });
+        if (!device || device.organizationId !== payload.organizationId) {
+          this.logger.warn(
+            `Connection rejected: Device not found or org mismatch (id: ${deviceId}, jwtOrg: ${payload.organizationId}, deviceOrg: ${device?.organizationId})`,
+          );
+          client.emit('error', { message: 'device_not_found' });
+          client.disconnect();
+          return null;
+        }
+        if (device.isDisabled) {
+          this.logger.warn(`Connection rejected: Device is disabled (id: ${deviceId})`);
+          client.emit('error', { message: 'device_disabled' });
+          client.disconnect();
+          return null;
+        }
 
         // 2.5: Device socket deduplication - disconnect old socket if device already connected
         const existingSocketId = this.deviceSockets.get(deviceId);
@@ -1075,11 +1127,13 @@ export class DeviceGateway
         const orgId = client.data?.organizationId;
         if (orgId) {
           try {
-            await this.notificationService.scheduleOfflineNotification(
-              deviceId,
-              deviceName,
-              orgId,
-            );
+            if (client.data?.suppressOfflineNotification !== true) {
+              await this.notificationService.scheduleOfflineNotification(
+                deviceId,
+                deviceName,
+                orgId,
+              );
+            }
           } catch (notifError) {
             this.logger.warn(`Failed to schedule offline notification for device ${deviceId}`);
           }
@@ -1457,7 +1511,8 @@ export class DeviceGateway
 
     // Get all sockets in the device room
     const roomName = `device:${deviceId}`;
-    const sockets = await this.server.in(roomName).fetchSockets();
+    const allSockets = await this.server.in(roomName).fetchSockets();
+    const sockets = this.filterDeliverySockets(allSockets as any[], deviceId);
 
     if (sockets.length === 0) {
       this.logger.warn(`pushPlaylist: no sockets in room ${roomName} for device ${deviceId} — queuing for reconnect`);
@@ -1499,7 +1554,8 @@ export class DeviceGateway
   async sendCommand(deviceId: string, command: DeviceCommand): Promise<{ delivered: boolean; reason?: string }> {
     const commandWithTimestamp = { ...command, timestamp: new Date().toISOString() };
     const roomName = `device:${deviceId}`;
-    const sockets = await this.server.in(roomName).fetchSockets();
+    const allSockets = await this.server.in(roomName).fetchSockets();
+    const sockets = this.filterDeliverySockets(allSockets as any[], deviceId);
 
     if (sockets.length === 0) {
       this.logger.warn(`sendCommand: no sockets for device ${deviceId} — queuing`);

--- a/realtime/src/services/notification.service.spec.ts
+++ b/realtime/src/services/notification.service.spec.ts
@@ -121,10 +121,21 @@ describe('NotificationService', () => {
   describe('wasDeviceOfflineLong', () => {
     it('should return false when no notification exists', async () => {
       mockRedisService.get.mockResolvedValueOnce(null);
+      mockRedisService.exists.mockResolvedValueOnce(false);
 
       const result = await service.wasDeviceOfflineLong('device-1');
 
       expect(result).toBe(false);
+    });
+
+    it('should return true when an offline notification already fired', async () => {
+      mockRedisService.get.mockResolvedValueOnce(null);
+      mockRedisService.exists.mockResolvedValueOnce(true);
+
+      const result = await service.wasDeviceOfflineLong('device-1');
+
+      expect(result).toBe(true);
+      expect(mockRedisService.exists).toHaveBeenCalledWith('notify:fired-offline:device-1');
     });
 
     it('should return true when scheduled time has passed', async () => {
@@ -187,6 +198,11 @@ describe('NotificationService', () => {
         }),
       });
       expect(mockRedisService.delete).toHaveBeenCalled();
+      expect(mockRedisService.set).toHaveBeenCalledWith(
+        'notify:fired-offline:device-1',
+        expect.any(String),
+        86400,
+      );
     });
 
     it('should not process notifications that are not yet due', async () => {

--- a/realtime/src/services/notification.service.ts
+++ b/realtime/src/services/notification.service.ts
@@ -15,6 +15,7 @@ export class NotificationService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(NotificationService.name);
   private readonly OFFLINE_DELAY_MS = 120000; // 2 minutes
   private readonly REDIS_KEY_PREFIX = 'notify:offline:';
+  private readonly REDIS_FIRED_KEY_PREFIX = 'notify:fired-offline:';
   private intervalId: NodeJS.Timeout | null = null;
   private isCheckingPendingNotifications = false;
 
@@ -78,15 +79,23 @@ export class NotificationService implements OnModuleInit, OnModuleDestroy {
    */
   async cancelOfflineNotification(deviceId: string): Promise<boolean> {
     const key = `${this.REDIS_KEY_PREFIX}${deviceId}`;
-    const exists = await this.redisService.exists(key);
+    const firedKey = `${this.REDIS_FIRED_KEY_PREFIX}${deviceId}`;
+    const [exists, firedExists] = await Promise.all([
+      this.redisService.exists(key),
+      this.redisService.exists(firedKey),
+    ]);
 
     if (exists) {
       await this.redisService.delete(key);
       this.logger.log(`Cancelled offline notification for device ${deviceId}`);
-      return true;
     }
 
-    return false;
+    if (firedExists) {
+      await this.redisService.delete(firedKey);
+      this.logger.log(`Cleared fired offline notification marker for device ${deviceId}`);
+    }
+
+    return Boolean(exists || firedExists);
   }
 
   /**
@@ -98,7 +107,7 @@ export class NotificationService implements OnModuleInit, OnModuleDestroy {
     const dataStr = await this.redisService.get(key);
 
     if (!dataStr) {
-      return false;
+      return Boolean(await this.redisService.exists(`${this.REDIS_FIRED_KEY_PREFIX}${deviceId}`));
     }
 
     try {
@@ -142,6 +151,12 @@ export class NotificationService implements OnModuleInit, OnModuleDestroy {
           if (now >= data.scheduledFor) {
             // Create the notification in the database
             await this.createOfflineNotification(data);
+
+            await this.redisService.set(
+              `${this.REDIS_FIRED_KEY_PREFIX}${data.deviceId}`,
+              JSON.stringify({ ...data, firedAt: now }),
+              86400,
+            );
 
             // Remove the scheduled notification from Redis
             await this.redisService.delete(key);

--- a/realtime/test/device-gateway.e2e-spec.ts
+++ b/realtime/test/device-gateway.e2e-spec.ts
@@ -93,10 +93,30 @@ describe('DeviceGateway (E2E)', () => {
       // Ignore Redis errors during cleanup
     }
 
-    // Cleanup seeded DB rows (delete display first; org has FK cascade)
+    // Cleanup seeded DB rows (delete displays first; org has FK cascade)
     try {
-      await databaseService.display.deleteMany({ where: { id: deviceId } });
-      await databaseService.organization.deleteMany({ where: { id: organizationId } });
+      await databaseService.display.deleteMany({
+        where: {
+          id: {
+            in: [
+              deviceId,
+              'test-device-0',
+              'test-device-1',
+              'test-device-2',
+              'test-device-3',
+              'test-device-4',
+              'test-device-concurrent-0',
+              'test-device-concurrent-1',
+              'test-device-concurrent-2',
+              'broadcast-device-1',
+              'broadcast-device-2',
+            ],
+          },
+        },
+      });
+      await databaseService.organization.deleteMany({
+        where: { id: { in: [organizationId, 'broadcast-org'] } },
+      });
     } catch {
       // ignore — test may have already cleaned up
     }
@@ -563,14 +583,37 @@ describe('DeviceGateway (E2E)', () => {
 
     it('should handle multiple devices connecting simultaneously', async () => {
       const deviceCount = 5;
-      const tokens = [];
+      const devices = Array.from({ length: deviceCount }, (_, i) => ({
+        id: `test-device-${i}`,
+        deviceIdentifier: `TEST-DEVICE-${i}`,
+      }));
+
+      await Promise.all(
+        devices.map((device) =>
+          databaseService.display.upsert({
+            where: { id: device.id },
+            create: {
+              id: device.id,
+              nickname: `E2E Test Device ${device.id}`,
+              deviceIdentifier: device.deviceIdentifier,
+              organizationId,
+              status: 'offline',
+            },
+            update: {
+              deviceIdentifier: device.deviceIdentifier,
+              organizationId,
+              status: 'offline',
+            },
+          })
+        )
+      );
 
       // Generate tokens for multiple devices
-      for (let i = 0; i < deviceCount; i++) {
-        const token = jwtService.sign(
+      const tokens = devices.map((device) =>
+        jwtService.sign(
           {
-            sub: `test-device-${i}`,
-            deviceIdentifier: `TEST-DEVICE-${i}`,
+            sub: device.id,
+            deviceIdentifier: device.deviceIdentifier,
             organizationId,
             type: 'device',
           },
@@ -578,9 +621,8 @@ describe('DeviceGateway (E2E)', () => {
             secret: process.env.DEVICE_JWT_SECRET,
             expiresIn: '1h',
           }
-        );
-        tokens.push(token);
-      }
+        )
+      );
 
       // Connect all devices
       const connectPromises = tokens.map((token) => {
@@ -611,13 +653,36 @@ describe('DeviceGateway (E2E)', () => {
 
     it('should handle concurrent heartbeats from multiple devices', async () => {
       const deviceCount = 3;
-      const tokens = [];
+      const devices = Array.from({ length: deviceCount }, (_, i) => ({
+        id: `test-device-concurrent-${i}`,
+        deviceIdentifier: `TEST-DEVICE-CONCURRENT-${i}`,
+      }));
 
-      for (let i = 0; i < deviceCount; i++) {
-        const token = jwtService.sign(
+      await Promise.all(
+        devices.map((device) =>
+          databaseService.display.upsert({
+            where: { id: device.id },
+            create: {
+              id: device.id,
+              nickname: `E2E Test Device ${device.id}`,
+              deviceIdentifier: device.deviceIdentifier,
+              organizationId,
+              status: 'offline',
+            },
+            update: {
+              deviceIdentifier: device.deviceIdentifier,
+              organizationId,
+              status: 'offline',
+            },
+          })
+        )
+      );
+
+      const tokens = devices.map((device) =>
+        jwtService.sign(
           {
-            sub: `test-device-concurrent-${i}`,
-            deviceIdentifier: `TEST-DEVICE-CONCURRENT-${i}`,
+            sub: device.id,
+            deviceIdentifier: device.deviceIdentifier,
             organizationId,
             type: 'device',
           },
@@ -625,9 +690,8 @@ describe('DeviceGateway (E2E)', () => {
             secret: process.env.DEVICE_JWT_SECRET,
             expiresIn: '1h',
           }
-        );
-        tokens.push(token);
-      }
+        )
+      );
 
       // Connect all devices
       for (const token of tokens) {
@@ -662,9 +726,51 @@ describe('DeviceGateway (E2E)', () => {
       });
     });
 
-    it('should broadcast to organization correctly', (done) => {
+    it('should broadcast to organization correctly', async () => {
       let receivedCount = 0;
       const expectedCount = 2;
+
+      await databaseService.organization.upsert({
+        where: { id: 'broadcast-org' },
+        create: {
+          id: 'broadcast-org',
+          name: 'Broadcast E2E Org',
+          slug: `broadcast-e2e-${Date.now()}`,
+        },
+        update: {},
+      });
+      await Promise.all([
+        databaseService.display.upsert({
+          where: { id: 'broadcast-device-1' },
+          create: {
+            id: 'broadcast-device-1',
+            nickname: 'Broadcast Device 1',
+            deviceIdentifier: 'BROADCAST-DEVICE-1',
+            organizationId: 'broadcast-org',
+            status: 'offline',
+          },
+          update: {
+            deviceIdentifier: 'BROADCAST-DEVICE-1',
+            organizationId: 'broadcast-org',
+            status: 'offline',
+          },
+        }),
+        databaseService.display.upsert({
+          where: { id: 'broadcast-device-2' },
+          create: {
+            id: 'broadcast-device-2',
+            nickname: 'Broadcast Device 2',
+            deviceIdentifier: 'BROADCAST-DEVICE-2',
+            organizationId: 'broadcast-org',
+            status: 'offline',
+          },
+          update: {
+            deviceIdentifier: 'BROADCAST-DEVICE-2',
+            organizationId: 'broadcast-org',
+            status: 'offline',
+          },
+        }),
+      ]);
 
       const token1 = jwtService.sign(
         {
@@ -704,32 +810,36 @@ describe('DeviceGateway (E2E)', () => {
 
       clients.push(client1, client2);
 
-      const checkDone = () => {
-        receivedCount++;
-        if (receivedCount === expectedCount) {
-          done();
-        }
-      };
+      const received = new Promise<void>((resolve) => {
+        const checkDone = () => {
+          receivedCount++;
+          if (receivedCount === expectedCount) {
+            resolve();
+          }
+        };
 
-      client1.on('test:broadcast', (data) => {
-        expect(data.message).toBe('Hello organization');
-        checkDone();
-      });
+        client1.on('test:broadcast', (data) => {
+          expect(data.message).toBe('Hello organization');
+          checkDone();
+        });
 
-      client2.on('test:broadcast', (data) => {
-        expect(data.message).toBe('Hello organization');
-        checkDone();
-      });
-
-      Promise.all([
-        new Promise<void>((resolve) => client1.on('connect', () => resolve())),
-        new Promise<void>((resolve) => client2.on('connect', () => resolve())),
-      ]).then(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 100));
-        await deviceGateway.broadcastToOrganization('broadcast-org', 'test:broadcast', {
-          message: 'Hello organization',
+        client2.on('test:broadcast', (data) => {
+          expect(data.message).toBe('Hello organization');
+          checkDone();
         });
       });
+
+      await Promise.all([
+        new Promise<void>((resolve) => client1.on('connect', () => resolve())),
+        new Promise<void>((resolve) => client2.on('connect', () => resolve())),
+      ]);
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      await deviceGateway.broadcastToOrganization('broadcast-org', 'test:broadcast', {
+        message: 'Hello organization',
+      });
+
+      await received;
     });
   });
 

--- a/realtime/test/device-gateway.e2e-spec.ts
+++ b/realtime/test/device-gateway.e2e-spec.ts
@@ -16,6 +16,7 @@ describe('DeviceGateway (E2E)', () => {
   let serverUrl: string;
   let deviceToken: string;
   let deviceId: string;
+  let deviceIdentifier: string;
   let organizationId: string;
 
   beforeAll(async () => {
@@ -38,11 +39,12 @@ describe('DeviceGateway (E2E)', () => {
 
     // Generate test device token
     deviceId = 'test-device-001';
+    deviceIdentifier = `TEST-DEVICE-001-${Date.now()}`;
     organizationId = 'test-org-001';
     deviceToken = jwtService.sign(
       {
         sub: deviceId,
-        deviceIdentifier: 'TEST-DEVICE-001',
+        deviceIdentifier,
         organizationId,
         type: 'device',
       },
@@ -72,11 +74,11 @@ describe('DeviceGateway (E2E)', () => {
       create: {
         id: deviceId,
         nickname: 'E2E Test Device',
-        deviceIdentifier: `TEST-DEVICE-001-${Date.now()}`,
+        deviceIdentifier,
         organizationId,
         status: 'offline',
       },
-      update: { organizationId, status: 'offline' },
+      update: { deviceIdentifier, organizationId, status: 'offline' },
     });
   });
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -51,6 +51,7 @@
 - [x] `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` - pass.
 - [x] `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vizora pnpm --filter @vizora/database exec prisma validate` - pass.
 - [x] `pnpm --filter @vizora/realtime test -- --runInBand` - pass, 11 suites / 256 tests.
+- [x] Post-PR E2E fixture follow-up: `pnpm --filter @vizora/realtime test -- device.gateway.spec.ts --runInBand` - pass, 1 suite / 85 tests. Local realtime E2E run is blocked in this worktree by generated `realtime/dist/package.json` Jest haste collision plus missing local E2E `DATABASE_URL`/Redis setup; GitHub CI is the authoritative E2E verifier.
 - [x] `pnpm --filter @vizora/web test -- --runInBand` - pass, 89 suites / 925 tests; existing React `act(...)` and jsdom navigation warnings remain.
 - [x] `pnpm --filter @vizora/display test -- --runInBand` - pass, 5 suites / 116 tests; expected negative-path logs and existing MaxListeners warning remain.
 - [x] `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` - pass.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,8 +1,75 @@
 # Vizora - Task Tracker
 
-## In Progress: PR #34 Readiness Residuals (2026-05-31)
+## In Progress: Customer Performance Readiness Pass 3 (2026-05-31)
+
+**Branch:** `feat/customer-performance-readiness-3`
+
+**Why now:** PRs #120-#122 closed the first display delivery, dashboard readiness, and stale PR #34 residual slices. The next repo-side push is a fresh customer-perspective review plus performance/code-review pass focused on content upload, pairing, content streaming, middleware hot paths, and any remaining production-readiness issues that are buildable and testable without operator-only actions.
+
+**New primitives introduced:** none planned. Prefer existing Next dashboard pages/components, NestJS modules/controllers/services/DTOs, Prisma models/indexes, realtime gateway/Socket.IO paths, display clients, ops scripts, and the existing response envelope.
+
+**Hermes-first analysis:** not applicable unless a selected fix involves business agents, MCP tools, Hermes skills, or AI/provider spend. This pass is dashboard UX, middleware/content performance, realtime/display reliability, and code-review hardening.
+
+**Plan/design:** `docs/plans/2026-05-31-customer-performance-readiness-3.md`
+
+**Plan**
+- [x] Merge PR #122 and close stale PR #34.
+- [x] Re-check production deploy gate.
+- [x] Run independent dashboard/customer UX analysis.
+- [x] Run independent middleware/content performance analysis.
+- [x] Run independent pairing/realtime/display reliability analysis.
+- [x] Run independent code-review/security/readiness analysis.
+- [x] Synthesize a ranked customer-facing issue list.
+- [x] Select a scoped buildable bundle with file/line evidence.
+- [x] Implement fixes with focused tests.
+- [x] Run multi-subagent review before broad tests.
+- [x] Run focused/broad local verification.
+- [ ] PR, CI, merge.
+- [ ] Re-check deployment gate and deploy only if prod checkout is safe.
+
+**Selected fix bundle**
+- [x] Reject disabled/deleted display tokens in realtime and device-content paths.
+- [x] Filter command/playlist delivery to active device sockets, not dashboard sockets in `device:{id}` rooms.
+- [x] Prevent web display token leakage to attacker-origin device-content lookalikes.
+- [x] Persist browser display `token:refresh` and move Electron pairing requests to `/api/v1`.
+- [x] Execute Electron main-process override commands even when the renderer path is unavailable.
+- [x] Preserve back-online notifications after offline notifications have already fired.
+- [x] Reserve upload quota atomically and release reservations on upload/DB failure.
+- [x] Fail closed for production MinIO upload failures instead of creating unreachable `/uploads` content.
+- [x] Keep DB rows when storage delete fails; avoid silent bucket/accounting drift.
+- [x] Add query-shaped database indexes for hot customer list and active schedule paths.
+- [x] Fix dashboard API-key scopes, device group filter, schedule group round-trip / multi-device targeting, active playlist KPI, and customization save durability.
+
+**Review gate**
+- [x] Backend/runtime reviewer: initial storage quota/delete/realtime findings fixed; final re-review CLEAN.
+- [x] Frontend/customer UX reviewer: initial schedule/customization/display-token findings fixed; final re-review CLEAN.
+
+**Local verification**
+- [x] `git diff --check` - pass; line-ending warnings only.
+- [x] `pnpm --filter @vizora/middleware test -- content.service.spec.ts --runInBand` - pass, 96 tests.
+- [x] `pnpm --filter @vizora/middleware test -- --runInBand` - pass, 143 suites / 2787 tests.
+- [x] `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` - pass.
+- [x] `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vizora pnpm --filter @vizora/database exec prisma validate` - pass.
+- [x] `pnpm --filter @vizora/realtime test -- --runInBand` - pass, 11 suites / 256 tests.
+- [x] `pnpm --filter @vizora/web test -- --runInBand` - pass, 89 suites / 925 tests; existing React `act(...)` and jsdom navigation warnings remain.
+- [x] `pnpm --filter @vizora/display test -- --runInBand` - pass, 5 suites / 116 tests; expected negative-path logs and existing MaxListeners warning remain.
+- [x] `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` - pass.
+- [x] `npx nx build @vizora/middleware` - pass with existing webpack warnings.
+- [x] `npx nx build @vizora/realtime` - pass with existing source-map / optional `ws` warnings.
+- [x] `NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 npx nx build @vizora/web` - pass with existing Next middleware deprecation and TypeScript project-reference warnings.
+
+**Current deployment gate**
+- GitHub main: `48affb3e0ff6163ae5babf6bbe74d702c67e5348` after PR #122.
+- Open PRs: none after closing stale PR #34.
+- Production health: `/api/v1/health` returned `success: true`, database connected at `2026-05-31T08:22:03.846Z`.
+- Production deploy is blocked: `/opt/vizora/app` is dirty, local `HEAD=bb76aa1838740bff5b58623dfef7a906d44f46a6`, and after fetch is `ahead 17, behind 38` relative to `origin/main=48affb3e0ff6163ae5babf6bbe74d702c67e5348`. Do not pull/reset/stash/restart services until prod-local work is reconciled.
+
+---
+
+## Completed: PR #34 Readiness Residuals (2026-05-31)
 
 **Branch:** `fix/readiness-pr34-residual`
+**PR / merge commit:** #122 / `48affb3e0ff6163ae5babf6bbe74d702c67e5348`
 
 **Why now:** PR #34 is the only remaining open PR, but it is stale, dirty against main, and has failing April checks. Current main already absorbed part of it (`TRUST_PROXY_HOPS`), while web CSP hardening, realtime orphan notification cleanup, and content lifecycle archive endpoint fixes still have residual gaps.
 
@@ -20,10 +87,12 @@
 - [x] Port content-lifecycle archive endpoint and failure-classification fixes while preserving current inline operator alerts.
 - [x] Update env/docs for `TRUST_PROXY_HOPS` and CI web build env.
 - [x] Run focused tests/builds, review, PR, CI, merge.
-- [ ] Close or supersede stale PR #34 after replacement is merged.
+- [x] Close or supersede stale PR #34 after replacement is merged.
 
 **Evidence**
 - Replacement PR branch: `fix/readiness-pr34-residual`; stale PR #34 is not mergeable on current main and is superseded by this branch.
+- PR #122 CI passed: audit, build, e2e, lint, security, test.
+- Stale PR #34 closed as superseded.
 - Security/runtime reviewer: initial CSP and external image findings fixed; final re-review CLEAN.
 - Ops/realtime reviewer: initial lock-scope, CI wiring, overlap, and archive-error findings fixed; final re-review CLEAN.
 - `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern=notification.service` - pass, 24 tests.
@@ -42,9 +111,10 @@
 
 ---
 
-## In Progress: Customer Dashboard Quality + Performance Pass (2026-05-31)
+## Completed: Customer Dashboard Quality + Performance Pass (2026-05-31)
 
 **Branch:** `feat/customer-dashboard-quality-pass`
+**PR / merge commit:** #121 / `043c82a18b0480a646be1c8b90f06e20fae7d5bb`
 
 **Why now:** After PR #120 closed the display-delivery reliability slice, the next customer-facing gaps are dashboard quality and middleware/display performance bottlenecks that are repo-side, testable, and do not need production secrets or hardware.
 
@@ -62,7 +132,7 @@
 - [x] Implement fixes with focused tests.
 - [x] Run multi-subagent review before broader tests.
 - [x] Run focused and broader verification.
-- [ ] Open PR, wait for CI, merge if clean.
+- [x] Open PR, wait for CI, merge if clean.
 
 **First scoped bundle selected from subagent reviews**
 - [x] SMTP env parity: `MailService` must accept `SMTP_PASS` as documented/health-checked.

--- a/web/src/app/dashboard/devices/__tests__/devices-page.test.tsx
+++ b/web/src/app/dashboard/devices/__tests__/devices-page.test.tsx
@@ -110,7 +110,29 @@ jest.mock('@/components/DeviceStatusIndicator', () => {
 });
 
 jest.mock('@/components/DeviceGroupSelector', () => {
-  return function MockGroupSelector() { return null; };
+  return function MockGroupSelector({ groups, selectedGroupIds, onChange }: any) {
+    return (
+      <div data-testid="group-selector">
+        {groups.map((group: any) => (
+          <label key={group.id}>
+            <input
+              aria-label={`group-${group.name}`}
+              type="checkbox"
+              checked={selectedGroupIds.includes(group.id)}
+              onChange={(event) => {
+                onChange(
+                  event.currentTarget.checked
+                    ? [...selectedGroupIds, group.id]
+                    : selectedGroupIds.filter((id: string) => id !== group.id),
+                );
+              }}
+            />
+            {group.name}
+          </label>
+        ))}
+      </div>
+    );
+  };
 });
 
 jest.mock('@/components/DevicePreviewModal', () => {
@@ -231,6 +253,26 @@ describe('DevicesClient', () => {
     await waitFor(() => {
       expect(mockGetDisplayGroups).toHaveBeenCalled();
     });
+  });
+
+  it('filters devices by selected device group membership', async () => {
+    mockGetDisplays.mockResolvedValue({ data: sampleDevices, meta: { total: 3 } });
+    mockGetDisplayGroups.mockResolvedValue({
+      data: [{ id: 'g1', name: 'Lobby Group', description: '', displays: [{ displayId: 'd1' }] }],
+    });
+
+    render(<DevicesClient initialDevices={sampleDevices as any} initialPlaylists={samplePlaylists as any} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Lobby Display')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Device Groups (1)'));
+    fireEvent.click(screen.getByLabelText('group-Lobby Group'));
+
+    expect(screen.getByText('Lobby Display')).toBeInTheDocument();
+    expect(screen.queryByText('Conference Room')).not.toBeInTheDocument();
+    expect(screen.queryByText('Cafeteria Screen')).not.toBeInTheDocument();
   });
 
   it('renders with provided playlists', async () => {

--- a/web/src/app/dashboard/devices/page-client.tsx
+++ b/web/src/app/dashboard/devices/page-client.tsx
@@ -159,7 +159,7 @@ export default function DevicesClient({ initialDevices, initialPlaylists }: Devi
  id: g.id,
  name: g.name,
  description: g.description || '',
- deviceIds: g.displays?.map((d: any) => d.displayId) || [],
+ deviceIds: g.deviceIds || g.displays?.map((d: any) => d.displayId || d.display?.id).filter(Boolean) || [],
  })));
  } catch (error) {
  toast.error('Failed to load device groups');
@@ -362,11 +362,17 @@ export default function DevicesClient({ initialDevices, initialPlaylists }: Devi
 
  // Filter and sort devices
  const filteredAndSortedDevices = devices
- .filter(d =>
+ .filter(d => {
+ const matchesSearch =
  !debouncedSearch ||
  (d.nickname || '').toLowerCase().includes(debouncedSearch.toLowerCase()) ||
- (d.location && d.location.toLowerCase().includes(debouncedSearch.toLowerCase()))
- )
+ (d.location && d.location.toLowerCase().includes(debouncedSearch.toLowerCase()));
+ if (!matchesSearch) return false;
+ if (selectedGroups.length === 0) return true;
+ return deviceGroups
+ .filter(group => selectedGroups.includes(group.id))
+ .some(group => group.deviceIds?.includes(d.id));
+ })
  .sort((a, b) => {
  if (!sortField) return 0;
  const aVal = a[sortField];
@@ -389,7 +395,7 @@ export default function DevicesClient({ initialDevices, initialPlaylists }: Devi
  useEffect(() => {
  setCurrentPage(1);
  setSelectedDeviceIds(new Set());
- }, [debouncedSearch]);
+ }, [debouncedSearch, selectedGroups]);
 
  const getSortIcon = (field: keyof Display) => {
  if (sortField !== field) return null;

--- a/web/src/app/dashboard/page-client.tsx
+++ b/web/src/app/dashboard/page-client.tsx
@@ -48,7 +48,7 @@ export default function DashboardClient({ initialContent, initialPlaylists }: Da
  },
  playlists: {
  total: playlists.length,
- active: playlists.filter((p: any) => p?.isActive === true).length,
+ active: playlists.filter((p: any) => (p?.items?.length || 0) > 0 || p?.isDefault === true).length,
  },
  }));
 
@@ -144,7 +144,7 @@ export default function DashboardClient({ initialContent, initialPlaylists }: Da
  ? {
  playlists: {
  total: playlists.length,
- active: playlists.filter((p: any) => p?.isActive === true).length,
+ active: playlists.filter((p: any) => (p?.items?.length || 0) > 0 || p?.isDefault === true).length,
  },
  }
  : {}),
@@ -273,7 +273,7 @@ export default function DashboardClient({ initialContent, initialPlaylists }: Da
  </div>
  <p className="text-4xl font-bold text-[var(--foreground)] font-[var(--font-sora)] mb-2">{stats.playlists.total}</p>
  <p className="text-sm text-[var(--foreground-tertiary)]">
- {stats.playlists.active} active
+ {stats.playlists.active} ready
  </p>
  </div>
 

--- a/web/src/app/dashboard/schedules/__tests__/schedules-page.test.tsx
+++ b/web/src/app/dashboard/schedules/__tests__/schedules-page.test.tsx
@@ -6,6 +6,7 @@ const mockGetPlaylists = jest.fn();
 const mockGetDisplays = jest.fn();
 const mockGetDisplayGroups = jest.fn();
 const mockCreateSchedule = jest.fn();
+const mockUpdateSchedule = jest.fn();
 const mockDeleteSchedule = jest.fn();
 
 jest.mock('@/lib/api', () => ({
@@ -15,6 +16,7 @@ jest.mock('@/lib/api', () => ({
     getDisplays: (...args: any[]) => mockGetDisplays(...args),
     getDisplayGroups: (...args: any[]) => mockGetDisplayGroups(...args),
     createSchedule: (...args: any[]) => mockCreateSchedule(...args),
+    updateSchedule: (...args: any[]) => mockUpdateSchedule(...args),
     deleteSchedule: (...args: any[]) => mockDeleteSchedule(...args),
   },
 }));
@@ -71,7 +73,15 @@ jest.mock('@/components/TimePicker', () => {
 });
 
 jest.mock('@/components/DaySelector', () => {
-  return function MockDaySelector() { return <div data-testid="day-selector">Day Selector</div>; };
+  return function MockDaySelector({ onChange }: any) {
+    return (
+      <div data-testid="day-selector">
+        <button type="button" onClick={() => onChange?.(['Monday', 'Tuesday'])}>
+          Select Weekdays
+        </button>
+      </div>
+    );
+  };
 });
 
 jest.mock('@/components/ScheduleCalendar', () => {
@@ -130,6 +140,15 @@ const samplePlaylists = [
   { id: 'p3', name: 'Holiday Playlist', isActive: false },
 ];
 
+const sampleDisplays = [
+  { id: 'd1', nickname: 'Lobby Display', status: 'online' },
+  { id: 'd2', nickname: 'Conference Room', status: 'online' },
+];
+
+const sampleGroups = [
+  { id: 'g1', name: 'Lobby Group', _count: { displays: 2 } },
+];
+
 describe('SchedulesClient', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -138,6 +157,7 @@ describe('SchedulesClient', () => {
     mockGetDisplays.mockResolvedValue({ data: [] });
     mockGetDisplayGroups.mockResolvedValue({ data: [] });
     mockCreateSchedule.mockResolvedValue({ id: 'new-1' });
+    mockUpdateSchedule.mockImplementation((id, payload) => Promise.resolve({ id, ...payload, isActive: true }));
     mockDeleteSchedule.mockResolvedValue({});
   });
 
@@ -214,5 +234,151 @@ describe('SchedulesClient', () => {
       expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
     });
     expect(screen.getAllByText(/schedule/i).length).toBeGreaterThan(0);
+  });
+
+  it('creates one backend schedule per selected device target', async () => {
+    mockGetSchedules.mockResolvedValue({ data: [] });
+    mockGetPlaylists.mockResolvedValue({ data: samplePlaylists });
+    mockGetDisplays.mockResolvedValue({ data: sampleDisplays });
+    mockCreateSchedule.mockImplementation((payload) => Promise.resolve({
+      id: `schedule-${payload.displayId}`,
+      ...payload,
+      isActive: true,
+    }));
+
+    render(<SchedulesClient />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByText('Create Schedule')[0]);
+    fireEvent.change(screen.getByPlaceholderText('e.g., Morning Content, Holiday Special'), {
+      target: { value: 'Morning Loop' },
+    });
+    fireEvent.click(screen.getByText('Select Weekdays'));
+
+    const selects = screen.getAllByRole('combobox');
+    fireEvent.change(selects[1], { target: { value: 'p1' } });
+    fireEvent.click(screen.getByLabelText('Lobby Display'));
+    fireEvent.click(screen.getByLabelText('Conference Room'));
+    fireEvent.click(screen.getByText('Create'));
+
+    await waitFor(() => {
+      expect(mockCreateSchedule).toHaveBeenCalledTimes(2);
+    });
+    expect(mockCreateSchedule).toHaveBeenNthCalledWith(1, expect.objectContaining({ displayId: 'd1' }));
+    expect(mockCreateSchedule).toHaveBeenNthCalledWith(2, expect.objectContaining({ displayId: 'd2' }));
+  });
+
+  it('rolls back already-created device schedules if a later target create fails', async () => {
+    mockGetSchedules.mockResolvedValue({ data: [] });
+    mockGetPlaylists.mockResolvedValue({ data: samplePlaylists });
+    mockGetDisplays.mockResolvedValue({ data: sampleDisplays });
+    mockCreateSchedule
+      .mockResolvedValueOnce({ id: 'schedule-d1', displayId: 'd1', playlistId: 'p1', daysOfWeek: [1] })
+      .mockRejectedValueOnce(new Error('create failed'));
+
+    render(<SchedulesClient />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByText('Create Schedule')[0]);
+    fireEvent.change(screen.getByPlaceholderText('e.g., Morning Content, Holiday Special'), {
+      target: { value: 'Morning Loop' },
+    });
+    fireEvent.click(screen.getByText('Select Weekdays'));
+
+    const selects = screen.getAllByRole('combobox');
+    fireEvent.change(selects[1], { target: { value: 'p1' } });
+    fireEvent.click(screen.getByLabelText('Lobby Display'));
+    fireEvent.click(screen.getByLabelText('Conference Room'));
+    fireEvent.click(screen.getByText('Create'));
+
+    await waitFor(() => {
+      expect(mockDeleteSchedule).toHaveBeenCalledWith('schedule-d1');
+    });
+  });
+
+  it('round-trips group-targeted schedules into group edit mode', async () => {
+    mockGetSchedules.mockResolvedValue({ data: sampleSchedules });
+    mockGetPlaylists.mockResolvedValue({ data: samplePlaylists });
+    mockGetDisplays.mockResolvedValue({ data: sampleDisplays });
+    mockGetDisplayGroups.mockResolvedValue({ data: sampleGroups });
+
+    render(<SchedulesClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Weekend Specials')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Lobby Group (2 devices)')).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByText('Edit')[1]);
+
+    const groupSelect = screen
+      .getAllByRole('combobox')
+      .find((select) => (select as HTMLSelectElement).value === 'g1') as HTMLSelectElement;
+
+    expect(groupSelect).toBeDefined();
+  });
+
+  it('submits null opposite target when editing a group schedule to an individual device', async () => {
+    mockGetSchedules.mockResolvedValue({ data: sampleSchedules });
+    mockGetPlaylists.mockResolvedValue({ data: samplePlaylists });
+    mockGetDisplays.mockResolvedValue({ data: sampleDisplays });
+    mockGetDisplayGroups.mockResolvedValue({ data: sampleGroups });
+
+    render(<SchedulesClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Weekend Specials')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByText('Edit')[1]);
+    fireEvent.click(screen.getByText('Individual Device'));
+    fireEvent.click(screen.getByLabelText('Lobby Display'));
+    fireEvent.click(screen.getByText('Update'));
+
+    await waitFor(() => {
+      expect(mockUpdateSchedule).toHaveBeenCalledWith(
+        's2',
+        expect.objectContaining({
+          displayId: 'd1',
+          displayGroupId: null,
+        }),
+      );
+    });
+  });
+
+  it('duplicates group schedules as group-targeted schedules', async () => {
+    mockGetSchedules.mockResolvedValue({ data: sampleSchedules });
+    mockGetPlaylists.mockResolvedValue({ data: samplePlaylists });
+    mockGetDisplays.mockResolvedValue({ data: sampleDisplays });
+    mockGetDisplayGroups.mockResolvedValue({ data: sampleGroups });
+
+    render(<SchedulesClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Weekend Specials')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByText('Duplicate')[1]);
+    fireEvent.click(screen.getByText('Create'));
+
+    await waitFor(() => {
+      expect(mockCreateSchedule).toHaveBeenCalledWith(
+        expect.objectContaining({
+          displayGroupId: 'g1',
+        }),
+      );
+    });
+    expect(mockCreateSchedule).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        displayId: 'g1',
+      }),
+    );
   });
 });

--- a/web/src/app/dashboard/schedules/page-client.tsx
+++ b/web/src/app/dashboard/schedules/page-client.tsx
@@ -146,8 +146,8 @@ export default function SchedulesClient() {
  ...s,
  // Convert daysOfWeek numbers to day names for UI
  days: s.daysOfWeek ? dayNumbersToNames(s.daysOfWeek) : [],
- // Convert displayId to deviceIds array for UI
- deviceIds: s.displayId ? [s.displayId] : [],
+ // Convert display/group target to a single UI selection array
+ deviceIds: s.displayId ? [s.displayId] : s.displayGroupId ? [s.displayGroupId] : [],
  // Calculate duration from integer startTime and endTime
  duration: calculateDuration(s.startTime as number | undefined, s.endTime as number | undefined),
  // Default timezone
@@ -198,19 +198,27 @@ export default function SchedulesClient() {
  return Object.keys(errors).length === 0;
  };
 
+ const handleTargetTypeChange = (nextTargetType: 'device' | 'group') => {
+ setTargetType(nextTargetType);
+ setFormData((prev) => ({ ...prev, deviceIds: [] }));
+ setFormErrors((prev) => {
+ const { deviceIds, ...rest } = prev;
+ return rest;
+ });
+ };
+
  const handleCreate = async () => {
  if (!validateForm()) return;
 
  try {
  setActionLoading(true);
 
- // Transform UI data to backend format
- const scheduleData = {
+ const buildScheduleData = (targetId: string) => ({
  name: formData.name,
  playlistId: formData.playlistId,
  ...(targetType === 'device'
- ? { displayId: formData.deviceIds[0] }
- : { displayGroupId: formData.deviceIds[0] }),
+ ? { displayId: targetId }
+ : { displayGroupId: targetId }),
  // Convert day names to numbers (0-6)
  daysOfWeek: dayNamesToNumbers(formData.days),
  // Start date is required - use today
@@ -221,24 +229,40 @@ export default function SchedulesClient() {
  endTime: calculateEndTimeMinutes(formData.startTime, formData.duration),
  isActive: true,
  priority: 1,
- };
+ });
 
- const createdSchedule = await apiClient.createSchedule(scheduleData);
+ const targets = targetType === 'device' ? formData.deviceIds : [formData.deviceIds[0]];
+ const createdSchedules: any[] = [];
+ try {
+ for (const targetId of targets) {
+ createdSchedules.push(await apiClient.createSchedule(buildScheduleData(targetId)));
+ }
+ } catch (error) {
+ if (createdSchedules.length > 0) {
+ await Promise.allSettled(
+ createdSchedules
+ .filter((schedule) => schedule?.id)
+ .map((schedule) => apiClient.deleteSchedule(schedule.id)),
+ );
+ await loadData();
+ }
+ throw error;
+ }
 
  // Transform response back to UI format and add to state
- const uiSchedule: Schedule = {
+ const uiSchedules: Schedule[] = createdSchedules.map((createdSchedule: any) => ({
  ...createdSchedule,
  days: dayNumbersToNames(createdSchedule.daysOfWeek || []),
- deviceIds: createdSchedule.displayId ? [createdSchedule.displayId] : [],
+ deviceIds: createdSchedule.displayId ? [createdSchedule.displayId] : createdSchedule.displayGroupId ? [createdSchedule.displayGroupId] : [],
  duration: calculateDuration(createdSchedule.startTime, createdSchedule.endTime),
  timezone: formData.timezone,
  active: createdSchedule.isActive,
- };
+ }));
 
- setSchedules([...schedules, uiSchedule]);
+ setSchedules([...schedules, ...uiSchedules]);
  resetForm();
  setIsCreateModalOpen(false);
- toast.success('Schedule created successfully');
+ toast.success(createdSchedules.length > 1 ? `${createdSchedules.length} schedules created successfully` : 'Schedule created successfully');
  } catch (error: any) {
  toast.error(error.message || 'Failed to create schedule');
  } finally {
@@ -257,8 +281,8 @@ export default function SchedulesClient() {
  name: formData.name,
  playlistId: formData.playlistId,
  ...(targetType === 'device'
- ? { displayId: formData.deviceIds[0] }
- : { displayGroupId: formData.deviceIds[0] }),
+ ? { displayId: formData.deviceIds[0], displayGroupId: null }
+ : { displayId: null, displayGroupId: formData.deviceIds[0] }),
  daysOfWeek: dayNamesToNumbers(formData.days),
  startTime: hhmmToMinutes(formData.startTime),
  endTime: calculateEndTimeMinutes(formData.startTime, formData.duration),
@@ -270,7 +294,7 @@ export default function SchedulesClient() {
  const uiSchedule: Schedule = {
  ...updatedSchedule,
  days: dayNumbersToNames(updatedSchedule.daysOfWeek || []),
- deviceIds: updatedSchedule.displayId ? [updatedSchedule.displayId] : [],
+ deviceIds: updatedSchedule.displayId ? [updatedSchedule.displayId] : updatedSchedule.displayGroupId ? [updatedSchedule.displayGroupId] : [],
  duration: calculateDuration(updatedSchedule.startTime, updatedSchedule.endTime),
  timezone: formData.timezone,
  active: updatedSchedule.isActive,
@@ -317,6 +341,7 @@ export default function SchedulesClient() {
  playlistId: schedule.playlistId,
  deviceIds: schedule.deviceIds || [],
  });
+ setTargetType((schedule as any).displayGroupId ? 'group' : 'device');
  setFormErrors({});
  setIsEditModalOpen(true);
  };
@@ -346,10 +371,15 @@ export default function SchedulesClient() {
  return playlists.find(p => p.id === playlistId)?.name || 'Unknown Playlist';
  };
 
- const getDeviceNames = (deviceIds: string[]) => {
- return deviceIds
- .map(id => devices.find(d => d.id === id)?.nickname || id)
- .join(', ');
+ const getScheduleTargetDescription = (schedule: Schedule) => {
+ if (schedule.displayGroupId) {
+ const group = displayGroups.find((g: any) => g.id === schedule.displayGroupId);
+ const displayCount = group?._count?.displays ?? group?.displays?.length;
+ return `${group?.name || schedule.displayGroupId}${typeof displayCount === 'number' ? ` (${displayCount} devices)` : ''}`;
+ }
+
+ const count = schedule.deviceIds?.length || 0;
+ return `${count} device${count !== 1 ? 's' : ''}`;
  };
 
  const formatScheduleTime = (startTime?: number | string, duration?: number) => {
@@ -509,8 +539,8 @@ export default function SchedulesClient() {
  <p className="text-[var(--foreground-secondary)] truncate">{getPlaylistName(schedule.playlistId)}</p>
  </div>
  <div>
- <span className="font-medium text-[var(--foreground-secondary)]">Devices:</span>
- <p className="text-[var(--foreground-secondary)] truncate">{(schedule.deviceIds?.length || 0)} device{(schedule.deviceIds?.length || 0) !== 1 ? 's' : ''}</p>
+ <span className="font-medium text-[var(--foreground-secondary)]">Target:</span>
+ <p className="text-[var(--foreground-secondary)] truncate">{getScheduleTargetDescription(schedule)}</p>
  </div>
  </div>
  </div>
@@ -529,6 +559,7 @@ export default function SchedulesClient() {
  onClick={() => {
  // Don't set selectedSchedule so it's treated as a new schedule
  setSelectedSchedule(null);
+ setTargetType((schedule as any).displayGroupId ? 'group' : 'device');
  setFormData({
  name: `${schedule.name} (Copy)`,
  startTime: schedule.startTime != null ? minutesToHHMM(schedule.startTime) : '09:00',
@@ -716,7 +747,7 @@ export default function SchedulesClient() {
  <div className="flex gap-2">
  <button
  type="button"
- onClick={() => setTargetType('device')}
+ onClick={() => handleTargetTypeChange('device')}
  className={`flex-1 px-4 py-2 rounded-lg text-sm font-medium transition ${
  targetType === 'device'
  ? 'bg-[#00E5A0] text-[#061A21]'
@@ -727,7 +758,7 @@ export default function SchedulesClient() {
  </button>
  <button
  type="button"
- onClick={() => setTargetType('group')}
+ onClick={() => handleTargetTypeChange('group')}
  className={`flex-1 px-4 py-2 rounded-lg text-sm font-medium transition ${
  targetType === 'group'
  ? 'bg-[#00E5A0] text-[#061A21]'

--- a/web/src/app/dashboard/settings/api-keys/__tests__/page.test.tsx
+++ b/web/src/app/dashboard/settings/api-keys/__tests__/page.test.tsx
@@ -88,7 +88,7 @@ const sampleApiKeys = [
     id: 'key-2',
     name: 'Test Key',
     prefix: 'vz_test',
-    scopes: ['read:content', 'read:playlists', 'read:displays', 'write:schedules'],
+    scopes: ['read:content', 'read:analytics', 'read:displays', 'write:schedules'],
     lastUsedAt: null,
     expiresAt: '2027-06-01T00:00:00Z',
     createdAt: '2026-02-01T00:00:00Z',

--- a/web/src/app/dashboard/settings/api-keys/page.tsx
+++ b/web/src/app/dashboard/settings/api-keys/page.tsx
@@ -14,14 +14,12 @@ import { Icon } from '@/theme/icons';
 const AVAILABLE_SCOPES = [
  { value: 'read:content', label: 'Read Content', description: 'View content items' },
  { value: 'write:content', label: 'Write Content', description: 'Create, update, delete content' },
- { value: 'read:playlists', label: 'Read Playlists', description: 'View playlists' },
  { value: 'write:playlists', label: 'Write Playlists', description: 'Create, update, delete playlists' },
  { value: 'read:displays', label: 'Read Displays', description: 'View display devices' },
  { value: 'write:displays', label: 'Write Displays', description: 'Manage display devices' },
- { value: 'read:schedules', label: 'Read Schedules', description: 'View schedules' },
  { value: 'write:schedules', label: 'Write Schedules', description: 'Create, update, delete schedules' },
+ { value: 'read:analytics', label: 'Read Analytics', description: 'View analytics and reports' },
  { value: 'read:all', label: 'Read All', description: 'Read access to all resources' },
- { value: 'write:all', label: 'Write All', description: 'Full read/write access to all resources' },
 ];
 
 export default function ApiKeysPage() {

--- a/web/src/app/dashboard/settings/customization/__tests__/page.test.tsx
+++ b/web/src/app/dashboard/settings/customization/__tests__/page.test.tsx
@@ -11,6 +11,8 @@ jest.mock('next/navigation', () => ({
 }));
 
 const mockUpdateBrandConfig = jest.fn();
+let currentBrandConfig: any;
+let currentOrganizationId: string | null;
 const mockBrandConfig = {
   id: 'org-1',
   name: 'Vizora Test',
@@ -27,10 +29,16 @@ const mockBrandConfig = {
 
 jest.mock('@/components/providers/CustomizationProvider', () => ({
   useCustomization: () => ({
-    brandConfig: mockBrandConfig,
+    brandConfig: currentBrandConfig,
     updateBrandConfig: mockUpdateBrandConfig,
-    organizationId: 'org-1',
+    organizationId: currentOrganizationId,
   }),
+}));
+
+jest.mock('@/lib/api', () => ({
+  apiClient: {
+    uploadBrandingLogo: jest.fn(),
+  },
 }));
 
 jest.mock('@/components/ui/Card', () => {
@@ -52,8 +60,8 @@ jest.mock('@/components/ui/Badge', () => ({
 }));
 
 jest.mock('@/components/Button', () => {
-  return function MockButton({ children, onClick, variant }: any) {
-    return <button data-testid={`btn-${variant}`} onClick={onClick}>{children}</button>;
+  return function MockButton({ children, onClick, variant, disabled }: any) {
+    return <button data-testid={`btn-${variant}`} onClick={onClick} disabled={disabled}>{children}</button>;
   };
 });
 
@@ -62,6 +70,9 @@ import CustomizationPage from '../page';
 describe('CustomizationPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    currentBrandConfig = mockBrandConfig;
+    currentOrganizationId = 'org-1';
+    mockUpdateBrandConfig.mockResolvedValue(mockBrandConfig);
   });
 
   it('renders without crashing', () => {
@@ -119,10 +130,12 @@ describe('CustomizationPage', () => {
     expect(screen.getByText('Reset')).toBeInTheDocument();
   });
 
-  it('calls updateBrandConfig on save', () => {
+  it('calls updateBrandConfig on save', async () => {
     render(<CustomizationPage />);
     fireEvent.click(screen.getByText('Save Changes'));
-    expect(mockUpdateBrandConfig).toHaveBeenCalledWith(mockBrandConfig);
+    await waitFor(() => {
+      expect(mockUpdateBrandConfig).toHaveBeenCalledWith(mockBrandConfig);
+    });
   });
 
   it('shows success message after save', async () => {
@@ -131,6 +144,56 @@ describe('CustomizationPage', () => {
     await waitFor(() => {
       expect(screen.getByText(/Brand configuration saved successfully/)).toBeInTheDocument();
     });
+  });
+
+  it('shows an error instead of success when save fails', async () => {
+    mockUpdateBrandConfig.mockRejectedValueOnce(new Error('Branding API failed'));
+
+    render(<CustomizationPage />);
+    fireEvent.click(screen.getByText('Save Changes'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Branding API failed')).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Brand configuration saved successfully/)).not.toBeInTheDocument();
+  });
+
+  it('disables saving while organization branding context is unavailable', () => {
+    currentOrganizationId = null;
+
+    render(<CustomizationPage />);
+
+    expect(screen.getByText('Save Changes')).toBeDisabled();
+  });
+
+  it('syncs form fields when async branding loads before the user edits', () => {
+    const { rerender } = render(<CustomizationPage />);
+
+    currentBrandConfig = {
+      ...mockBrandConfig,
+      name: 'Loaded Brand',
+      primaryColor: '#111111',
+    };
+    rerender(<CustomizationPage />);
+
+    const nameInput = screen.getByPlaceholderText('Your Brand Name') as HTMLInputElement;
+    expect(nameInput.value).toBe('Loaded Brand');
+  });
+
+  it('does not overwrite local edits when provider branding refreshes', () => {
+    const { rerender } = render(<CustomizationPage />);
+    const nameInput = screen.getByPlaceholderText('Your Brand Name') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: 'Unsaved Local Brand' } });
+
+    currentBrandConfig = {
+      ...mockBrandConfig,
+      name: 'Loaded Brand',
+    };
+    rerender(<CustomizationPage />);
+
+    expect((screen.getByPlaceholderText('Your Brand Name') as HTMLInputElement).value).toBe(
+      'Unsaved Local Brand',
+    );
   });
 
   it('renders preview section with logo', () => {

--- a/web/src/app/dashboard/settings/customization/page.tsx
+++ b/web/src/app/dashboard/settings/customization/page.tsx
@@ -1,39 +1,57 @@
 'use client';
 
-import React, { useState, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useCustomization } from '@/components/providers/CustomizationProvider';
 import { Card } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
 import Button from '@/components/Button';
+import { apiClient } from '@/lib/api';
 
 export const dynamic = 'force-dynamic';
 
 export default function CustomizationPage() {
  const { brandConfig, updateBrandConfig, organizationId } = useCustomization();
  const [formData, setFormData] = useState(brandConfig);
+ const [isDirty, setIsDirty] = useState(false);
  const [saveSuccess, setSaveSuccess] = useState(false);
  const [logoUploading, setLogoUploading] = useState(false);
  const [logoUploadError, setLogoUploadError] = useState<string | null>(null);
+ const [saveError, setSaveError] = useState<string | null>(null);
  const fileInputRef = useRef<HTMLInputElement>(null);
 
  const handleInputChange = (
  e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>
  ) => {
  const { name, value, type } = e.currentTarget;
+ setIsDirty(true);
  setFormData((prev) => ({
  ...prev,
  [name]: type === 'checkbox' ? (e.currentTarget as HTMLInputElement).checked : value,
  }));
  };
 
- const handleSave = () => {
- updateBrandConfig(formData);
+ useEffect(() => {
+ if (!isDirty) {
+ setFormData(brandConfig);
+ }
+ }, [brandConfig, isDirty]);
+
+ const handleSave = async () => {
+ setSaveError(null);
+ try {
+ await updateBrandConfig(formData);
+ setIsDirty(false);
  setSaveSuccess(true);
  setTimeout(() => setSaveSuccess(false), 3000);
+ } catch (error: any) {
+ setSaveSuccess(false);
+ setSaveError(error.message || 'Failed to save brand configuration');
+ }
  };
 
  const handleReset = () => {
  setFormData(brandConfig);
+ setIsDirty(false);
  };
 
  const handleLogoUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -55,23 +73,10 @@ export default function CustomizationPage() {
  setLogoUploadError(null);
 
  try {
-   const formDataUpload = new FormData();
-   formDataUpload.append('file', file);
-
-   const res = await fetch(`/api/organizations/${organizationId}/branding/logo`, {
-     method: 'POST',
-     credentials: 'include',
-     body: formDataUpload,
-   });
-
-   if (!res.ok) {
-     const err = await res.json().catch(() => ({}));
-     throw new Error(err.message || 'Upload failed');
-   }
-
-   const result = await res.json();
+   const result = await apiClient.uploadBrandingLogo(organizationId, file);
+   setIsDirty(true);
    setFormData((prev) => ({ ...prev, logo: result.logoUrl }));
-   updateBrandConfig({ logo: result.logoUrl });
+   await updateBrandConfig({ logo: result.logoUrl });
  } catch (err: any) {
    setLogoUploadError(err.message || 'Failed to upload logo');
  } finally {
@@ -97,6 +102,14 @@ export default function CustomizationPage() {
  <div className="bg-success-100 dark:bg-success-900 border border-success-300 dark:border-success-700 rounded-lg p-4">
  <p className="text-success-800 dark:text-success-100 font-medium">
  Brand configuration saved successfully!
+ </p>
+ </div>
+ )}
+
+ {saveError && (
+ <div className="bg-red-100 dark:bg-red-900 border border-red-300 dark:border-red-700 rounded-lg p-4">
+ <p className="text-red-800 dark:text-red-100 font-medium">
+ {saveError}
  </p>
  </div>
  )}
@@ -360,6 +373,7 @@ export default function CustomizationPage() {
  onClick={handleSave}
  variant="primary"
  className="flex-1"
+ disabled={!organizationId}
  >
  Save Changes
  </Button>

--- a/web/src/app/display/DisplayClient.tsx
+++ b/web/src/app/display/DisplayClient.tsx
@@ -30,6 +30,7 @@ export function DisplayClient() {
     error: pairingError,
     requestPairingCode,
     resetPairing,
+    updateDeviceToken,
   } = usePairing();
 
   // Stable callback that delegates to the connection's emitImpression once available
@@ -97,6 +98,7 @@ export function DisplayClient() {
     onConfig: handleConfig,
     onContentPush: handleContentPush,
     onUnauthorized: handleUnauthorized,
+    onTokenRefresh: updateDeviceToken,
     currentContentId: player.currentContentId,
   });
 

--- a/web/src/app/display/components/ContentRenderer.tsx
+++ b/web/src/app/display/components/ContentRenderer.tsx
@@ -10,6 +10,7 @@ interface ContentRendererProps {
   url: string;
   name?: string;
   metadata?: LayoutMetadata;
+  authenticateUrl?: (url: string) => string;
   onEnded?: () => void;
   onError?: (errorType: string, errorMessage: string) => void;
 }
@@ -61,11 +62,12 @@ function shouldFetchImageAsBlob(url: string): boolean {
   return url.includes('/device-content/') && url.includes('/file');
 }
 
-export function ContentRenderer({ type, url, name, metadata, onEnded, onError }: ContentRendererProps) {
+export function ContentRenderer({ type, url, name, metadata, authenticateUrl, onEnded, onError }: ContentRendererProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
+  const renderedUrl = authenticateUrl ? authenticateUrl(url) : url;
   const isImage = type === 'image';
-  const shouldFetchBlob = isImage && shouldFetchImageAsBlob(url);
-  const { blobUrl, error: fetchError } = useBlobUrl(url, shouldFetchBlob);
+  const shouldFetchBlob = isImage && shouldFetchImageAsBlob(renderedUrl);
+  const { blobUrl, error: fetchError } = useBlobUrl(renderedUrl, shouldFetchBlob);
 
   // Attempt autoplay when video mounts
   useEffect(() => {
@@ -78,25 +80,25 @@ export function ContentRenderer({ type, url, name, metadata, onEnded, onError }:
         }
       });
     }
-  }, [type, url]);
+  }, [type, renderedUrl]);
 
   // Report fetch errors for images
   useEffect(() => {
     if (isImage && fetchError) {
-      onError?.('load_error', `Image fetch failed: ${fetchError} (url: ${url})`);
+      onError?.('load_error', `Image fetch failed: ${fetchError} (url: ${renderedUrl})`);
     }
-  }, [isImage, fetchError, url, onError]);
+  }, [isImage, fetchError, renderedUrl, onError]);
 
   switch (type) {
     case 'image':
       if (!shouldFetchBlob) {
         return (
           <img
-            src={url}
+            src={renderedUrl}
             alt={name || 'Display content'}
             style={styles.image}
             onError={() => {
-              onError?.('load_error', `Image failed to load: ${url}`);
+              onError?.('load_error', `Image failed to load: ${renderedUrl}`);
               onEnded?.();
             }}
           />
@@ -105,7 +107,7 @@ export function ContentRenderer({ type, url, name, metadata, onEnded, onError }:
       if (fetchError) {
         return (
           <div style={{ ...styles.image, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#ff6b6b', fontSize: '14px', padding: '20px', textAlign: 'center' as const }}>
-            Image load error: {fetchError}<br />URL: {url?.substring(0, 80)}...
+            Image load error: {fetchError}<br />URL: {renderedUrl?.substring(0, 80)}...
           </div>
         );
       }
@@ -132,14 +134,14 @@ export function ContentRenderer({ type, url, name, metadata, onEnded, onError }:
       return (
         <video
           ref={videoRef}
-          src={url}
+          src={renderedUrl}
           autoPlay
           muted
           playsInline
           style={styles.video}
           onEnded={onEnded}
           onError={() => {
-            onError?.('load_error', `Video failed to load: ${url}`);
+            onError?.('load_error', `Video failed to load: ${renderedUrl}`);
             onEnded?.();
           }}
         />
@@ -149,12 +151,12 @@ export function ContentRenderer({ type, url, name, metadata, onEnded, onError }:
     case 'webpage':
       return (
         <iframe
-          src={url}
+          src={renderedUrl}
           style={styles.iframe}
           allow="autoplay; fullscreen"
           title={name || 'Web content'}
           onError={() => {
-            onError?.('load_error', `Webpage failed to load: ${url}`);
+            onError?.('load_error', `Webpage failed to load: ${renderedUrl}`);
             onEnded?.();
           }}
         />
@@ -164,7 +166,7 @@ export function ContentRenderer({ type, url, name, metadata, onEnded, onError }:
     case 'template':
       return (
         <iframe
-          srcDoc={url}
+          srcDoc={renderedUrl}
           sandbox="allow-scripts"
           style={styles.iframe}
           title={name || 'HTML content'}
@@ -173,7 +175,7 @@ export function ContentRenderer({ type, url, name, metadata, onEnded, onError }:
 
     case 'layout':
       if (metadata) {
-        return <LayoutRenderer metadata={metadata} onError={onError} />;
+        return <LayoutRenderer metadata={metadata} authenticateUrl={authenticateUrl} onError={onError} />;
       }
       return null;
 

--- a/web/src/app/display/components/ContentScreen.tsx
+++ b/web/src/app/display/components/ContentScreen.tsx
@@ -17,11 +17,28 @@ interface ContentScreenProps {
  */
 function authenticateUrl(url: string, token?: string): string {
   if (!token || !url) return url;
-  if (url.includes('/device-content/') && url.includes('/file')) {
-    const separator = url.includes('?') ? '&' : '?';
-    return `${url}${separator}token=${encodeURIComponent(token)}`;
+  try {
+    const baseOrigin = typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
+    const parsed = new URL(url, baseOrigin);
+    const apiOrigin = process.env.NEXT_PUBLIC_API_URL
+      ? new URL(process.env.NEXT_PUBLIC_API_URL).origin
+      : baseOrigin;
+    const trustedOrigins = new Set([baseOrigin, apiOrigin]);
+    const isDeviceContentPath =
+      /^\/(?:api\/v1\/)?device-content\/[^/]+\/file$/.test(parsed.pathname);
+
+    if (!trustedOrigins.has(parsed.origin) || !isDeviceContentPath) {
+      return url;
+    }
+
+    parsed.searchParams.set('token', token);
+    if (/^[a-z][a-z\d+\-.]*:/i.test(url)) {
+      return parsed.toString();
+    }
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return url;
   }
-  return url;
 }
 
 export function ContentScreen({
@@ -39,6 +56,7 @@ export function ContentScreen({
           type={temporaryContent.type}
           url={authenticateUrl(temporaryContent.url, deviceToken)}
           name={temporaryContent.name}
+          authenticateUrl={(url) => authenticateUrl(url, deviceToken)}
           onEnded={onVideoEnded}
           onError={(errType, errMsg) => onContentError?.(temporaryContent.id, errType, errMsg)}
         />
@@ -55,6 +73,7 @@ export function ContentScreen({
           url={authenticateUrl(currentItem.content.url, deviceToken)}
           name={currentItem.content.name}
           metadata={currentItem.content.metadata}
+          authenticateUrl={(url) => authenticateUrl(url, deviceToken)}
           onEnded={onVideoEnded}
           onError={(errType, errMsg) => onContentError?.(currentItem.content!.id, errType, errMsg)}
         />

--- a/web/src/app/display/components/LayoutRenderer.tsx
+++ b/web/src/app/display/components/LayoutRenderer.tsx
@@ -6,10 +6,11 @@ import { ContentRenderer } from './ContentRenderer';
 
 interface LayoutRendererProps {
   metadata: LayoutMetadata;
+  authenticateUrl?: (url: string) => string;
   onError?: (errorType: string, errorMessage: string) => void;
 }
 
-export function LayoutRenderer({ metadata, onError }: LayoutRendererProps) {
+export function LayoutRenderer({ metadata, authenticateUrl, onError }: LayoutRendererProps) {
   const gridStyle: React.CSSProperties = {
     width: '100%',
     height: '100%',
@@ -27,13 +28,21 @@ export function LayoutRenderer({ metadata, onError }: LayoutRendererProps) {
   return (
     <div style={gridStyle}>
       {metadata.zones.map((zone) => (
-        <ZonePlayer key={zone.id} zone={zone} onError={onError} />
+        <ZonePlayer key={zone.id} zone={zone} authenticateUrl={authenticateUrl} onError={onError} />
       ))}
     </div>
   );
 }
 
-function ZonePlayer({ zone, onError }: { zone: LayoutZone; onError?: (t: string, m: string) => void }) {
+function ZonePlayer({
+  zone,
+  authenticateUrl,
+  onError,
+}: {
+  zone: LayoutZone;
+  authenticateUrl?: (url: string) => string;
+  onError?: (t: string, m: string) => void;
+}) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -69,7 +78,7 @@ function ZonePlayer({ zone, onError }: { zone: LayoutZone; onError?: (t: string,
       <div style={zoneStyle}>
         <ContentRenderer
           type={zone.resolvedContent.type}
-          url={zone.resolvedContent.url}
+          url={authenticateUrl ? authenticateUrl(zone.resolvedContent.url) : zone.resolvedContent.url}
           name={zone.resolvedContent.name}
           onError={onError}
         />
@@ -87,7 +96,7 @@ function ZonePlayer({ zone, onError }: { zone: LayoutZone; onError?: (t: string,
     <div style={zoneStyle}>
       <ContentRenderer
         type={item.content.type}
-        url={item.content.url}
+        url={authenticateUrl ? authenticateUrl(item.content.url) : item.content.url}
         name={item.content.name}
         onEnded={advance}
         onError={onError}

--- a/web/src/app/display/components/__tests__/ContentScreen.test.tsx
+++ b/web/src/app/display/components/__tests__/ContentScreen.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from '@testing-library/react';
+import { ContentScreen } from '../ContentScreen';
+
+jest.mock('../ContentRenderer', () => ({
+  ContentRenderer: ({ url, name, type, metadata, authenticateUrl }: any) => {
+    const zoneUrl = metadata?.zones?.[0]?.resolvedContent?.url;
+    return (
+      <div
+        data-testid="renderer"
+        data-url={url}
+        data-zone-url={zoneUrl && authenticateUrl ? authenticateUrl(zoneUrl) : zoneUrl}
+        data-type={type}
+      >
+        {name}
+      </div>
+    );
+  },
+}));
+
+describe('ContentScreen', () => {
+  it('adds device token to same-origin protected device-content URLs', () => {
+    render(
+      <ContentScreen
+        currentItem={{
+          id: 'item-1',
+          contentId: 'content-1',
+          duration: 10,
+          order: 0,
+          content: {
+            id: 'content-1',
+            name: 'Menu',
+            type: 'image',
+            url: '/api/v1/device-content/content-1/file?version=1',
+          },
+        } as any}
+        temporaryContent={null}
+        onVideoEnded={jest.fn()}
+        deviceToken="device-token"
+      />,
+    );
+
+    expect(screen.getByTestId('renderer')).toHaveAttribute(
+      'data-url',
+      '/api/v1/device-content/content-1/file?version=1&token=device-token',
+    );
+  });
+
+  it('does not leak device token to attacker-origin lookalike URLs', () => {
+    render(
+      <ContentScreen
+        currentItem={{
+          id: 'item-1',
+          contentId: 'content-1',
+          duration: 10,
+          order: 0,
+          content: {
+            id: 'content-1',
+            name: 'Menu',
+            type: 'image',
+            url: 'https://evil.example/api/v1/device-content/content-1/file',
+          },
+        } as any}
+        temporaryContent={null}
+        onVideoEnded={jest.fn()}
+        deviceToken="device-token"
+      />,
+    );
+
+    expect(screen.getByTestId('renderer')).toHaveAttribute(
+      'data-url',
+      'https://evil.example/api/v1/device-content/content-1/file',
+    );
+  });
+
+  it('passes token authentication through to protected layout zone URLs', () => {
+    render(
+      <ContentScreen
+        currentItem={{
+          id: 'item-1',
+          contentId: 'layout-1',
+          duration: 10,
+          order: 0,
+          content: {
+            id: 'layout-1',
+            name: 'Menu Layout',
+            type: 'layout',
+            url: '',
+            metadata: {
+              zones: [
+                {
+                  id: 'zone-1',
+                  gridArea: '1 / 1 / 2 / 2',
+                  resolvedContent: {
+                    type: 'image',
+                    name: 'Dish',
+                    url: '/api/v1/device-content/content-2/file',
+                  },
+                },
+              ],
+            },
+          },
+        } as any}
+        temporaryContent={null}
+        onVideoEnded={jest.fn()}
+        deviceToken="device-token"
+      />,
+    );
+
+    expect(screen.getByTestId('renderer')).toHaveAttribute(
+      'data-zone-url',
+      '/api/v1/device-content/content-2/file?token=device-token',
+    );
+  });
+});

--- a/web/src/app/display/hooks/__tests__/useDeviceConnection.test.tsx
+++ b/web/src/app/display/hooks/__tests__/useDeviceConnection.test.tsx
@@ -18,6 +18,7 @@ describe('useDeviceConnection', () => {
     emit: jest.fn(),
     disconnect: jest.fn(),
     connected: true,
+    auth: {},
   });
 
   const renderConnection = (overrides: Partial<Parameters<typeof useDeviceConnection>[0]> = {}) => {
@@ -37,6 +38,7 @@ describe('useDeviceConnection', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    localStorage.clear();
   });
 
   it('acknowledges playlist updates after applying them', () => {
@@ -144,6 +146,63 @@ describe('useDeviceConnection', () => {
     expect(ack).toHaveBeenCalledWith({
       ok: false,
       error: 'command failed',
+    });
+  });
+
+  it('persists refreshed device tokens for future reconnects', () => {
+    const socket = createSocket();
+    (io as jest.Mock).mockReturnValue(socket);
+    const onTokenRefresh = jest.fn();
+    localStorage.setItem(
+      'vizora_display_credentials',
+      JSON.stringify({ deviceToken: 'old-token', deviceId: 'display-1', organizationId: 'org-1' }),
+    );
+
+    renderConnection({ onTokenRefresh });
+    const refreshHandler = socket.on.mock.calls.find(
+      (call: any[]) => call[0] === 'token:refresh',
+    )?.[1];
+
+    act(() => {
+      refreshHandler({ token: 'new-token' });
+    });
+
+    expect(JSON.parse(localStorage.getItem('vizora_display_credentials') || '{}')).toEqual(
+      expect.objectContaining({ deviceToken: 'new-token', deviceId: 'display-1' }),
+    );
+    expect(socket.auth).toEqual(
+      expect.objectContaining({
+        token: 'new-token',
+        capabilities: expect.objectContaining({ deliveryAck: true }),
+      }),
+    );
+    expect(onTokenRefresh).toHaveBeenCalledWith('new-token');
+  });
+
+  it('still adopts refreshed tokens when stored credentials JSON is corrupt', () => {
+    const socket = createSocket();
+    (io as jest.Mock).mockReturnValue(socket);
+    const onTokenRefresh = jest.fn();
+    localStorage.setItem('vizora_display_credentials', '{not-json');
+
+    renderConnection({ onTokenRefresh });
+    const refreshHandler = socket.on.mock.calls.find(
+      (call: any[]) => call[0] === 'token:refresh',
+    )?.[1];
+
+    act(() => {
+      refreshHandler({ token: 'new-token' });
+    });
+
+    expect(socket.auth).toEqual(
+      expect.objectContaining({
+        token: 'new-token',
+        capabilities: expect.objectContaining({ deliveryAck: true }),
+      }),
+    );
+    expect(onTokenRefresh).toHaveBeenCalledWith('new-token');
+    expect(JSON.parse(localStorage.getItem('vizora_display_credentials') || '{}')).toEqual({
+      deviceToken: 'new-token',
     });
   });
 });

--- a/web/src/app/display/hooks/useDeviceConnection.ts
+++ b/web/src/app/display/hooks/useDeviceConnection.ts
@@ -21,10 +21,12 @@ interface UseDeviceConnectionOptions {
   onConfig: (config: DeviceConfig) => void;
   onContentPush?: (content: PushContent, duration: number) => void;
   onUnauthorized: () => void;
+  onTokenRefresh?: (deviceToken: string) => void;
   currentContentId: string | null;
 }
 
 const SOCKET_URL = process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:3002';
+const CREDENTIALS_KEY = 'vizora_display_credentials';
 
 export function useDeviceConnection({
   credentials,
@@ -33,6 +35,7 @@ export function useDeviceConnection({
   onConfig,
   onContentPush,
   onUnauthorized,
+  onTokenRefresh,
   currentContentId,
 }: UseDeviceConnectionOptions) {
   const [status, setStatus] = useState<ConnectionStatus>('disconnected');
@@ -145,6 +148,40 @@ export function useDeviceConnection({
 
     socket.on('config', (config: DeviceConfig) => {
       onConfig(config);
+    });
+
+    socket.on('token:refresh', (data: { token?: string }) => {
+      if (!data?.token || typeof window === 'undefined') return;
+
+      let parsed: Record<string, unknown> = {};
+      try {
+        const stored = localStorage.getItem(CREDENTIALS_KEY);
+        parsed = stored ? JSON.parse(stored) : {};
+      } catch (err) {
+        console.error('[Vizora Display] Failed to parse stored display credentials:', err);
+      }
+
+      try {
+        localStorage.setItem(
+          CREDENTIALS_KEY,
+          JSON.stringify({
+            ...parsed,
+            deviceToken: data.token,
+          }),
+        );
+      } catch (err) {
+        console.error('[Vizora Display] Failed to persist refreshed device token:', err);
+      }
+
+      socket.auth = {
+        ...(socket.auth || {}),
+        token: data.token,
+        capabilities: {
+          ...((socket.auth as any)?.capabilities || {}),
+          deliveryAck: true,
+        },
+      };
+      onTokenRefresh?.(data.token);
     });
 
     socket.on('playlist:update', (data: { playlist: Playlist }, ack?: SocketAck) => {

--- a/web/src/app/display/hooks/usePairing.ts
+++ b/web/src/app/display/hooks/usePairing.ts
@@ -148,6 +148,15 @@ export function usePairing() {
     setError(null);
   }, []);
 
+  const updateDeviceToken = useCallback((deviceToken: string) => {
+    setCredentials((prev) => {
+      if (!prev) return prev;
+      const next = { ...prev, deviceToken };
+      storeCredentials(next);
+      return next;
+    });
+  }, []);
+
   return {
     pairingCode,
     qrCode,
@@ -156,5 +165,6 @@ export function usePairing() {
     error,
     requestPairingCode,
     resetPairing,
+    updateDeviceToken,
   };
 }

--- a/web/src/components/providers/CustomizationProvider.tsx
+++ b/web/src/components/providers/CustomizationProvider.tsx
@@ -1,15 +1,26 @@
 'use client';
 
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import { BrandConfig, loadBrandConfig, updateBrandConfig, applyCSSVariables } from '@/lib/customization';
+import { BrandConfig, loadBrandConfig, applyCSSVariables } from '@/lib/customization';
+import { apiClient } from '@/lib/api';
 
 interface CustomizationContextType {
   brandConfig: BrandConfig;
-  updateBrandConfig: (updates: Partial<BrandConfig>) => void;
+  updateBrandConfig: (updates: Partial<BrandConfig>) => Promise<BrandConfig>;
   organizationId: string | null;
 }
 
 const CustomizationContext = createContext<CustomizationContextType | undefined>(undefined);
+
+const defaultBrandConfig: BrandConfig = {
+  id: 'default',
+  name: 'Vizora',
+  primaryColor: '#00E5A0',
+  secondaryColor: '#00B4D8',
+  accentColor: '#00CC8E',
+  fontFamily: 'sans',
+  showPoweredBy: true,
+};
 
 export function CustomizationProvider({ children }: { children: React.ReactNode }) {
   const [brandConfig, setBrandConfig] = useState<BrandConfig | null>(null);
@@ -99,38 +110,36 @@ export function CustomizationProvider({ children }: { children: React.ReactNode 
   }, []);
 
   const handleUpdateBrandConfig = async (updates: Partial<BrandConfig>) => {
-    const newConfig = updateBrandConfig(updates);
+    const newConfig = {
+      ...(brandConfig ?? loadBrandConfig()),
+      ...updates,
+    };
+
+    if (!organizationId) {
+      throw new Error('Organization branding is still loading');
+    }
+
+    await apiClient.updateBranding(organizationId, {
+      name: newConfig.name,
+      logoUrl: newConfig.logo,
+      primaryColor: newConfig.primaryColor,
+      secondaryColor: newConfig.secondaryColor,
+      accentColor: newConfig.accentColor,
+      fontFamily: newConfig.fontFamily,
+      showPoweredBy: newConfig.showPoweredBy,
+      customDomain: newConfig.customDomain,
+      customCSS: newConfig.customCSS,
+    });
+
     setBrandConfig(newConfig);
     applyCSSVariables(newConfig);
+    loadBrandConfig(newConfig);
 
-    // Save to localStorage for persistence
+    // Save to localStorage after the durable API write succeeds.
     if (typeof window !== 'undefined') {
       localStorage.setItem('brand-config', JSON.stringify(newConfig));
     }
-
-    // Persist to API if we have an org ID
-    if (organizationId) {
-      try {
-        await fetch(`/api/v1/organizations/${organizationId}/branding`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'include',
-          body: JSON.stringify({
-            name: newConfig.name,
-            logoUrl: newConfig.logo,
-            primaryColor: newConfig.primaryColor,
-            secondaryColor: newConfig.secondaryColor,
-            accentColor: newConfig.accentColor,
-            fontFamily: newConfig.fontFamily,
-            showPoweredBy: newConfig.showPoweredBy,
-            customDomain: newConfig.customDomain,
-            customCSS: newConfig.customCSS,
-          }),
-        });
-      } catch {
-        // API save failed, localStorage still has the update
-      }
-    }
+    return newConfig;
   };
 
   // Don't render until client-side hydration is complete
@@ -153,16 +162,10 @@ export function CustomizationProvider({ children }: { children: React.ReactNode 
 
 // Default fallback when context is not yet available (pre-hydration)
 const defaultCustomizationContext: CustomizationContextType = {
-  brandConfig: {
-    id: 'default',
-    name: 'Vizora',
-    primaryColor: '#00E5A0',
-    secondaryColor: '#00B4D8',
-    accentColor: '#00CC8E',
-    fontFamily: 'sans',
-    showPoweredBy: true,
+  brandConfig: defaultBrandConfig,
+  updateBrandConfig: async () => {
+    throw new Error('Organization branding is still loading');
   },
-  updateBrandConfig: () => {},
   organizationId: null,
 };
 

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -69,8 +69,8 @@ export interface RegisterResponse {
 export interface ScheduleData {
   name: string;
   playlistId: string;
-  displayId?: string;
-  displayGroupId?: string;
+  displayId?: string | null;
+  displayGroupId?: string | null;
   startDate: string;
   endDate?: string;
   startTime?: string | number;


### PR DESCRIPTION
## Summary
- Harden device-token enforcement, realtime delivery targeting, display token refresh, and protected media URL handling.
- Make content upload/delete quota and storage accounting fail closed around MinIO failures and DB-delete failures.
- Fix customer dashboard correctness issues in API keys, device groups, schedules, dashboard playlist stats, and branding customization saves.
- Add Prisma hot-path indexes for customer list and active schedule queries.

## Review Gate
- Backend/runtime reviewer: initial findings fixed; final re-review CLEAN.
- Frontend/customer UX reviewer: initial findings fixed; final re-review CLEAN.

## Local Verification
- `git diff --check` - pass; line-ending warnings only.
- `pnpm --filter @vizora/middleware test -- content.service.spec.ts --runInBand` - pass, 96 tests.
- `pnpm --filter @vizora/middleware test -- --runInBand` - pass, 143 suites / 2787 tests.
- `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` - pass.
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vizora pnpm --filter @vizora/database exec prisma validate` - pass.
- `pnpm --filter @vizora/realtime test -- --runInBand` - pass, 11 suites / 256 tests.
- `pnpm --filter @vizora/web test -- --runInBand` - pass, 89 suites / 925 tests.
- `pnpm --filter @vizora/display test -- --runInBand` - pass, 5 suites / 116 tests.
- `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` - pass.
- `npx nx build @vizora/middleware` - pass with existing webpack warnings.
- `npx nx build @vizora/realtime` - pass with existing source-map / optional ws warnings.
- `NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 npx nx build @vizora/web` - pass with existing Next warnings.

## Deployment
- Do not deploy until production checkout is re-verified clean. Earlier deploy gate showed `/opt/vizora/app` dirty and diverged from `origin/main`.