### PR TITLE
Enforce current device token hashes

### DIFF
--- a/docs/plans/2026-05-31-device-token-current-hash-enforcement.md
+++ b/docs/plans/2026-05-31-device-token-current-hash-enforcement.md
@@ -48,11 +48,13 @@ Awesome-hermes-agent ecosystem check: not applicable; this is a local auth-bound
    - Preserve user-token handshake behavior.
    - Store the authenticated token hash on `client.data`.
    - Revalidate `client.data.deviceTokenHash` against the DB-current `Display.jwtToken` in `WsDeviceGuard` so already-connected sockets fail closed after re-pair.
+   - Revalidate server-to-device delivery sockets before playlist, command, and QR-overlay pushes so idle stale sockets cannot receive payloads after re-pair.
    - Disable automatic token rotation until a future design supports grace tokens or an ACK-backed two-phase rotation flow.
+   - Keep the guard revalidation cache very short; this reduces burst duplicate checks but does not weaken server-push enforcement.
 
 3. Tests
    - Middleware: stale signed device token is rejected before content lookup, heartbeat write, or schedule lookup; missing stored token hash is rejected; matching hash still streams.
-   - Realtime: stale signed device token is rejected before room join/status update; matching hash connects; connected device sockets are rejected by guard if their token hash is no longer current; near-expiry tokens do not auto-rotate.
+   - Realtime: stale signed device token is rejected before room join/status update; matching hash connects; connected device sockets are rejected by guard if their token hash is no longer current; server-push delivery skips stale sockets; near-expiry tokens do not auto-rotate.
 
 ## Runtime-State Verification
 
@@ -66,6 +68,7 @@ Before any deployment of fail-closed token-hash enforcement:
 
 - `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="displays.controller|schedules.controller|device-content.controller"`
 - `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern="device.gateway|ws-auth.guard"`
+- `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="subscription-active.guard|displays.controller|schedules.controller|device-content.controller"`
 - `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
 - `npx nx build @vizora/realtime`
 - Multi-agent review before broader affected tests.

--- a/docs/plans/2026-05-31-device-token-current-hash-enforcement.md
+++ b/docs/plans/2026-05-31-device-token-current-hash-enforcement.md
@@ -49,12 +49,13 @@ Awesome-hermes-agent ecosystem check: not applicable; this is a local auth-bound
    - Store the authenticated token hash on `client.data`.
    - Revalidate `client.data.deviceTokenHash` against the DB-current `Display.jwtToken` in `WsDeviceGuard` so already-connected sockets fail closed after re-pair.
    - Revalidate server-to-device delivery sockets before playlist, command, and QR-overlay pushes so idle stale sockets cannot receive payloads after re-pair.
+   - Route organization-room broadcasts through filtered per-socket emits so stale device sockets do not receive dashboard/status/notification/screenshot payloads after re-pair.
    - Disable automatic token rotation until a future design supports grace tokens or an ACK-backed two-phase rotation flow.
-   - Keep the guard revalidation cache very short; this reduces burst duplicate checks but does not weaken server-push enforcement.
+   - Revalidate guarded device messages every time; no short cache window is kept because re-pair invalidation must be immediate.
 
 3. Tests
    - Middleware: stale signed device token is rejected before content lookup, heartbeat write, or schedule lookup; missing stored token hash is rejected; matching hash still streams.
-   - Realtime: stale signed device token is rejected before room join/status update; matching hash connects; connected device sockets are rejected by guard if their token hash is no longer current; server-push delivery skips stale sockets; near-expiry tokens do not auto-rotate.
+   - Realtime: stale signed device token is rejected before room join/status update; matching hash connects; connected device sockets are rejected by guard if their token hash is no longer current; direct and organization-room server-push delivery skips stale sockets; near-expiry tokens do not auto-rotate.
 
 ## Runtime-State Verification
 
@@ -69,6 +70,7 @@ Before any deployment of fail-closed token-hash enforcement:
 - `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="displays.controller|schedules.controller|device-content.controller"`
 - `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern="device.gateway|ws-auth.guard"`
 - `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="subscription-active.guard|displays.controller|schedules.controller|device-content.controller"`
+- `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern="device.gateway|ws-auth.guard|app.controller"`
 - `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
 - `npx nx build @vizora/realtime`
 - Multi-agent review before broader affected tests.

--- a/docs/plans/2026-05-31-device-token-current-hash-enforcement.md
+++ b/docs/plans/2026-05-31-device-token-current-hash-enforcement.md
@@ -1,0 +1,71 @@
+# Device Token Current-Hash Enforcement Plan
+
+Date: 2026-05-31
+Branch: `feat/customer-performance-review-5`
+
+## Goal
+
+Reject stale display JWTs after re-pairing or token rotation by enforcing that the presented raw device token hashes to the current `Display.jwtToken` value in both authenticated device-content streaming and realtime Socket.IO handshakes.
+
+## New primitives introduced
+
+None. This reuses the existing `Display.jwtToken` hash column, existing pairing-token SHA-256 storage, the dual device JWT model, middleware device-content controller, and realtime gateway.
+
+## Hermes-first analysis
+
+This pass does not add business-agent behavior, MCP tools, Hermes skills, AI provider calls, or spend paths.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Device JWT authentication | none applicable | Use existing middleware/realtime auth paths and `Display.jwtToken`. |
+| Token rotation persistence | none applicable | Use existing Prisma display update path. |
+
+Awesome-hermes-agent ecosystem check: not applicable; this is a local auth-boundary hardening task, not agent orchestration.
+
+## Evidence
+
+- Pairing already stores a SHA-256 hash, not plaintext, on `Display.jwtToken` in `middleware/src/modules/displays/pairing.service.ts`.
+- Existing-device pairing also stores the hash in `middleware/src/modules/displays/displays.service.ts`.
+- `GET /api/v1/device-content/:id/file` verifies the token signature and display/org/disabled state, but does not compare the raw token hash to `Display.jwtToken`.
+- Realtime `authenticateConnection()` verifies the token signature and display/org/disabled state, but does not compare the raw token hash to `Display.jwtToken`.
+- Realtime token rotation emits `token:refresh` but does not persist the new token hash, leaving the old token as the DB-current token.
+
+## Design
+
+1. Middleware device-content
+   - Extract both the verified payload and raw token from the request.
+   - Hash the raw token with SHA-256.
+   - Select `jwtToken` with the display row.
+   - Reject if the display is missing, org mismatched, disabled, has no stored token hash, or has a stored hash that differs from the presented token hash.
+   - Keep all content lookup and streaming behavior unchanged after authorization succeeds.
+
+2. Realtime gateway
+   - Select `jwtToken` during device handshake.
+   - Reject device sockets when the stored hash is missing or differs from the presented raw token hash.
+   - Preserve user-token handshake behavior.
+   - During near-expiry rotation, update `Display.jwtToken` to the new token hash only when the row still has the old current hash, then emit `token:refresh` only after the update succeeds.
+   - If rotation persistence fails or races, keep the existing authenticated socket connected but do not emit an unusable replacement token.
+
+3. Tests
+   - Middleware: stale signed device token is rejected before content lookup; missing stored token hash is rejected; matching hash still streams.
+   - Realtime: stale signed device token is rejected before room join/status update; matching hash connects; rotation writes the new hash before emitting the refresh event; failed rotation update does not emit a refresh token.
+
+## Runtime-State Verification
+
+Before any deployment of fail-closed token-hash enforcement:
+
+- Query prod display token-hash coverage: total displays, active paired displays, and displays where `jwtToken IS NULL`.
+- Reconcile any legacy active displays missing `jwtToken` through an operator-approved re-pair/migration plan.
+- Reconcile prod `/opt/vizora/app` dirty/diverged checkout before any pull/restart/deploy.
+
+## Verification
+
+- `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=device-content.controller`
+- `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern=device.gateway`
+- `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
+- `npx nx build @vizora/realtime`
+- Multi-agent review before broader affected tests.
+
+## Deploy Gate
+
+Deployment remains blocked until production checkout state and display token-hash runtime state are safe. This branch must not pull/reset/stash/restart production services.

--- a/docs/plans/2026-05-31-device-token-current-hash-enforcement.md
+++ b/docs/plans/2026-05-31-device-token-current-hash-enforcement.md
@@ -5,11 +5,11 @@ Branch: `feat/customer-performance-review-5`
 
 ## Goal
 
-Reject stale display JWTs after re-pairing or token rotation by enforcing that the presented raw device token hashes to the current `Display.jwtToken` value in both authenticated device-content streaming and realtime Socket.IO handshakes.
+Reject stale display JWTs after re-pairing by enforcing that the presented raw device token hashes to the current `Display.jwtToken` value across display-facing REST and realtime paths.
 
 ## New primitives introduced
 
-None. This reuses the existing `Display.jwtToken` hash column, existing pairing-token SHA-256 storage, the dual device JWT model, middleware device-content controller, and realtime gateway.
+One small shared middleware auth helper and one realtime hash helper. They reuse the existing `Display.jwtToken` hash column, existing pairing-token SHA-256 storage, the dual device JWT model, middleware controllers, and realtime gateway/guards.
 
 ## Hermes-first analysis
 
@@ -18,7 +18,7 @@ This pass does not add business-agent behavior, MCP tools, Hermes skills, AI pro
 | Domain | Hermes skill found? | Decision |
 |---|---|---|
 | Device JWT authentication | none applicable | Use existing middleware/realtime auth paths and `Display.jwtToken`. |
-| Token rotation persistence | none applicable | Use existing Prisma display update path. |
+| Token rotation | none applicable | Disable unsafe auto-rotation until a grace/ACK-backed design exists. |
 
 Awesome-hermes-agent ecosystem check: not applicable; this is a local auth-boundary hardening task, not agent orchestration.
 
@@ -26,42 +26,46 @@ Awesome-hermes-agent ecosystem check: not applicable; this is a local auth-bound
 
 - Pairing already stores a SHA-256 hash, not plaintext, on `Display.jwtToken` in `middleware/src/modules/displays/pairing.service.ts`.
 - Existing-device pairing also stores the hash in `middleware/src/modules/displays/displays.service.ts`.
-- `GET /api/v1/device-content/:id/file` verifies the token signature and display/org/disabled state, but does not compare the raw token hash to `Display.jwtToken`.
-- Realtime `authenticateConnection()` verifies the token signature and display/org/disabled state, but does not compare the raw token hash to `Display.jwtToken`.
-- Realtime token rotation emits `token:refresh` but does not persist the new token hash, leaving the old token as the DB-current token.
+- `GET /api/v1/device-content/:id/file` verified the token signature and display/org/disabled state, but did not compare the raw token hash to `Display.jwtToken`.
+- `POST /api/v1/displays/:deviceId/heartbeat` and `GET /api/v1/schedules/active/:displayId` also verified only signed JWT claims.
+- Realtime `authenticateConnection()` verified the token signature and display/org/disabled state, but did not compare the raw token hash to `Display.jwtToken`.
+- Realtime message guards trusted `client.data.deviceId`, so an already-connected socket could keep operating after a re-pair changed the DB-current token hash.
+- Realtime auto-rotation cannot be made reliable with a single current-token hash because either update-before-emit or emit-before-update can strand displays if delivery, persistence, or ACK is lost.
 
 ## Design
 
-1. Middleware device-content
-   - Extract both the verified payload and raw token from the request.
+1. Middleware device JWT helper
+   - Extract the token from the Authorization header, with query-token support only for media streaming.
+   - Verify HS256 device JWT claims.
    - Hash the raw token with SHA-256.
    - Select `jwtToken` with the display row.
-   - Reject if the display is missing, org mismatched, disabled, has no stored token hash, or has a stored hash that differs from the presented token hash.
-   - Keep all content lookup and streaming behavior unchanged after authorization succeeds.
+   - Reject if the display is missing, org mismatched, disabled, has no stored token hash, has a malformed/non-hex hash, or has a stored hash that differs from the presented token hash.
+   - Reuse the helper in device-content streaming, display heartbeat, and active schedules.
 
-2. Realtime gateway
+2. Realtime gateway and guards
    - Select `jwtToken` during device handshake.
    - Reject device sockets when the stored hash is missing or differs from the presented raw token hash.
    - Preserve user-token handshake behavior.
-   - During near-expiry rotation, update `Display.jwtToken` to the new token hash only when the row still has the old current hash, then emit `token:refresh` only after the update succeeds.
-   - If rotation persistence fails or races, keep the existing authenticated socket connected but do not emit an unusable replacement token.
+   - Store the authenticated token hash on `client.data`.
+   - Revalidate `client.data.deviceTokenHash` against the DB-current `Display.jwtToken` in `WsDeviceGuard` so already-connected sockets fail closed after re-pair.
+   - Disable automatic token rotation until a future design supports grace tokens or an ACK-backed two-phase rotation flow.
 
 3. Tests
-   - Middleware: stale signed device token is rejected before content lookup; missing stored token hash is rejected; matching hash still streams.
-   - Realtime: stale signed device token is rejected before room join/status update; matching hash connects; rotation writes the new hash before emitting the refresh event; failed rotation update does not emit a refresh token.
+   - Middleware: stale signed device token is rejected before content lookup, heartbeat write, or schedule lookup; missing stored token hash is rejected; matching hash still streams.
+   - Realtime: stale signed device token is rejected before room join/status update; matching hash connects; connected device sockets are rejected by guard if their token hash is no longer current; near-expiry tokens do not auto-rotate.
 
 ## Runtime-State Verification
 
 Before any deployment of fail-closed token-hash enforcement:
 
-- Query prod display token-hash coverage: total displays, active paired displays, and displays where `jwtToken IS NULL`.
+- Query prod display token-hash coverage: total displays, active paired displays, displays where `jwtToken IS NULL`, and malformed/non-SHA256 hashes.
 - Reconcile any legacy active displays missing `jwtToken` through an operator-approved re-pair/migration plan.
 - Reconcile prod `/opt/vizora/app` dirty/diverged checkout before any pull/restart/deploy.
 
 ## Verification
 
-- `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=device-content.controller`
-- `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern=device.gateway`
+- `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="displays.controller|schedules.controller|device-content.controller"`
+- `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern="device.gateway|ws-auth.guard"`
 - `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
 - `npx nx build @vizora/realtime`
 - Multi-agent review before broader affected tests.

--- a/middleware/src/modules/billing/guards/subscription-active.guard.spec.ts
+++ b/middleware/src/modules/billing/guards/subscription-active.guard.spec.ts
@@ -1,10 +1,12 @@
 import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { SubscriptionActiveGuard } from './subscription-active.guard';
 import { DatabaseService } from '../../database/database.service';
 
 describe('SubscriptionActiveGuard', () => {
   let guard: SubscriptionActiveGuard;
   let mockDatabaseService: jest.Mocked<DatabaseService>;
+  let mockReflector: jest.Mocked<Reflector>;
   let mockExecutionContext: jest.Mocked<ExecutionContext>;
   let mockRequest: any;
 
@@ -13,6 +15,9 @@ describe('SubscriptionActiveGuard', () => {
       organization: {
         findUnique: jest.fn(),
       },
+    } as any;
+    mockReflector = {
+      getAllAndOverride: jest.fn().mockReturnValue(false),
     } as any;
 
     mockRequest = {
@@ -27,9 +32,11 @@ describe('SubscriptionActiveGuard', () => {
       switchToHttp: jest.fn().mockReturnValue({
         getRequest: jest.fn().mockReturnValue(mockRequest),
       }),
+      getHandler: jest.fn().mockReturnValue(function handler() {}),
+      getClass: jest.fn().mockReturnValue(class TestController {}),
     } as any;
 
-    guard = new SubscriptionActiveGuard(mockDatabaseService);
+    guard = new SubscriptionActiveGuard(mockDatabaseService, mockReflector);
   });
 
   it('should be defined', () => {
@@ -64,6 +71,17 @@ describe('SubscriptionActiveGuard', () => {
         } as any);
 
         await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(ForbiddenException);
+      });
+
+      it('should allow public POST device endpoints without a dashboard user', async () => {
+        mockRequest.method = 'POST';
+        mockRequest.user = undefined;
+        mockReflector.getAllAndOverride.mockReturnValueOnce(true);
+
+        const result = await guard.canActivate(mockExecutionContext);
+
+        expect(result).toBe(true);
+        expect(mockDatabaseService.organization.findUnique).not.toHaveBeenCalled();
       });
 
       it('should block PATCH requests with expired subscription', async () => {

--- a/middleware/src/modules/billing/guards/subscription-active.guard.ts
+++ b/middleware/src/modules/billing/guards/subscription-active.guard.ts
@@ -4,7 +4,9 @@ import {
   ExecutionContext,
   ForbiddenException,
 } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { DatabaseService } from '../../database/database.service';
+import { IS_PUBLIC_KEY } from '../../auth/decorators/public.decorator';
 
 /**
  * Guards write operations (POST, PUT, PATCH, DELETE) behind active subscription.
@@ -16,9 +18,20 @@ import { DatabaseService } from '../../database/database.service';
  */
 @Injectable()
 export class SubscriptionActiveGuard implements CanActivate {
-  constructor(private readonly db: DatabaseService) {}
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly reflector: Reflector,
+  ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic) {
+      return true;
+    }
+
     const request = context.switchToHttp().getRequest();
 
     // Allow read-only access (GET/HEAD) regardless of subscription status

--- a/middleware/src/modules/common/device-token-auth.util.ts
+++ b/middleware/src/modules/common/device-token-auth.util.ts
@@ -1,0 +1,112 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { createHash, timingSafeEqual } from 'node:crypto';
+import type { Request } from 'express';
+import { DatabaseService } from '../database/database.service';
+
+export const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/i;
+
+export interface DeviceJwtPayload {
+  sub: string;
+  deviceIdentifier: string;
+  organizationId: string;
+  type: 'device';
+}
+
+export interface VerifiedCurrentDeviceToken {
+  payload: DeviceJwtPayload;
+  token: string;
+  tokenHash: string;
+}
+
+export function hashDeviceToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+export function isCurrentDeviceToken(
+  storedHash: string | null | undefined,
+  presentedHash: string,
+): boolean {
+  if (
+    !storedHash ||
+    !SHA256_HEX_PATTERN.test(storedHash) ||
+    !SHA256_HEX_PATTERN.test(presentedHash)
+  ) {
+    return false;
+  }
+
+  return timingSafeEqual(
+    Buffer.from(storedHash, 'hex'),
+    Buffer.from(presentedHash, 'hex'),
+  );
+}
+
+export function getDeviceTokenFromRequest(
+  req: Request,
+  options: { allowQueryToken?: boolean } = {},
+): string {
+  const authHeader = req.headers.authorization;
+  const bearerToken = authHeader?.startsWith('Bearer ')
+    ? authHeader.substring(7)
+    : undefined;
+  const queryToken = options.allowQueryToken && typeof req.query?.token === 'string'
+    ? req.query.token
+    : undefined;
+  const token = bearerToken || queryToken;
+
+  if (!token) {
+    throw new UnauthorizedException('Device authentication required');
+  }
+
+  return token;
+}
+
+export async function verifyCurrentDeviceToken(params: {
+  jwtService: JwtService;
+  databaseService: DatabaseService;
+  token: string;
+  expectedDisplayId?: string;
+}): Promise<VerifiedCurrentDeviceToken> {
+  let payload: DeviceJwtPayload;
+  try {
+    payload = params.jwtService.verify<DeviceJwtPayload>(params.token, {
+      secret: process.env.DEVICE_JWT_SECRET,
+      algorithms: ['HS256'],
+    });
+  } catch {
+    throw new UnauthorizedException('Invalid or expired device token');
+  }
+
+  if (
+    payload.type !== 'device' ||
+    typeof payload.sub !== 'string' ||
+    payload.sub.trim() === '' ||
+    typeof payload.deviceIdentifier !== 'string' ||
+    payload.deviceIdentifier.trim() === '' ||
+    typeof payload.organizationId !== 'string' ||
+    payload.organizationId.trim() === ''
+  ) {
+    throw new UnauthorizedException('Invalid token type');
+  }
+
+  if (params.expectedDisplayId && payload.sub !== params.expectedDisplayId) {
+    throw new UnauthorizedException('Device token does not match requested display');
+  }
+
+  const tokenHash = hashDeviceToken(params.token);
+  const display = await params.databaseService.display.findUnique({
+    where: { id: payload.sub },
+    select: { id: true, organizationId: true, isDisabled: true, jwtToken: true },
+  });
+
+  if (
+    !display ||
+    display.organizationId !== payload.organizationId ||
+    display.isDisabled ||
+    !isCurrentDeviceToken(display.jwtToken, tokenHash)
+  ) {
+    throw new UnauthorizedException('Device is not authorized');
+  }
+
+  return { payload, token: params.token, tokenHash };
+}

--- a/middleware/src/modules/content/device-content.controller.spec.ts
+++ b/middleware/src/modules/content/device-content.controller.spec.ts
@@ -18,6 +18,7 @@ import { DeviceContentController } from './device-content.controller';
 import { ContentService } from './content.service';
 import { StorageService } from '../storage/storage.service';
 import { DatabaseService } from '../database/database.service';
+import { createHash } from 'node:crypto';
 import { Readable, Writable } from 'node:stream';
 
 describe('DeviceContentController', () => {
@@ -31,6 +32,9 @@ describe('DeviceContentController', () => {
   const deviceId = 'device-456';
   const contentId = 'content-789';
   const objectKey = `${organizationId}/uploads/test-image.jpg`;
+
+  const hashToken = (token: string) =>
+    createHash('sha256').update(token).digest('hex');
 
   const validDevicePayload = {
     sub: deviceId,
@@ -71,6 +75,7 @@ describe('DeviceContentController', () => {
           id: deviceId,
           organizationId,
           isDisabled: false,
+          jwtToken: hashToken('valid-device-token'),
         }),
       },
     };
@@ -103,6 +108,15 @@ describe('DeviceContentController', () => {
       }
       if (queryToken) {
         req.query.token = queryToken;
+      }
+      const presentedToken = token ?? queryToken;
+      if (presentedToken) {
+        mockDatabaseService.display.findUnique.mockResolvedValue({
+          id: deviceId,
+          organizationId,
+          isDisabled: false,
+          jwtToken: hashToken(presentedToken),
+        });
       }
       return req;
     };
@@ -168,9 +182,48 @@ describe('DeviceContentController', () => {
         id: deviceId,
         organizationId,
         isDisabled: true,
+        jwtToken: hashToken('valid-device-token'),
       });
 
       await expect(controller.serveFile(contentId, req, res)).rejects.toThrow(UnauthorizedException);
+
+      expect(mockContentService.findByIdForDevice).not.toHaveBeenCalled();
+      expect(mockStorageService.getObject).not.toHaveBeenCalled();
+    });
+
+    it('should reject a signed device JWT that is not the current stored token', async () => {
+      const req = createMockRequest('stale-device-token');
+      const res = createMockResponse();
+      mockJwtService.verify.mockReturnValue(validDevicePayload);
+      mockDatabaseService.display.findUnique.mockResolvedValueOnce({
+        id: deviceId,
+        organizationId,
+        isDisabled: false,
+        jwtToken: hashToken('current-device-token'),
+      });
+
+      await expect(controller.serveFile(contentId, req, res)).rejects.toThrow(
+        UnauthorizedException,
+      );
+
+      expect(mockContentService.findByIdForDevice).not.toHaveBeenCalled();
+      expect(mockStorageService.getObject).not.toHaveBeenCalled();
+    });
+
+    it('should reject a signed device JWT when the display has no stored token hash', async () => {
+      const req = createMockRequest('valid-device-token');
+      const res = createMockResponse();
+      mockJwtService.verify.mockReturnValue(validDevicePayload);
+      mockDatabaseService.display.findUnique.mockResolvedValueOnce({
+        id: deviceId,
+        organizationId,
+        isDisabled: false,
+        jwtToken: null,
+      });
+
+      await expect(controller.serveFile(contentId, req, res)).rejects.toThrow(
+        UnauthorizedException,
+      );
 
       expect(mockContentService.findByIdForDevice).not.toHaveBeenCalled();
       expect(mockStorageService.getObject).not.toHaveBeenCalled();

--- a/middleware/src/modules/content/device-content.controller.spec.ts
+++ b/middleware/src/modules/content/device-content.controller.spec.ts
@@ -229,6 +229,25 @@ describe('DeviceContentController', () => {
       expect(mockStorageService.getObject).not.toHaveBeenCalled();
     });
 
+    it('should reject a signed device JWT when the stored token hash is malformed', async () => {
+      const req = createMockRequest('valid-device-token');
+      const res = createMockResponse();
+      mockJwtService.verify.mockReturnValue(validDevicePayload);
+      mockDatabaseService.display.findUnique.mockResolvedValueOnce({
+        id: deviceId,
+        organizationId,
+        isDisabled: false,
+        jwtToken: 'legacy-plaintext-token',
+      });
+
+      await expect(controller.serveFile(contentId, req, res)).rejects.toThrow(
+        UnauthorizedException,
+      );
+
+      expect(mockContentService.findByIdForDevice).not.toHaveBeenCalled();
+      expect(mockStorageService.getObject).not.toHaveBeenCalled();
+    });
+
     it('should serve content file with valid device JWT from query parameter', async () => {
       const req = createMockRequest(undefined, 'valid-query-token');
       const res = createMockResponse();

--- a/middleware/src/modules/content/device-content.controller.ts
+++ b/middleware/src/modules/content/device-content.controller.ts
@@ -19,24 +19,14 @@ import { SkipOutputSanitize } from '../common/interceptors/sanitize.interceptor'
 import { ContentService } from './content.service';
 import { StorageService } from '../storage/storage.service';
 import { DatabaseService } from '../database/database.service';
-import { createHash, timingSafeEqual } from 'node:crypto';
 import { pipeline } from 'node:stream/promises';
+import {
+  getDeviceTokenFromRequest,
+  verifyCurrentDeviceToken,
+} from '../common/device-token-auth.util';
 
 const MINIO_URL_PREFIX = 'minio://';
 const MAX_DEVICE_CONTENT_FILE_SIZE = 100 * 1024 * 1024;
-const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/i;
-
-interface DeviceJwtPayload {
-  sub: string;
-  deviceIdentifier: string;
-  organizationId: string;
-  type: 'device';
-}
-
-interface VerifiedDeviceToken {
-  payload: DeviceJwtPayload;
-  token: string;
-}
 
 interface ByteRange {
   start: number;
@@ -63,67 +53,6 @@ export class DeviceContentController {
     private readonly jwtService: JwtService,
     private readonly databaseService: DatabaseService,
   ) {}
-
-  /**
-   * Verify a device JWT token from the Authorization header or query parameter.
-   * Query parameter is needed because img.src and video.src cannot send headers.
-   */
-  private verifyDeviceToken(req: Request): VerifiedDeviceToken {
-    const authHeader = req.headers.authorization;
-    const queryToken = (req.query as Record<string, string | undefined>)?.token;
-    const token = authHeader?.startsWith('Bearer ')
-      ? authHeader.substring(7)
-      : queryToken;
-    if (!token) {
-      throw new UnauthorizedException('Device authentication required');
-    }
-
-    try {
-      const payload = this.jwtService.verify<DeviceJwtPayload>(token, {
-        secret: process.env.DEVICE_JWT_SECRET,
-        algorithms: ['HS256'],
-      });
-
-      if (
-        payload.type !== 'device' ||
-        typeof payload.sub !== 'string' ||
-        payload.sub.trim() === '' ||
-        typeof payload.deviceIdentifier !== 'string' ||
-        payload.deviceIdentifier.trim() === '' ||
-        typeof payload.organizationId !== 'string' ||
-        payload.organizationId.trim() === ''
-      ) {
-        throw new UnauthorizedException('Invalid token type');
-      }
-
-      return { payload, token };
-    } catch (error) {
-      if (error instanceof UnauthorizedException) throw error;
-      throw new UnauthorizedException('Invalid or expired device token');
-    }
-  }
-
-  private hashToken(token: string): string {
-    return createHash('sha256').update(token).digest('hex');
-  }
-
-  private isCurrentDeviceToken(
-    storedHash: string | null | undefined,
-    presentedHash: string,
-  ): boolean {
-    if (
-      !storedHash ||
-      !SHA256_HEX_PATTERN.test(storedHash) ||
-      !SHA256_HEX_PATTERN.test(presentedHash)
-    ) {
-      return false;
-    }
-
-    return timingSafeEqual(
-      Buffer.from(storedHash, 'hex'),
-      Buffer.from(presentedHash, 'hex'),
-    );
-  }
 
   private parseRangeHeader(rangeHeader: string | undefined, fileSize: number): RangeParseResult {
     if (!rangeHeader) {
@@ -215,21 +144,11 @@ export class DeviceContentController {
     // Device JWT is mandatory — throws UnauthorizedException if missing/invalid.
     // Verify it BEFORE the DB query so an unauth caller can't probe content
     // IDs for existence via timing or DB error patterns.
-    const { payload: devicePayload, token: rawDeviceToken } = this.verifyDeviceToken(req);
-    const presentedTokenHash = this.hashToken(rawDeviceToken);
-
-    const display = await this.databaseService.display.findUnique({
-      where: { id: devicePayload.sub },
-      select: { id: true, organizationId: true, isDisabled: true, jwtToken: true },
+    const { payload: devicePayload } = await verifyCurrentDeviceToken({
+      jwtService: this.jwtService,
+      databaseService: this.databaseService,
+      token: getDeviceTokenFromRequest(req, { allowQueryToken: true }),
     });
-    if (
-      !display ||
-      display.organizationId !== devicePayload.organizationId ||
-      display.isDisabled ||
-      !this.isCurrentDeviceToken(display.jwtToken, presentedTokenHash)
-    ) {
-      throw new UnauthorizedException('Device is not authorized');
-    }
 
     const content = await this.contentService.findByIdForDevice(
       id,

--- a/middleware/src/modules/content/device-content.controller.ts
+++ b/middleware/src/modules/content/device-content.controller.ts
@@ -19,16 +19,23 @@ import { SkipOutputSanitize } from '../common/interceptors/sanitize.interceptor'
 import { ContentService } from './content.service';
 import { StorageService } from '../storage/storage.service';
 import { DatabaseService } from '../database/database.service';
+import { createHash, timingSafeEqual } from 'node:crypto';
 import { pipeline } from 'node:stream/promises';
 
 const MINIO_URL_PREFIX = 'minio://';
 const MAX_DEVICE_CONTENT_FILE_SIZE = 100 * 1024 * 1024;
+const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/i;
 
 interface DeviceJwtPayload {
   sub: string;
   deviceIdentifier: string;
   organizationId: string;
   type: 'device';
+}
+
+interface VerifiedDeviceToken {
+  payload: DeviceJwtPayload;
+  token: string;
 }
 
 interface ByteRange {
@@ -61,7 +68,7 @@ export class DeviceContentController {
    * Verify a device JWT token from the Authorization header or query parameter.
    * Query parameter is needed because img.src and video.src cannot send headers.
    */
-  private verifyDeviceToken(req: Request): DeviceJwtPayload {
+  private verifyDeviceToken(req: Request): VerifiedDeviceToken {
     const authHeader = req.headers.authorization;
     const queryToken = (req.query as Record<string, string | undefined>)?.token;
     const token = authHeader?.startsWith('Bearer ')
@@ -89,11 +96,33 @@ export class DeviceContentController {
         throw new UnauthorizedException('Invalid token type');
       }
 
-      return payload;
+      return { payload, token };
     } catch (error) {
       if (error instanceof UnauthorizedException) throw error;
       throw new UnauthorizedException('Invalid or expired device token');
     }
+  }
+
+  private hashToken(token: string): string {
+    return createHash('sha256').update(token).digest('hex');
+  }
+
+  private isCurrentDeviceToken(
+    storedHash: string | null | undefined,
+    presentedHash: string,
+  ): boolean {
+    if (
+      !storedHash ||
+      !SHA256_HEX_PATTERN.test(storedHash) ||
+      !SHA256_HEX_PATTERN.test(presentedHash)
+    ) {
+      return false;
+    }
+
+    return timingSafeEqual(
+      Buffer.from(storedHash, 'hex'),
+      Buffer.from(presentedHash, 'hex'),
+    );
   }
 
   private parseRangeHeader(rangeHeader: string | undefined, fileSize: number): RangeParseResult {
@@ -186,13 +215,19 @@ export class DeviceContentController {
     // Device JWT is mandatory — throws UnauthorizedException if missing/invalid.
     // Verify it BEFORE the DB query so an unauth caller can't probe content
     // IDs for existence via timing or DB error patterns.
-    const devicePayload = this.verifyDeviceToken(req);
+    const { payload: devicePayload, token: rawDeviceToken } = this.verifyDeviceToken(req);
+    const presentedTokenHash = this.hashToken(rawDeviceToken);
 
     const display = await this.databaseService.display.findUnique({
       where: { id: devicePayload.sub },
-      select: { id: true, organizationId: true, isDisabled: true },
+      select: { id: true, organizationId: true, isDisabled: true, jwtToken: true },
     });
-    if (!display || display.organizationId !== devicePayload.organizationId || display.isDisabled) {
+    if (
+      !display ||
+      display.organizationId !== devicePayload.organizationId ||
+      display.isDisabled ||
+      !this.isCurrentDeviceToken(display.jwtToken, presentedTokenHash)
+    ) {
       throw new UnauthorizedException('Device is not authorized');
     }
 

--- a/middleware/src/modules/displays/displays.controller.spec.ts
+++ b/middleware/src/modules/displays/displays.controller.spec.ts
@@ -1,16 +1,21 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { Reflector } from '@nestjs/core';
 import { JwtService } from '@nestjs/jwt';
+import { UnauthorizedException } from '@nestjs/common';
 import { DisplaysController } from './displays.controller';
 import { DisplaysService } from './displays.service';
 import { DatabaseService } from '../database/database.service';
+import { createHash } from 'node:crypto';
 
 describe('DisplaysController', () => {
   let controller: DisplaysController;
   let mockDisplaysService: jest.Mocked<DisplaysService>;
   let mockDatabaseService: jest.Mocked<DatabaseService>;
+  let mockJwtService: jest.Mocked<JwtService>;
 
   const organizationId = 'org-123';
+  const hashToken = (token: string) =>
+    createHash('sha256').update(token).digest('hex');
 
   beforeEach(async () => {
     mockDisplaysService = {
@@ -39,6 +44,24 @@ describe('DisplaysController', () => {
           _count: { displays: 5 },
         }),
       },
+      display: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'device-123',
+          organizationId,
+          isDisabled: false,
+          jwtToken: hashToken('valid-device-token'),
+        }),
+      },
+    } as any;
+
+    mockJwtService = {
+      verify: jest.fn().mockReturnValue({
+        type: 'device',
+        deviceIdentifier: 'device-123',
+        sub: 'device-123',
+        organizationId,
+      }),
+      verifyAsync: jest.fn(),
     } as any;
 
     const module: TestingModule = await Test.createTestingModule({
@@ -46,7 +69,7 @@ describe('DisplaysController', () => {
       providers: [
         { provide: DisplaysService, useValue: mockDisplaysService },
         { provide: DatabaseService, useValue: mockDatabaseService },
-        { provide: JwtService, useValue: { verify: jest.fn().mockReturnValue({ type: 'device', deviceIdentifier: 'device-123', sub: 'device-123' }), verifyAsync: jest.fn() } },
+        { provide: JwtService, useValue: mockJwtService },
         Reflector,
       ],
     }).compile();
@@ -156,6 +179,22 @@ describe('DisplaysController', () => {
 
       expect(result).toEqual(expectedResult);
       expect(mockDisplaysService.updateHeartbeat).toHaveBeenCalledWith('device-123');
+    });
+
+    it('should reject a signed heartbeat token that is not the current stored token', async () => {
+      mockDatabaseService.display.findUnique.mockResolvedValueOnce({
+        id: 'device-123',
+        organizationId,
+        isDisabled: false,
+        jwtToken: hashToken('current-device-token'),
+      } as any);
+
+      const mockReq = { headers: { authorization: 'Bearer stale-device-token' } };
+
+      await expect(controller.heartbeat('device-123', mockReq as any)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      expect(mockDisplaysService.updateHeartbeat).not.toHaveBeenCalled();
     });
 
     it('should work with valid device JWT (public endpoint)', async () => {

--- a/middleware/src/modules/displays/displays.controller.ts
+++ b/middleware/src/modules/displays/displays.controller.ts
@@ -16,6 +16,7 @@ import {
 } from '@nestjs/common';
 import type { Request } from 'express';
 import { JwtService } from '@nestjs/jwt';
+import { DatabaseService } from '../database/database.service';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CheckQuota } from '../billing/decorators/check-quota.decorator';
@@ -31,6 +32,10 @@ import { PushContentDto } from './dto/push-content.dto';
 import { PaginationDto } from '../common/dto/pagination.dto';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { Public } from '../auth/decorators/public.decorator';
+import {
+  getDeviceTokenFromRequest,
+  verifyCurrentDeviceToken,
+} from '../common/device-token-auth.util';
 
 @UseGuards(RolesGuard)
 @RequiresSubscription()
@@ -39,6 +44,7 @@ export class DisplaysController {
   constructor(
     private readonly displaysService: DisplaysService,
     private readonly jwtService: JwtService,
+    private readonly databaseService: DatabaseService,
   ) {}
 
   @Post()
@@ -116,27 +122,13 @@ export class DisplaysController {
 
   @Post(':deviceId/heartbeat')
   @Public() // Bypass user JWT guard -- device JWT verified manually below
-  heartbeat(@Param('deviceId', ParseUUIDPipe) deviceId: string, @Req() req: Request) {
-    // Verify device JWT to prevent unauthenticated heartbeat calls
-    const token = (req.headers.authorization as string)?.replace('Bearer ', '');
-    if (!token) {
-      throw new UnauthorizedException('Device authentication required');
-    }
-    try {
-      const payload = this.jwtService.verify(token, {
-        secret: process.env.DEVICE_JWT_SECRET,
-      });
-      if (payload.type !== 'device') {
-        throw new UnauthorizedException('Invalid token type');
-      }
-      // Validate the device is sending its own heartbeat
-      if (payload.deviceIdentifier !== deviceId && payload.sub !== deviceId) {
-        throw new UnauthorizedException('Device identity mismatch');
-      }
-    } catch (error) {
-      if (error instanceof UnauthorizedException) throw error;
-      throw new UnauthorizedException('Invalid or expired device token');
-    }
+  async heartbeat(@Param('deviceId', ParseUUIDPipe) deviceId: string, @Req() req: Request) {
+    await verifyCurrentDeviceToken({
+      jwtService: this.jwtService,
+      databaseService: this.databaseService,
+      token: getDeviceTokenFromRequest(req),
+      expectedDisplayId: deviceId,
+    });
     return this.displaysService.updateHeartbeat(deviceId);
   }
 

--- a/middleware/src/modules/schedules/schedules.controller.spec.ts
+++ b/middleware/src/modules/schedules/schedules.controller.spec.ts
@@ -5,13 +5,18 @@ import { SchedulesController } from './schedules.controller';
 import { SchedulesService } from './schedules.service';
 import { SubscriptionActiveGuard } from '../billing/guards/subscription-active.guard';
 import { DatabaseService } from '../database/database.service';
+import { UnauthorizedException } from '@nestjs/common';
+import { createHash } from 'node:crypto';
 
 describe('SchedulesController', () => {
   let controller: SchedulesController;
   let mockSchedulesService: jest.Mocked<SchedulesService>;
   let mockJwtService: any;
+  let mockDatabaseService: any;
 
   const organizationId = 'org-123';
+  const hashToken = (token: string) =>
+    createHash('sha256').update(token).digest('hex');
 
   const createMockRequest = (token?: string) => ({
     headers: {
@@ -32,8 +37,29 @@ describe('SchedulesController', () => {
     } as any;
 
     mockJwtService = {
-      verify: jest.fn().mockReturnValue({ type: 'device', sub: 'display-123', organizationId }),
-      verifyAsync: jest.fn().mockResolvedValue({ type: 'device', sub: 'display-123', organizationId }),
+      verify: jest.fn().mockReturnValue({
+        type: 'device',
+        sub: 'display-123',
+        deviceIdentifier: 'DEVICE-123',
+        organizationId,
+      }),
+      verifyAsync: jest.fn().mockResolvedValue({
+        type: 'device',
+        sub: 'display-123',
+        deviceIdentifier: 'DEVICE-123',
+        organizationId,
+      }),
+    };
+
+    mockDatabaseService = {
+      display: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'display-123',
+          organizationId,
+          isDisabled: false,
+          jwtToken: hashToken('valid-device-token'),
+        }),
+      },
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -42,7 +68,7 @@ describe('SchedulesController', () => {
         { provide: SchedulesService, useValue: mockSchedulesService },
         { provide: JwtService, useValue: mockJwtService },
         { provide: ConfigService, useValue: { get: jest.fn().mockReturnValue('test-secret') } },
-        { provide: DatabaseService, useValue: {} },
+        { provide: DatabaseService, useValue: mockDatabaseService },
         SubscriptionActiveGuard,
       ],
     }).compile();
@@ -201,11 +227,23 @@ describe('SchedulesController', () => {
       expect(mockSchedulesService.findActiveSchedules).toHaveBeenCalledWith('display-123', organizationId);
       expect(mockJwtService.verify).toHaveBeenCalledWith('valid-device-token', {
         secret: process.env.DEVICE_JWT_SECRET,
+        algorithms: ['HS256'],
       });
     });
 
     it('should work with valid device JWT (public endpoint)', async () => {
-      mockJwtService.verify.mockReturnValueOnce({ type: 'device', sub: 'display-456', organizationId });
+      mockJwtService.verify.mockReturnValueOnce({
+        type: 'device',
+        sub: 'display-456',
+        deviceIdentifier: 'DEVICE-456',
+        organizationId,
+      });
+      mockDatabaseService.display.findUnique.mockResolvedValueOnce({
+        id: 'display-456',
+        organizationId,
+        isDisabled: false,
+        jwtToken: hashToken('valid-device-token'),
+      });
       mockSchedulesService.findActiveSchedules.mockResolvedValue([]);
 
       const mockReq = createMockRequest('valid-device-token');
@@ -214,13 +252,34 @@ describe('SchedulesController', () => {
       expect(result).toEqual([]);
     });
 
+    it('should reject a signed schedule token that is not the current stored token', async () => {
+      mockDatabaseService.display.findUnique.mockResolvedValueOnce({
+        id: 'display-123',
+        organizationId,
+        isDisabled: false,
+        jwtToken: hashToken('current-device-token'),
+      });
+
+      const mockReq = createMockRequest('stale-device-token');
+
+      await expect(controller.findActiveSchedules('display-123', mockReq as any)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      expect(mockSchedulesService.findActiveSchedules).not.toHaveBeenCalled();
+    });
+
     it('should reject a device JWT for a different display', async () => {
-      mockJwtService.verify.mockReturnValueOnce({ type: 'device', sub: 'display-999', organizationId });
+      mockJwtService.verify.mockReturnValueOnce({
+        type: 'device',
+        sub: 'display-999',
+        deviceIdentifier: 'DEVICE-999',
+        organizationId,
+      });
 
       const mockReq = createMockRequest('valid-device-token');
 
-      expect(() => controller.findActiveSchedules('display-456', mockReq as any))
-        .toThrow('Device token does not match requested display');
+      await expect(controller.findActiveSchedules('display-456', mockReq as any))
+        .rejects.toThrow('Device token does not match requested display');
       expect(mockSchedulesService.findActiveSchedules).not.toHaveBeenCalled();
     });
   });

--- a/middleware/src/modules/schedules/schedules.controller.ts
+++ b/middleware/src/modules/schedules/schedules.controller.ts
@@ -16,6 +16,7 @@ import {
 import { ParseIdPipe } from '../common/pipes/parse-id.pipe';
 import type { Request } from 'express';
 import { JwtService } from '@nestjs/jwt';
+import { DatabaseService } from '../database/database.service';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { RequiresSubscription } from '../billing/decorators/requires-subscription.decorator';
@@ -26,6 +27,10 @@ import { CheckConflictsDto } from './dto/check-conflicts.dto';
 import { PaginationDto } from '../common/dto/pagination.dto';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { Public } from '../auth/decorators/public.decorator';
+import {
+  getDeviceTokenFromRequest,
+  verifyCurrentDeviceToken,
+} from '../common/device-token-auth.util';
 
 @UseGuards(RolesGuard)
 @RequiresSubscription()
@@ -34,6 +39,7 @@ export class SchedulesController {
   constructor(
     private readonly schedulesService: SchedulesService,
     private readonly jwtService: JwtService,
+    private readonly databaseService: DatabaseService,
   ) {}
 
   @Post()
@@ -72,32 +78,14 @@ export class SchedulesController {
 
   @Get('active/:displayId')
   @Public() // Bypass user JWT guard -- device JWT verified manually below
-  findActiveSchedules(@Param('displayId', ParseIdPipe) displayId: string, @Req() req: Request) {
-    // Verify device JWT to prevent unauthenticated schedule access
-    const token = (req.headers.authorization as string)?.replace('Bearer ', '');
-    if (!token) {
-      throw new UnauthorizedException('Device authentication required');
-    }
-    let organizationId: string;
-    try {
-      const payload = this.jwtService.verify(token, {
-        secret: process.env.DEVICE_JWT_SECRET,
-      });
-      if (payload.type !== 'device') {
-        throw new UnauthorizedException('Invalid token type');
-      }
-      if (!payload.sub || payload.sub !== displayId) {
-        throw new UnauthorizedException('Device token does not match requested display');
-      }
-      if (!payload.organizationId) {
-        throw new UnauthorizedException('Device token missing organization');
-      }
-      organizationId = payload.organizationId;
-    } catch (error) {
-      if (error instanceof UnauthorizedException) throw error;
-      throw new UnauthorizedException('Invalid or expired device token');
-    }
-    return this.schedulesService.findActiveSchedules(displayId, organizationId);
+  async findActiveSchedules(@Param('displayId', ParseIdPipe) displayId: string, @Req() req: Request) {
+    const { payload } = await verifyCurrentDeviceToken({
+      jwtService: this.jwtService,
+      databaseService: this.databaseService,
+      token: getDeviceTokenFromRequest(req),
+      expectedDisplayId: displayId,
+    });
+    return this.schedulesService.findActiveSchedules(displayId, payload.organizationId);
   }
 
   @Get(':id')

--- a/realtime/src/app/app.controller.spec.ts
+++ b/realtime/src/app/app.controller.spec.ts
@@ -30,6 +30,7 @@ describe('AppController', () => {
       } as any,
       sendPlaylistUpdate: jest.fn(),
       sendCommand: jest.fn(),
+      broadcastToOrganization: jest.fn().mockResolvedValue(undefined),
       hasActiveDeviceSocket: jest.fn((deviceId: string) => mockRooms.has(`device:${deviceId}`)),
       disconnectDevice: jest.fn(),
     };
@@ -177,6 +178,29 @@ describe('AppController', () => {
       });
       expect(mockDeviceGateway.disconnectDevice).toHaveBeenCalledWith('dev-a', 'device_disabled');
       expect(mockDeviceGateway.sendCommand).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('broadcastNotification', () => {
+    it('routes notification broadcasts through DeviceGateway filtering', async () => {
+      const notification = { id: 'notif-1', type: 'device_online', message: 'Display online' };
+
+      const result = await controller.broadcastNotification({
+        organizationId: 'org-1',
+        notification,
+      });
+
+      expect(result).toEqual({
+        success: true,
+        message: 'Notification broadcasted to organization',
+      });
+      expect(mockDeviceGateway.broadcastToOrganization).toHaveBeenCalledWith(
+        'org-1',
+        'notification:new',
+        notification,
+      );
+      expect(mockTo).not.toHaveBeenCalled();
+      expect(mockEmit).not.toHaveBeenCalled();
     });
   });
 

--- a/realtime/src/app/app.controller.ts
+++ b/realtime/src/app/app.controller.ts
@@ -261,9 +261,11 @@ export class AppController {
     // before we reach this body — the prior inline `{organizationId,
     // notification}` type bypassed validation and forced runtime
     // typeof checks that drifted from the documented contract.
-    this.deviceGateway.server
-      .to(`org:${data.organizationId}`)
-      .emit('notification:new', data.notification);
+    await this.deviceGateway.broadcastToOrganization(
+      data.organizationId,
+      'notification:new',
+      data.notification as any,
+    );
     this.logger.log(`Broadcasted notification to org:${data.organizationId}`);
     return {
       success: true,

--- a/realtime/src/app/app.module.ts
+++ b/realtime/src/app/app.module.ts
@@ -16,6 +16,7 @@ import { MetricsModule } from '../metrics/metrics.module';
 import { SentryInterceptor } from '../interceptors/sentry.interceptor';
 import { MetricsInterceptor } from '../interceptors/metrics.interceptor';
 import { MetricsAuthMiddleware } from '../metrics/metrics-auth.middleware';
+import { WsAuthGuard, WsDeviceGuard } from '../gateways/guards/ws-auth.guard';
 
 @Module({
   imports: [
@@ -40,6 +41,8 @@ import { MetricsAuthMiddleware } from '../metrics/metrics-auth.middleware';
     HeartbeatService,
     PlaylistService,
     NotificationService,
+    WsAuthGuard,
+    WsDeviceGuard,
     {
       provide: APP_INTERCEPTOR,
       useClass: SentryInterceptor,

--- a/realtime/src/gateways/device-token-hash.ts
+++ b/realtime/src/gateways/device-token-hash.ts
@@ -1,0 +1,26 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+export const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/i;
+
+export function hashDeviceToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+export function isCurrentDeviceToken(
+  storedHash: string | null | undefined,
+  presentedHash: string | null | undefined,
+): boolean {
+  if (
+    !storedHash ||
+    !presentedHash ||
+    !SHA256_HEX_PATTERN.test(storedHash) ||
+    !SHA256_HEX_PATTERN.test(presentedHash)
+  ) {
+    return false;
+  }
+
+  return timingSafeEqual(
+    Buffer.from(storedHash, 'hex'),
+    Buffer.from(presentedHash, 'hex'),
+  );
+}

--- a/realtime/src/gateways/device.gateway.spec.ts
+++ b/realtime/src/gateways/device.gateway.spec.ts
@@ -444,9 +444,8 @@ describe('DeviceGateway', () => {
       expect(client.join).not.toHaveBeenCalledWith('device:device-1');
     });
 
-    it('should persist a rotated device token hash before emitting token refresh', async () => {
+    it('should not auto-rotate near-expiry device tokens without an ACK-backed grace design', async () => {
       const oldToken = 'valid-token';
-      const newToken = 'rotated-device-token';
       mockJwtService.verify.mockReturnValue({
         sub: 'device-1',
         type: 'device',
@@ -454,14 +453,12 @@ describe('DeviceGateway', () => {
         deviceIdentifier: 'test-id',
         exp: Math.floor(Date.now() / 1000) + 3 * 86400,
       });
-      mockJwtService.sign.mockReturnValue(newToken);
       mockDatabaseService.display.findUnique.mockResolvedValue({
         id: 'device-1',
         organizationId: 'org-1',
         isDisabled: false,
         jwtToken: hashToken(oldToken),
       });
-      mockDatabaseService.display.updateMany.mockResolvedValue({ count: 1 });
 
       const client = createMockSocket({
         handshake: { auth: { token: oldToken }, address: '127.0.0.1' },
@@ -469,45 +466,13 @@ describe('DeviceGateway', () => {
 
       await gateway.handleConnection(client as any);
 
+      expect(mockJwtService.sign).not.toHaveBeenCalled();
       expect(mockDatabaseService.display.updateMany).toHaveBeenCalledWith({
-        where: {
-          id: 'device-1',
-          organizationId: 'org-1',
-          isDisabled: false,
-          jwtToken: hashToken(oldToken),
-        },
-        data: { jwtToken: hashToken(newToken) },
+        where: { id: 'device-1' },
+        data: expect.objectContaining({ status: 'online' }),
       });
-      expect(client.emit).toHaveBeenCalledWith('token:refresh', { token: newToken });
-    });
-
-    it('should not emit a rotated token when persisting the new hash races or fails', async () => {
-      const oldToken = 'valid-token';
-      const newToken = 'rotated-device-token';
-      mockJwtService.verify.mockReturnValue({
-        sub: 'device-1',
-        type: 'device',
-        organizationId: 'org-1',
-        deviceIdentifier: 'test-id',
-        exp: Math.floor(Date.now() / 1000) + 3 * 86400,
-      });
-      mockJwtService.sign.mockReturnValue(newToken);
-      mockDatabaseService.display.findUnique.mockResolvedValue({
-        id: 'device-1',
-        organizationId: 'org-1',
-        isDisabled: false,
-        jwtToken: hashToken(oldToken),
-      });
-      mockDatabaseService.display.updateMany.mockResolvedValue({ count: 0 });
-
-      const client = createMockSocket({
-        handshake: { auth: { token: oldToken }, address: '127.0.0.1' },
-      });
-
-      await gateway.handleConnection(client as any);
-
       expect(client.disconnect).not.toHaveBeenCalled();
-      expect(client.emit).not.toHaveBeenCalledWith('token:refresh', { token: newToken });
+      expect(client.emit).not.toHaveBeenCalledWith('token:refresh', expect.anything());
     });
 
     it('should reject connections with a revoked token', async () => {

--- a/realtime/src/gateways/device.gateway.spec.ts
+++ b/realtime/src/gateways/device.gateway.spec.ts
@@ -102,14 +102,30 @@ describe('DeviceGateway', () => {
     getPresignedUrl: jest.fn().mockResolvedValue('https://storage/test.png'),
   };
 
-  // Mock socket that auto-invokes ack callbacks on emit
-  const mockRemoteSocket = {
-    id: 'remote-socket-1',
-    data: { deliveryAckCapable: true, deviceId: 'device-1' },
-    emit: jest.fn((_event: string, _data: any, ackCb?: () => void) => {
+  const createDeliverySocket = (
+    id: string,
+    options: {
+      token?: string;
+      deviceId?: string;
+      organizationId?: string;
+      deliveryAckCapable?: boolean;
+      emit?: jest.Mock;
+    } = {},
+  ) => ({
+    id,
+    data: {
+      deliveryAckCapable: options.deliveryAckCapable ?? true,
+      deviceId: options.deviceId ?? 'device-1',
+      organizationId: options.organizationId ?? 'org-1',
+      deviceTokenHash: hashToken(options.token ?? 'valid-token'),
+    },
+    emit: options.emit ?? jest.fn((_event: string, _data: any, ackCb?: () => void) => {
       if (ackCb) ackCb();
     }),
-  };
+  });
+
+  // Mock socket that auto-invokes ack callbacks on emit
+  const mockRemoteSocket = createDeliverySocket('remote-socket-1');
 
   const mockServer = {
     to: jest.fn().mockReturnValue({
@@ -144,6 +160,26 @@ describe('DeviceGateway', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    mockRemoteSocket.emit.mockImplementation((_event: string, _data: any, ackCb?: () => void) => {
+      if (ackCb) ackCb();
+    });
+    mockDatabaseService.display.findUnique.mockResolvedValue({
+      id: 'device-1',
+      organizationId: 'org-1',
+      isDisabled: false,
+      nickname: 'Test Device',
+      deviceIdentifier: 'test-id',
+      jwtToken: hashToken('valid-token'),
+    });
+    mockDatabaseService.display.update.mockResolvedValue({
+      nickname: 'Test Device',
+      deviceIdentifier: 'test-id',
+    });
+    mockDatabaseService.display.updateMany.mockResolvedValue({ count: 1 });
+    mockDatabaseService.display.findMany.mockResolvedValue([]);
+    mockServer.in.mockReturnValue({
+      fetchSockets: jest.fn().mockResolvedValue([mockRemoteSocket]),
+    });
     // Use fake timers to prevent setInterval leaks
     jest.useFakeTimers();
 
@@ -736,6 +772,7 @@ describe('DeviceGateway', () => {
         data: {
           deviceId: 'device-1',
           organizationId: 'org-1',
+          deviceTokenHash: hashToken('valid-token'),
           deliveryAckCapable: true,
         },
         emit,
@@ -775,6 +812,7 @@ describe('DeviceGateway', () => {
         data: {
           deviceId: 'device-1',
           organizationId: 'org-1',
+          deviceTokenHash: hashToken('valid-token'),
           deliveryAckCapable: true,
         },
       });
@@ -805,6 +843,7 @@ describe('DeviceGateway', () => {
         data: {
           deviceId: 'device-1',
           organizationId: 'org-1',
+          deviceTokenHash: hashToken('valid-token'),
           deliveryAckCapable: true,
         },
         emit,
@@ -1206,6 +1245,7 @@ describe('DeviceGateway', () => {
         data: {
           deviceId: 'device-1',
           organizationId: 'org-1',
+          deviceTokenHash: hashToken('valid-token'),
           deliveryAckCapable: true,
         },
         emit: pendingClientEmit,
@@ -1273,6 +1313,32 @@ describe('DeviceGateway', () => {
       );
     });
 
+    it('should queue playlist and disconnect a stale active device socket before server push', async () => {
+      const staleSocket = createDeliverySocket('stale-socket', { token: 'stale-device-token' });
+      staleSocket.disconnect = jest.fn();
+      mockDatabaseService.display.findUnique.mockResolvedValueOnce({
+        id: 'device-1',
+        organizationId: 'org-1',
+        isDisabled: false,
+        jwtToken: hashToken('current-device-token'),
+      });
+      (gateway as any).deviceSockets.set('device-1', 'stale-socket');
+      mockServer.in.mockReturnValueOnce({
+        fetchSockets: jest.fn().mockResolvedValue([staleSocket]),
+      });
+
+      const result = await gateway.sendPlaylistUpdate('device-1', { id: 'p-stale', name: 'Stale', items: [] } as any);
+
+      expect(result).toEqual({ delivered: false, reason: 'no_sockets' });
+      expect(staleSocket.emit).toHaveBeenCalledWith('error', { message: 'device_token_stale' });
+      expect(staleSocket.disconnect).toHaveBeenCalledWith(true);
+      expect(staleSocket.emit).not.toHaveBeenCalledWith('playlist:update', expect.anything(), expect.any(Function));
+      expect(mockRedisService.setPendingPlaylist).toHaveBeenCalledWith(
+        'device-1',
+        expect.objectContaining({ id: 'p-stale' }),
+      );
+    });
+
     it('should requeue playlist when the device sends a negative ack', async () => {
       mockRemoteSocket.emit.mockImplementationOnce(
         (_event: string, _data: any, ackCb?: (ack?: { ok: boolean; error?: string }) => void) => {
@@ -1293,7 +1359,12 @@ describe('DeviceGateway', () => {
     it('should treat no-ack legacy sockets as best-effort delivered', async () => {
       const legacySocket = {
         id: 'legacy-socket',
-        data: { deliveryAckCapable: false, deviceId: 'device-1' },
+        data: {
+          deliveryAckCapable: false,
+          deviceId: 'device-1',
+          organizationId: 'org-1',
+          deviceTokenHash: hashToken('valid-token'),
+        },
         emit: jest.fn(),
       };
       (gateway as any).deviceSockets.set('device-1', 'legacy-socket');
@@ -1388,7 +1459,12 @@ describe('DeviceGateway', () => {
     it('should treat no-ack legacy sockets as best-effort delivered for commands', async () => {
       const legacySocket = {
         id: 'legacy-socket',
-        data: { deliveryAckCapable: false, deviceId: 'device-1' },
+        data: {
+          deliveryAckCapable: false,
+          deviceId: 'device-1',
+          organizationId: 'org-1',
+          deviceTokenHash: hashToken('valid-token'),
+        },
         emit: jest.fn(),
       };
       (gateway as any).deviceSockets.set('device-1', 'legacy-socket');
@@ -1405,6 +1481,33 @@ describe('DeviceGateway', () => {
         expect.objectContaining({ type: 'reload', timestamp: expect.any(String) }),
       );
       expect(mockRedisService.addDeviceCommand).not.toHaveBeenCalled();
+    });
+
+    it('should queue command and disconnect a stale active device socket before server push', async () => {
+      const staleSocket = createDeliverySocket('stale-socket', { token: 'stale-device-token' });
+      staleSocket.disconnect = jest.fn();
+      mockDatabaseService.display.findUnique.mockResolvedValueOnce({
+        id: 'device-1',
+        organizationId: 'org-1',
+        isDisabled: false,
+        jwtToken: hashToken('current-device-token'),
+      });
+      (gateway as any).deviceSockets.set('device-1', 'stale-socket');
+      mockServer.in.mockReturnValueOnce({
+        fetchSockets: jest.fn().mockResolvedValue([staleSocket]),
+      });
+      const command = { type: 'reload' as any };
+
+      const result = await gateway.sendCommand('device-1', command);
+
+      expect(result).toEqual({ delivered: false, reason: 'no_sockets' });
+      expect(staleSocket.emit).toHaveBeenCalledWith('error', { message: 'device_token_stale' });
+      expect(staleSocket.disconnect).toHaveBeenCalledWith(true);
+      expect(staleSocket.emit).not.toHaveBeenCalledWith('command', expect.anything(), expect.any(Function));
+      expect(mockRedisService.addDeviceCommand).toHaveBeenCalledWith(
+        'device-1',
+        expect.objectContaining({ type: 'reload', timestamp: expect.any(String) }),
+      );
     });
   });
 
@@ -1660,14 +1763,13 @@ describe('DeviceGateway', () => {
   });
 
   describe('sendQrOverlayUpdate', () => {
-    it('should emit qr-overlay:update to device room', async () => {
+    it('should emit qr-overlay:update to the current active device socket', async () => {
       const qrOverlay = { enabled: true, url: 'https://example.com', position: 'bottom-right' };
 
       await gateway.sendQrOverlayUpdate('device-1', qrOverlay);
 
-      expect(mockServer.to).toHaveBeenCalledWith('device:device-1');
-      const emitFn = mockServer.to('device:device-1').emit;
-      expect(emitFn).toHaveBeenCalledWith(
+      expect(mockServer.in).toHaveBeenCalledWith('device:device-1');
+      expect(mockRemoteSocket.emit).toHaveBeenCalledWith(
         'qr-overlay:update',
         expect.objectContaining({ qrOverlay }),
       );
@@ -1675,17 +1777,52 @@ describe('DeviceGateway', () => {
 
     it('should pass through data and include timestamp', async () => {
       const qrOverlay = { enabled: false };
+      const qrSocket = createDeliverySocket('qr-socket', { deviceId: 'device-5' });
+      (gateway as any).deviceSockets.set('device-5', 'qr-socket');
+      mockServer.in.mockReturnValueOnce({
+        fetchSockets: jest.fn().mockResolvedValue([qrSocket]),
+      });
+      mockDatabaseService.display.findUnique.mockResolvedValueOnce({
+        id: 'device-5',
+        organizationId: 'org-1',
+        isDisabled: false,
+        jwtToken: hashToken('valid-token'),
+      });
 
       await gateway.sendQrOverlayUpdate('device-5', qrOverlay);
 
-      expect(mockServer.to).toHaveBeenCalledWith('device:device-5');
-      const emitFn = mockServer.to('device:device-5').emit;
-      expect(emitFn).toHaveBeenCalledWith(
+      expect(mockServer.in).toHaveBeenCalledWith('device:device-5');
+      expect(qrSocket.emit).toHaveBeenCalledWith(
         'qr-overlay:update',
         expect.objectContaining({
           qrOverlay: { enabled: false },
           timestamp: expect.any(String),
         }),
+      );
+    });
+
+    it('should not emit qr-overlay:update to a stale active device socket', async () => {
+      const qrOverlay = { enabled: true };
+      const staleSocket = createDeliverySocket('stale-socket', { token: 'stale-device-token' });
+      staleSocket.disconnect = jest.fn();
+      mockDatabaseService.display.findUnique.mockResolvedValueOnce({
+        id: 'device-1',
+        organizationId: 'org-1',
+        isDisabled: false,
+        jwtToken: hashToken('current-device-token'),
+      });
+      (gateway as any).deviceSockets.set('device-1', 'stale-socket');
+      mockServer.in.mockReturnValueOnce({
+        fetchSockets: jest.fn().mockResolvedValue([staleSocket]),
+      });
+
+      await gateway.sendQrOverlayUpdate('device-1', qrOverlay);
+
+      expect(staleSocket.emit).toHaveBeenCalledWith('error', { message: 'device_token_stale' });
+      expect(staleSocket.disconnect).toHaveBeenCalledWith(true);
+      expect(staleSocket.emit).not.toHaveBeenCalledWith(
+        'qr-overlay:update',
+        expect.objectContaining({ qrOverlay }),
       );
     });
   });

--- a/realtime/src/gateways/device.gateway.spec.ts
+++ b/realtime/src/gateways/device.gateway.spec.ts
@@ -1514,12 +1514,19 @@ describe('DeviceGateway', () => {
   describe('broadcastToOrganization', () => {
     it('should broadcast event to org room', async () => {
       const data = { message: 'hello' };
+      const dashboardSocket = {
+        id: 'dashboard-1',
+        data: { isDashboard: true, userId: 'user-1', organizationId: 'org-1' },
+        emit: jest.fn(),
+      };
+      mockServer.in.mockReturnValueOnce({
+        fetchSockets: jest.fn().mockResolvedValue([dashboardSocket]),
+      });
 
       await gateway.broadcastToOrganization('org-1', 'announcement', data);
 
-      expect(mockServer.to).toHaveBeenCalledWith('org:org-1');
-      const emitFn = mockServer.to('org:org-1').emit;
-      expect(emitFn).toHaveBeenCalledWith(
+      expect(mockServer.in).toHaveBeenCalledWith('org:org-1');
+      expect(dashboardSocket.emit).toHaveBeenCalledWith(
         'announcement',
         expect.objectContaining({ message: 'hello' }),
       );
@@ -1527,12 +1534,19 @@ describe('DeviceGateway', () => {
 
     it('should pass through event name and include timestamp', async () => {
       const data = { key: 'value' };
+      const dashboardSocket = {
+        id: 'dashboard-2',
+        data: { isDashboard: true, userId: 'user-2', organizationId: 'org-2' },
+        emit: jest.fn(),
+      };
+      mockServer.in.mockReturnValueOnce({
+        fetchSockets: jest.fn().mockResolvedValue([dashboardSocket]),
+      });
 
       await gateway.broadcastToOrganization('org-2', 'custom:event', data);
 
-      expect(mockServer.to).toHaveBeenCalledWith('org:org-2');
-      const emitFn = mockServer.to('org:org-2').emit;
-      expect(emitFn).toHaveBeenCalledWith(
+      expect(mockServer.in).toHaveBeenCalledWith('org:org-2');
+      expect(dashboardSocket.emit).toHaveBeenCalledWith(
         'custom:event',
         expect.objectContaining({
           key: 'value',
@@ -1748,9 +1762,8 @@ describe('DeviceGateway', () => {
 
       await gateway.handleScreenshotResponse(client as any, data as any);
 
-      expect(mockServer.to).toHaveBeenCalledWith('org:org-1');
-      const emitFn = mockServer.to('org:org-1').emit;
-      expect(emitFn).toHaveBeenCalledWith(
+      expect(mockServer.in).toHaveBeenCalledWith('org:org-1');
+      expect(mockRemoteSocket.emit).toHaveBeenCalledWith(
         'screenshot:ready',
         expect.objectContaining({
           deviceId: 'device-1',
@@ -1823,6 +1836,39 @@ describe('DeviceGateway', () => {
       expect(staleSocket.emit).not.toHaveBeenCalledWith(
         'qr-overlay:update',
         expect.objectContaining({ qrOverlay }),
+      );
+    });
+
+    it('should skip stale device sockets in org-room broadcasts', async () => {
+      const dashboardSocket = {
+        id: 'dashboard-1',
+        data: { isDashboard: true, userId: 'user-1', organizationId: 'org-1' },
+        emit: jest.fn(),
+      };
+      const staleDeviceSocket = createDeliverySocket('stale-socket', { token: 'stale-device-token' });
+      staleDeviceSocket.disconnect = jest.fn();
+      mockDatabaseService.display.findUnique.mockResolvedValueOnce({
+        id: 'device-1',
+        organizationId: 'org-1',
+        isDisabled: false,
+        jwtToken: hashToken('current-device-token'),
+      });
+      (gateway as any).deviceSockets.set('device-1', 'stale-socket');
+      mockServer.in.mockReturnValueOnce({
+        fetchSockets: jest.fn().mockResolvedValue([dashboardSocket, staleDeviceSocket]),
+      });
+
+      await gateway.broadcastToOrganization('org-1', 'announcement', { message: 'hello' });
+
+      expect(dashboardSocket.emit).toHaveBeenCalledWith(
+        'announcement',
+        expect.objectContaining({ message: 'hello' }),
+      );
+      expect(staleDeviceSocket.emit).toHaveBeenCalledWith('error', { message: 'device_token_stale' });
+      expect(staleDeviceSocket.disconnect).toHaveBeenCalledWith(true);
+      expect(staleDeviceSocket.emit).not.toHaveBeenCalledWith(
+        'announcement',
+        expect.objectContaining({ message: 'hello' }),
       );
     });
   });

--- a/realtime/src/gateways/device.gateway.spec.ts
+++ b/realtime/src/gateways/device.gateway.spec.ts
@@ -8,6 +8,7 @@ import { NotificationService } from '../services/notification.service';
 import { MetricsService } from '../metrics/metrics.service';
 import { DatabaseService } from '../database/database.service';
 import { StorageService } from '../storage/storage.service';
+import { createHash } from 'node:crypto';
 
 // Mock Sentry
 jest.mock('@sentry/nestjs', () => ({
@@ -25,7 +26,11 @@ describe('DeviceGateway', () => {
 
   const mockJwtService = {
     verify: jest.fn(),
+    sign: jest.fn(),
   };
+
+  const hashToken = (token: string) =>
+    createHash('sha256').update(token).digest('hex');
 
   const mockRedisService = {
     setDeviceStatus: jest.fn().mockResolvedValue(undefined),
@@ -70,7 +75,14 @@ describe('DeviceGateway', () => {
     display: {
       update: jest.fn().mockResolvedValue({ nickname: 'Test Device', deviceIdentifier: 'test-id' }),
       updateMany: jest.fn().mockResolvedValue({ count: 1 }),
-      findUnique: jest.fn().mockResolvedValue({ nickname: 'Test Device', deviceIdentifier: 'test-id' }),
+      findUnique: jest.fn().mockResolvedValue({
+        id: 'device-1',
+        organizationId: 'org-1',
+        isDisabled: false,
+        nickname: 'Test Device',
+        deviceIdentifier: 'test-id',
+        jwtToken: hashToken('valid-token'),
+      }),
       findMany: jest.fn().mockResolvedValue([]),
     },
     playlist: {
@@ -344,7 +356,12 @@ describe('DeviceGateway', () => {
         organizationId: 'org-1',
         deviceIdentifier: 'test-id',
       });
-      mockDatabaseService.display.findUnique.mockResolvedValue({ id: 'device-1', organizationId: 'org-1' });
+      mockDatabaseService.display.findUnique.mockResolvedValue({
+        id: 'device-1',
+        organizationId: 'org-1',
+        isDisabled: false,
+        jwtToken: hashToken('valid-token'),
+      });
 
       const client = createMockSocket();
 
@@ -366,6 +383,7 @@ describe('DeviceGateway', () => {
         id: 'device-1',
         organizationId: 'org-1',
         isDisabled: true,
+        jwtToken: hashToken('valid-token'),
       });
 
       const client = createMockSocket();
@@ -375,6 +393,121 @@ describe('DeviceGateway', () => {
       expect(client.emit).toHaveBeenCalledWith('error', { message: 'device_disabled' });
       expect(client.disconnect).toHaveBeenCalled();
       expect(client.join).not.toHaveBeenCalledWith('device:device-1');
+    });
+
+    it('should reject a signed device token that is not the current stored token', async () => {
+      mockJwtService.verify.mockReturnValue({
+        sub: 'device-1',
+        type: 'device',
+        organizationId: 'org-1',
+        deviceIdentifier: 'test-id',
+      });
+      mockDatabaseService.display.findUnique.mockResolvedValue({
+        id: 'device-1',
+        organizationId: 'org-1',
+        isDisabled: false,
+        jwtToken: hashToken('current-device-token'),
+      });
+
+      const client = createMockSocket({
+        handshake: { auth: { token: 'stale-device-token' }, address: '127.0.0.1' },
+      });
+
+      await gateway.handleConnection(client as any);
+
+      expect(client.emit).toHaveBeenCalledWith('error', { message: 'device_token_stale' });
+      expect(client.disconnect).toHaveBeenCalled();
+      expect(client.join).not.toHaveBeenCalledWith('device:device-1');
+      expect(mockRedisService.setDeviceStatus).not.toHaveBeenCalled();
+    });
+
+    it('should reject a signed device token when the display has no stored token hash', async () => {
+      mockJwtService.verify.mockReturnValue({
+        sub: 'device-1',
+        type: 'device',
+        organizationId: 'org-1',
+        deviceIdentifier: 'test-id',
+      });
+      mockDatabaseService.display.findUnique.mockResolvedValue({
+        id: 'device-1',
+        organizationId: 'org-1',
+        isDisabled: false,
+        jwtToken: null,
+      });
+
+      const client = createMockSocket();
+
+      await gateway.handleConnection(client as any);
+
+      expect(client.emit).toHaveBeenCalledWith('error', { message: 'device_token_stale' });
+      expect(client.disconnect).toHaveBeenCalled();
+      expect(client.join).not.toHaveBeenCalledWith('device:device-1');
+    });
+
+    it('should persist a rotated device token hash before emitting token refresh', async () => {
+      const oldToken = 'valid-token';
+      const newToken = 'rotated-device-token';
+      mockJwtService.verify.mockReturnValue({
+        sub: 'device-1',
+        type: 'device',
+        organizationId: 'org-1',
+        deviceIdentifier: 'test-id',
+        exp: Math.floor(Date.now() / 1000) + 3 * 86400,
+      });
+      mockJwtService.sign.mockReturnValue(newToken);
+      mockDatabaseService.display.findUnique.mockResolvedValue({
+        id: 'device-1',
+        organizationId: 'org-1',
+        isDisabled: false,
+        jwtToken: hashToken(oldToken),
+      });
+      mockDatabaseService.display.updateMany.mockResolvedValue({ count: 1 });
+
+      const client = createMockSocket({
+        handshake: { auth: { token: oldToken }, address: '127.0.0.1' },
+      });
+
+      await gateway.handleConnection(client as any);
+
+      expect(mockDatabaseService.display.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: 'device-1',
+          organizationId: 'org-1',
+          isDisabled: false,
+          jwtToken: hashToken(oldToken),
+        },
+        data: { jwtToken: hashToken(newToken) },
+      });
+      expect(client.emit).toHaveBeenCalledWith('token:refresh', { token: newToken });
+    });
+
+    it('should not emit a rotated token when persisting the new hash races or fails', async () => {
+      const oldToken = 'valid-token';
+      const newToken = 'rotated-device-token';
+      mockJwtService.verify.mockReturnValue({
+        sub: 'device-1',
+        type: 'device',
+        organizationId: 'org-1',
+        deviceIdentifier: 'test-id',
+        exp: Math.floor(Date.now() / 1000) + 3 * 86400,
+      });
+      mockJwtService.sign.mockReturnValue(newToken);
+      mockDatabaseService.display.findUnique.mockResolvedValue({
+        id: 'device-1',
+        organizationId: 'org-1',
+        isDisabled: false,
+        jwtToken: hashToken(oldToken),
+      });
+      mockDatabaseService.display.updateMany.mockResolvedValue({ count: 0 });
+
+      const client = createMockSocket({
+        handshake: { auth: { token: oldToken }, address: '127.0.0.1' },
+      });
+
+      await gateway.handleConnection(client as any);
+
+      expect(client.disconnect).not.toHaveBeenCalled();
+      expect(client.emit).not.toHaveBeenCalledWith('token:refresh', { token: newToken });
     });
 
     it('should reject connections with a revoked token', async () => {
@@ -485,7 +618,12 @@ describe('DeviceGateway', () => {
         organizationId: 'org-1',
         deviceIdentifier: 'test-id',
       });
-      mockDatabaseService.display.findUnique.mockResolvedValue({ id: 'device-1', organizationId: 'org-1' });
+      mockDatabaseService.display.findUnique.mockResolvedValue({
+        id: 'device-1',
+        organizationId: 'org-1',
+        isDisabled: false,
+        jwtToken: hashToken('valid-token'),
+      });
 
       // Exhaust the rate limit (11 connections from same IP)
       for (let i = 0; i < 11; i++) {
@@ -513,7 +651,12 @@ describe('DeviceGateway', () => {
         deviceIdentifier: token,
       }));
       mockDatabaseService.display.findUnique.mockImplementation(({ where }: any) =>
-        Promise.resolve({ id: where.id, organizationId: 'org-1', isDisabled: false }),
+        Promise.resolve({
+          id: where.id,
+          organizationId: 'org-1',
+          isDisabled: false,
+          jwtToken: hashToken(where.id),
+        }),
       );
 
       const clients = [];

--- a/realtime/src/gateways/device.gateway.ts
+++ b/realtime/src/gateways/device.gateway.ts
@@ -196,11 +196,53 @@ export class DeviceGateway
     );
   }
 
-  private filterDeliverySockets<T extends { id?: string; data?: Record<string, any> }>(
+  private async isCurrentDeliveryDeviceSocket(
+    client: { id?: string; data?: Record<string, any>; emit?: (...args: any[]) => void; disconnect?: (close?: boolean) => void },
+    deviceId: string,
+  ): Promise<boolean> {
+    if (!this.isDeliveryDeviceSocket(client, deviceId)) {
+      return false;
+    }
+
+    const display = await this.databaseService.display.findUnique({
+      where: { id: deviceId },
+      select: { organizationId: true, isDisabled: true, jwtToken: true },
+    });
+
+    if (
+      display &&
+      display.organizationId === client.data?.organizationId &&
+      !display.isDisabled &&
+      isCurrentDeviceToken(display.jwtToken, client.data?.deviceTokenHash)
+    ) {
+      return true;
+    }
+
+    this.logger.warn(`Skipping delivery to stale device socket ${client.id} for device ${deviceId}`);
+    client.emit?.('error', { message: 'device_token_stale' });
+    client.disconnect?.(true);
+    if (this.isActiveDeviceSocket(client, deviceId)) {
+      this.deviceSockets.delete(deviceId);
+    }
+    return false;
+  }
+
+  private async filterCurrentDeliverySockets<T extends {
+    id?: string;
+    data?: Record<string, any>;
+    emit?: (...args: any[]) => void;
+    disconnect?: (close?: boolean) => void;
+  }>(
     sockets: T[],
     deviceId: string,
-  ): T[] {
-    return sockets.filter((socket) => this.isDeliveryDeviceSocket(socket, deviceId));
+  ): Promise<T[]> {
+    const currentSockets: T[] = [];
+    for (const socket of sockets) {
+      if (await this.isCurrentDeliveryDeviceSocket(socket, deviceId)) {
+        currentSockets.push(socket);
+      }
+    }
+    return currentSockets;
   }
 
   hasActiveDeviceSocket(deviceId: string): boolean {
@@ -1501,7 +1543,7 @@ export class DeviceGateway
     // Get all sockets in the device room
     const roomName = `device:${deviceId}`;
     const allSockets = await this.server.in(roomName).fetchSockets();
-    const sockets = this.filterDeliverySockets(allSockets as any[], deviceId);
+    const sockets = await this.filterCurrentDeliverySockets(allSockets as any[], deviceId);
 
     if (sockets.length === 0) {
       this.logger.warn(`pushPlaylist: no sockets in room ${roomName} for device ${deviceId} — queuing for reconnect`);
@@ -1544,7 +1586,7 @@ export class DeviceGateway
     const commandWithTimestamp = { ...command, timestamp: new Date().toISOString() };
     const roomName = `device:${deviceId}`;
     const allSockets = await this.server.in(roomName).fetchSockets();
-    const sockets = this.filterDeliverySockets(allSockets as any[], deviceId);
+    const sockets = await this.filterCurrentDeliverySockets(allSockets as any[], deviceId);
 
     if (sockets.length === 0) {
       this.logger.warn(`sendCommand: no sockets for device ${deviceId} — queuing`);
@@ -1820,11 +1862,17 @@ export class DeviceGateway
    * Send a QR overlay update to a specific device
    */
   async sendQrOverlayUpdate(deviceId: string, qrOverlay: any): Promise<void> {
-    this.server.to(`device:${deviceId}`).emit('qr-overlay:update', {
-      qrOverlay,
-      timestamp: new Date().toISOString(),
-    });
-    this.logger.log(`Sent QR overlay update to device: ${deviceId}`);
+    const roomName = `device:${deviceId}`;
+    const allSockets = await this.server.in(roomName).fetchSockets();
+    const sockets = await this.filterCurrentDeliverySockets(allSockets as any[], deviceId);
+
+    for (const socket of sockets) {
+      socket.emit?.('qr-overlay:update', {
+        qrOverlay,
+        timestamp: new Date().toISOString(),
+      });
+    }
+    this.logger.log(`Sent QR overlay update to ${sockets.length} active socket(s) for device: ${deviceId}`);
   }
 
   /**

--- a/realtime/src/gateways/device.gateway.ts
+++ b/realtime/src/gateways/device.gateway.ts
@@ -245,6 +245,47 @@ export class DeviceGateway
     return currentSockets;
   }
 
+  private isDashboardSocket(client: { data?: Record<string, any> }): boolean {
+    return client.data?.isDashboard === true || Boolean(client.data?.userId);
+  }
+
+  private async emitToOrganization(
+    organizationId: string,
+    event: string,
+    data: Record<string, any>,
+  ): Promise<number> {
+    const allSockets = await this.server.in(`org:${organizationId}`).fetchSockets();
+    let emitted = 0;
+
+    for (const socket of allSockets as Array<{
+      id?: string;
+      data?: Record<string, any>;
+      emit?: (...args: any[]) => void;
+      disconnect?: (close?: boolean) => void;
+    }>) {
+      if (socket.data?.organizationId !== organizationId) {
+        continue;
+      }
+
+      if (this.isDashboardSocket(socket)) {
+        socket.emit?.(event, data);
+        emitted += 1;
+        continue;
+      }
+
+      const socketDeviceId = socket.data?.deviceId;
+      if (
+        typeof socketDeviceId === 'string' &&
+        await this.isCurrentDeliveryDeviceSocket(socket, socketDeviceId)
+      ) {
+        socket.emit?.(event, data);
+        emitted += 1;
+      }
+    }
+
+    return emitted;
+  }
+
   hasActiveDeviceSocket(deviceId: string): boolean {
     const socketId = this.deviceSockets.get(deviceId);
     return Boolean(socketId && this.server?.sockets?.sockets?.has(socketId));
@@ -1007,8 +1048,9 @@ export class DeviceGateway
           deviceName,
           orgId,
         );
-        // Emit notification to dashboard
-        this.server.to(`org:${orgId}`).emit('notification:new', {
+        // Emit notification to current org-room sockets. Stale device
+        // sockets are filtered/disconnected before any payload is sent.
+        await this.emitToOrganization(orgId, 'notification:new', {
           type: 'device_online',
           deviceId,
           deviceName,
@@ -1025,7 +1067,7 @@ export class DeviceGateway
 
     // Notify dashboard about device online status
     const now = new Date().toISOString();
-    this.server.to(`org:${orgId}`).emit('device:status', {
+    await this.emitToOrganization(orgId, 'device:status', {
       deviceId,
       status: 'online',
       lastSeen: now,
@@ -1171,14 +1213,12 @@ export class DeviceGateway
           this.metricsService.updateDeviceStatus(deviceId, orgId, 'offline');
 
           const now = new Date().toISOString();
-          this.server
-            .to(`org:${orgId}`)
-            .emit('device:status', {
-              deviceId,
-              status: 'offline',
-              lastSeen: now,
-              timestamp: now,
-            });
+          await this.emitToOrganization(orgId, 'device:status', {
+            deviceId,
+            status: 'offline',
+            lastSeen: now,
+            timestamp: now,
+          });
         }
       }
     } catch (error: unknown) {
@@ -1620,12 +1660,12 @@ export class DeviceGateway
   }
 
   async broadcastToOrganization(organizationId: string, event: string, data: BroadcastData): Promise<void> {
-    this.server.to(`org:${organizationId}`).emit(event, {
+    const emitted = await this.emitToOrganization(organizationId, event, {
       ...data,
       timestamp: new Date().toISOString(),
     });
 
-    this.logger.log(`Broadcast ${event} to organization: ${organizationId}`);
+    this.logger.log(`Broadcast ${event} to ${emitted} socket(s) in organization: ${organizationId}`);
   }
 
   /**
@@ -1837,7 +1877,7 @@ export class DeviceGateway
       this.logger.log(`Screenshot saved for device ${deviceId}: ${objectKey}`);
 
       // Emit screenshot:ready event to organization room so dashboard can update
-      this.server.to(`org:${organizationId}`).emit('screenshot:ready', {
+      await this.emitToOrganization(organizationId, 'screenshot:ready', {
         deviceId,
         requestId: data.requestId,
         url: presignedUrl,

--- a/realtime/src/gateways/device.gateway.ts
+++ b/realtime/src/gateways/device.gateway.ts
@@ -37,10 +37,11 @@ import {
   BroadcastData,
 } from '../types';
 import * as Sentry from '@sentry/nestjs';
-import { createHash, timingSafeEqual } from 'node:crypto';
+import { createHash } from 'node:crypto';
 import { WsAllExceptionsFilter } from './filters/ws-exception.filter';
 import { WsAuthGuard, WsDeviceGuard } from './guards/ws-auth.guard';
 import { redactSensitiveTokens } from '../utils/redact-sensitive-url';
+import { hashDeviceToken, isCurrentDeviceToken } from './device-token-hash';
 
 interface DevicePayload {
   sub: string; // device ID
@@ -58,8 +59,6 @@ interface UserPayload {
   jti?: string;
   iat?: number; // issued-at (epoch seconds), set by jsonwebtoken — used for password-change session invalidation
 }
-
-const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/i;
 
 type AuthPayload =
   | { kind: 'device'; payload: DevicePayload }
@@ -639,28 +638,6 @@ export class DeviceGateway
     return null;
   }
 
-  private hashDeviceToken(token: string): string {
-    return createHash('sha256').update(token).digest('hex');
-  }
-
-  private isCurrentDeviceToken(
-    storedHash: string | null | undefined,
-    presentedHash: string,
-  ): boolean {
-    if (
-      !storedHash ||
-      !SHA256_HEX_PATTERN.test(storedHash) ||
-      !SHA256_HEX_PATTERN.test(presentedHash)
-    ) {
-      return false;
-    }
-
-    return timingSafeEqual(
-      Buffer.from(storedHash, 'hex'),
-      Buffer.from(presentedHash, 'hex'),
-    );
-  }
-
   /**
    * Authenticate the connection: verify JWT (device or user), check revocation, deduplicate sockets.
    * Returns a discriminated union on success, or null if connection was rejected.
@@ -693,7 +670,7 @@ export class DeviceGateway
         }
 
         const deviceId = payload.sub;
-        const presentedTokenHash = this.hashDeviceToken(token);
+        const presentedTokenHash = hashDeviceToken(token);
         const device = await this.databaseService.display.findUnique({
           where: { id: deviceId },
           select: { id: true, organizationId: true, isDisabled: true, jwtToken: true },
@@ -712,7 +689,7 @@ export class DeviceGateway
           client.disconnect();
           return null;
         }
-        if (!this.isCurrentDeviceToken(device.jwtToken, presentedTokenHash)) {
+        if (!isCurrentDeviceToken(device.jwtToken, presentedTokenHash)) {
           this.logger.warn(`Connection rejected: Device token is not current (id: ${deviceId})`);
           client.emit('error', { message: 'device_token_stale' });
           client.disconnect();
@@ -736,51 +713,7 @@ export class DeviceGateway
         client.data.deviceIdentifier = payload.deviceIdentifier;
         client.data.capabilities = client.handshake.auth?.capabilities;
         client.data.deliveryAckCapable = this.supportsDeliveryAck(client);
-
-        // Auto-rotate device token if it expires within 14 days. Persist the
-        // new current-token hash before instructing the device to use it.
-        // TODO: Rate-limit rotation to once per 24h per device via Redis key 'token_rotated:{deviceId}'
-        if (payload.exp) {
-          const daysUntilExpiry = (payload.exp - Math.floor(Date.now() / 1000)) / 86400;
-          if (daysUntilExpiry < 14) {
-            const newToken = this.jwtService.sign(
-              {
-                sub: payload.sub,
-                deviceIdentifier: payload.deviceIdentifier,
-                organizationId: payload.organizationId,
-                type: 'device',
-              },
-              { secret: process.env.DEVICE_JWT_SECRET, expiresIn: '90d' },
-            );
-            try {
-              const rotation = await this.databaseService.display.updateMany({
-                where: {
-                  id: deviceId,
-                  organizationId: payload.organizationId,
-                  isDisabled: false,
-                  jwtToken: presentedTokenHash,
-                },
-                data: { jwtToken: this.hashDeviceToken(newToken) },
-              });
-
-              if (rotation.count === 1) {
-                client.emit('token:refresh', { token: newToken });
-                this.logger.log(
-                  `Rotated token for device ${payload.deviceIdentifier} (${Math.floor(daysUntilExpiry)} days remaining)`,
-                );
-              } else {
-                this.logger.warn(
-                  `Skipped token refresh for device ${payload.deviceIdentifier}: current token hash changed before rotation persisted`,
-                );
-              }
-            } catch (error) {
-              const message = error instanceof Error ? error.message : 'unknown error';
-              this.logger.warn(
-                `Skipped token refresh for device ${payload.deviceIdentifier}: failed to persist rotated token hash (${message})`,
-              );
-            }
-          }
-        }
+        client.data.deviceTokenHash = presentedTokenHash;
 
         return { kind: 'device', payload };
       }

--- a/realtime/src/gateways/device.gateway.ts
+++ b/realtime/src/gateways/device.gateway.ts
@@ -37,7 +37,7 @@ import {
   BroadcastData,
 } from '../types';
 import * as Sentry from '@sentry/nestjs';
-import { createHash } from 'node:crypto';
+import { createHash, timingSafeEqual } from 'node:crypto';
 import { WsAllExceptionsFilter } from './filters/ws-exception.filter';
 import { WsAuthGuard, WsDeviceGuard } from './guards/ws-auth.guard';
 import { redactSensitiveTokens } from '../utils/redact-sensitive-url';
@@ -58,6 +58,8 @@ interface UserPayload {
   jti?: string;
   iat?: number; // issued-at (epoch seconds), set by jsonwebtoken — used for password-change session invalidation
 }
+
+const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/i;
 
 type AuthPayload =
   | { kind: 'device'; payload: DevicePayload }
@@ -637,6 +639,28 @@ export class DeviceGateway
     return null;
   }
 
+  private hashDeviceToken(token: string): string {
+    return createHash('sha256').update(token).digest('hex');
+  }
+
+  private isCurrentDeviceToken(
+    storedHash: string | null | undefined,
+    presentedHash: string,
+  ): boolean {
+    if (
+      !storedHash ||
+      !SHA256_HEX_PATTERN.test(storedHash) ||
+      !SHA256_HEX_PATTERN.test(presentedHash)
+    ) {
+      return false;
+    }
+
+    return timingSafeEqual(
+      Buffer.from(storedHash, 'hex'),
+      Buffer.from(presentedHash, 'hex'),
+    );
+  }
+
   /**
    * Authenticate the connection: verify JWT (device or user), check revocation, deduplicate sockets.
    * Returns a discriminated union on success, or null if connection was rejected.
@@ -669,9 +693,10 @@ export class DeviceGateway
         }
 
         const deviceId = payload.sub;
+        const presentedTokenHash = this.hashDeviceToken(token);
         const device = await this.databaseService.display.findUnique({
           where: { id: deviceId },
-          select: { id: true, organizationId: true, isDisabled: true },
+          select: { id: true, organizationId: true, isDisabled: true, jwtToken: true },
         });
         if (!device || device.organizationId !== payload.organizationId) {
           this.logger.warn(
@@ -684,6 +709,12 @@ export class DeviceGateway
         if (device.isDisabled) {
           this.logger.warn(`Connection rejected: Device is disabled (id: ${deviceId})`);
           client.emit('error', { message: 'device_disabled' });
+          client.disconnect();
+          return null;
+        }
+        if (!this.isCurrentDeviceToken(device.jwtToken, presentedTokenHash)) {
+          this.logger.warn(`Connection rejected: Device token is not current (id: ${deviceId})`);
+          client.emit('error', { message: 'device_token_stale' });
           client.disconnect();
           return null;
         }
@@ -706,9 +737,8 @@ export class DeviceGateway
         client.data.capabilities = client.handshake.auth?.capabilities;
         client.data.deliveryAckCapable = this.supportsDeliveryAck(client);
 
-        // Auto-rotate device token if it expires within 14 days.
-        // NOTE: The old token remains valid until natural expiry (stateless JWT limitation).
-        // TODO: For high-security deployments, consider a token blacklist in Redis.
+        // Auto-rotate device token if it expires within 14 days. Persist the
+        // new current-token hash before instructing the device to use it.
         // TODO: Rate-limit rotation to once per 24h per device via Redis key 'token_rotated:{deviceId}'
         if (payload.exp) {
           const daysUntilExpiry = (payload.exp - Math.floor(Date.now() / 1000)) / 86400;
@@ -722,10 +752,33 @@ export class DeviceGateway
               },
               { secret: process.env.DEVICE_JWT_SECRET, expiresIn: '90d' },
             );
-            client.emit('token:refresh', { token: newToken });
-            this.logger.log(
-              `Rotated token for device ${payload.deviceIdentifier} (${Math.floor(daysUntilExpiry)} days remaining)`,
-            );
+            try {
+              const rotation = await this.databaseService.display.updateMany({
+                where: {
+                  id: deviceId,
+                  organizationId: payload.organizationId,
+                  isDisabled: false,
+                  jwtToken: presentedTokenHash,
+                },
+                data: { jwtToken: this.hashDeviceToken(newToken) },
+              });
+
+              if (rotation.count === 1) {
+                client.emit('token:refresh', { token: newToken });
+                this.logger.log(
+                  `Rotated token for device ${payload.deviceIdentifier} (${Math.floor(daysUntilExpiry)} days remaining)`,
+                );
+              } else {
+                this.logger.warn(
+                  `Skipped token refresh for device ${payload.deviceIdentifier}: current token hash changed before rotation persisted`,
+                );
+              }
+            } catch (error) {
+              const message = error instanceof Error ? error.message : 'unknown error';
+              this.logger.warn(
+                `Skipped token refresh for device ${payload.deviceIdentifier}: failed to persist rotated token hash (${message})`,
+              );
+            }
           }
         }
 

--- a/realtime/src/gateways/guards/ws-auth.guard.spec.ts
+++ b/realtime/src/gateways/guards/ws-auth.guard.spec.ts
@@ -59,6 +59,31 @@ describe('WebSocket auth guards', () => {
       expect(client.disconnect).toHaveBeenCalledWith(true);
     });
 
+    it('should reject device sockets when the stored token hash is malformed', async () => {
+      databaseService.display.findUnique.mockResolvedValueOnce({
+        id: 'device-1',
+        organizationId: 'org-1',
+        isDisabled: false,
+        jwtToken: 'legacy-plaintext-token',
+      } as any);
+      const guard = new WsDeviceGuard(databaseService);
+      const client = {
+        id: 'socket-1',
+        data: {
+          deviceId: 'device-1',
+          organizationId: 'org-1',
+          deviceTokenHash: hashToken('valid-token'),
+        },
+        emit: jest.fn(),
+        disconnect: jest.fn(),
+      };
+
+      await expect(guard.canActivate(createContext(client))).rejects.toThrow(WsException);
+
+      expect(client.emit).toHaveBeenCalledWith('error', { message: 'device_token_stale' });
+      expect(client.disconnect).toHaveBeenCalledWith(true);
+    });
+
     it('should allow device sockets whose token hash is still current', async () => {
       const guard = new WsDeviceGuard(databaseService);
       const client = {
@@ -76,8 +101,7 @@ describe('WebSocket auth guards', () => {
       expect(client.disconnect).not.toHaveBeenCalled();
     });
 
-    it('should reuse a fresh token validation within the short guard cache window', async () => {
-      jest.spyOn(Date, 'now').mockReturnValue(1_000);
+    it('should revalidate every guarded device message so re-pair invalidates immediately', async () => {
       const guard = new WsDeviceGuard(databaseService);
       const client = {
         id: 'socket-1',
@@ -91,10 +115,17 @@ describe('WebSocket auth guards', () => {
       };
 
       await expect(guard.canActivate(createContext(client))).resolves.toBe(true);
-      await expect(guard.canActivate(createContext(client))).resolves.toBe(true);
+      databaseService.display.findUnique.mockResolvedValueOnce({
+        id: 'device-1',
+        organizationId: 'org-1',
+        isDisabled: false,
+        jwtToken: hashToken('new-current-token'),
+      } as any);
+      await expect(guard.canActivate(createContext(client))).rejects.toThrow(WsException);
 
-      expect(databaseService.display.findUnique).toHaveBeenCalledTimes(1);
-      jest.restoreAllMocks();
+      expect(databaseService.display.findUnique).toHaveBeenCalledTimes(2);
+      expect(client.emit).toHaveBeenCalledWith('error', { message: 'device_token_stale' });
+      expect(client.disconnect).toHaveBeenCalledWith(true);
     });
   });
 });

--- a/realtime/src/gateways/guards/ws-auth.guard.spec.ts
+++ b/realtime/src/gateways/guards/ws-auth.guard.spec.ts
@@ -75,5 +75,26 @@ describe('WebSocket auth guards', () => {
       await expect(guard.canActivate(createContext(client))).resolves.toBe(true);
       expect(client.disconnect).not.toHaveBeenCalled();
     });
+
+    it('should reuse a fresh token validation within the short guard cache window', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(1_000);
+      const guard = new WsDeviceGuard(databaseService);
+      const client = {
+        id: 'socket-1',
+        data: {
+          deviceId: 'device-1',
+          organizationId: 'org-1',
+          deviceTokenHash: hashToken('valid-token'),
+        },
+        emit: jest.fn(),
+        disconnect: jest.fn(),
+      };
+
+      await expect(guard.canActivate(createContext(client))).resolves.toBe(true);
+      await expect(guard.canActivate(createContext(client))).resolves.toBe(true);
+
+      expect(databaseService.display.findUnique).toHaveBeenCalledTimes(1);
+      jest.restoreAllMocks();
+    });
   });
 });

--- a/realtime/src/gateways/guards/ws-auth.guard.spec.ts
+++ b/realtime/src/gateways/guards/ws-auth.guard.spec.ts
@@ -1,0 +1,79 @@
+import { ExecutionContext } from '@nestjs/common';
+import { WsException } from '@nestjs/websockets';
+import { createHash } from 'node:crypto';
+import { WsAuthGuard, WsDeviceGuard } from './ws-auth.guard';
+import { DatabaseService } from '../../database/database.service';
+
+describe('WebSocket auth guards', () => {
+  const hashToken = (token: string) =>
+    createHash('sha256').update(token).digest('hex');
+
+  const createContext = (client: Record<string, any>): ExecutionContext => ({
+    switchToWs: () => ({
+      getClient: () => client,
+    }),
+  } as any);
+
+  describe('WsAuthGuard', () => {
+    it('should reject sockets without authenticated device or user data', () => {
+      const guard = new WsAuthGuard();
+
+      expect(() => guard.canActivate(createContext({ id: 'socket-1', data: {} }))).toThrow(
+        WsException,
+      );
+    });
+  });
+
+  describe('WsDeviceGuard', () => {
+    let databaseService: jest.Mocked<DatabaseService>;
+
+    beforeEach(() => {
+      databaseService = {
+        display: {
+          findUnique: jest.fn().mockResolvedValue({
+            id: 'device-1',
+            organizationId: 'org-1',
+            isDisabled: false,
+            jwtToken: hashToken('valid-token'),
+          }),
+        },
+      } as any;
+    });
+
+    it('should reject device sockets whose token hash is no longer current', async () => {
+      const guard = new WsDeviceGuard(databaseService);
+      const client = {
+        id: 'socket-1',
+        data: {
+          deviceId: 'device-1',
+          organizationId: 'org-1',
+          deviceTokenHash: hashToken('stale-token'),
+        },
+        emit: jest.fn(),
+        disconnect: jest.fn(),
+      };
+
+      await expect(guard.canActivate(createContext(client))).rejects.toThrow(WsException);
+
+      expect(client.emit).toHaveBeenCalledWith('error', { message: 'device_token_stale' });
+      expect(client.disconnect).toHaveBeenCalledWith(true);
+    });
+
+    it('should allow device sockets whose token hash is still current', async () => {
+      const guard = new WsDeviceGuard(databaseService);
+      const client = {
+        id: 'socket-1',
+        data: {
+          deviceId: 'device-1',
+          organizationId: 'org-1',
+          deviceTokenHash: hashToken('valid-token'),
+        },
+        emit: jest.fn(),
+        disconnect: jest.fn(),
+      };
+
+      await expect(guard.canActivate(createContext(client))).resolves.toBe(true);
+      expect(client.disconnect).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/realtime/src/gateways/guards/ws-auth.guard.ts
+++ b/realtime/src/gateways/guards/ws-auth.guard.ts
@@ -4,8 +4,6 @@ import { Socket } from 'socket.io';
 import { DatabaseService } from '../../database/database.service';
 import { isCurrentDeviceToken } from '../device-token-hash';
 
-const DEVICE_TOKEN_REVALIDATION_CACHE_MS = 1000;
-
 /**
  * Defense-in-depth guard for WebSocket message handlers.
  * Verifies that client.data was populated during connection authentication.
@@ -47,16 +45,6 @@ export class WsDeviceGuard implements CanActivate {
       throw new WsException('Device-only endpoint');
     }
 
-    const validatedAt = client.data.deviceTokenValidatedAt;
-    const validatedHash = client.data.deviceTokenValidatedHash;
-    if (
-      typeof validatedAt === 'number' &&
-      validatedHash === client.data.deviceTokenHash &&
-      Date.now() - validatedAt <= DEVICE_TOKEN_REVALIDATION_CACHE_MS
-    ) {
-      return true;
-    }
-
     const display = await this.databaseService.display.findUnique({
       where: { id: client.data.deviceId },
       select: { organizationId: true, isDisabled: true, jwtToken: true },
@@ -73,9 +61,6 @@ export class WsDeviceGuard implements CanActivate {
       client.disconnect(true);
       throw new WsException('Device token stale');
     }
-
-    client.data.deviceTokenValidatedAt = Date.now();
-    client.data.deviceTokenValidatedHash = client.data.deviceTokenHash;
 
     return true;
   }

--- a/realtime/src/gateways/guards/ws-auth.guard.ts
+++ b/realtime/src/gateways/guards/ws-auth.guard.ts
@@ -1,6 +1,8 @@
 import { CanActivate, ExecutionContext, Injectable, Logger } from '@nestjs/common';
 import { WsException } from '@nestjs/websockets';
 import { Socket } from 'socket.io';
+import { DatabaseService } from '../../database/database.service';
+import { isCurrentDeviceToken } from '../device-token-hash';
 
 /**
  * Defense-in-depth guard for WebSocket message handlers.
@@ -33,12 +35,31 @@ export class WsAuthGuard implements CanActivate {
 export class WsDeviceGuard implements CanActivate {
   private readonly logger = new Logger(WsDeviceGuard.name);
 
-  canActivate(context: ExecutionContext): boolean {
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const client = context.switchToWs().getClient<Socket>();
 
     if (!client.data?.deviceId) {
       this.logger.warn(`Non-device message attempt from socket ${client.id}`);
       throw new WsException('Device-only endpoint');
+    }
+
+    const display = await this.databaseService.display.findUnique({
+      where: { id: client.data.deviceId },
+      select: { organizationId: true, isDisabled: true, jwtToken: true },
+    });
+
+    if (
+      !display ||
+      display.organizationId !== client.data.organizationId ||
+      display.isDisabled ||
+      !isCurrentDeviceToken(display.jwtToken, client.data.deviceTokenHash)
+    ) {
+      this.logger.warn(`Stale device socket rejected: ${client.data.deviceId} (${client.id})`);
+      client.emit('error', { message: 'device_token_stale' });
+      client.disconnect(true);
+      throw new WsException('Device token stale');
     }
 
     return true;

--- a/realtime/src/gateways/guards/ws-auth.guard.ts
+++ b/realtime/src/gateways/guards/ws-auth.guard.ts
@@ -4,6 +4,8 @@ import { Socket } from 'socket.io';
 import { DatabaseService } from '../../database/database.service';
 import { isCurrentDeviceToken } from '../device-token-hash';
 
+const DEVICE_TOKEN_REVALIDATION_CACHE_MS = 1000;
+
 /**
  * Defense-in-depth guard for WebSocket message handlers.
  * Verifies that client.data was populated during connection authentication.
@@ -45,6 +47,16 @@ export class WsDeviceGuard implements CanActivate {
       throw new WsException('Device-only endpoint');
     }
 
+    const validatedAt = client.data.deviceTokenValidatedAt;
+    const validatedHash = client.data.deviceTokenValidatedHash;
+    if (
+      typeof validatedAt === 'number' &&
+      validatedHash === client.data.deviceTokenHash &&
+      Date.now() - validatedAt <= DEVICE_TOKEN_REVALIDATION_CACHE_MS
+    ) {
+      return true;
+    }
+
     const display = await this.databaseService.display.findUnique({
       where: { id: client.data.deviceId },
       select: { organizationId: true, isDisabled: true, jwtToken: true },
@@ -61,6 +73,9 @@ export class WsDeviceGuard implements CanActivate {
       client.disconnect(true);
       throw new WsException('Device token stale');
     }
+
+    client.data.deviceTokenValidatedAt = Date.now();
+    client.data.deviceTokenValidatedHash = client.data.deviceTokenHash;
 
     return true;
   }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -26,6 +26,8 @@
 - [x] Add failing realtime tests for stale/missing `Display.jwtToken` rejection and rotation persistence.
 - [x] Implement current-hash validation in middleware and realtime.
 - [x] Add connected-socket current-hash revalidation in `WsDeviceGuard`.
+- [x] Add server-push current-hash revalidation for playlist, command, and QR-overlay delivery.
+- [x] Exempt public device endpoints from subscription guard pre-emption before device JWT validation.
 - [x] Disable unsafe realtime auto-rotation until a grace/ACK-backed rotation design exists.
 - [x] Run focused verification.
 - [ ] Run multi-subagent review before broad verification.
@@ -45,6 +47,8 @@
 - [x] Review-fix red run: middleware heartbeat/active schedules and realtime guard tests failed before widening the implementation.
 - [x] `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="displays.controller|schedules.controller|device-content.controller"` - pass, 3 suites / 65 tests.
 - [x] `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern="device.gateway|ws-auth.guard"` - pass, 3 suites / 102 tests.
+- [x] Second review-fix run: realtime server-push stale-socket tests and subscription public-endpoint test added; `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="subscription-active.guard|displays.controller|schedules.controller|device-content.controller"` - pass, 4 suites / 88 tests.
+- [x] `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern="device.gateway|ws-auth.guard"` - pass after server-push revalidation, 3 suites / 106 tests.
 
 ---
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -31,8 +31,8 @@
 - [x] Exempt public device endpoints from subscription guard pre-emption before device JWT validation.
 - [x] Disable unsafe realtime auto-rotation until a grace/ACK-backed rotation design exists.
 - [x] Run focused verification.
-- [ ] Run multi-subagent review before broad verification.
-- [ ] Run broader affected tests/builds.
+- [x] Run multi-subagent review before broad verification.
+- [x] Run broader affected tests/builds.
 - [ ] PR, CI, merge.
 - [ ] Re-check deployment gate; deploy only if prod checkout and runtime token state are safe.
 
@@ -52,6 +52,19 @@
 - [x] `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern="device.gateway|ws-auth.guard"` - pass after server-push revalidation, 3 suites / 106 tests.
 - [x] Final review-fix run: malformed-hash tests added, `WsDeviceGuard` cache removed, org-room broadcasts filtered. `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="subscription-active.guard|displays.controller|schedules.controller|device-content.controller"` - pass, 4 suites / 89 tests.
 - [x] `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern="device.gateway|ws-auth.guard|app.controller"` - pass, 4 suites / 117 tests.
+
+**Review gate**
+- [x] Subagent code-path review: CLEAN for stale device-token enforcement across middleware REST routes, realtime handshakes, guarded socket messages, direct server-push delivery, and org-room broadcasts. Residual risk documented: guarded realtime messages and server-push fanout now hit the DB for current-hash checks.
+- [x] Subagent verification/deploy review: initial gate was not clean until full suites/builds were run; requested broad verification completed below. Deployment remains blocked by prod-local dirty/diverged checkout.
+
+**Broader verification**
+- [x] `pnpm --filter @vizora/middleware test -- --runInBand` - pass, 143 suites / 2796 tests.
+- [x] `pnpm --filter @vizora/realtime test -- --runInBand` - pass, 12 suites / 271 tests.
+- [x] `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` - pass.
+- [x] `npx nx build @vizora/realtime` - pass with existing webpack/source-map/optional `ws` warnings.
+- [x] Initial parallel `npx nx build @vizora/middleware` collided with simultaneous `@vizora/database:build` copying into `packages/database/dist/generated` on Windows (`EPIPE`, file in use). Serial rerun completed successfully.
+- [x] `npx nx build @vizora/middleware` - pass with existing webpack warnings.
+- [x] `git diff --check origin/main...HEAD` - pass.
 
 ---
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -27,6 +27,7 @@
 - [x] Implement current-hash validation in middleware and realtime.
 - [x] Add connected-socket current-hash revalidation in `WsDeviceGuard`.
 - [x] Add server-push current-hash revalidation for playlist, command, and QR-overlay delivery.
+- [x] Add organization-room broadcast current-hash filtering for stale device sockets.
 - [x] Exempt public device endpoints from subscription guard pre-emption before device JWT validation.
 - [x] Disable unsafe realtime auto-rotation until a grace/ACK-backed rotation design exists.
 - [x] Run focused verification.
@@ -49,6 +50,8 @@
 - [x] `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern="device.gateway|ws-auth.guard"` - pass, 3 suites / 102 tests.
 - [x] Second review-fix run: realtime server-push stale-socket tests and subscription public-endpoint test added; `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="subscription-active.guard|displays.controller|schedules.controller|device-content.controller"` - pass, 4 suites / 88 tests.
 - [x] `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern="device.gateway|ws-auth.guard"` - pass after server-push revalidation, 3 suites / 106 tests.
+- [x] Final review-fix run: malformed-hash tests added, `WsDeviceGuard` cache removed, org-room broadcasts filtered. `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="subscription-active.guard|displays.controller|schedules.controller|device-content.controller"` - pass, 4 suites / 89 tests.
+- [x] `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern="device.gateway|ws-auth.guard|app.controller"` - pass, 4 suites / 117 tests.
 
 ---
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -22,11 +22,11 @@
 - [x] Record PR #127 merge/CI/deploy evidence.
 - [x] Drift-check device token storage and validation paths.
 - [x] Write plan/design and checklist.
-- [ ] Add failing middleware tests for stale/missing `Display.jwtToken` rejection in device-content streaming.
-- [ ] Add failing realtime tests for stale/missing `Display.jwtToken` rejection and rotation persistence.
-- [ ] Implement current-hash validation in middleware and realtime.
-- [ ] Persist new token hash before realtime emits `token:refresh`.
-- [ ] Run focused verification.
+- [x] Add failing middleware tests for stale/missing `Display.jwtToken` rejection in device-content streaming.
+- [x] Add failing realtime tests for stale/missing `Display.jwtToken` rejection and rotation persistence.
+- [x] Implement current-hash validation in middleware and realtime.
+- [x] Persist new token hash before realtime emits `token:refresh`.
+- [x] Run focused verification.
 - [ ] Run multi-subagent review before broad verification.
 - [ ] Run broader affected tests/builds.
 - [ ] PR, CI, merge.
@@ -36,6 +36,10 @@
 - [x] Query prod display token-hash coverage: 15 displays total, 15 with `jwtToken`, 0 missing `jwtToken`, 15 active non-pairing, 0 active non-pairing missing `jwtToken`.
 - [x] Reconcile any legacy displays without a current hash before deploying fail-closed enforcement: no legacy missing-token displays found in the read-only prod count.
 - [ ] Reconcile prod `/opt/vizora/app` dirty/diverged checkout before any pull/restart/deploy.
+
+**Focused verification**
+- [x] `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=device-content.controller` - red first on stale/missing token-hash acceptance, then pass, 26 tests.
+- [x] `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern=device.gateway` - red first on stale-token acceptance and rotation-without-persist, then pass, 2 suites / 100 tests.
 
 ---
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -6,7 +6,7 @@
 
 **Why now:** PR #127 merged and CI is green, but deployment remains blocked by dirty/diverged prod-local work. A fresh realtime/display/code review found a P0 auth-boundary gap: signed display JWTs remain accepted after re-pairing or token rotation because middleware and realtime verify signature claims but do not compare the presented token to the current token hash stored on `Display.jwtToken`.
 
-**New primitives introduced:** none. Reuse the existing display `jwtToken` hash column, pairing token hash behavior, device JWT model, middleware device-content controller, and realtime gateway.
+**New primitives introduced:** one shared middleware device-token helper and one realtime hash helper. Reuse the existing display `jwtToken` hash column, pairing token hash behavior, device JWT model, middleware controllers, realtime gateway, and WebSocket guards.
 
 **Hermes-first analysis:** not applicable; this pass does not add business-agent behavior, MCP tools, Hermes skills, AI provider calls, or spend paths.
 
@@ -25,7 +25,8 @@
 - [x] Add failing middleware tests for stale/missing `Display.jwtToken` rejection in device-content streaming.
 - [x] Add failing realtime tests for stale/missing `Display.jwtToken` rejection and rotation persistence.
 - [x] Implement current-hash validation in middleware and realtime.
-- [x] Persist new token hash before realtime emits `token:refresh`.
+- [x] Add connected-socket current-hash revalidation in `WsDeviceGuard`.
+- [x] Disable unsafe realtime auto-rotation until a grace/ACK-backed rotation design exists.
 - [x] Run focused verification.
 - [ ] Run multi-subagent review before broad verification.
 - [ ] Run broader affected tests/builds.
@@ -34,12 +35,16 @@
 
 **Runtime-state gate before deploy**
 - [x] Query prod display token-hash coverage: 15 displays total, 15 with `jwtToken`, 0 missing `jwtToken`, 15 active non-pairing, 0 active non-pairing missing `jwtToken`.
-- [x] Reconcile any legacy displays without a current hash before deploying fail-closed enforcement: no legacy missing-token displays found in the read-only prod count.
+- [x] Query prod malformed hash coverage: 0 malformed `jwtToken` hashes, 0 active non-pairing malformed hashes.
+- [x] Reconcile any legacy displays without a current hash before deploying fail-closed enforcement: no legacy missing-token or malformed-token displays found in the read-only prod counts.
 - [ ] Reconcile prod `/opt/vizora/app` dirty/diverged checkout before any pull/restart/deploy.
 
 **Focused verification**
 - [x] `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=device-content.controller` - red first on stale/missing token-hash acceptance, then pass, 26 tests.
 - [x] `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern=device.gateway` - red first on stale-token acceptance and rotation-without-persist, then pass, 2 suites / 100 tests.
+- [x] Review-fix red run: middleware heartbeat/active schedules and realtime guard tests failed before widening the implementation.
+- [x] `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="displays.controller|schedules.controller|device-content.controller"` - pass, 3 suites / 65 tests.
+- [x] `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern="device.gateway|ws-auth.guard"` - pass, 3 suites / 102 tests.
 
 ---
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,8 +1,48 @@
 # Vizora - Task Tracker
 
-## In Progress: Customer Dashboard UX Hotspots (2026-05-31)
+## In Progress: Device Token Current-Hash Enforcement (2026-05-31)
+
+**Branch:** `feat/customer-performance-review-5`
+
+**Why now:** PR #127 merged and CI is green, but deployment remains blocked by dirty/diverged prod-local work. A fresh realtime/display/code review found a P0 auth-boundary gap: signed display JWTs remain accepted after re-pairing or token rotation because middleware and realtime verify signature claims but do not compare the presented token to the current token hash stored on `Display.jwtToken`.
+
+**New primitives introduced:** none. Reuse the existing display `jwtToken` hash column, pairing token hash behavior, device JWT model, middleware device-content controller, and realtime gateway.
+
+**Hermes-first analysis:** not applicable; this pass does not add business-agent behavior, MCP tools, Hermes skills, AI provider calls, or spend paths.
+
+**Plan/design:** `docs/plans/2026-05-31-device-token-current-hash-enforcement.md`
+
+**Reviewer synthesis**
+- [x] Customer/UX review: PR #127 fixed pairing-token rendering and bulk upload progress; remaining customer-visible issues include billing redirect shape, stale schedule conflict UI, push-to-device false success, and no-op playlist publish.
+- [x] Performance review: larger follow-ups remain for memory-buffered uploads, authenticated media caching/preload, dashboard list payloads, and folder indexes.
+- [x] Realtime/display review: P0 stale device JWT acceptance selected for this slice; other follow-ups include active-schedule playback, template display rendering, initial playlist ACKs, and direct-playlist clear semantics.
+- [x] Adversarial review: SSRF redirect handling, server-side API cookie/envelope drift, and CSRF mounting remain queued after this auth-boundary slice.
+
+**Plan**
+- [x] Record PR #127 merge/CI/deploy evidence.
+- [x] Drift-check device token storage and validation paths.
+- [x] Write plan/design and checklist.
+- [ ] Add failing middleware tests for stale/missing `Display.jwtToken` rejection in device-content streaming.
+- [ ] Add failing realtime tests for stale/missing `Display.jwtToken` rejection and rotation persistence.
+- [ ] Implement current-hash validation in middleware and realtime.
+- [ ] Persist new token hash before realtime emits `token:refresh`.
+- [ ] Run focused verification.
+- [ ] Run multi-subagent review before broad verification.
+- [ ] Run broader affected tests/builds.
+- [ ] PR, CI, merge.
+- [ ] Re-check deployment gate; deploy only if prod checkout and runtime token state are safe.
+
+**Runtime-state gate before deploy**
+- [x] Query prod display token-hash coverage: 15 displays total, 15 with `jwtToken`, 0 missing `jwtToken`, 15 active non-pairing, 0 active non-pairing missing `jwtToken`.
+- [x] Reconcile any legacy displays without a current hash before deploying fail-closed enforcement: no legacy missing-token displays found in the read-only prod count.
+- [ ] Reconcile prod `/opt/vizora/app` dirty/diverged checkout before any pull/restart/deploy.
+
+---
+
+## Completed: Customer Dashboard UX Hotspots (2026-05-31)
 
 **Branch:** `fix/customer-dashboard-ux-hotspots`
+**PR / merge commit:** #127 / `c82b1521da7db94ba07caeced4339b8a1b17731a`
 
 **Why now:** PR #126 merged and CI is green, but deployment is blocked by dirty/diverged prod-local work. The next customer-visible repo-side issues are small, testable dashboard defects in existing-device pairing and bulk content upload.
 
@@ -21,8 +61,8 @@
 - [x] Run focused verification.
 - [x] Run multi-subagent review before broad verification.
 - [x] Run broader web verification/build.
-- [ ] PR, CI, merge.
-- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+- [x] PR, CI, merge.
+- [x] Re-check deployment gate; deployment remains blocked by dirty/diverged prod checkout.
 
 **Focused verification**
 - [x] `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="devices-page|content-page"` - red first on missing `pairingToken` rendering and missing bulk `uploadContentWithProgress`, then pass, 2 suites / 30 tests.
@@ -41,6 +81,13 @@
 - [x] Customer/UX reviewer: initial P1 hidden queued files after switching to URL mode fixed with disabled URL option and guarded change handler; P2 modal-close upload state loss fixed by ignoring close while uploading.
 - [x] Performance/concurrency reviewer: no P0/P1; P2 modal-close finding fixed and pairing response type tightened to required backend shape.
 - [x] Post-fix re-review: initial P1 removed-file URL upload path fixed by clearing selected file state when queue items are removed/cleared and by requiring a file upload type before using the file branch.
+
+**Merge / CI / deployment gate**
+- [x] PR #127 merged after GitHub checks passed: lint, audit, test, build, security, and e2e.
+- [x] Open PRs after merge: none.
+- [x] GitHub main after merge: `c82b1521da7db94ba07caeced4339b8a1b17731a`.
+- [x] Production health probe returned `success: true`, database connected at `2026-05-31T13:09:33.049Z`.
+- [x] Production deploy remains blocked: `/opt/vizora/app` is dirty and diverged (`HEAD=bb76aa1838740bff5b58623dfef7a906d44f46a6`, `origin/main=c82b1521da7db94ba07caeced4339b8a1b17731a`, `ahead 17, behind 51`). Do not pull/reset/stash/restart services until prod-local work is reconciled.
 
 ---
 


### PR DESCRIPTION
## Summary
- Enforce presented display JWTs against the current `Display.jwtToken` hash in middleware device routes.
- Enforce current token hashes in realtime handshakes, guarded device socket messages, direct device pushes, and org-room broadcasts.
- Disable unsafe realtime token auto-rotation until a grace/ACK-backed rotation design exists.
- Exempt public device endpoints from subscription guard pre-emption so manual device-token validation can run.

## Verification
- `pnpm --filter @vizora/middleware test -- --runInBand` - 143 suites / 2796 tests passed
- `pnpm --filter @vizora/realtime test -- --runInBand` - 12 suites / 271 tests passed
- `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
- `npx nx build @vizora/middleware` - pass with existing webpack warnings
- `npx nx build @vizora/realtime` - pass with existing webpack/source-map/optional ws warnings
- `git diff --check origin/main...HEAD`

## Review
- Multi-subagent code-path review: CLEAN after widening enforcement to REST, handshake, guarded socket messages, direct server-push, and org-room broadcast paths.
- Multi-subagent verification/deploy review: clean after broad verification; deployment remains blocked by dirty/diverged prod-local checkout.

## Deployment note
Do not deploy by pulling/resetting `/opt/vizora/app`; production checkout remains dirty/diverged and needs operator reconciliation before any restart/deploy.