### PR TITLE
fix: harden display auth telemetry paths

### DIFF
--- a/display/src/electron/device-client.spec.ts
+++ b/display/src/electron/device-client.spec.ts
@@ -134,7 +134,10 @@ describe('DeviceClient', () => {
         cb(mockResponse);
         // Simulate async data
         Promise.resolve().then(() => {
-          dataCallback(JSON.stringify({ code: 'ABC123', qrCode: 'data:image/png;base64,...' }));
+          dataCallback(JSON.stringify({
+            success: true,
+            data: { code: 'ABC123', qrCode: 'data:image/png;base64,...' },
+          }));
           endCallback();
         });
         return mockReq;
@@ -237,7 +240,10 @@ describe('DeviceClient', () => {
         requestedUrl = url.toString();
         cb(mockResponse);
         Promise.resolve().then(() => {
-          dataCallback(JSON.stringify({ status: 'paired', deviceToken: 'jwt-token-123' }));
+          dataCallback(JSON.stringify({
+            success: true,
+            data: { status: 'paired', deviceToken: 'jwt-token-123' },
+          }));
           endCallback();
         });
         return mockReq;

--- a/display/src/electron/device-client.ts
+++ b/display/src/electron/device-client.ts
@@ -13,6 +13,13 @@ interface DeviceClientConfig {
 type SocketAck = (response?: { ok: boolean; error?: string }) => void;
 const SELF_TERMINATING_COMMAND_ACK_FLUSH_MS = 500;
 
+function unwrapResponseEnvelope<T>(parsed: T | { data?: T }): T {
+  if (parsed && typeof parsed === 'object' && 'data' in parsed && (parsed as any).data !== undefined) {
+    return (parsed as any).data as T;
+  }
+  return parsed as T;
+}
+
 export class DeviceClient {
   private socket: Socket | null = null;
   private heartbeatInterval: NodeJS.Timeout | null = null;
@@ -118,7 +125,7 @@ export class DeviceClient {
             console.log('[DeviceClient] Response data length:', data.length);
             if (res.statusCode === 200 || res.statusCode === 201) {
               try {
-                const result = JSON.parse(data);
+                const result = unwrapResponseEnvelope<any>(JSON.parse(data));
                 console.log('[DeviceClient] ✅ Pairing code received successfully:', result.code);
                 console.log('[DeviceClient] QR Code present:', !!result.qrCode);
                 if (result.qrCode) {
@@ -192,7 +199,7 @@ export class DeviceClient {
           res.on('end', () => {
             try {
               if (res.statusCode === 200) {
-                const result = JSON.parse(data) as { status?: string; deviceToken?: string };
+                const result = unwrapResponseEnvelope<{ status?: string; deviceToken?: string }>(JSON.parse(data));
 
                 if (result.status === 'paired' && result.deviceToken) {
                   console.log('[DeviceClient] ✅ ✅ ✅ DEVICE PAIRED! Token received');

--- a/docs/plans/2026-05-31-customer-dashboard-performance-pass-4.md
+++ b/docs/plans/2026-05-31-customer-dashboard-performance-pass-4.md
@@ -1,0 +1,59 @@
+# Customer Dashboard + Performance Pass 4
+
+Date: 2026-05-31
+Branch: `feat/customer-dashboard-performance-pass`
+
+## Goal
+
+Move Vizora closer to customer-1 readiness by fixing repo-side issues found in the fresh customer, performance, and adversarial scans after PRs #123-#125 merged.
+
+## New primitives introduced
+
+None planned. Reuse existing Electron display client, NestJS controllers/services, realtime gateway, display web components, response envelope, and critical smoke script.
+
+## Hermes-first analysis
+
+This pass does not add business-agent behavior, MCP tools, Hermes skills, AI provider calls, or spend paths.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Display pairing/runtime | none applicable | Use existing Electron and middleware pairing paths. |
+| Device schedule authorization | none applicable | Use existing device JWT and schedules controller/service. |
+| Display content-error telemetry | none applicable | Use existing web display and realtime error path with redaction. |
+| Customer dashboard upload UX | none applicable | Use existing Next dashboard content page and upload API client. |
+
+Awesome-hermes-agent ecosystem check: not applicable to these display/dashboard/runtime fixes; no agent orchestration or skill runtime is being introduced.
+
+## Findings Synthesized
+
+High-priority buildable issues from reviewer scans:
+
+- Electron display pairing does not unwrap Vizora's `{ success, data }` response envelope.
+- `GET /api/v1/schedules/active/:displayId` accepts any valid same-org device JWT instead of enforcing the token subject matches the requested display.
+- Display content-error messages can include authenticated media URLs with `token=` query params and then persist/export them via realtime Redis/Sentry.
+- Critical smoke pairing-complete parsing still reads `display.id` instead of enveloped `data.display.id`.
+
+Broader customer/performance backlog to address after this security/runtime bundle:
+
+- Bulk upload queue is sequential, lacks per-file progress, and can upload queued files under the wrong content type after type changes.
+- Existing-device dashboard "Pair" flow renders `pairingCode` although the API returns `pairingToken`.
+- Schedule conflict warnings render but are never populated from `check-conflicts`.
+- Mobile dashboard tables and builders need scroll/card fallbacks.
+- Large dashboard list pages still fetch all pages and render full lists client-side.
+- Streaming upload and cache-aware device media delivery remain larger architecture/performance follow-ups.
+
+## Scoped Patch Plan
+
+- Add Electron pairing envelope unwrapping and tests with enveloped pairing request/status fixtures.
+- Enforce device JWT `sub === :displayId` in active schedule endpoint; reject missing/mismatched device identities and add controller tests.
+- Validate active schedule display lookup as active same-org display before returning schedules.
+- Redact `token` query params before web display UI/error strings, realtime Redis error storage, and Sentry extras; add focused unit tests.
+- Fix critical smoke pairing-complete display id parsing with a backward-compatible fallback.
+
+## Review and Verification
+
+- Run focused tests for display device client, schedules controller/service, web display renderer, realtime gateway/heartbeat, and smoke syntax.
+- Dispatch multiple read-only reviewers on the diff before broad tests.
+- Run broader affected package tests/builds after review findings are clean or fixed.
+- Open PR, wait for CI, merge only if clean.
+- Re-check production deploy gate after merge. Do not deploy while `/opt/vizora/app` remains dirty/diverged.

--- a/middleware/src/modules/schedules/schedules.controller.spec.ts
+++ b/middleware/src/modules/schedules/schedules.controller.spec.ts
@@ -32,8 +32,8 @@ describe('SchedulesController', () => {
     } as any;
 
     mockJwtService = {
-      verify: jest.fn().mockReturnValue({ type: 'device', sub: 'device-123', organizationId }),
-      verifyAsync: jest.fn().mockResolvedValue({ type: 'device', sub: 'device-123', organizationId }),
+      verify: jest.fn().mockReturnValue({ type: 'device', sub: 'display-123', organizationId }),
+      verifyAsync: jest.fn().mockResolvedValue({ type: 'device', sub: 'display-123', organizationId }),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -205,12 +205,23 @@ describe('SchedulesController', () => {
     });
 
     it('should work with valid device JWT (public endpoint)', async () => {
+      mockJwtService.verify.mockReturnValueOnce({ type: 'device', sub: 'display-456', organizationId });
       mockSchedulesService.findActiveSchedules.mockResolvedValue([]);
 
       const mockReq = createMockRequest('valid-device-token');
       const result = await controller.findActiveSchedules('display-456', mockReq as any);
 
       expect(result).toEqual([]);
+    });
+
+    it('should reject a device JWT for a different display', async () => {
+      mockJwtService.verify.mockReturnValueOnce({ type: 'device', sub: 'display-999', organizationId });
+
+      const mockReq = createMockRequest('valid-device-token');
+
+      expect(() => controller.findActiveSchedules('display-456', mockReq as any))
+        .toThrow('Device token does not match requested display');
+      expect(mockSchedulesService.findActiveSchedules).not.toHaveBeenCalled();
     });
   });
 

--- a/middleware/src/modules/schedules/schedules.controller.ts
+++ b/middleware/src/modules/schedules/schedules.controller.ts
@@ -86,6 +86,12 @@ export class SchedulesController {
       if (payload.type !== 'device') {
         throw new UnauthorizedException('Invalid token type');
       }
+      if (!payload.sub || payload.sub !== displayId) {
+        throw new UnauthorizedException('Device token does not match requested display');
+      }
+      if (!payload.organizationId) {
+        throw new UnauthorizedException('Device token missing organization');
+      }
       organizationId = payload.organizationId;
     } catch (error) {
       if (error instanceof UnauthorizedException) throw error;

--- a/middleware/src/modules/schedules/schedules.service.spec.ts
+++ b/middleware/src/modules/schedules/schedules.service.spec.ts
@@ -342,7 +342,7 @@ describe('SchedulesService', () => {
         },
       ];
 
-      databaseService.display.findFirst.mockResolvedValue({ timezone: 'UTC' } as any);
+      databaseService.display.findFirst.mockResolvedValue({ timezone: 'UTC', isDisabled: false } as any);
       databaseService.schedule.findMany.mockResolvedValue(mockActiveSchedules);
 
       const result = await service.findActiveSchedules(mockDisplayId, mockOrganizationId);
@@ -352,7 +352,7 @@ describe('SchedulesService', () => {
     });
 
     it('should filter by current date, time, day of week, and organizationId', async () => {
-      databaseService.display.findFirst.mockResolvedValue({ timezone: 'UTC' } as any);
+      databaseService.display.findFirst.mockResolvedValue({ timezone: 'UTC', isDisabled: false } as any);
       databaseService.schedule.findMany.mockResolvedValue([]);
 
       await service.findActiveSchedules(mockDisplayId, mockOrganizationId);
@@ -363,6 +363,22 @@ describe('SchedulesService', () => {
       expect(callArgs.where.startDate).toHaveProperty('lte');
       expect(callArgs.where.daysOfWeek).toHaveProperty('has');
       expect(callArgs.orderBy).toEqual({ priority: 'desc' });
+    });
+
+    it('should reject missing displays before querying schedules', async () => {
+      databaseService.display.findFirst.mockResolvedValue(null);
+
+      await expect(service.findActiveSchedules(mockDisplayId, mockOrganizationId))
+        .rejects.toThrow(NotFoundException);
+      expect(databaseService.schedule.findMany).not.toHaveBeenCalled();
+    });
+
+    it('should reject disabled displays before querying schedules', async () => {
+      databaseService.display.findFirst.mockResolvedValue({ timezone: 'UTC', isDisabled: true } as any);
+
+      await expect(service.findActiveSchedules(mockDisplayId, mockOrganizationId))
+        .rejects.toThrow(NotFoundException);
+      expect(databaseService.schedule.findMany).not.toHaveBeenCalled();
     });
   });
 

--- a/middleware/src/modules/schedules/schedules.service.ts
+++ b/middleware/src/modules/schedules/schedules.service.ts
@@ -145,9 +145,12 @@ export class SchedulesService {
     // Fetch the display's timezone to compute "now" in local time
     const display = await this.db.display.findFirst({
       where: { id: displayId, organizationId },
-      select: { timezone: true },
+      select: { timezone: true, isDisabled: true },
     });
-    const timezone = display?.timezone || 'UTC';
+    if (!display || display.isDisabled) {
+      throw new NotFoundException('Display not found');
+    }
+    const timezone = display.timezone || 'UTC';
 
     // Compute current day/time in the display's timezone
     const now = new Date();

--- a/realtime/src/gateways/device.gateway.spec.ts
+++ b/realtime/src/gateways/device.gateway.spec.ts
@@ -908,6 +908,42 @@ describe('DeviceGateway', () => {
       );
     });
 
+    it('should redact device tokens before storing or reporting content errors', async () => {
+      const Sentry = require('@sentry/nestjs');
+      const client = createMockSocket();
+      const data = {
+        contentId: 'content-1',
+        errorType: 'network_error',
+        errorMessage: 'failed http://localhost:3000/api/v1/device-content/content-1/file?token=device-jwt',
+        context: {
+          url: 'http://localhost:3000/api/v1/device-content/content-1/file?variant=original&token=device-jwt',
+        },
+      };
+
+      await gateway.handleContentError(client as any, data as any);
+
+      expect(mockHeartbeatService.logError).toHaveBeenCalledWith(
+        'device-1',
+        expect.objectContaining({
+          errorMessage: 'failed http://localhost:3000/api/v1/device-content/content-1/file?token=[redacted]',
+          context: {
+            url: 'http://localhost:3000/api/v1/device-content/content-1/file?variant=original&token=[redacted]',
+          },
+        }),
+      );
+      expect(Sentry.captureMessage).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          extra: expect.objectContaining({
+            errorMessage: 'failed http://localhost:3000/api/v1/device-content/content-1/file?token=[redacted]',
+            context: {
+              url: 'http://localhost:3000/api/v1/device-content/content-1/file?variant=original&token=[redacted]',
+            },
+          }),
+        }),
+      );
+    });
+
     it('should record content error metrics', async () => {
       const client = createMockSocket();
       const data = { contentId: 'content-1', errorType: 'decode_error' };

--- a/realtime/src/gateways/device.gateway.ts
+++ b/realtime/src/gateways/device.gateway.ts
@@ -40,6 +40,7 @@ import * as Sentry from '@sentry/nestjs';
 import { createHash } from 'node:crypto';
 import { WsAllExceptionsFilter } from './filters/ws-exception.filter';
 import { WsAuthGuard, WsDeviceGuard } from './guards/ws-auth.guard';
+import { redactSensitiveTokens } from '../utils/redact-sensitive-url';
 
 interface DevicePayload {
   sub: string; // device ID
@@ -1282,8 +1283,10 @@ export class DeviceGateway
     this.logger.warn(`Content error on ${deviceId}: ${data.errorType} - ${data.contentId}`);
 
     try {
+      const sanitizedData = redactSensitiveTokens(data);
+
       // Log error for analytics
-      await this.heartbeatService.logError(deviceId, data);
+      await this.heartbeatService.logError(deviceId, sanitizedData);
 
       // Record metrics
       this.metricsService.recordContentError(deviceId, data.errorType);
@@ -1297,9 +1300,9 @@ export class DeviceGateway
           contentId: data.contentId,
         },
         extra: {
-          errorMessage: data.errorMessage,
-          errorCode: data.errorCode,
-          context: data.context,
+          errorMessage: sanitizedData.errorMessage,
+          errorCode: sanitizedData.errorCode,
+          context: sanitizedData.context,
         },
       });
 

--- a/realtime/src/services/heartbeat.service.spec.ts
+++ b/realtime/src/services/heartbeat.service.spec.ts
@@ -235,6 +235,27 @@ describe('HeartbeatService', () => {
       expect(storedData[0].timestamp).toBeDefined();
     });
 
+    it('should redact device tokens before storing errors', async () => {
+      const data = {
+        contentId: 'c-1',
+        errorType: 'decode_error',
+        errorMessage: 'failed /api/v1/device-content/c-1/file?token=device-jwt',
+        context: {
+          url: '/api/v1/device-content/c-1/file?variant=original&token=device-jwt',
+        },
+      };
+
+      await service.logError('device-1', data as any);
+
+      const storedData = JSON.parse(mockRedisService.set.mock.calls[0][1]);
+      expect(storedData[0].errorMessage).toBe(
+        'failed /api/v1/device-content/c-1/file?token=[redacted]',
+      );
+      expect(storedData[0].context.url).toBe(
+        '/api/v1/device-content/c-1/file?variant=original&token=[redacted]',
+      );
+    });
+
     it('should not throw when Redis fails', async () => {
       mockRedisService.get.mockRejectedValueOnce(new Error('Redis down'));
 

--- a/realtime/src/services/heartbeat.service.ts
+++ b/realtime/src/services/heartbeat.service.ts
@@ -8,6 +8,7 @@ import {
   DeviceMetrics,
   CurrentContentState,
 } from '../types';
+import { redactSensitiveTokens } from '../utils/redact-sensitive-url';
 
 interface StoredHeartbeat {
   deviceId: string;
@@ -127,9 +128,10 @@ export class HeartbeatService {
    */
   async logError(deviceId: string, data: ContentErrorData): Promise<void> {
     try {
+      const sanitizedData = redactSensitiveTokens(data);
       const errorLog: StoredError = {
         deviceId,
-        ...data,
+        ...sanitizedData,
         timestamp: Date.now(),
       };
 

--- a/realtime/src/utils/redact-sensitive-url.ts
+++ b/realtime/src/utils/redact-sensitive-url.ts
@@ -1,0 +1,25 @@
+export function redactSensitiveUrl(value: string): string {
+  if (!value) return value;
+  return value.replace(/([?&]token=)[^&#\s)]+/gi, '$1[redacted]');
+}
+
+export function redactSensitiveTokens<T>(value: T): T {
+  if (typeof value === 'string') {
+    return redactSensitiveUrl(value) as T;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactSensitiveTokens(entry)) as T;
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, entry]) => [
+        key,
+        redactSensitiveTokens(entry),
+      ]),
+    ) as T;
+  }
+
+  return value;
+}

--- a/scripts/smoke/api-critical-path.sh
+++ b/scripts/smoke/api-critical-path.sh
@@ -349,7 +349,10 @@ fi
 COMPLETE_BODY=$(CODE="$CODE" json_body code=__env__:CODE nickname="Smoke Display")
 COMPLETE_OUT="$(tmp_json pairing-complete)"
 post_json "Pairing complete" "201" "$API_BASE/api/v1/devices/pairing/complete" "$COMPLETE_BODY" "$COMPLETE_OUT" "${auth_headers[@]}"
-DISPLAY_ID="$(json_get "$COMPLETE_OUT" "display.id")"
+DISPLAY_ID="$(json_get "$COMPLETE_OUT" "data.display.id")"
+if [[ -z "$DISPLAY_ID" ]]; then
+  DISPLAY_ID="$(json_get "$COMPLETE_OUT" "display.id")"
+fi
 make_label "Display id parsed"
 parse_label="$CHECK_LABEL"
 if [[ -n "$DISPLAY_ID" ]]; then

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,8 +1,59 @@
 # Vizora - Task Tracker
 
-## In Progress: Display Runtime Reliability (2026-05-31)
+## In Progress: Customer Dashboard + Performance Pass 4 (2026-05-31)
+
+**Branch:** `feat/customer-dashboard-performance-pass`
+
+**Why now:** PRs #123-#125 are merged and CI-green, but production deploy is blocked by dirty/diverged prod-local work. Fresh customer, performance, and adversarial scans found several repo-side issues that directly affect customer-1 readiness without requiring operator-only actions.
+
+**New primitives introduced:** none. Reuse existing Electron display client, NestJS controllers/services, realtime gateway, display web components, response envelope, and critical smoke script.
+
+**Hermes-first analysis:** not applicable; this pass does not add business-agent behavior, MCP tools, Hermes skills, AI provider calls, or spend paths.
+
+**Plan/design:** `docs/plans/2026-05-31-customer-dashboard-performance-pass-4.md`
+
+**Selected fix bundle**
+- [x] Electron pairing unwraps the middleware response envelope.
+- [x] Active schedule endpoint rejects device JWTs whose subject does not match the requested display.
+- [x] Active schedule lookup rejects missing/disabled displays before returning schedules.
+- [x] Display content-error messages redact device JWT query params before UI, Redis, or Sentry.
+- [x] Critical smoke pairing-complete parsing handles enveloped `data.display.id`.
+- [x] Run multi-subagent review before broad verification.
+- [ ] Run focused/broad verification.
+- [ ] PR, CI, merge.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Review gate**
+- [x] Subagent runtime/security review: CLEAN.
+- [x] Subagent customer/performance review: initial untracked-helper CI-safety finding fixed by staging the full intended patch; re-review CLEAN.
+
+**Local verification**
+- [x] `pnpm exec prisma generate --schema prisma/schema.prisma` in `packages/database` - pass; generated local Prisma client needed before realtime tests in this worktree.
+- [x] `npx nx build @vizora/database` - pass.
+- [x] `pnpm --filter @vizora/display test -- --runInBand --testPathPattern=device-client` - pass, 47 tests.
+- [x] `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="schedules.controller|schedules.service"` - pass, 51 tests.
+- [x] `pnpm --filter @vizora/web test -- --runInBand --testPathPattern=ContentRenderer` - pass, 3 tests.
+- [x] `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern="device.gateway|heartbeat.service"` - pass, 3 suites / 124 tests.
+- [x] `git diff --check --cached` - pass.
+- [x] `C:\Program Files\Git\bin\bash.exe -n scripts/smoke/api-critical-path.sh` - pass.
+- [x] `pnpm --filter @vizora/display test:ci` - pass, 6 suites / 124 tests.
+- [x] `pnpm --filter @vizora/display typecheck` - pass.
+- [x] `pnpm --filter @vizora/middleware test -- --runInBand` - pass, 143 suites / 2790 tests.
+- [x] `pnpm --filter @vizora/realtime test -- --runInBand` - pass, 11 suites / 258 tests.
+- [x] `pnpm --filter @vizora/web test -- --runInBand` - pass, 89 suites / 927 tests; existing React `act(...)` and jsdom navigation warnings remain.
+- [x] `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` - pass.
+- [x] `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` - pass.
+- [x] `npx nx build @vizora/middleware` - pass with existing webpack warnings.
+- [x] `npx nx build @vizora/realtime` - pass with existing source-map / optional `ws` warnings.
+- [x] `NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 BACKEND_URL=http://localhost:3000 npx nx build @vizora/web` - pass with existing Next middleware deprecation and TypeScript project-reference warnings.
+- [x] `pnpm --filter @vizora/display build` - pass.
+
+---
+
+## Completed: Display Runtime Reliability (2026-05-31)
 
 **Branch:** `fix/display-runtime-reliability`
+**PR / merge commit:** #125 / `0a509cb0c1ee03f2fda558a7be38247c19bc8f3a`
 
 **Why now:** PR #124 merged critical upload/streaming smoke coverage, and production deploy remains blocked by dirty/diverged prod-local work. The next repo-side customer-1 reliability gap is unattended display runtime behavior: after reboot/screensaver/power policy changes, displays must come back and continue emitting reliable proof-of-play signals.
 
@@ -21,8 +72,8 @@
 - [x] Gate display renderer/main typecheck and display build in CI.
 - [x] Run multi-subagent review before broad verification.
 - [x] Run focused/broad verification.
-- [ ] PR, CI, merge.
-- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+- [x] PR, CI, merge.
+- [x] Re-check deployment gate; deployment remains blocked by dirty/diverged prod checkout.
 
 **Review gate**
 - [x] Electron runtime reviewer: initial packaged-guard and process-listener findings fixed; final re-review CLEAN.
@@ -37,9 +88,10 @@
 
 ---
 
-## In Progress: Critical Smoke Upload + Streaming Coverage (2026-05-31)
+## Completed: Critical Smoke Upload + Streaming Coverage (2026-05-31)
 
 **Branch:** `feat/customer-readiness-next`
+**PR / merge commit:** #124 / `81e5cd25da6c2030d339b3d48866f40bba15a4c7`
 
 **Why now:** PR #123 merged the customer-readiness hot-path hardening, but the operator smoke still proves URL content creation rather than real multipart upload and authenticated media streaming. Customer-1 go-live needs the smoke to exercise the path displays actually use for uploaded assets.
 
@@ -57,8 +109,8 @@
 - [x] Add uploaded-object cleanup so production smoke runs do not leave MinIO objects behind.
 - [x] Run subagent review before broad verification.
 - [x] Run focused verification; full smoke blocked because Docker/local services are unavailable.
-- [ ] PR, CI, merge.
-- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+- [x] PR, CI, merge.
+- [x] Re-check deployment gate; deployment remains blocked by dirty/diverged prod checkout.
 
 **Review gate**
 - [x] Bash/operator-safety reviewer: initial run-ID, range-validation, and interrupt-handling notes fixed; final re-review CLEAN.

--- a/web/src/app/display/DisplayClient.tsx
+++ b/web/src/app/display/DisplayClient.tsx
@@ -11,6 +11,7 @@ import { PairingScreen } from './components/PairingScreen';
 import { ContentScreen } from './components/ContentScreen';
 import { StatusBar } from './components/StatusBar';
 import { FullscreenButton } from './components/FullscreenButton';
+import { redactSensitiveUrl } from './lib/redact-sensitive-url';
 
 export function DisplayClient() {
   const [state, setState] = useState<DisplayState>('LOADING');
@@ -152,7 +153,7 @@ export function DisplayClient() {
     connection.emitContentError({
       contentId,
       errorType,
-      errorMessage: errMsg,
+      errorMessage: redactSensitiveUrl(errMsg),
       timestamp: Date.now(),
     });
   }, [connection]);

--- a/web/src/app/display/components/ContentRenderer.tsx
+++ b/web/src/app/display/components/ContentRenderer.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import type { ContentType } from '../lib/types';
 import { LayoutRenderer } from './LayoutRenderer';
 import type { LayoutMetadata } from '../lib/types';
+import { redactSensitiveUrl } from '../lib/redact-sensitive-url';
 
 interface ContentRendererProps {
   type: ContentType;
@@ -65,6 +66,7 @@ function shouldFetchImageAsBlob(url: string): boolean {
 export function ContentRenderer({ type, url, name, metadata, authenticateUrl, onEnded, onError }: ContentRendererProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const renderedUrl = authenticateUrl ? authenticateUrl(url) : url;
+  const safeRenderedUrl = redactSensitiveUrl(renderedUrl);
   const isImage = type === 'image';
   const shouldFetchBlob = isImage && shouldFetchImageAsBlob(renderedUrl);
   const { blobUrl, error: fetchError } = useBlobUrl(renderedUrl, shouldFetchBlob);
@@ -85,9 +87,9 @@ export function ContentRenderer({ type, url, name, metadata, authenticateUrl, on
   // Report fetch errors for images
   useEffect(() => {
     if (isImage && fetchError) {
-      onError?.('load_error', `Image fetch failed: ${fetchError} (url: ${renderedUrl})`);
+      onError?.('load_error', `Image fetch failed: ${fetchError} (url: ${safeRenderedUrl})`);
     }
-  }, [isImage, fetchError, renderedUrl, onError]);
+  }, [isImage, fetchError, safeRenderedUrl, onError]);
 
   switch (type) {
     case 'image':
@@ -98,7 +100,7 @@ export function ContentRenderer({ type, url, name, metadata, authenticateUrl, on
             alt={name || 'Display content'}
             style={styles.image}
             onError={() => {
-              onError?.('load_error', `Image failed to load: ${renderedUrl}`);
+              onError?.('load_error', `Image failed to load: ${safeRenderedUrl}`);
               onEnded?.();
             }}
           />
@@ -107,7 +109,7 @@ export function ContentRenderer({ type, url, name, metadata, authenticateUrl, on
       if (fetchError) {
         return (
           <div style={{ ...styles.image, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#ff6b6b', fontSize: '14px', padding: '20px', textAlign: 'center' as const }}>
-            Image load error: {fetchError}<br />URL: {renderedUrl?.substring(0, 80)}...
+            Image load error: {fetchError}<br />URL: {safeRenderedUrl?.substring(0, 80)}...
           </div>
         );
       }
@@ -141,7 +143,7 @@ export function ContentRenderer({ type, url, name, metadata, authenticateUrl, on
           style={styles.video}
           onEnded={onEnded}
           onError={() => {
-            onError?.('load_error', `Video failed to load: ${renderedUrl}`);
+            onError?.('load_error', `Video failed to load: ${safeRenderedUrl}`);
             onEnded?.();
           }}
         />
@@ -156,7 +158,7 @@ export function ContentRenderer({ type, url, name, metadata, authenticateUrl, on
           allow="autoplay; fullscreen"
           title={name || 'Web content'}
           onError={() => {
-            onError?.('load_error', `Webpage failed to load: ${renderedUrl}`);
+            onError?.('load_error', `Webpage failed to load: ${safeRenderedUrl}`);
             onEnded?.();
           }}
         />

--- a/web/src/app/display/components/__tests__/ContentRenderer.test.tsx
+++ b/web/src/app/display/components/__tests__/ContentRenderer.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { ContentRenderer } from '../ContentRenderer';
+import { redactSensitiveUrl } from '../../lib/redact-sensitive-url';
 
 describe('ContentRenderer', () => {
   const originalFetch = global.fetch;
@@ -25,6 +26,32 @@ describe('ContentRenderer', () => {
     expect(screen.getByRole('img', { name: 'Menu' })).toHaveAttribute(
       'src',
       'https://cdn.example.com/menu.png',
+    );
+  });
+
+  it('redacts device tokens from load errors', () => {
+    const onError = jest.fn();
+
+    render(
+      <ContentRenderer
+        type="image"
+        url="https://cdn.example.com/menu.png?token=device-jwt"
+        name="Menu"
+        onError={onError}
+      />,
+    );
+
+    fireEvent.error(screen.getByRole('img', { name: 'Menu' }));
+
+    expect(onError).toHaveBeenCalledWith(
+      'load_error',
+      'Image failed to load: https://cdn.example.com/menu.png?token=[redacted]',
+    );
+  });
+
+  it('redacts token query params in generic strings', () => {
+    expect(redactSensitiveUrl('url: /file?token=abc123&variant=original')).toBe(
+      'url: /file?token=[redacted]&variant=original',
     );
   });
 });

--- a/web/src/app/display/lib/redact-sensitive-url.ts
+++ b/web/src/app/display/lib/redact-sensitive-url.ts
@@ -1,0 +1,4 @@
+export function redactSensitiveUrl(value: string): string {
+  if (!value) return value;
+  return value.replace(/([?&]token=)[^&#\s)]+/gi, '$1[redacted]');
+}


### PR DESCRIPTION
## Summary
- unwrap response envelopes in Electron display pairing request/status calls
- restrict active schedule reads to the device JWT subject and reject missing/disabled displays
- redact `token=` query params from display playback error UI, realtime Redis storage, and Sentry extras
- fix critical smoke pairing-complete parsing for enveloped `data.display.id`
- document the customer/dashboard/performance pass and verification evidence

## Reviews
- Runtime/security subagent review: CLEAN
- Customer/performance subagent review: initial untracked-helper CI-safety finding fixed; re-review CLEAN

## Tests
- pnpm exec prisma generate --schema prisma/schema.prisma (packages/database)
- npx nx build @vizora/database
- pnpm --filter @vizora/display test -- --runInBand --testPathPattern=device-client
- pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=schedules.controller|schedules.service
- pnpm --filter @vizora/web test -- --runInBand --testPathPattern=ContentRenderer
- pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern=device.gateway|heartbeat.service
- git diff --check --cached
- C:\Program Files\Git\bin\bash.exe -n scripts/smoke/api-critical-path.sh
- pnpm --filter @vizora/display test:ci
- pnpm --filter @vizora/display typecheck
- pnpm --filter @vizora/middleware test -- --runInBand
- pnpm --filter @vizora/realtime test -- --runInBand
- pnpm --filter @vizora/web test -- --runInBand
- pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false
- pnpm --filter @vizora/web exec tsc --noEmit --pretty false
- npx nx build @vizora/middleware
- npx nx build @vizora/realtime
- NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 BACKEND_URL=http://localhost:3000 npx nx build @vizora/web
- pnpm --filter @vizora/display build

## Deploy
Not deployed from this PR. Production checkout is currently dirty/diverged and must be reconciled before any deploy/pull/reset/restart.