### PR TITLE
fix: improve dashboard pairing and bulk uploads

### DIFF
--- a/docs/plans/2026-05-31-customer-dashboard-ux-hotspots.md
+++ b/docs/plans/2026-05-31-customer-dashboard-ux-hotspots.md
@@ -1,0 +1,46 @@
+# Customer Dashboard UX Hotspots Plan
+
+**Goal:** Fix two customer-visible dashboard issues: existing-device pairing shows `N/A` because the frontend expects the wrong field, and bulk uploads are sequential, progress-blind, and can upload files under the wrong type.
+
+**New primitives introduced:** none. This reuses the existing dashboard client, `ApiClient`, `/content/upload` XHR progress path, and `/displays/:id/pair` response.
+
+**Hermes-first analysis:** not applicable; this pass does not add business-agent behavior, MCP tools, Hermes skills, AI provider calls, or spend paths.
+
+## Evidence
+
+- `middleware/src/modules/displays/displays.service.ts` returns `pairingToken`, `expiresIn`, `displayId`, and `deviceIdentifier` from existing-device pairing.
+- `web/src/lib/api/displays.ts` types `generatePairingToken()` as `{ pairingCode: string }`.
+- `web/src/app/dashboard/devices/page-client.tsx` renders `response.pairingCode || 'N/A'`, so customers cannot see the returned token.
+- `web/src/app/dashboard/content/page-client.tsx` stores only `{ file, status, progress }` in the queue.
+- Bulk upload uses `apiClient.createContent({ type: uploadForm.type, file })`, so queued files can be uploaded with a different type if the customer changes the selector after queuing.
+- Bulk upload runs sequentially and never uses the existing `uploadContentWithProgress()` helper.
+
+## Design
+
+1. Pairing contract
+   - Update `generatePairingToken()` return type to include the backend fields, with optional `pairingCode` only as a legacy fallback.
+   - Render `pairingToken || pairingCode || 'N/A'`.
+   - Rename modal copy from "Pairing Code" to "Pairing Token" and show the actual expiry returned by the backend when available.
+
+2. Bulk upload queue
+   - Add a per-item `type` captured when files are dropped.
+   - Disable the content-type selector, dropzone, clear, and item remove buttons while uploads are running.
+   - Use `apiClient.uploadContentWithProgress()` for queued files so each row receives progress updates.
+   - Upload with a small bounded worker pool (`BULK_UPLOAD_CONCURRENCY = 3`) to improve throughput without firing unbounded uploads.
+   - Preserve the modal on partial failure, show success/error counts, and refresh content if at least one file uploaded.
+
+3. Tests
+   - Add a devices page regression test proving the pairing modal renders backend `pairingToken`, not `N/A`.
+   - Add content page tests proving queued files keep their original type after the selector changes and use `uploadContentWithProgress`.
+   - Add a content page test proving Clear All/remove controls are disabled while queued upload is in progress.
+
+## Verification
+
+- `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="devices-page|content-page"`
+- `pnpm --filter @vizora/web exec tsc --noEmit --pretty false`
+- `NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 BACKEND_URL=http://localhost:3000 npx nx build @vizora/web`
+- Multi-agent review before broader tests.
+
+## Deploy Gate
+
+Deployment remains blocked until production `/opt/vizora/app` dirty/diverged work is classified. This branch must not pull/reset/stash/restart production services.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -15,14 +15,19 @@
 **Plan**
 - [x] Drift-check pairing and bulk upload against repo truth.
 - [x] Write plan/design and checklist.
-- [ ] Add failing tests for pairing-token rendering and bulk-upload behavior.
-- [ ] Implement pairing contract and copy alignment.
-- [ ] Implement per-file upload type, progress, bounded concurrency, and upload-while-running locks.
-- [ ] Run focused verification.
+- [x] Add failing tests for pairing-token rendering and bulk-upload behavior.
+- [x] Implement pairing contract and copy alignment.
+- [x] Implement per-file upload type, progress, bounded concurrency, and upload-while-running locks.
+- [x] Run focused verification.
 - [ ] Run multi-subagent review before broad verification.
 - [ ] Run broader web verification/build.
 - [ ] PR, CI, merge.
 - [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Focused verification**
+- [x] `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="devices-page|content-page"` - red first on missing `pairingToken` rendering and missing bulk `uploadContentWithProgress`, then pass, 2 suites / 30 tests.
+- [x] `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` - pass.
+- [x] `git diff --check` - pass; line-ending warnings only.
 
 ---
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -26,8 +26,14 @@
 
 **Focused verification**
 - [x] `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="devices-page|content-page"` - red first on missing `pairingToken` rendering and missing bulk `uploadContentWithProgress`, then pass, 2 suites / 30 tests.
+- [x] Post-review regression run for hidden URL-mode queue and modal-close upload lock - red first, then pass, 2 suites / 32 tests.
 - [x] `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` - pass.
 - [x] `git diff --check` - pass; line-ending warnings only.
+
+**Review gate**
+- [x] Customer/UX reviewer: initial P1 hidden queued files after switching to URL mode fixed with disabled URL option and guarded change handler; P2 modal-close upload state loss fixed by ignoring close while uploading.
+- [x] Performance/concurrency reviewer: no P0/P1; P2 modal-close finding fixed and pairing response type tightened to required backend shape.
+- [ ] Post-fix re-review.
 
 ---
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -20,7 +20,7 @@
 - [x] Implement per-file upload type, progress, bounded concurrency, and upload-while-running locks.
 - [x] Run focused verification.
 - [x] Run multi-subagent review before broad verification.
-- [ ] Run broader web verification/build.
+- [x] Run broader web verification/build.
 - [ ] PR, CI, merge.
 - [ ] Re-check deployment gate; deploy only if prod checkout is safe.
 
@@ -30,6 +30,12 @@
 - [x] Re-review regression for removed-file URL upload - red first, then pass, content page 21 tests; combined focused suite now 2 suites / 33 tests.
 - [x] `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` - pass.
 - [x] `git diff --check` - pass; line-ending warnings only.
+
+**Broader verification**
+- [x] `pnpm --filter @vizora/web test -- --runInBand` - pass, 89 suites / 934 tests; existing React `act(...)` and jsdom navigation warnings remain.
+- [x] `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` - pass.
+- [x] `git diff --check origin/main...HEAD` - pass.
+- [x] `NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 BACKEND_URL=http://localhost:3000 npx nx build @vizora/web` - pass with existing Next middleware deprecation and TypeScript project-reference warnings.
 
 **Review gate**
 - [x] Customer/UX reviewer: initial P1 hidden queued files after switching to URL mode fixed with disabled URL option and guarded change handler; P2 modal-close upload state loss fixed by ignoring close while uploading.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -19,7 +19,7 @@
 - [x] Implement pairing contract and copy alignment.
 - [x] Implement per-file upload type, progress, bounded concurrency, and upload-while-running locks.
 - [x] Run focused verification.
-- [ ] Run multi-subagent review before broad verification.
+- [x] Run multi-subagent review before broad verification.
 - [ ] Run broader web verification/build.
 - [ ] PR, CI, merge.
 - [ ] Re-check deployment gate; deploy only if prod checkout is safe.
@@ -27,13 +27,14 @@
 **Focused verification**
 - [x] `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="devices-page|content-page"` - red first on missing `pairingToken` rendering and missing bulk `uploadContentWithProgress`, then pass, 2 suites / 30 tests.
 - [x] Post-review regression run for hidden URL-mode queue and modal-close upload lock - red first, then pass, 2 suites / 32 tests.
+- [x] Re-review regression for removed-file URL upload - red first, then pass, content page 21 tests; combined focused suite now 2 suites / 33 tests.
 - [x] `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` - pass.
 - [x] `git diff --check` - pass; line-ending warnings only.
 
 **Review gate**
 - [x] Customer/UX reviewer: initial P1 hidden queued files after switching to URL mode fixed with disabled URL option and guarded change handler; P2 modal-close upload state loss fixed by ignoring close while uploading.
 - [x] Performance/concurrency reviewer: no P0/P1; P2 modal-close finding fixed and pairing response type tightened to required backend shape.
-- [ ] Post-fix re-review.
+- [x] Post-fix re-review: initial P1 removed-file URL upload path fixed by clearing selected file state when queue items are removed/cleared and by requiring a file upload type before using the file branch.
 
 ---
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,8 +1,35 @@
 # Vizora - Task Tracker
 
-## In Progress: Customer Dashboard + Performance Pass 4 (2026-05-31)
+## In Progress: Customer Dashboard UX Hotspots (2026-05-31)
+
+**Branch:** `fix/customer-dashboard-ux-hotspots`
+
+**Why now:** PR #126 merged and CI is green, but deployment is blocked by dirty/diverged prod-local work. The next customer-visible repo-side issues are small, testable dashboard defects in existing-device pairing and bulk content upload.
+
+**New primitives introduced:** none. Reuse existing dashboard pages, `ApiClient`, `/content/upload`, XHR upload progress, and `/displays/:id/pair`.
+
+**Hermes-first analysis:** not applicable; this pass does not add business-agent behavior, MCP tools, Hermes skills, AI provider calls, or spend paths.
+
+**Plan/design:** `docs/plans/2026-05-31-customer-dashboard-ux-hotspots.md`
+
+**Plan**
+- [x] Drift-check pairing and bulk upload against repo truth.
+- [x] Write plan/design and checklist.
+- [ ] Add failing tests for pairing-token rendering and bulk-upload behavior.
+- [ ] Implement pairing contract and copy alignment.
+- [ ] Implement per-file upload type, progress, bounded concurrency, and upload-while-running locks.
+- [ ] Run focused verification.
+- [ ] Run multi-subagent review before broad verification.
+- [ ] Run broader web verification/build.
+- [ ] PR, CI, merge.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+---
+
+## Completed: Customer Dashboard + Performance Pass 4 (2026-05-31)
 
 **Branch:** `feat/customer-dashboard-performance-pass`
+**PR / merge commit:** #126 / `cd978e4d8474393c85e0e4342218b4cbd708585f`
 
 **Why now:** PRs #123-#125 are merged and CI-green, but production deploy is blocked by dirty/diverged prod-local work. Fresh customer, performance, and adversarial scans found several repo-side issues that directly affect customer-1 readiness without requiring operator-only actions.
 
@@ -19,9 +46,9 @@
 - [x] Display content-error messages redact device JWT query params before UI, Redis, or Sentry.
 - [x] Critical smoke pairing-complete parsing handles enveloped `data.display.id`.
 - [x] Run multi-subagent review before broad verification.
-- [ ] Run focused/broad verification.
-- [ ] PR, CI, merge.
-- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+- [x] Run focused/broad verification.
+- [x] PR, CI, merge.
+- [x] Re-check deployment gate; deployment remains blocked by dirty/diverged prod checkout.
 
 **Review gate**
 - [x] Subagent runtime/security review: CLEAN.
@@ -47,6 +74,12 @@
 - [x] `npx nx build @vizora/realtime` - pass with existing source-map / optional `ws` warnings.
 - [x] `NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 BACKEND_URL=http://localhost:3000 npx nx build @vizora/web` - pass with existing Next middleware deprecation and TypeScript project-reference warnings.
 - [x] `pnpm --filter @vizora/display build` - pass.
+
+**Current deployment gate**
+- GitHub main: `cd978e4d8474393c85e0e4342218b4cbd708585f` after PR #126.
+- Open PRs: none after merging PR #126.
+- Production health: `/api/v1/health` returned `success: true`, database connected at `2026-05-31T12:24:48.285Z`.
+- Production deploy is blocked: `/opt/vizora/app` is dirty, local `HEAD=bb76aa1838740bff5b58623dfef7a906d44f46a6`, and after fetch is `ahead 17, behind 45` relative to `origin/main=cd978e4d8474393c85e0e4342218b4cbd708585f`. Do not pull/reset/stash/restart services until prod-local work is reconciled.
 
 ---
 

--- a/web/src/app/dashboard/content/__tests__/content-page.test.tsx
+++ b/web/src/app/dashboard/content/__tests__/content-page.test.tsx
@@ -8,7 +8,10 @@ const mockGetDisplays = jest.fn();
 const mockGetPlaylists = jest.fn();
 const mockDeleteContent = jest.fn();
 const mockUploadContent = jest.fn();
+const mockCreateContent = jest.fn();
+const mockUploadContentWithProgress = jest.fn();
 const mockGenerateThumbnail = jest.fn();
+let lastDropzoneOptions: any;
 
 jest.mock('@/lib/api', () => ({
   apiClient: {
@@ -19,6 +22,8 @@ jest.mock('@/lib/api', () => ({
     getPlaylists: (...args: any[]) => mockGetPlaylists(...args),
     deleteContent: (...args: any[]) => mockDeleteContent(...args),
     uploadContent: (...args: any[]) => mockUploadContent(...args),
+    createContent: (...args: any[]) => mockCreateContent(...args),
+    uploadContentWithProgress: (...args: any[]) => mockUploadContentWithProgress(...args),
     generateThumbnail: (...args: any[]) => mockGenerateThumbnail(...args),
   },
 }));
@@ -134,11 +139,14 @@ jest.mock('@/components/ViewToggle', () => ({
 }));
 
 jest.mock('react-dropzone', () => ({
-  useDropzone: () => ({
+  useDropzone: (options: any) => {
+    lastDropzoneOptions = options;
+    return ({
     getRootProps: () => ({}),
     getInputProps: () => ({}),
     isDragActive: false,
-  }),
+    });
+  },
 }));
 
 const sampleContent = [
@@ -186,7 +194,18 @@ describe('ContentClient', () => {
     mockGetPlaylists.mockResolvedValue({ data: [] });
     mockDeleteContent.mockResolvedValue({});
     mockUploadContent.mockResolvedValue({ id: 'new-1', title: 'New Content' });
+    mockCreateContent.mockResolvedValue({ id: 'new-1', title: 'New Content' });
+    mockUploadContentWithProgress.mockResolvedValue({ id: 'new-1', title: 'New Content' });
     mockGenerateThumbnail.mockResolvedValue({});
+    lastDropzoneOptions = undefined;
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: jest.fn(() => 'blob:mock-url'),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: jest.fn(),
+    });
   });
 
   const waitForInitialRequestsToSettle = async () => {
@@ -390,5 +409,128 @@ describe('ContentClient', () => {
   it('also fetches displays and playlists for push/add features', async () => {
     render(<ContentClient />);
     await waitForInitialRequestsToSettle();
+  });
+
+  it('bulk upload preserves each queued file type after the selector changes', async () => {
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+    render(<ContentClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    fireEvent.click(screen.getAllByText('Upload Content')[0]);
+    const imageFile = new File(['image-bytes'], 'lobby.png', { type: 'image/png' });
+
+    await act(async () => {
+      lastDropzoneOptions.onDrop([imageFile]);
+    });
+
+    fireEvent.change(screen.getByDisplayValue('Image'), { target: { value: 'video' } });
+    fireEvent.click(screen.getByText('Upload 1 File'));
+
+    await waitFor(() => {
+      expect(mockUploadContentWithProgress).toHaveBeenCalled();
+    });
+    expect(mockUploadContentWithProgress.mock.calls[0][0].title).toBe('lobby');
+    expect(mockUploadContentWithProgress.mock.calls[0][0].type).toBe('image');
+    expect(mockUploadContentWithProgress.mock.calls[0][0].file).toBe(imageFile);
+    expect(mockCreateContent).not.toHaveBeenCalledWith(expect.objectContaining({ file: imageFile }));
+  });
+
+  it('locks queued bulk upload controls while files are uploading', async () => {
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+    let resolveUpload: (content: any) => void = () => {};
+    mockUploadContentWithProgress.mockImplementation((_data, onProgress) => {
+      onProgress?.(42);
+      return new Promise((resolve) => {
+        resolveUpload = resolve;
+      });
+    });
+
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    fireEvent.click(screen.getAllByText('Upload Content')[0]);
+    const imageFile = new File(['image-bytes'], 'locked.png', { type: 'image/png' });
+
+    await act(async () => {
+      lastDropzoneOptions.onDrop([imageFile]);
+    });
+
+    fireEvent.click(screen.getByText('Upload 1 File'));
+
+    await waitFor(() => {
+      expect(mockUploadContentWithProgress).toHaveBeenCalled();
+      expect(screen.getByRole('button', { name: /clear all/i })).toBeDisabled();
+      expect(screen.getByLabelText(/remove locked.png from upload queue/i)).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveUpload({ id: 'new-1', title: 'Locked' });
+    });
+  });
+
+  it('limits queued bulk uploads to three concurrent files', async () => {
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+    const deferredUploads: Array<{ resolve: (content: any) => void; promise: Promise<any> }> = [];
+    mockUploadContentWithProgress.mockImplementation((_data, onProgress) => {
+      onProgress?.(10);
+      let resolveUpload: (content: any) => void = () => {};
+      const promise = new Promise((resolve) => {
+        resolveUpload = resolve;
+      });
+      deferredUploads.push({ resolve: resolveUpload, promise });
+      return promise;
+    });
+
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    fireEvent.click(screen.getAllByText('Upload Content')[0]);
+    const files = [
+      new File(['1'], 'file-1.png', { type: 'image/png' }),
+      new File(['2'], 'file-2.png', { type: 'image/png' }),
+      new File(['3'], 'file-3.png', { type: 'image/png' }),
+      new File(['4'], 'file-4.png', { type: 'image/png' }),
+    ];
+
+    await act(async () => {
+      lastDropzoneOptions.onDrop(files);
+    });
+
+    fireEvent.click(screen.getByText('Upload 4 Files'));
+
+    await waitFor(() => {
+      expect(mockUploadContentWithProgress).toHaveBeenCalledTimes(3);
+    });
+    expect(mockUploadContentWithProgress.mock.calls[0][0].title).toBe('file-1');
+    expect(mockUploadContentWithProgress.mock.calls[1][0].title).toBe('file-2');
+    expect(mockUploadContentWithProgress.mock.calls[2][0].title).toBe('file-3');
+    expect(screen.getAllByText('10%')).toHaveLength(3);
+
+    await act(async () => {
+      deferredUploads[0].resolve({ id: 'new-1', title: 'File 1' });
+      await deferredUploads[0].promise;
+    });
+
+    await waitFor(() => {
+      expect(mockUploadContentWithProgress).toHaveBeenCalledTimes(4);
+    });
+    expect(mockUploadContentWithProgress.mock.calls[3][0].title).toBe('file-4');
+
+    await act(async () => {
+      for (const deferred of deferredUploads.slice(1)) {
+        deferred.resolve({ id: 'new-rest', title: 'Rest' });
+      }
+      await Promise.all(deferredUploads.slice(1).map((deferred) => deferred.promise));
+    });
   });
 });

--- a/web/src/app/dashboard/content/__tests__/content-page.test.tsx
+++ b/web/src/app/dashboard/content/__tests__/content-page.test.tsx
@@ -80,8 +80,14 @@ jest.mock('@/components/EmptyState', () => {
 });
 
 jest.mock('@/components/Modal', () => {
-  return function MockModal({ isOpen, children, title }: any) {
-    return isOpen ? <div data-testid="modal"><h2>{title}</h2>{children}</div> : null;
+  return function MockModal({ isOpen, children, title, onClose }: any) {
+    return isOpen ? (
+      <div data-testid="modal">
+        <h2>{title}</h2>
+        <button type="button" aria-label="Close modal" onClick={onClose}>Close</button>
+        {children}
+      </div>
+    ) : null;
   };
 });
 
@@ -439,6 +445,32 @@ describe('ContentClient', () => {
     expect(mockCreateContent).not.toHaveBeenCalledWith(expect.objectContaining({ file: imageFile }));
   });
 
+  it('keeps queued files visible by blocking URL mode until the queue is cleared', async () => {
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+    render(<ContentClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    fireEvent.click(screen.getAllByText('Upload Content')[0]);
+    const imageFile = new File(['image-bytes'], 'queued.png', { type: 'image/png' });
+
+    await act(async () => {
+      lastDropzoneOptions.onDrop([imageFile]);
+    });
+
+    expect(screen.getByText('queued.png')).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'URL/Web Page' })).toBeDisabled();
+
+    fireEvent.change(screen.getByDisplayValue('Image'), { target: { value: 'url' } });
+
+    expect(screen.getByDisplayValue('Image')).toBeInTheDocument();
+    expect(screen.getByText('queued.png')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('https://example.com/page')).not.toBeInTheDocument();
+  });
+
   it('locks queued bulk upload controls while files are uploading', async () => {
     mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
     let resolveUpload: (content: any) => void = () => {};
@@ -472,6 +504,46 @@ describe('ContentClient', () => {
 
     await act(async () => {
       resolveUpload({ id: 'new-1', title: 'Locked' });
+    });
+  });
+
+  it('does not close or clear queued upload progress while files are uploading', async () => {
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+    let resolveUpload: (content: any) => void = () => {};
+    mockUploadContentWithProgress.mockImplementation((_data, onProgress) => {
+      onProgress?.(42);
+      return new Promise((resolve) => {
+        resolveUpload = resolve;
+      });
+    });
+
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    fireEvent.click(screen.getAllByText('Upload Content')[0]);
+    const imageFile = new File(['image-bytes'], 'in-flight.png', { type: 'image/png' });
+
+    await act(async () => {
+      lastDropzoneOptions.onDrop([imageFile]);
+    });
+
+    fireEvent.click(screen.getByText('Upload 1 File'));
+
+    await waitFor(() => {
+      expect(screen.getByText('in-flight.png')).toBeInTheDocument();
+      expect(screen.getByText('42%')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText('Close modal'));
+
+    expect(screen.getByText('in-flight.png')).toBeInTheDocument();
+    expect(screen.getByText('42%')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveUpload({ id: 'new-1', title: 'In Flight' });
     });
   });
 

--- a/web/src/app/dashboard/content/__tests__/content-page.test.tsx
+++ b/web/src/app/dashboard/content/__tests__/content-page.test.tsx
@@ -471,6 +471,41 @@ describe('ContentClient', () => {
     expect(screen.queryByPlaceholderText('https://example.com/page')).not.toBeInTheDocument();
   });
 
+  it('does not upload a removed queued file when switching to URL content', async () => {
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+    render(<ContentClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    fireEvent.click(screen.getAllByText('Upload Content')[0]);
+    const removedFile = new File(['image-bytes'], 'removed.png', { type: 'image/png' });
+
+    await act(async () => {
+      lastDropzoneOptions.onDrop([removedFile]);
+    });
+
+    fireEvent.click(screen.getByLabelText(/remove removed.png from upload queue/i));
+    fireEvent.change(screen.getByDisplayValue('Image'), { target: { value: 'url' } });
+    fireEvent.change(screen.getByPlaceholderText('https://example.com/page'), {
+      target: { value: 'https://example.com/menu' },
+    });
+
+    const submitButtons = screen.getAllByRole('button', { name: 'Upload Content' });
+    fireEvent.click(submitButtons[submitButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(mockCreateContent).toHaveBeenCalledWith({
+        title: 'removed',
+        type: 'url',
+        url: 'https://example.com/menu',
+      });
+    });
+    expect(mockUploadContentWithProgress).not.toHaveBeenCalled();
+  });
+
   it('locks queued bulk upload controls while files are uploading', async () => {
     mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
     let resolveUpload: (content: any) => void = () => {};

--- a/web/src/app/dashboard/content/page-client.tsx
+++ b/web/src/app/dashboard/content/page-client.tsx
@@ -1297,6 +1297,7 @@ export default function ContentClient() {
  <Modal
  isOpen={isUploadModalOpen}
  onClose={() => {
+ if (actionLoading) return;
  if (uploadForm.url.startsWith('blob:')) {
  URL.revokeObjectURL(uploadForm.url);
  }
@@ -1345,16 +1346,18 @@ export default function ContentClient() {
  </label>
  <select
  value={uploadForm.type}
- onChange={(e) =>
- setUploadForm({ ...uploadForm, type: e.target.value as UploadFormType })
- }
+ onChange={(e) => {
+ const nextType = e.target.value as UploadFormType;
+ if (uploadQueue.length > 0 && !isFileUploadType(nextType)) return;
+ setUploadForm({ ...uploadForm, type: nextType });
+ }}
  disabled={actionLoading}
  className="w-full px-4 py-2 border border-[var(--border)] rounded-lg focus:ring-2 focus:ring-[#00E5A0] focus:border-transparent text-[var(--foreground)]"
  >
  <option value="image">Image</option>
  <option value="video">Video</option>
  <option value="pdf">PDF</option>
- <option value="url">URL/Web Page</option>
+ <option value="url" disabled={uploadQueue.length > 0}>URL/Web Page</option>
  </select>
  </div>
  

--- a/web/src/app/dashboard/content/page-client.tsx
+++ b/web/src/app/dashboard/content/page-client.tsx
@@ -385,6 +385,30 @@ export default function ContentClient() {
  }
  };
 
+ const clearSelectedUploadFile = () => {
+ if (uploadForm.url.startsWith('blob:')) {
+ URL.revokeObjectURL(uploadForm.url);
+ }
+ setUploadForm(prev => ({
+ ...prev,
+ file: null,
+ url: prev.url.startsWith('blob:') ? '' : prev.url,
+ }));
+ };
+
+ const clearUploadQueue = () => {
+ setUploadQueue([]);
+ clearSelectedUploadFile();
+ };
+
+ const removeUploadQueueItem = (index: number) => {
+ const removedItem = uploadQueue[index];
+ setUploadQueue(prev => prev.filter((_, i) => i !== index));
+ if (removedItem && uploadForm.file === removedItem.file) {
+ clearSelectedUploadFile();
+ }
+ };
+
  const handleUpload = async () => {
  // If queue has files, use bulk upload
  if (uploadQueue.length > 0) {
@@ -405,7 +429,7 @@ export default function ContentClient() {
  setUploadProgress(0);
 
  let newContent;
- if (uploadForm.file) {
+ if (uploadForm.file && isFileUploadType(uploadForm.type)) {
  // Use progress-tracking upload for file uploads
  newContent = await apiClient.uploadContentWithProgress(
  { title: uploadForm.title, type: uploadForm.type, file: uploadForm.file },
@@ -1302,7 +1326,7 @@ export default function ContentClient() {
  URL.revokeObjectURL(uploadForm.url);
  }
  setUploadForm({ title: '', type: 'image', url: '', file: null });
- setUploadQueue([]);
+ clearUploadQueue();
  setIsUploadModalOpen(false);
  }}
  title="Upload Content"
@@ -1417,7 +1441,7 @@ export default function ContentClient() {
  Upload Queue ({uploadQueue.length} file{uploadQueue.length > 1 ? 's' : ''})
  </p>
  <button
- onClick={() => setUploadQueue([])}
+ onClick={clearUploadQueue}
  disabled={actionLoading}
  className="text-xs text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 disabled:opacity-50 disabled:cursor-not-allowed"
  >
@@ -1463,7 +1487,7 @@ export default function ContentClient() {
  <span className="text-red-600 dark:text-red-400" title={item.error}>✗</span>
  )}
  <button
- onClick={() => setUploadQueue(prev => prev.filter((_, i) => i !== idx))}
+ onClick={() => removeUploadQueueItem(idx)}
  disabled={actionLoading}
  aria-label={`Remove ${item.file.name} from upload queue`}
  className="text-[var(--foreground-tertiary)] hover:text-red-600 dark:hover:text-red-400 disabled:opacity-50 disabled:cursor-not-allowed"
@@ -1535,7 +1559,7 @@ export default function ContentClient() {
  URL.revokeObjectURL(uploadForm.url);
  }
  setUploadForm({ title: '', type: 'image', url: '', file: null });
- setUploadQueue([]);
+ clearUploadQueue();
  setUploadProgress(0);
  setIsUploadModalOpen(false);
  }}

--- a/web/src/app/dashboard/content/page-client.tsx
+++ b/web/src/app/dashboard/content/page-client.tsx
@@ -33,6 +33,27 @@ interface ModerationMetadata {
   reviewNote?: string;
 }
 
+type UploadFormType = 'image' | 'video' | 'pdf' | 'url' | 'html' | 'template';
+type FileUploadType = Extract<UploadFormType, 'image' | 'video' | 'pdf'>;
+type UploadQueueStatus = 'pending' | 'uploading' | 'success' | 'error';
+type UploadQueueItem = {
+ file: File;
+ type: FileUploadType;
+ status: UploadQueueStatus;
+ progress: number;
+ error?: string;
+};
+
+const BULK_UPLOAD_CONCURRENCY = 3;
+const FILE_UPLOAD_TYPES = new Set<UploadFormType>(['image', 'video', 'pdf']);
+
+const isFileUploadType = (type: UploadFormType): type is FileUploadType => FILE_UPLOAD_TYPES.has(type);
+
+const formatUploadType = (type: FileUploadType): string => {
+ if (type === 'pdf') return 'PDF';
+ return type.charAt(0).toUpperCase() + type.slice(1);
+};
+
 export default function ContentClient() {
  const toast = useToast();
  const [content, setContent] = useState<Content[]>([]);
@@ -51,7 +72,7 @@ export default function ContentClient() {
  const [pushDuration, setPushDuration] = useState(5);
  const [uploadForm, setUploadForm] = useState({
  title: '',
- type: 'image' as 'image' | 'video' | 'pdf' | 'url' | 'html' | 'template',
+ type: 'image' as UploadFormType,
  url: '',
  file: null as File | null,
  });
@@ -66,12 +87,7 @@ export default function ContentClient() {
  const [selectedItems, setSelectedItems] = useState<Set<string>>(new Set());
  const [formErrors, setFormErrors] = useState<Record<string, string>>({});
  const [uploadProgress, setUploadProgress] = useState<number>(0);
- const [uploadQueue, setUploadQueue] = useState<Array<{
- file: File;
- status: 'pending' | 'uploading' | 'success' | 'error';
- progress: number;
- error?: string;
- }>>([]);
+ const [uploadQueue, setUploadQueue] = useState<UploadQueueItem[]>([]);
  const [tags] = useState<ContentTag[]>([
  { id: '1', name: 'Marketing', color: 'blue' },
  { id: '2', name: 'Seasonal', color: 'green' },
@@ -297,43 +313,56 @@ export default function ContentClient() {
  }
 
  setActionLoading(true);
+ const uploadTargets = uploadQueue
+ .map((item, index) => ({ item, index }))
+ .filter(({ item }) => item.status !== 'success');
  const results: Array<'success' | 'error'> = [];
+ let nextUploadIndex = 0;
 
- // Upload files sequentially
- for (let i = 0; i < uploadQueue.length; i++) {
- const item = uploadQueue[i];
- 
- // Update status to uploading
- setUploadQueue(prev => prev.map((q, idx) => 
- idx === i ? { ...q, status: 'uploading' as const } : q
+ const uploadOne = async (item: UploadQueueItem, index: number) => {
+ setUploadQueue(prev => prev.map((q, idx) =>
+ idx === index ? { ...q, status: 'uploading' as const, progress: 0, error: undefined } : q
  ));
 
  try {
  const title = item.file.name.replace(/\.[^/.]+$/, '');
 
- // Pass file directly to API - it will handle multipart upload
- const newContent = await apiClient.createContent({
- title,
- type: uploadForm.type,
- file: item.file, // Pass file object instead of blob URL
- });
-
- // Mark as success
+ await apiClient.uploadContentWithProgress(
+ { title, type: item.type, file: item.file },
+ (percent) => {
  setUploadQueue(prev => prev.map((q, idx) =>
- idx === i ? { ...q, status: 'success' as const, progress: 100 } : q
+ idx === index ? { ...q, progress: percent } : q
+ ));
+ },
+ );
+
+ setUploadQueue(prev => prev.map((q, idx) =>
+ idx === index ? { ...q, status: 'success' as const, progress: 100 } : q
  ));
  results.push('success');
  } catch (error: any) {
- // Mark as error
  setUploadQueue(prev => prev.map((q, idx) =>
- idx === i ? { ...q, status: 'error' as const, error: error.message } : q
+ idx === index ? { ...q, status: 'error' as const, error: error.message || 'Upload failed' } : q
  ));
  results.push('error');
  }
+ };
+
+ const worker = async () => {
+ while (nextUploadIndex < uploadTargets.length) {
+ const current = uploadTargets[nextUploadIndex];
+ nextUploadIndex += 1;
+ await uploadOne(current.item, current.index);
+ }
+ };
+
+ try {
+ const workerCount = Math.min(BULK_UPLOAD_CONCURRENCY, uploadTargets.length);
+ await Promise.all(Array.from({ length: workerCount }, () => worker()));
+ } finally {
+ setActionLoading(false);
  }
 
- setActionLoading(false);
- 
  const successCount = results.filter(r => r === 'success').length;
  const errorCount = results.filter(r => r === 'error').length;
  
@@ -347,7 +376,12 @@ export default function ContentClient() {
  setUploadForm({ title: '', type: 'image', url: '', file: null });
  loadContent();
  } else {
+ if (successCount > 0) {
+ loadContent();
+ toast.error(`${successCount} file(s) uploaded, ${errorCount} failed`);
+ } else {
  toast.error(`${errorCount} file(s) failed to upload`);
+ }
  }
  };
 
@@ -707,12 +741,15 @@ export default function ContentClient() {
  const { getRootProps, getInputProps, isDragActive } = useDropzone({
  accept: getAcceptedFileTypes() as any,
  multiple: true, // Enable multiple file selection
- disabled: uploadForm.type === 'url',
+ disabled: actionLoading || !isFileUploadType(uploadForm.type),
  useFsAccessApi: false,
  onDrop: (acceptedFiles) => {
+ if (!isFileUploadType(uploadForm.type)) return;
+ const queuedType = uploadForm.type;
  // Add files to upload queue
  const newQueueItems = acceptedFiles.map(file => ({
  file,
+ type: queuedType,
  status: 'pending' as const,
  progress: 0,
  }));
@@ -1309,8 +1346,9 @@ export default function ContentClient() {
  <select
  value={uploadForm.type}
  onChange={(e) =>
- setUploadForm({ ...uploadForm, type: e.target.value as any })
+ setUploadForm({ ...uploadForm, type: e.target.value as UploadFormType })
  }
+ disabled={actionLoading}
  className="w-full px-4 py-2 border border-[var(--border)] rounded-lg focus:ring-2 focus:ring-[#00E5A0] focus:border-transparent text-[var(--foreground)]"
  >
  <option value="image">Image</option>
@@ -1328,7 +1366,9 @@ export default function ContentClient() {
  </label>
  <div
  {...getRootProps()}
- className={`border-2 border-dashed rounded-lg p-6 text-center transition-all cursor-pointer ${
+ className={`border-2 border-dashed rounded-lg p-6 text-center transition-all ${
+ actionLoading ? 'cursor-not-allowed opacity-70' : 'cursor-pointer'
+ } ${
  isDragActive
  ? 'border-[#00E5A0] bg-[#00E5A0]/5'
  : 'border-[var(--border)] hover:border-[#00E5A0] hover:bg-[var(--surface-hover)]'
@@ -1375,7 +1415,8 @@ export default function ContentClient() {
  </p>
  <button
  onClick={() => setUploadQueue([])}
- className="text-xs text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300"
+ disabled={actionLoading}
+ className="text-xs text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 disabled:opacity-50 disabled:cursor-not-allowed"
  >
  Clear All
  </button>
@@ -1391,15 +1432,26 @@ export default function ContentClient() {
  {item.file.name}
  </p>
  <p className="text-xs text-[var(--foreground-tertiary)]">
- {(item.file.size / 1024).toFixed(1)} KB
+ {(item.file.size / 1024).toFixed(1)} KB - {formatUploadType(item.type)}
  </p>
+ {item.status === 'uploading' && (
+ <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-[var(--border)]">
+ <div
+ className="h-full rounded-full bg-[#00E5A0] transition-all duration-300"
+ style={{ width: `${item.progress}%` }}
+ />
+ </div>
+ )}
  </div>
  <div className="ml-4 flex items-center gap-2">
  {item.status === 'pending' && (
  <span className="text-xs text-[var(--foreground-tertiary)]">Pending</span>
  )}
  {item.status === 'uploading' && (
+ <span className="flex items-center gap-2 text-xs text-[#00E5A0]">
  <LoadingSpinner size="sm" />
+ {item.progress}%
+ </span>
  )}
  {item.status === 'success' && (
  <span className="text-green-600 dark:text-green-400">✓</span>
@@ -1409,7 +1461,9 @@ export default function ContentClient() {
  )}
  <button
  onClick={() => setUploadQueue(prev => prev.filter((_, i) => i !== idx))}
- className="text-[var(--foreground-tertiary)] hover:text-red-600 dark:hover:text-red-400"
+ disabled={actionLoading}
+ aria-label={`Remove ${item.file.name} from upload queue`}
+ className="text-[var(--foreground-tertiary)] hover:text-red-600 dark:hover:text-red-400 disabled:opacity-50 disabled:cursor-not-allowed"
  >
  ×
  </button>

--- a/web/src/app/dashboard/devices/__tests__/devices-page.test.tsx
+++ b/web/src/app/dashboard/devices/__tests__/devices-page.test.tsx
@@ -7,6 +7,7 @@ const mockGetPlaylists = jest.fn();
 const mockGetDisplayGroups = jest.fn();
 const mockDeleteDisplay = jest.fn();
 const mockUpdateDisplay = jest.fn();
+const mockGeneratePairingToken = jest.fn();
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({
@@ -27,6 +28,7 @@ jest.mock('@/lib/api', () => ({
     getDisplayGroups: (...args: any[]) => mockGetDisplayGroups(...args),
     deleteDisplay: (...args: any[]) => mockDeleteDisplay(...args),
     updateDisplay: (...args: any[]) => mockUpdateDisplay(...args),
+    generatePairingToken: (...args: any[]) => mockGeneratePairingToken(...args),
     getCurrentUser: jest.fn().mockRejectedValue(new Error('401')),
     setAuthenticated: jest.fn(),
     getActiveOverrides: jest.fn().mockResolvedValue([]),
@@ -197,6 +199,12 @@ describe('DevicesClient', () => {
     mockGetDisplayGroups.mockResolvedValue({ data: [] });
     mockDeleteDisplay.mockResolvedValue({});
     mockUpdateDisplay.mockResolvedValue({});
+    mockGeneratePairingToken.mockResolvedValue({
+      pairingToken: 'eyJ.mock.pairing-token',
+      expiresIn: '30d',
+      displayId: 'd1',
+      deviceIdentifier: 'device-d1',
+    });
   });
 
   it('renders and loads data with empty initial props', async () => {
@@ -289,6 +297,24 @@ describe('DevicesClient', () => {
     });
     // Page renders with device management UI
     expect(screen.getAllByText(/device/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders backend pairingToken when pairing an existing device', async () => {
+    mockGetDisplays.mockResolvedValue({ data: sampleDevices, meta: { total: 3 } });
+
+    render(<DevicesClient initialDevices={sampleDevices as any} initialPlaylists={samplePlaylists as any} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Lobby Display')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByText('Pair')[0]);
+
+    await waitFor(() => {
+      expect(mockGeneratePairingToken).toHaveBeenCalledWith('d1');
+      expect(screen.getByText('eyJ.mock.pairing-token')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('N/A')).not.toBeInTheDocument();
   });
 
   it('handles empty device list gracefully', async () => {

--- a/web/src/app/dashboard/devices/page-client.tsx
+++ b/web/src/app/dashboard/devices/page-client.tsx
@@ -268,7 +268,7 @@ export default function DevicesClient({ initialDevices, initialPlaylists }: Devi
  try {
  setActionLoading(true);
  const response = await apiClient.generatePairingToken(device.id);
- setPairingCode(response.pairingToken || response.pairingCode || 'N/A');
+ setPairingCode(response.pairingToken);
  setPairingExpiresIn(response.expiresIn || '5 minutes');
  setSelectedDevice(device);
  setIsPairingModalOpen(true);

--- a/web/src/app/dashboard/devices/page-client.tsx
+++ b/web/src/app/dashboard/devices/page-client.tsx
@@ -42,6 +42,7 @@ export default function DevicesClient({ initialDevices, initialPlaylists }: Devi
  const [isPairingModalOpen, setIsPairingModalOpen] = useState(false);
  const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false);
  const [pairingCode, setPairingCode] = useState('');
+ const [pairingExpiresIn, setPairingExpiresIn] = useState('');
  const [editForm, setEditForm] = useState({ nickname: '', location: '' });
  const [actionLoading, setActionLoading] = useState(false);
  const [searchQuery, setSearchQuery] = useState('');
@@ -267,7 +268,8 @@ export default function DevicesClient({ initialDevices, initialPlaylists }: Devi
  try {
  setActionLoading(true);
  const response = await apiClient.generatePairingToken(device.id);
- setPairingCode(response.pairingCode || 'N/A');
+ setPairingCode(response.pairingToken || response.pairingCode || 'N/A');
+ setPairingExpiresIn(response.expiresIn || '5 minutes');
  setSelectedDevice(device);
  setIsPairingModalOpen(true);
  } catch (error: any) {
@@ -634,13 +636,13 @@ export default function DevicesClient({ initialDevices, initialPlaylists }: Devi
  </div>
  </Modal>
 
- <Modal isOpen={isPairingModalOpen} onClose={() => setIsPairingModalOpen(false)} title="Pairing Code">
+ <Modal isOpen={isPairingModalOpen} onClose={() => setIsPairingModalOpen(false)} title="Pairing Token">
  <div className="text-center space-y-5">
- <p className="text-[var(--foreground-secondary)]">Enter this code on your display device to pair it:</p>
+ <p className="text-[var(--foreground-secondary)]">Use this token on your display device to pair it:</p>
  <div className="bg-[var(--background-secondary)] rounded-lg p-6">
- <div className="text-4xl font-bold font-mono text-[#00E5A0] tracking-widest">{pairingCode}</div>
+ <div className="break-all text-lg font-bold font-mono text-[#00E5A0] tracking-wide">{pairingCode}</div>
  </div>
- <p className="text-sm text-[var(--foreground-tertiary)]">This code will expire in 5 minutes</p>
+ <p className="text-sm text-[var(--foreground-tertiary)]">This token expires in {pairingExpiresIn}</p>
  <button onClick={() => setIsPairingModalOpen(false)} className="eh-btn-neon rounded-xl w-full px-4 py-2 text-sm font-medium">Done</button>
  </div>
  </Modal>

--- a/web/src/lib/api/displays.ts
+++ b/web/src/lib/api/displays.ts
@@ -4,11 +4,10 @@ import type { Display, DisplayOrientation, PaginatedResponse, DisplayGroup, QrOv
 import { ApiClient } from './client';
 
 export interface PairingTokenResponse {
-  pairingToken?: string;
-  pairingCode?: string;
-  expiresIn?: string;
-  displayId?: string;
-  deviceIdentifier?: string;
+  pairingToken: string;
+  expiresIn: string;
+  displayId: string;
+  deviceIdentifier: string;
 }
 
 declare module './client' {

--- a/web/src/lib/api/displays.ts
+++ b/web/src/lib/api/displays.ts
@@ -3,6 +3,14 @@
 import type { Display, DisplayOrientation, PaginatedResponse, DisplayGroup, QrOverlayConfig } from '../types';
 import { ApiClient } from './client';
 
+export interface PairingTokenResponse {
+  pairingToken?: string;
+  pairingCode?: string;
+  expiresIn?: string;
+  displayId?: string;
+  deviceIdentifier?: string;
+}
+
 declare module './client' {
   interface ApiClient {
     getDisplays(params?: { page?: number; limit?: number }): Promise<PaginatedResponse<Display>>;
@@ -10,7 +18,7 @@ declare module './client' {
     createDisplay(data: { nickname: string; location?: string }): Promise<Display>;
     updateDisplay(id: string, data: Partial<{ nickname: string; location?: string; currentPlaylistId?: string | null; orientation?: DisplayOrientation }>): Promise<Display>;
     deleteDisplay(id: string): Promise<void>;
-    generatePairingToken(id: string): Promise<{ pairingCode: string }>;
+    generatePairingToken(id: string): Promise<PairingTokenResponse>;
     completePairing(data: { code: string; nickname: string; location?: string }): Promise<Display>;
     pushContentToDisplay(displayId: string, contentId: string, duration?: number): Promise<{ success: boolean; message: string }>;
     requestDeviceScreenshot(displayId: string): Promise<{ requestId: string; status: string }>;
@@ -76,8 +84,8 @@ ApiClient.prototype.deleteDisplay = async function (id: string): Promise<void> {
   });
 };
 
-ApiClient.prototype.generatePairingToken = async function (id: string): Promise<{ pairingCode: string }> {
-  return this.request<{ pairingCode: string }>(`/displays/${id}/pair`, {
+ApiClient.prototype.generatePairingToken = async function (id: string): Promise<PairingTokenResponse> {
+  return this.request<PairingTokenResponse>(`/displays/${id}/pair`, {
     method: 'POST',
   });
 };


### PR DESCRIPTION
## Summary
- align existing-device Pair modal with backend `pairingToken` response shape
- make bulk uploads use per-file type and XHR progress with a 3-upload concurrency bound
- lock/harden upload queue state so hidden or removed files cannot upload unexpectedly

## Tests
- pnpm --filter @vizora/web test -- --runInBand --testPathPattern=devices-page|content-page
- pnpm --filter @vizora/web test -- --runInBand
- pnpm --filter @vizora/web exec tsc --noEmit --pretty false
- git diff --check origin/main...HEAD
- NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 BACKEND_URL=http://localhost:3000 npx nx build @vizora/web

## Review
- multi-subagent customer/UX + performance/code-safety reviews completed
- final targeted re-review: CLEAN

## Deploy
- not deployed from this PR; production checkout remains dirty/diverged and must be reconciled before deploy