### PR TITLE
test: cover upload streaming in critical smoke

### DIFF
--- a/docs/plans/2026-05-31-critical-smoke-upload-streaming.md
+++ b/docs/plans/2026-05-31-critical-smoke-upload-streaming.md
@@ -1,0 +1,58 @@
+# Critical Smoke Upload + Streaming Coverage
+
+**Goal:** Extend the operator-facing critical-path smoke so a go-live check proves real multipart upload and authenticated device-content byte-range streaming, not only URL content creation.
+
+**New primitives introduced:** none. Reuse the existing Bash smoke harness, `/api/v1/content/upload`, device JWT from pairing, `/api/v1/device-content/:id/file`, response envelope parsing helpers, and temp-file cleanup.
+
+**Hermes-first analysis:**
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| API smoke coverage | none applicable | Build in existing `scripts/smoke/api-critical-path.sh`. |
+| Multipart content upload | none applicable | Reuse existing middleware upload endpoint and storage path. |
+| Device-content streaming | none applicable | Reuse existing authenticated device-content controller and byte-range support. |
+
+Awesome-Hermes-agent ecosystem check: not applicable; this change does not introduce business-agent workflows, MCP tools, AI provider calls, or spend paths.
+
+## Drift Check
+
+- `scripts/smoke/api-critical-path.sh` already covers health, register/login, pairing, URL content creation, playlist, schedule, active schedule device read, and notifications.
+- The script does not upload a real file through multipart form data.
+- The script does not probe authenticated `/api/v1/device-content/:id/file` streaming or range responses.
+- Unit coverage exists for upload quota and device-content range behavior, but the operator smoke does not prove the integrated storage path.
+
+## Plan
+
+- [x] Add a tiny generated PDF fixture inside the smoke temp directory.
+- [x] Upload it through `/api/v1/content/upload` using the authenticated cookie/CSRF path.
+- [x] Parse the uploaded content ID through the standard response envelope helper.
+- [x] Fetch an authenticated byte range from `/api/v1/device-content/:id/file` with the paired device JWT.
+- [x] Verify status `206`, exact `Content-Range` total, and PDF header bytes.
+- [x] Delete the uploaded content after the range probe, with best-effort exit cleanup for interrupted runs.
+- [x] Run syntax verification and focused smoke-script checks; run full smoke only if a local stack is available.
+
+## Review Focus
+
+- Keep the script re-runnable and cleanup-safe.
+- Do not commit binary fixtures or secrets.
+- Avoid image uploads in the smoke fixture so production runs do not leave generated thumbnail files behind.
+- Do not make local development smoke brittle where existing MinIO setup is expected.
+- Preserve existing critical-path checks and result reporting.
+
+## Review Gate
+
+- Bash/operator-safety reviewer: initial low findings on run uniqueness, `Content-Range`, and signal traps fixed; final re-review CLEAN.
+- Customer-readiness/operator-state reviewer: initial persistent production artifact finding fixed by switching to a PDF fixture and deleting uploaded content; final re-review CLEAN.
+
+## Verification
+
+- `pnpm install --frozen-lockfile` - pass.
+- `C:\Program Files\Git\bin\bash.exe -n scripts/smoke/api-critical-path.sh` - pass.
+- `git diff --check` - pass; line-ending warnings only for existing Windows checkout behavior.
+- `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="file-validation.service|content.controller|device-content.controller"` - pass, 7 suites / 190 tests.
+- `pnpm --filter @vizora/middleware test -- --runInBand` - pass, 143 suites / 2787 tests.
+- `pnpm --dir packages/database exec prisma validate --schema prisma/schema.prisma` with `NODE_OPTIONS=--use-system-ca` - pass.
+
+## Residual Risk
+
+- Full local critical-path smoke was not run because Docker Desktop is not running and local services on ports 3000/3001/3002 are unavailable. Do not run the smoke against production as a substitute while the production deploy gate remains blocked.

--- a/scripts/smoke/api-critical-path.sh
+++ b/scripts/smoke/api-critical-path.sh
@@ -3,7 +3,8 @@
 # api-critical-path.sh - operator-facing smoke test for the customer-1
 # critical path. It proves the minimum onboarding path:
 # health -> register -> login -> pair display -> create content ->
-# create playlist -> schedule playlist -> device reads active schedule.
+# upload content -> stream uploaded content -> create playlist ->
+# schedule playlist -> device reads active schedule.
 #
 # Usage:
 #   bash scripts/smoke/api-critical-path.sh
@@ -22,16 +23,18 @@ WEB_BASE="${WEB_BASE:-http://localhost:3001}"
 RT_BASE="${RT_BASE:-http://localhost:3002}"
 CURL_CONNECT_TIMEOUT="${CURL_CONNECT_TIMEOUT:-5}"
 CURL_MAX_TIME="${CURL_MAX_TIME:-20}"
+SMOKE_CLEANUP_UPLOAD="${SMOKE_CLEANUP_UPLOAD:-true}"
 umask 077
 
 RESULTS=()
 FAILED=0
 CHECK_NUM=0
 TIMESTAMP=$(date +%s)
-EMAIL="smoke-test-${TIMESTAMP}@vizora.test"
+RUN_SUFFIX="${TIMESTAMP}-${RANDOM}-$$"
+EMAIL="smoke-test-${RUN_SUFFIX}@vizora.test"
 PASSWORD='SmokeTest123!@#'
-ORG_NAME="smoke-test-${TIMESTAMP}"
-DEVICE_ID="smoke-device-${TIMESTAMP}"
+ORG_NAME="smoke-test-${RUN_SUFFIX}"
+DEVICE_ID="smoke-device-${RUN_SUFFIX}"
 TMP_PARENT="${TMPDIR:-/tmp}"
 TMP_DIR="$(mktemp -d "${TMP_PARENT%/}/vizora-smoke-${TIMESTAMP}.XXXXXX")"
 if [[ -z "$TMP_DIR" || ! -d "$TMP_DIR" ]]; then
@@ -42,6 +45,9 @@ COOKIE_JAR="$TMP_DIR/cookie.txt"
 TMP_FILES=()
 CSRF_TOKEN=""
 CHECK_LABEL=""
+UPLOAD_CONTENT_ID=""
+UPLOAD_CONTENT_DELETED=0
+CLEANED_UP=0
 
 tmp_json() {
   local name="$1"
@@ -57,12 +63,41 @@ tmp_headers() {
   printf '%s' "$path"
 }
 
+tmp_file() {
+  local name="$1"
+  local path="$TMP_DIR/$name"
+  TMP_FILES+=("$path")
+  printf '%s' "$path"
+}
+
 cleanup() {
+  if [[ "${CLEANED_UP:-0}" == "1" ]]; then
+    return
+  fi
+  CLEANED_UP=1
+
+  if [[
+    "${SMOKE_CLEANUP_UPLOAD:-true}" != "false" &&
+    "${SMOKE_CLEANUP_UPLOAD:-true}" != "0" &&
+    -n "${UPLOAD_CONTENT_ID:-}" &&
+    "${UPLOAD_CONTENT_DELETED:-0}" != "1" &&
+    -n "${COOKIE_JAR:-}" &&
+    -f "${COOKIE_JAR:-}"
+  ]]; then
+    local cleanup_headers=(-b "$COOKIE_JAR")
+    if [[ -n "${CSRF_TOKEN:-}" ]]; then
+      cleanup_headers+=(-H "X-CSRF-Token: $CSRF_TOKEN")
+    fi
+    curl "${curl_common[@]}" -X DELETE "${cleanup_headers[@]}" \
+      "$API_BASE/api/v1/content/$UPLOAD_CONTENT_ID" >/dev/null 2>&1 || true
+  fi
+
   if [[ -n "${TMP_DIR:-}" && -d "$TMP_DIR" && "$TMP_DIR" == *vizora-smoke-* ]]; then
     rm -rf "$TMP_DIR" 2>/dev/null || true
   fi
 }
-trap cleanup EXIT HUP INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' HUP INT TERM
 
 make_label() {
   CHECK_NUM=$((CHECK_NUM + 1))
@@ -141,6 +176,19 @@ print(json.dumps(payload))
 PY
 }
 
+write_smoke_pdf() {
+  local output_path="$1"
+  python3 - "$output_path" <<'PY'
+import sys
+
+# Tiny PDF-like fixture. It exercises multipart upload and byte-range
+# streaming without triggering image thumbnail generation.
+pdf = b"%PDF-1.1\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF\n"
+with open(sys.argv[1], "wb") as handle:
+    handle.write(pdf)
+PY
+}
+
 auth_headers=()
 curl_common=(-s --connect-timeout "$CURL_CONNECT_TIMEOUT" --max-time "$CURL_MAX_TIME")
 refresh_auth_headers() {
@@ -190,6 +238,33 @@ post_json() {
   : > "$out"
   actual="$(curl "${curl_common[@]}" -o "$out" -w '%{http_code}' \
     -X POST -H "Content-Type: application/json" "$@" -d "$body" "$url" 2>/dev/null)"
+
+  if [[ "$actual" == "$expected" ]]; then
+    record_ok "$label" "$actual"
+  else
+    record_fail "$label" "got '$actual'; expected '$expected'"
+    echo "$label response body:"
+    print_response_preview "$out"
+  fi
+}
+
+post_multipart_upload() {
+  local label expected url file_path out actual
+  make_label "$1"
+  label="$CHECK_LABEL"
+  expected="$2"
+  url="$3"
+  file_path="$4"
+  out="$5"
+  shift 5
+
+  : > "$out"
+  actual="$(curl "${curl_common[@]}" -o "$out" -w '%{http_code}' \
+    -X POST "$@" \
+    -F "file=@${file_path};type=application/pdf;filename=smoke-upload.pdf" \
+    -F "name=Smoke Upload ${TIMESTAMP}" \
+    -F "type=pdf" \
+    "$url" 2>/dev/null)"
 
   if [[ "$actual" == "$expected" ]]; then
     record_ok "$label" "$actual"
@@ -317,6 +392,97 @@ else
 fi
 
 probe_status_authed "List content" "200" "$API_BASE/api/v1/content"
+
+UPLOAD_FILE="$(tmp_file smoke-upload.pdf)"
+write_smoke_pdf "$UPLOAD_FILE"
+UPLOAD_FILE_SIZE="$(python3 - "$UPLOAD_FILE" <<'PY'
+import os
+import sys
+
+try:
+    print(os.path.getsize(sys.argv[1]))
+except Exception:
+    print("")
+PY
+)"
+UPLOAD_OUT="$(tmp_json upload-content)"
+post_multipart_upload "Upload PDF content" "201" "$API_BASE/api/v1/content/upload" "$UPLOAD_FILE" "$UPLOAD_OUT" "${auth_headers[@]}"
+UPLOAD_CONTENT_ID="$(json_get "$UPLOAD_OUT" "data.content.id")"
+if [[ -z "$UPLOAD_CONTENT_ID" ]]; then
+  UPLOAD_CONTENT_ID="$(json_get "$UPLOAD_OUT" "content.id")"
+fi
+make_label "Uploaded content id parsed"
+parse_label="$CHECK_LABEL"
+if [[ -n "$UPLOAD_CONTENT_ID" ]]; then
+  record_ok "$parse_label" "$UPLOAD_CONTENT_ID"
+else
+  record_fail "$parse_label" "missing uploaded content id"
+fi
+
+RANGE_OUT="$(tmp_file uploaded-content-range.bin)"
+RANGE_HEADERS="$(tmp_headers uploaded-content-range)"
+make_label "Device streams uploaded content range"
+range_label="$CHECK_LABEL"
+if [[ -n "$UPLOAD_CONTENT_ID" && -n "$DEVICE_TOKEN" ]]; then
+  : > "$RANGE_OUT"
+  : > "$RANGE_HEADERS"
+  RANGE_STATUS="$(curl "${curl_common[@]}" -D "$RANGE_HEADERS" -o "$RANGE_OUT" -w '%{http_code}' \
+    -H "Authorization: Bearer $DEVICE_TOKEN" \
+    -H "Range: bytes=0-4" \
+    "$API_BASE/api/v1/device-content/$UPLOAD_CONTENT_ID/file" 2>/dev/null)"
+  RANGE_HEX="$(python3 - "$RANGE_OUT" <<'PY'
+import sys
+
+try:
+    with open(sys.argv[1], "rb") as handle:
+        print(handle.read().hex())
+except Exception:
+    print("")
+PY
+)"
+  CONTENT_RANGE="$(python3 - "$RANGE_HEADERS" <<'PY'
+import sys
+
+try:
+    with open(sys.argv[1], "r", encoding="utf-8", errors="ignore") as handle:
+        for line in handle:
+            if line.lower().startswith("content-range:"):
+                print(line.split(":", 1)[1].strip())
+                break
+except Exception:
+    pass
+PY
+)"
+  EXPECTED_CONTENT_RANGE="bytes 0-4/$UPLOAD_FILE_SIZE"
+  if [[ "$RANGE_STATUS" == "206" && "$RANGE_HEX" == "255044462d" && "$CONTENT_RANGE" == "$EXPECTED_CONTENT_RANGE" ]]; then
+    record_ok "$range_label" "206 + PDF header range"
+  else
+    record_fail "$range_label" "got status '$RANGE_STATUS', range '$CONTENT_RANGE', hex '$RANGE_HEX'; expected 206 $EXPECTED_CONTENT_RANGE PDF header"
+    print_response_preview "$RANGE_OUT"
+  fi
+else
+  record_fail "$range_label" "missing uploaded content id or device token"
+fi
+
+DELETE_UPLOAD_OUT="$(tmp_json delete-upload-content)"
+make_label "Delete uploaded PDF content"
+delete_upload_label="$CHECK_LABEL"
+if [[ -n "$UPLOAD_CONTENT_ID" ]]; then
+  : > "$DELETE_UPLOAD_OUT"
+  refresh_auth_headers
+  DELETE_UPLOAD_STATUS="$(curl "${curl_common[@]}" -o "$DELETE_UPLOAD_OUT" -w '%{http_code}' \
+    -X DELETE "${auth_headers[@]}" \
+    "$API_BASE/api/v1/content/$UPLOAD_CONTENT_ID" 2>/dev/null)"
+  if [[ "$DELETE_UPLOAD_STATUS" == "200" || "$DELETE_UPLOAD_STATUS" == "204" ]]; then
+    UPLOAD_CONTENT_DELETED=1
+    record_ok "$delete_upload_label" "$DELETE_UPLOAD_STATUS"
+  else
+    record_fail "$delete_upload_label" "got '$DELETE_UPLOAD_STATUS'; expected 200 or 204"
+    print_response_preview "$DELETE_UPLOAD_OUT"
+  fi
+else
+  record_fail "$delete_upload_label" "missing uploaded content id"
+fi
 
 PLAYLIST_ITEMS=$(CONTENT_ID="$CONTENT_ID" python3 - <<'PY'
 import json

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,8 +1,47 @@
 # Vizora - Task Tracker
 
-## In Progress: Customer Performance Readiness Pass 3 (2026-05-31)
+## In Progress: Critical Smoke Upload + Streaming Coverage (2026-05-31)
+
+**Branch:** `feat/customer-readiness-next`
+
+**Why now:** PR #123 merged the customer-readiness hot-path hardening, but the operator smoke still proves URL content creation rather than real multipart upload and authenticated media streaming. Customer-1 go-live needs the smoke to exercise the path displays actually use for uploaded assets.
+
+**New primitives introduced:** none. Reuse the existing smoke script, upload endpoint, device JWT pairing flow, and device-content streaming route.
+
+**Hermes-first analysis:** not applicable; this is API smoke coverage in existing middleware/display paths, not a business-agent, MCP, Hermes, or AI/spend path.
+
+**Plan/design:** `docs/plans/2026-05-31-critical-smoke-upload-streaming.md`
+
+**Plan**
+- [x] Re-check current branch/CI/prod deploy gate after PR #123 merge.
+- [x] Drift-check smoke coverage for upload and device-content streaming.
+- [x] Add generated tiny PDF multipart upload to the critical-path smoke.
+- [x] Add authenticated device-content byte-range streaming verification.
+- [x] Add uploaded-object cleanup so production smoke runs do not leave MinIO objects behind.
+- [x] Run subagent review before broad verification.
+- [x] Run focused verification; full smoke blocked because Docker/local services are unavailable.
+- [ ] PR, CI, merge.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Review gate**
+- [x] Bash/operator-safety reviewer: initial run-ID, range-validation, and interrupt-handling notes fixed; final re-review CLEAN.
+- [x] Customer-readiness/operator-state reviewer: initial persistent-artifact finding fixed with PDF fixture + uploaded-content delete; final re-review CLEAN.
+
+**Local verification**
+- [x] `pnpm install --frozen-lockfile` - pass.
+- [x] `C:\Program Files\Git\bin\bash.exe -n scripts/smoke/api-critical-path.sh` - pass.
+- [x] `git diff --check` - pass; line-ending warnings only.
+- [x] `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="file-validation.service|content.controller|device-content.controller"` - pass, 7 suites / 190 tests.
+- [x] `pnpm --filter @vizora/middleware test -- --runInBand` - pass, 143 suites / 2787 tests.
+- [x] `pnpm --dir packages/database exec prisma validate --schema prisma/schema.prisma` with `NODE_OPTIONS=--use-system-ca` - pass.
+- [x] Full local smoke not run: Docker Desktop is not running and local 3000/3001/3002 services are unavailable. Production smoke is intentionally not used as a substitute while prod deploy gate is blocked.
+
+---
+
+## Completed: Customer Performance Readiness Pass 3 (2026-05-31)
 
 **Branch:** `feat/customer-performance-readiness-3`
+**PR / merge commit:** #123 / `0c45c468243b5271eb3afee24284dc16ecce370f`
 
 **Why now:** PRs #120-#122 closed the first display delivery, dashboard readiness, and stale PR #34 residual slices. The next repo-side push is a fresh customer-perspective review plus performance/code-review pass focused on content upload, pairing, content streaming, middleware hot paths, and any remaining production-readiness issues that are buildable and testable without operator-only actions.
 
@@ -24,8 +63,8 @@
 - [x] Implement fixes with focused tests.
 - [x] Run multi-subagent review before broad tests.
 - [x] Run focused/broad local verification.
-- [ ] PR, CI, merge.
-- [ ] Re-check deployment gate and deploy only if prod checkout is safe.
+- [x] PR, CI, merge.
+- [x] Re-check deployment gate; deployment remains blocked by dirty/diverged prod checkout.
 
 **Selected fix bundle**
 - [x] Reject disabled/deleted display tokens in realtime and device-content paths.
@@ -60,10 +99,10 @@
 - [x] `NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 npx nx build @vizora/web` - pass with existing Next middleware deprecation and TypeScript project-reference warnings.
 
 **Current deployment gate**
-- GitHub main: `48affb3e0ff6163ae5babf6bbe74d702c67e5348` after PR #122.
-- Open PRs: none after closing stale PR #34.
-- Production health: `/api/v1/health` returned `success: true`, database connected at `2026-05-31T08:22:03.846Z`.
-- Production deploy is blocked: `/opt/vizora/app` is dirty, local `HEAD=bb76aa1838740bff5b58623dfef7a906d44f46a6`, and after fetch is `ahead 17, behind 38` relative to `origin/main=48affb3e0ff6163ae5babf6bbe74d702c67e5348`. Do not pull/reset/stash/restart services until prod-local work is reconciled.
+- GitHub main: `0c45c468243b5271eb3afee24284dc16ecce370f` after PR #123.
+- Open PRs: none after merging PR #123.
+- Production health: `/api/v1/health` returned `success: true`, database connected at `2026-05-31T10:16:01.382Z`.
+- Production deploy is blocked: `/opt/vizora/app` is dirty, local `HEAD=bb76aa1838740bff5b58623dfef7a906d44f46a6`, and after fetch is `ahead 17, behind 39` relative to `origin/main=0c45c468243b5271eb3afee24284dc16ecce370f`. Do not pull/reset/stash/restart services until prod-local work is reconciled.
 
 ---
 


### PR DESCRIPTION
## Summary
- extend the operator critical-path smoke to upload a generated PDF via `/api/v1/content/upload`
- verify authenticated `/api/v1/device-content/:id/file` byte-range streaming with the paired device JWT
- delete the uploaded smoke content and add guarded exit cleanup to avoid persistent uploaded-media artifacts
- record review/verification evidence in `tasks/todo.md` and the plan doc

## Review
- Bash/operator-safety reviewer: initial run-ID, range-validation, and interrupt-handling notes fixed; final re-review CLEAN.
- Customer-readiness/operator-state reviewer: initial persistent-artifact finding fixed with PDF fixture + uploaded-content delete; final re-review CLEAN.

## Verification
- `pnpm install --frozen-lockfile`
- `C:\Program Files\Git\bin\bash.exe -n scripts/smoke/api-critical-path.sh`
- `git diff --check` (line-ending warnings only)
- `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=file-validation.service|content.controller|device-content.controller` (7 suites / 190 tests)
- `pnpm --filter @vizora/middleware test -- --runInBand` (143 suites / 2787 tests)
- `pnpm --dir packages/database exec prisma validate --schema prisma/schema.prisma` with `NODE_OPTIONS=--use-system-ca`

## Not run
- Full local critical-path smoke: Docker Desktop is not running and local services on ports 3000/3001/3002 are unavailable. Production smoke was not used as a substitute while the production deploy gate remains blocked.