### PR TITLE
fix: harden display runtime reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,14 @@ jobs:
         working-directory: realtime
         run: pnpm test --passWithNoTests
 
+      - name: Run display unit tests
+        working-directory: display
+        run: pnpm test -- --runInBand
+
+      - name: Typecheck display client
+        working-directory: display
+        run: pnpm typecheck
+
       - name: Run ops unit tests
         run: pnpm test:ops
 
@@ -199,6 +207,10 @@ jobs:
 
       - name: Build realtime
         run: npx nx build @vizora/realtime
+
+      - name: Build display client
+        working-directory: display
+        run: pnpm build
 
   security:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Run display unit tests
         working-directory: display
-        run: pnpm test -- --runInBand
+        run: pnpm test:ci
 
       - name: Typecheck display client
         working-directory: display

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,7 +238,7 @@ backlog.md                 # P0-P4 active backlog with status + effort estimates
 
 ## Display Clients
 
-**Electron** (`display/`): Desktop app for Windows/macOS/Linux. Webpack + TypeScript. Packages via electron-builder.
+**Electron** (`display/`): Desktop app for Windows/macOS/Linux. Webpack + TypeScript. Packages via electron-builder. Packaged display clients configure OS auto-start and use Electron `powerSaveBlocker` to prevent display sleep.
 
 **Android TV**: Extracted to standalone repo (`vizora-tv`). Capacitor 6 + Vite + TypeScript. See [github.com/Trivenidigital/vizora-tv](https://github.com/Trivenidigital/vizora-tv).
 
@@ -262,8 +262,8 @@ Available at `http://localhost:3000/api/v1/docs` in development mode only.
 - **Aggregate**: 3411 unit/integration tests passing, **ZERO failures** across all 3 services.
 - **TypeScript**: middleware `tsc --noEmit` exit 0; realtime + web pass via ts-jest (no separate type-check needed).
 - **Playwright (E2E)**: 24 spec files in `e2e-tests/`. Post-2026-05-09 fix (mass `/api/` → `/api/v1/` + h1 copy regex updates), estimated >90% pass rate. ~26 remaining failures concentrated in 9 specs (heaviest: 16-billing); see `docs/plans/2026-05-09-playwright-results.md`. Critical-path flows verified.
-- **Display**: No test coverage yet (Electron testing framework not wired). Rely on real-device walkthrough per release.
-- **Builds**: All 3 services compile via `npx nx build @vizora/{middleware,web,realtime}`. `web` may need `NODE_OPTIONS="--max-old-space-size=4096"` on memory-constrained dev machines.
+- **Display**: Jest unit coverage exists for Electron main/preload/device/cache/renderer helpers and is CI-gated via `pnpm --filter @vizora/display test -- --runInBand`; display typecheck/build are gated via `pnpm --filter @vizora/display typecheck` and `pnpm --filter @vizora/display build`. Real-device walkthrough is still required per release.
+- **Builds**: All 3 services compile via `npx nx build @vizora/{middleware,web,realtime}`; Electron display compiles via `pnpm --filter @vizora/display build`. `web` may need `NODE_OPTIONS="--max-old-space-size=4096"` on memory-constrained dev machines.
 
 **API smoke test**: `bash scripts/smoke/api-critical-path.sh` probes 12 critical endpoints in <30 seconds; verified 12/12 pass against local stack 2026-05-09.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,7 +262,7 @@ Available at `http://localhost:3000/api/v1/docs` in development mode only.
 - **Aggregate**: 3411 unit/integration tests passing, **ZERO failures** across all 3 services.
 - **TypeScript**: middleware `tsc --noEmit` exit 0; realtime + web pass via ts-jest (no separate type-check needed).
 - **Playwright (E2E)**: 24 spec files in `e2e-tests/`. Post-2026-05-09 fix (mass `/api/` → `/api/v1/` + h1 copy regex updates), estimated >90% pass rate. ~26 remaining failures concentrated in 9 specs (heaviest: 16-billing); see `docs/plans/2026-05-09-playwright-results.md`. Critical-path flows verified.
-- **Display**: Jest unit coverage exists for Electron main/preload/device/cache/renderer helpers and is CI-gated via `pnpm --filter @vizora/display test -- --runInBand`; display typecheck/build are gated via `pnpm --filter @vizora/display typecheck` and `pnpm --filter @vizora/display build`. Real-device walkthrough is still required per release.
+- **Display**: Jest unit coverage exists for Electron main/preload/device/cache/renderer helpers and is CI-gated via `pnpm --filter @vizora/display test:ci`; display typecheck/build are gated via `pnpm --filter @vizora/display typecheck` and `pnpm --filter @vizora/display build`. Real-device walkthrough is still required per release.
 - **Builds**: All 3 services compile via `npx nx build @vizora/{middleware,web,realtime}`; Electron display compiles via `pnpm --filter @vizora/display build`. `web` may need `NODE_OPTIONS="--max-old-space-size=4096"` on memory-constrained dev machines.
 
 **API smoke test**: `bash scripts/smoke/api-critical-path.sh` probes 12 critical endpoints in <30 seconds; verified 12/12 pass against local stack 2026-05-09.

--- a/backlog.md
+++ b/backlog.md
@@ -254,10 +254,10 @@ Items the audit listed but we are NOT pursuing live (Engage/kiosk, live remote v
 
 | # | Issue | Severity | Status | Notes |
 |---|-------|----------|--------|-------|
-| K1 | Electron auto-start on boot not configured | Low | TODO | Android TV has it, Electron doesn't |
-| K2 | Electron powerSaveBlocker not enabled | Low | TODO | Screen may sleep |
+| K1 | Electron auto-start on boot not configured | Low | FIXED | Packaged display clients configure OS auto-start (Windows/macOS login item, Linux autostart desktop file with AppImage path support) |
+| K2 | Electron powerSaveBlocker not enabled | Low | FIXED | Packaged display clients start `prevent-display-sleep` and stop it on quit |
 | K3 | Electron auto-update not configured | Low | TODO | electron-updater referenced but not wired |
-| K4 | Display client has 0 test coverage | Medium | TODO | Android TV app untested |
+| K4 | Display client has 0 test coverage | Medium | FIXED | Electron display Jest suite, typecheck, and build are CI-gated; real-device walkthrough still required |
 | K5 | 3 pre-existing RSC admin test failures | Low | TODO | React Server Component edge cases |
 | K6 | AI Designer returns "launching soon" stub | Info | TODO | Intentional — needs API budget |
 | K7 | Push-to-group iterates client-side | Low | TODO | No server-side batch endpoint |

--- a/display/package.json
+++ b/display/package.json
@@ -9,6 +9,7 @@
     "start": "electron .",
     "dev": "webpack-dev-server --mode development",
     "build": "webpack --mode production && tsc -p tsconfig.electron.json",
+    "typecheck": "tsc -p tsconfig.app.json --noEmit && tsc -p tsconfig.electron.json --noEmit",
     "package": "npm run build && electron-builder --publish never",
     "package:win": "npm run build && electron-builder --win --publish never",
     "package:mac": "npm run build && electron-builder --mac --publish never",

--- a/display/package.json
+++ b/display/package.json
@@ -15,7 +15,8 @@
     "package:mac": "npm run build && electron-builder --mac --publish never",
     "package:linux": "npm run build && electron-builder --linux --publish never",
     "package:all": "npm run build && electron-builder -mwl --publish never",
-    "test": "jest"
+    "test": "jest",
+    "test:ci": "jest --runInBand"
   },
   "build": {
     "appId": "com.vizora.display",

--- a/display/src/electron/main.spec.ts
+++ b/display/src/electron/main.spec.ts
@@ -35,6 +35,14 @@ jest.mock('./device-client', () => ({
   DeviceClient: jest.fn().mockImplementation(() => mockDeviceClient),
 }));
 
+const mockMkdirSync = jest.fn();
+const mockWriteFileSync = jest.fn();
+
+jest.mock('fs', () => ({
+  mkdirSync: (...args: any[]) => mockMkdirSync(...args),
+  writeFileSync: (...args: any[]) => mockWriteFileSync(...args),
+}));
+
 // Capture handlers registered via ipcMain.handle and app event listeners
 const ipcHandlers: Record<string, Function> = {};
 const ipcListeners: Record<string, Function[]> = {};
@@ -71,8 +79,16 @@ const mockMainWindow = {
   reload: jest.fn(),
 };
 
+const mockSetLoginItemSettings = jest.fn();
+const mockPowerSaveBlocker = {
+  start: jest.fn().mockReturnValue(42),
+  stop: jest.fn(),
+  isStarted: jest.fn().mockReturnValue(true),
+};
+
 jest.mock('electron', () => ({
   app: {
+    isPackaged: false,
     whenReady: jest.fn().mockReturnValue({ then: jest.fn() }),
     on: jest.fn().mockImplementation((event: string, cb: Function) => {
       if (!appEventListeners[event]) appEventListeners[event] = [];
@@ -80,6 +96,7 @@ jest.mock('electron', () => ({
     }),
     getVersion: jest.fn().mockReturnValue('1.0.0'),
     getPath: jest.fn().mockReturnValue('/tmp/test'),
+    setLoginItemSettings: (...args: any[]) => mockSetLoginItemSettings(...args),
     quit: jest.fn(),
   },
   BrowserWindow: jest.fn().mockImplementation(() => mockMainWindow),
@@ -95,6 +112,7 @@ jest.mock('electron', () => ({
       ipcListeners[channel] = (ipcListeners[channel] || []).filter((l) => l !== listener);
     }),
   },
+  powerSaveBlocker: mockPowerSaveBlocker,
   screen: {
     getPrimaryDisplay: jest.fn().mockReturnValue({
       workAreaSize: { width: 1920, height: 1080 },
@@ -112,10 +130,14 @@ jest.mock('path', () => ({
 }));
 
 // Clear module cache to force fresh require of main.ts
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockStoreGet.mockReturnValue(null);
-    Object.keys(ipcHandlers).forEach((k) => delete ipcHandlers[k]);
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockStoreGet.mockReturnValue(null);
+  Object.defineProperty(app, 'isPackaged', { value: false, configurable: true });
+  delete process.env.APPIMAGE;
+  mockPowerSaveBlocker.start.mockReturnValue(42);
+  mockPowerSaveBlocker.isStarted.mockReturnValue(true);
+  Object.keys(ipcHandlers).forEach((k) => delete ipcHandlers[k]);
   Object.keys(ipcListeners).forEach((k) => delete ipcListeners[k]);
   Object.keys(appEventListeners).forEach((k) => delete appEventListeners[k]);
   Object.keys(webContentsListeners).forEach((k) => delete webContentsListeners[k]);
@@ -123,7 +145,7 @@ jest.mock('path', () => ({
 });
 
 // Import after mocks are set up
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, ipcMain, powerSaveBlocker } from 'electron';
 
 describe('main.ts - Electron main process', () => {
   describe('IPC handler registration', () => {
@@ -207,6 +229,97 @@ describe('main.ts - Electron main process', () => {
     it('should register before-quit handler', () => {
       expect(appEventListeners['before-quit']).toBeDefined();
       expect(appEventListeners['before-quit'].length).toBeGreaterThan(0);
+    });
+
+    it('does not configure production runtime guards for unpackaged test runs', () => {
+      const thenMock = (app.whenReady as jest.Mock).mock.results[0].value.then;
+      const createWindowCallback = thenMock.mock.calls[0][0];
+      createWindowCallback();
+
+      expect(mockSetLoginItemSettings).not.toHaveBeenCalled();
+      expect(powerSaveBlocker.start).not.toHaveBeenCalled();
+      expect(mockMkdirSync).not.toHaveBeenCalled();
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+    });
+
+    it('does not configure runtime guards for unpackaged NODE_ENV production runs', () => {
+      const originalNodeEnv = process.env.NODE_ENV;
+      try {
+        process.env.NODE_ENV = 'production';
+
+        const thenMock = (app.whenReady as jest.Mock).mock.results[0].value.then;
+        const createWindowCallback = thenMock.mock.calls[0][0];
+        createWindowCallback();
+
+        expect(mockSetLoginItemSettings).not.toHaveBeenCalled();
+        expect(powerSaveBlocker.start).not.toHaveBeenCalled();
+        expect(mockMkdirSync).not.toHaveBeenCalled();
+        expect(mockWriteFileSync).not.toHaveBeenCalled();
+      } finally {
+        if (originalNodeEnv === undefined) {
+          delete process.env.NODE_ENV;
+        } else {
+          process.env.NODE_ENV = originalNodeEnv;
+        }
+      }
+    });
+
+    it('enables login item auto-start and display sleep prevention for packaged Windows displays', () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      Object.defineProperty(app, 'isPackaged', { value: true, configurable: true });
+
+      const thenMock = (app.whenReady as jest.Mock).mock.results[0].value.then;
+      const createWindowCallback = thenMock.mock.calls[0][0];
+      createWindowCallback();
+
+      expect(mockSetLoginItemSettings).toHaveBeenCalledWith({
+        openAtLogin: true,
+        openAsHidden: false,
+        path: process.execPath,
+      });
+      expect(powerSaveBlocker.start).toHaveBeenCalledWith('prevent-display-sleep');
+
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    });
+
+    it('writes a Linux desktop autostart entry for packaged Linux displays', () => {
+      const originalPlatform = process.platform;
+      process.env.APPIMAGE = '/opt/Vizora Display.AppImage';
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+      Object.defineProperty(app, 'isPackaged', { value: true, configurable: true });
+
+      const thenMock = (app.whenReady as jest.Mock).mock.results[0].value.then;
+      const createWindowCallback = thenMock.mock.calls[0][0];
+      createWindowCallback();
+
+      expect(mockMkdirSync).toHaveBeenCalledWith('/tmp/test/.config/autostart', { recursive: true });
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        '/tmp/test/.config/autostart/vizora-display.desktop',
+        expect.stringContaining('Exec="/opt/Vizora Display.AppImage"'),
+        'utf8',
+      );
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        '/tmp/test/.config/autostart/vizora-display.desktop',
+        expect.stringContaining('X-GNOME-Autostart-enabled=true'),
+        'utf8',
+      );
+      expect(mockSetLoginItemSettings).not.toHaveBeenCalled();
+
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    });
+
+    it('stops display sleep prevention before quitting', () => {
+      Object.defineProperty(app, 'isPackaged', { value: true, configurable: true });
+
+      const thenMock = (app.whenReady as jest.Mock).mock.results[0].value.then;
+      const createWindowCallback = thenMock.mock.calls[0][0];
+      createWindowCallback();
+
+      const handler = appEventListeners['before-quit'][0];
+      handler();
+
+      expect(powerSaveBlocker.stop).toHaveBeenCalledWith(42);
     });
 
     it('disconnects an existing device client before reinitializing after renderer reload', () => {

--- a/display/src/electron/main.ts
+++ b/display/src/electron/main.ts
@@ -1,4 +1,5 @@
-import { app, BrowserWindow, ipcMain, screen } from 'electron';
+import { app, BrowserWindow, ipcMain, powerSaveBlocker, screen } from 'electron';
+import * as fs from 'fs';
 import * as path from 'path';
 import { DeviceClient } from './device-client';
 import { CacheManager } from './cache-manager';
@@ -15,8 +16,119 @@ const store = new Store({
 let mainWindow: BrowserWindow | null = null;
 let deviceClient: DeviceClient | null = null;
 let cacheManager: CacheManager | null = null;
+let sleepBlockerId: number | null = null;
 const PLAYLIST_RENDERER_ACK_TIMEOUT_MS = 5000;
 const COMMAND_RENDERER_ACK_TIMEOUT_MS = 5000;
+const LINUX_AUTOSTART_FILE = 'vizora-display.desktop';
+const PROCESS_ERROR_HANDLERS_REGISTERED = '__vizoraDisplayProcessErrorHandlersRegistered';
+
+function shouldEnableRuntimeGuards(): boolean {
+  return app.isPackaged;
+}
+
+function quoteDesktopExec(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function getLinuxAutostartExecPath(): string {
+  return process.env.APPIMAGE || process.execPath;
+}
+
+function configureAutoStart(): void {
+  if (!shouldEnableRuntimeGuards()) {
+    return;
+  }
+
+  try {
+    if (process.platform === 'win32' || process.platform === 'darwin') {
+      app.setLoginItemSettings({
+        openAtLogin: true,
+        openAsHidden: false,
+        path: process.execPath,
+      });
+      console.log('[Main] Auto-start enabled via login item settings');
+      return;
+    }
+
+    if (process.platform === 'linux') {
+      const autostartDir = path.join(app.getPath('home'), '.config', 'autostart');
+      const desktopPath = path.join(autostartDir, LINUX_AUTOSTART_FILE);
+      fs.mkdirSync(autostartDir, { recursive: true });
+      fs.writeFileSync(
+        desktopPath,
+        [
+          '[Desktop Entry]',
+          'Type=Application',
+          'Name=Vizora Display',
+          `Exec=${quoteDesktopExec(getLinuxAutostartExecPath())}`,
+          'Terminal=false',
+          'X-GNOME-Autostart-enabled=true',
+          '',
+        ].join('\n'),
+        'utf8',
+      );
+      console.log(`[Main] Auto-start enabled via ${desktopPath}`);
+    }
+  } catch (error) {
+    console.error('[Main] Failed to configure auto-start:', error);
+  }
+}
+
+function registerProcessErrorHandlers(): void {
+  const handlerState = globalThis as typeof globalThis & {
+    [PROCESS_ERROR_HANDLERS_REGISTERED]?: boolean;
+  };
+
+  if (handlerState[PROCESS_ERROR_HANDLERS_REGISTERED]) {
+    return;
+  }
+
+  // Handle uncaught exceptions from renderer process
+  process.on('uncaughtException', (error) => {
+    console.error('[Main] Uncaught exception:', error);
+    // Continue running - don't crash
+  });
+
+  // Handle unhandled promise rejections
+  process.on('unhandledRejection', (reason, promise) => {
+    console.error('[Main] Unhandled rejection at:', promise, 'reason:', reason);
+    // Continue running - don't crash
+  });
+
+  handlerState[PROCESS_ERROR_HANDLERS_REGISTERED] = true;
+}
+
+function startDisplaySleepBlocker(): void {
+  if (!shouldEnableRuntimeGuards()) {
+    return;
+  }
+
+  try {
+    if (sleepBlockerId !== null && powerSaveBlocker.isStarted(sleepBlockerId)) {
+      return;
+    }
+    sleepBlockerId = powerSaveBlocker.start('prevent-display-sleep');
+    console.log(`[Main] Display sleep prevention enabled (${sleepBlockerId})`);
+  } catch (error) {
+    console.error('[Main] Failed to enable display sleep prevention:', error);
+  }
+}
+
+function stopDisplaySleepBlocker(): void {
+  if (sleepBlockerId === null) {
+    return;
+  }
+
+  try {
+    if (powerSaveBlocker.isStarted(sleepBlockerId)) {
+      powerSaveBlocker.stop(sleepBlockerId);
+    }
+  } catch (error) {
+    console.error('[Main] Failed to stop display sleep prevention:', error);
+  } finally {
+    sleepBlockerId = null;
+  }
+}
 
 function sendPlaylistToRenderer(playlist: any): Promise<void> {
   if (!mainWindow) {
@@ -386,7 +498,11 @@ ipcMain.handle('cache:clear', async () => {
 });
 
 // App lifecycle
-app.whenReady().then(createWindow);
+app.whenReady().then(() => {
+  configureAutoStart();
+  startDisplaySleepBlocker();
+  createWindow();
+});
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
@@ -402,17 +518,8 @@ app.on('activate', () => {
 
 // Handle app termination
 app.on('before-quit', () => {
+  stopDisplaySleepBlocker();
   deviceClient?.disconnect();
 });
 
-// Handle uncaught exceptions from renderer process
-process.on('uncaughtException', (error) => {
-  console.error('[Main] Uncaught exception:', error);
-  // Continue running - don't crash
-});
-
-// Handle unhandled promise rejections
-process.on('unhandledRejection', (reason, promise) => {
-  console.error('[Main] Unhandled rejection at:', promise, 'reason:', reason);
-  // Continue running - don't crash
-});
+registerProcessErrorHandlers();

--- a/display/src/renderer/app.ts
+++ b/display/src/renderer/app.ts
@@ -1,4 +1,6 @@
 // Renderer process code
+import { getEntityId } from './ids';
+
 declare global {
   interface Window {
     electronAPI: {
@@ -37,10 +39,8 @@ class DisplayApp {
   private currentIndex = 0;
   private playbackTimer: NodeJS.Timeout | null = null;
   private pairingCheckInterval: NodeJS.Timeout | null = null;
-  private currentCode: string | null = null;
   private isPairingScreenShown = false;
   private contentStartTime: number = 0;
-  private qrOverlayConfig: any = null;
   private zoneTimers: Map<string, NodeJS.Timeout> = new Map();
   private zoneIndices: Map<string, number> = new Map();
 
@@ -150,7 +150,6 @@ class DisplayApp {
       }
 
       if (result.code) {
-        this.currentCode = result.code;
         // Store the pairing code in case we need it again
         localStorage.setItem('lastPairingCode', result.code);
         this.displayPairingCode(result.code);
@@ -249,7 +248,6 @@ class DisplayApp {
           try {
             const newResult = await window.electronAPI.getPairingCode();
             console.log('[App] ✅ New pairing code received:', newResult.code);
-            this.currentCode = newResult.code;
             currentCode = newResult.code;
             localStorage.setItem('lastPairingCode', newResult.code);
             this.displayPairingCode(newResult.code);
@@ -306,7 +304,6 @@ class DisplayApp {
             try {
               const newResult = await window.electronAPI.getPairingCode();
               console.log('[App] ✅ New pairing code received after errors:', newResult.code);
-              this.currentCode = newResult.code;
               currentCode = newResult.code;
               localStorage.setItem('lastPairingCode', newResult.code);
               this.displayPairingCode(newResult.code);
@@ -429,7 +426,6 @@ class DisplayApp {
     const contentDiv = document.createElement('div');
     contentDiv.className = 'content-item active';
 
-    const startTime = Date.now();
 
     // Support both 'source' and 'url' field names for compatibility
     let contentSource = currentItem.content?.source || currentItem.content?.url;
@@ -437,16 +433,20 @@ class DisplayApp {
     // Check cache for image/video content
     if (currentItem.content?.type === 'image' || currentItem.content?.type === 'video') {
       try {
-        const contentId = currentItem.content._id || currentItem.content.id;
-        const cached = await window.electronAPI.cacheGet(contentId);
-        if (cached.path) {
-          contentSource = cached.path;
-          console.log('[App] Using cached content:', cached.path);
+        const contentId = getEntityId(currentItem.content);
+        if (contentId && contentSource) {
+          const cached = await window.electronAPI.cacheGet(contentId);
+          if (cached.path) {
+            contentSource = cached.path;
+            console.log('[App] Using cached content:', cached.path);
+          } else {
+            // Background download for future use
+            const mimeType = currentItem.content.mimeType || (currentItem.content.type === 'video' ? 'video/mp4' : 'image/jpeg');
+            window.electronAPI.cacheDownload(contentId, contentSource, mimeType)
+              .catch(err => console.warn('[App] Background cache failed:', err));
+          }
         } else {
-          // Background download for future use
-          const mimeType = currentItem.content.mimeType || (currentItem.content.type === 'video' ? 'video/mp4' : 'image/jpeg');
-          window.electronAPI.cacheDownload(contentId, contentSource, mimeType)
-            .catch(err => console.warn('[App] Background cache failed:', err));
+          console.warn('[App] Skipping cache for content without id or source');
         }
       } catch (err) {
         console.warn('[App] Cache check failed:', err);
@@ -509,8 +509,8 @@ class DisplayApp {
 
     // Log initial impression
     window.electronAPI.logImpression({
-      contentId: currentItem.content?._id,
-      playlistId: this.currentPlaylist._id,
+      contentId: getEntityId(currentItem.content),
+      playlistId: getEntityId(this.currentPlaylist),
       timestamp: this.contentStartTime,
     });
 
@@ -522,8 +522,8 @@ class DisplayApp {
 
         // Log completion with duration and completion data
         window.electronAPI.logImpression({
-          contentId: currentItem.content?._id,
-          playlistId: this.currentPlaylist._id,
+          contentId: getEntityId(currentItem.content),
+          playlistId: getEntityId(this.currentPlaylist),
           duration: Math.round(actualDurationMs / 1000),
           completionPercentage,
           timestamp: Date.now(),
@@ -547,8 +547,8 @@ class DisplayApp {
       const completionPercentage = Math.min(100, Math.round((actualDurationMs / expectedDuration) * 100));
 
       window.electronAPI.logImpression({
-        contentId: currentItem.content?._id,
-        playlistId: this.currentPlaylist._id,
+        contentId: getEntityId(currentItem.content),
+        playlistId: getEntityId(this.currentPlaylist),
         duration: Math.round(actualDurationMs / 1000),
         completionPercentage,
         timestamp: Date.now(),
@@ -574,7 +574,7 @@ class DisplayApp {
     console.error('Content error:', errorMessage, item);
 
     window.electronAPI.logError({
-      contentId: item.content?._id,
+      contentId: getEntityId(item.content),
       errorType: 'playback_error',
       errorMessage,
       timestamp: Date.now(),
@@ -610,11 +610,9 @@ class DisplayApp {
     if (!config || !config.enabled) {
       overlay.classList.add('hidden');
       overlay.innerHTML = '';
-      this.qrOverlayConfig = null;
       return;
     }
 
-    this.qrOverlayConfig = config;
     overlay.innerHTML = '';
     overlay.className = config.position || 'bottom-right';
     overlay.style.backgroundColor = config.backgroundColor || '#ffffff';
@@ -778,7 +776,7 @@ class DisplayApp {
 
   private cleanupLayout() {
     // Stop all zone timers
-    for (const [zoneId, timer] of this.zoneTimers) {
+    for (const timer of this.zoneTimers.values()) {
       clearTimeout(timer);
     }
     this.zoneTimers.clear();
@@ -792,10 +790,15 @@ class DisplayApp {
       if (type !== 'image' && type !== 'video') continue;
 
       const contentUrl = item.content.source || item.content.url;
-      const contentId = item.content._id || item.content.id;
+      const contentId = getEntityId(item.content);
       const mimeType = item.content.mimeType || (type === 'video' ? 'video/mp4' : 'image/jpeg');
 
       try {
+        if (!contentId || !contentUrl) {
+          console.warn('[App] Skipping preload for content without id or source');
+          continue;
+        }
+
         const cached = await window.electronAPI.cacheGet(contentId);
         if (!cached.path) {
           console.log('[App] Preloading content:', contentId);

--- a/display/src/renderer/ids.spec.ts
+++ b/display/src/renderer/ids.spec.ts
@@ -1,0 +1,16 @@
+import { getEntityId } from './ids';
+
+describe('getEntityId', () => {
+  it('prefers API id over legacy _id', () => {
+    expect(getEntityId({ id: 'api-id', _id: 'legacy-id' })).toBe('api-id');
+  });
+
+  it('falls back to legacy _id', () => {
+    expect(getEntityId({ _id: 'legacy-id' })).toBe('legacy-id');
+  });
+
+  it('returns undefined for missing or blank ids', () => {
+    expect(getEntityId({ id: '', _id: '   ' })).toBeUndefined();
+    expect(getEntityId(null)).toBeUndefined();
+  });
+});

--- a/display/src/renderer/ids.ts
+++ b/display/src/renderer/ids.ts
@@ -1,0 +1,15 @@
+export function getEntityId(entity: unknown): string | undefined {
+  if (!entity || typeof entity !== 'object') {
+    return undefined;
+  }
+
+  const record = entity as { id?: unknown; _id?: unknown };
+  if (typeof record.id === 'string' && record.id.trim() !== '') {
+    return record.id;
+  }
+  if (typeof record._id === 'string' && record._id.trim() !== '') {
+    return record._id;
+  }
+
+  return undefined;
+}

--- a/display/tsconfig.app.json
+++ b/display/tsconfig.app.json
@@ -16,5 +16,5 @@
     "src/**/*.spec.ts",
     "src/**/*.test.ts"
   ],
-  "include": ["src/**/*.ts"]
+  "include": ["src/app/**/*.ts", "src/renderer/**/*.ts"]
 }

--- a/docs/plans/2026-05-31-display-runtime-reliability.md
+++ b/docs/plans/2026-05-31-display-runtime-reliability.md
@@ -1,0 +1,51 @@
+# Display Runtime Reliability
+
+**Goal:** Close the next customer-1 display reliability slice: unattended display clients should relaunch after reboot, keep screens awake during playback, emit proof-of-play IDs that match current API payloads, and have display unit tests gated in CI.
+
+**New primitives introduced:** none. Reuse Electron main-process lifecycle hooks, Electron `powerSaveBlocker`, OS login/autostart mechanisms, the existing display Jest suite, and the existing CI workflow.
+
+**Hermes-first analysis:**
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Electron display runtime reliability | none applicable | Build in existing Electron main process. |
+| Proof-of-play ID mapping | none applicable | Build in existing renderer helper path and realtime payload contract. |
+| CI test gating | none applicable | Extend existing GitHub Actions CI workflow. |
+
+Awesome-Hermes-agent ecosystem check: not applicable; this change does not introduce business-agent workflows, MCP tools, AI provider calls, or spend paths.
+
+## Drift Check
+
+- K1/K2 are now closed in this branch: Electron main configures packaged-client auto-start and sleep prevention.
+- K3 remains real in backlog: Electron main still only has an update-command stub; auto-update needs separate provider/signing/operator decisions.
+- K4 is now closed in this branch: display Jest wiring and unit tests existed, and CI now runs `@vizora/display` tests, typecheck, and build.
+- The Electron renderer now uses `getEntityId()` for proof-of-play/error IDs and cache/preload paths, preferring Prisma `id` with `_id` fallback.
+- Auto-update is larger because it needs updater dependency, publish provider, signing/release-channel decisions, and operator release process; keep it out of this scoped PR.
+
+## Plan
+
+- [x] Add packaged-display auto-start in Electron main for Windows/macOS and Linux autostart desktops.
+- [x] Add packaged-display sleep prevention via `powerSaveBlocker` with shutdown cleanup.
+- [x] Add focused Electron main-process tests for auto-start and sleep-prevention behavior.
+- [x] Add renderer ID helper and use it for proof-of-play/error payloads.
+- [x] Add focused renderer helper tests.
+- [x] Gate display unit tests in GitHub Actions CI.
+- [x] Gate display typecheck/build in GitHub Actions CI.
+- [x] Run multi-agent review before broad verification.
+- [x] Run display tests/build and relevant broader checks.
+
+## Review And Verification Evidence
+
+- Electron runtime reviewer: initial packaged-guard and process-listener findings fixed; final re-review CLEAN.
+- Customer-readiness/CI reviewer: initial cache ID, AppImage, and docs findings fixed; final re-review found only stale wording, now corrected.
+- `pnpm --filter @vizora/display test -- --runInBand` - pass, 6 suites / 124 tests.
+- `pnpm --filter @vizora/display typecheck` - pass.
+- `pnpm --filter @vizora/display build` - pass.
+- `git diff --check` - pass; line-ending warnings only.
+
+## Review Focus
+
+- Avoid changing production middleware/realtime state.
+- Keep runtime guards scoped to packaged/production display clients so developer Electron sessions do not unexpectedly register login items.
+- Do not introduce updater or release-provider plumbing in this PR.
+- Ensure display tests run on Ubuntu CI without Electron GUI launch.

--- a/docs/plans/2026-05-31-display-runtime-reliability.md
+++ b/docs/plans/2026-05-31-display-runtime-reliability.md
@@ -39,6 +39,7 @@ Awesome-Hermes-agent ecosystem check: not applicable; this change does not intro
 - Electron runtime reviewer: initial packaged-guard and process-listener findings fixed; final re-review CLEAN.
 - Customer-readiness/CI reviewer: initial cache ID, AppImage, and docs findings fixed; final re-review found only stale wording, now corrected.
 - `pnpm --filter @vizora/display test -- --runInBand` - pass, 6 suites / 124 tests.
+- `pnpm --filter @vizora/display test:ci` - pass, 6 suites / 124 tests; validates the CI-safe Jest invocation after GitHub Actions exposed pnpm argument-forwarding drift.
 - `pnpm --filter @vizora/display typecheck` - pass.
 - `pnpm --filter @vizora/display build` - pass.
 - `git diff --check` - pass; line-ending warnings only.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -30,6 +30,7 @@
 
 **Local verification**
 - [x] `pnpm --filter @vizora/display test -- --runInBand` - pass, 6 suites / 124 tests.
+- [x] `pnpm --filter @vizora/display test:ci` - pass, 6 suites / 124 tests; validates the CI-safe Jest invocation after GitHub Actions exposed pnpm argument-forwarding drift.
 - [x] `pnpm --filter @vizora/display typecheck` - pass.
 - [x] `pnpm --filter @vizora/display build` - pass.
 - [x] `git diff --check` - pass; line-ending warnings only.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,41 @@
 # Vizora - Task Tracker
 
+## In Progress: Display Runtime Reliability (2026-05-31)
+
+**Branch:** `fix/display-runtime-reliability`
+
+**Why now:** PR #124 merged critical upload/streaming smoke coverage, and production deploy remains blocked by dirty/diverged prod-local work. The next repo-side customer-1 reliability gap is unattended display runtime behavior: after reboot/screensaver/power policy changes, displays must come back and continue emitting reliable proof-of-play signals.
+
+**New primitives introduced:** none. Reuse Electron lifecycle APIs, `powerSaveBlocker`, Linux desktop autostart files, existing renderer proof-of-play paths, and CI workflow patterns.
+
+**Hermes-first analysis:** not applicable; this is display runtime/CI hardening, not a business-agent, MCP, Hermes, or AI/spend path.
+
+**Plan/design:** `docs/plans/2026-05-31-display-runtime-reliability.md`
+
+**Plan**
+- [x] Drift-check K1/K2/K3/K4 and renderer proof-of-play ID paths.
+- [x] Add packaged-display auto-start.
+- [x] Add packaged-display sleep prevention.
+- [x] Fix renderer proof-of-play/error IDs to prefer API `id` with `_id` fallback.
+- [x] Gate display unit tests in CI.
+- [x] Gate display renderer/main typecheck and display build in CI.
+- [x] Run multi-subagent review before broad verification.
+- [x] Run focused/broad verification.
+- [ ] PR, CI, merge.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Review gate**
+- [x] Electron runtime reviewer: initial packaged-guard and process-listener findings fixed; final re-review CLEAN.
+- [x] Customer-readiness/CI reviewer: initial cache ID, AppImage, and docs findings fixed; final re-review found only stale wording, now corrected.
+
+**Local verification**
+- [x] `pnpm --filter @vizora/display test -- --runInBand` - pass, 6 suites / 124 tests.
+- [x] `pnpm --filter @vizora/display typecheck` - pass.
+- [x] `pnpm --filter @vizora/display build` - pass.
+- [x] `git diff --check` - pass; line-ending warnings only.
+
+---
+
 ## In Progress: Critical Smoke Upload + Streaming Coverage (2026-05-31)
 
 **Branch:** `feat/customer-readiness-next`


### PR DESCRIPTION
## Summary
- Enable packaged Electron display auto-start on Windows/macOS and Linux, with AppImage-aware Linux autostart entries.
- Keep packaged displays awake during playback with Electron powerSaveBlocker and stop it on quit.
- Normalize renderer IDs for proof-of-play/error/cache paths with Prisma `id` preferred and `_id` fallback.
- Gate display Jest, typecheck, and build in CI.

## Review
- Electron runtime reviewer: initial packaged-guard and process-listener findings fixed; final re-review CLEAN.
- Customer-readiness/CI reviewer: initial cache ID, AppImage, and docs findings fixed; final re-review found only stale wording, corrected.

## Verification
- `pnpm --filter @vizora/display test -- --runInBand` - pass, 6 suites / 124 tests.
- `pnpm --filter @vizora/display typecheck` - pass.
- `pnpm --filter @vizora/display build` - pass.
- `git diff --check` - pass; line-ending warnings only.

## Deploy
- No deploy in this PR. Production deploy remains gated on clean prod checkout/state verification.