### PR TITLE
Harden customer contract paths

### DIFF
--- a/docs/plans/2026-05-31-customer-contract-security-performance-pass-6.md
+++ b/docs/plans/2026-05-31-customer-contract-security-performance-pass-6.md
@@ -1,0 +1,59 @@
+# Customer Contract, Security, and Performance Pass 6 Plan
+
+**Goal:** Fix the next small, high-impact repo-side issues that a customer would feel directly after PR #128: broken billing redirects, SSR API prefetch drift, false-success device pushes, SSRF redirect gaps, and ineffective authenticated media preloading.
+
+**New primitives introduced:** none. Reuse the existing `ApiClient`, Next server fetch helper, middleware display push path, realtime push response contract, shared SSRF guard, and display Cache API preload path.
+
+**Hermes-first analysis:** not applicable. This pass does not add business-agent behavior, MCP tools, Hermes skills, AI provider calls, or spend paths.
+
+## Selected Fix Bundle
+
+1. **Billing checkout/portal response normalization**
+   - Backend returns `{ checkoutUrl }` and `{ portalUrl }`; web types/pages expect `{ url }`.
+   - Fix in `web/src/lib/api/billing.ts` by normalizing backend-shaped responses at the API boundary.
+   - Tests: add API-client tests that fail on backend-shaped responses before the normalization.
+
+2. **Server-side dashboard/admin prefetch auth and envelope handling**
+   - `serverFetch` reads a non-existent `token` cookie and returns raw envelopes.
+   - Fix in `web/src/lib/server-api.ts` by reading `vizora_auth_token`, forwarding it as both cookie and bearer auth, and unwrapping `{ success, data }`.
+   - Tests: mock `next/headers` and `fetch` to verify cookie forwarding, envelope unwrap, and error parsing.
+
+3. **Display push-content false success**
+   - Middleware posts to realtime `/api/push/content` but ignores `success: false` responses.
+   - Fix in `middleware/src/modules/displays/displays.service.ts` by checking the realtime response and surfacing delivery failure as a 503.
+   - Tests: add `DisplaysService.pushContent` coverage for success, realtime `success:false`, and missing internal secret.
+
+4. **RSS/thumbnail SSRF redirect hardening**
+   - RSS preview and thumbnail URL fetches validate the original URL but fetch with redirects enabled.
+   - Fix by using the shared SSRF guard and `redirect: 'manual'`; reject 3xx redirects in this slice rather than implementing recursive redirect following.
+   - Tests: RSS preview rejects redirect responses; thumbnail URL generation rejects redirect responses after initial validation.
+
+5. **Authenticated display media preload**
+   - Display preloads unauthenticated raw content URLs, while render-time playback appends the device token later.
+   - Fix in `web/src/app/display/DisplayClient.tsx` by preloading authenticated URLs with the same token path used by playback.
+   - Tests: display client/cache tests verify preloaded URLs include the device token for `/device-content/...` paths.
+
+## Deferred Larger Work
+
+- Direct-to-storage multipart uploads and background media processing.
+- Versioned signed media URLs/CDN cache design.
+- Full schedule conflict confirmation UX.
+- CSRF middleware mounting across all mutating routes.
+- API-key-authenticated customer API surface or removal of dashboard API-key docs.
+
+## Verification Plan
+
+- Focused red/green tests for each changed surface.
+- Multi-subagent code review before broader tests.
+- Broader affected suites:
+  - `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="billing|server-api|DisplayClient|useBrowserCache"`
+  - `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="displays.service|widgets.controller|thumbnail.service"`
+  - `pnpm --filter @vizora/web exec tsc --noEmit --pretty false`
+  - `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
+  - `npx nx build @vizora/web`
+  - `npx nx build @vizora/middleware`
+  - `git diff --check origin/main...HEAD`
+
+## Deploy Gate
+
+Do not deploy this pass unless `/opt/vizora/app` is reconciled. The current production checkout is dirty and diverged from `origin/main`; source pull/restart/deploy would risk overwriting prod-local work.

--- a/middleware/src/modules/common/utils/ssrf-guard.spec.ts
+++ b/middleware/src/modules/common/utils/ssrf-guard.spec.ts
@@ -260,5 +260,44 @@ describe('ssrf-guard', () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
+
+    it('drops non-safe headers on cross-origin redirects when requested', async () => {
+      mockLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+      mockFetch
+        .mockResolvedValueOnce({
+          status: 302,
+          headers: {
+            get: jest.fn((name: string) => (
+              name.toLowerCase() === 'location'
+                ? 'https://api2.example.com/final'
+                : null
+            )),
+          },
+        })
+        .mockResolvedValueOnce({ ok: true, status: 200, headers: { get: jest.fn() } });
+
+      await fetchWithSsrfGuard(
+        'https://api1.example.com/start',
+        {
+          headers: {
+            Accept: 'application/json',
+            'User-Agent': 'Vizora-Test/1.0',
+            'X-Api-Key': 'secret-value',
+          },
+        },
+        { dropHeadersOnCrossOriginRedirect: true },
+      );
+
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        'https://api2.example.com/final',
+        expect.objectContaining({
+          headers: {
+            accept: 'application/json',
+            'user-agent': 'Vizora-Test/1.0',
+          },
+        }),
+      );
+    });
   });
 });

--- a/middleware/src/modules/common/utils/ssrf-guard.spec.ts
+++ b/middleware/src/modules/common/utils/ssrf-guard.spec.ts
@@ -1,6 +1,7 @@
 import * as dns from 'dns/promises';
 import {
   assertUrlIsPublic,
+  fetchWithSsrfGuard,
   isPrivateAddress,
   SsrfError,
 } from './ssrf-guard';
@@ -193,6 +194,71 @@ describe('ssrf-guard', () => {
       ['not-an-ip', false],
     ])('classifies %s → private=%s', (ip, expected) => {
       expect(isPrivateAddress(ip)).toBe(expected);
+    });
+  });
+
+  describe('fetchWithSsrfGuard', () => {
+    const originalFetch = global.fetch;
+    const mockFetch = jest.fn();
+
+    beforeEach(() => {
+      global.fetch = mockFetch;
+      mockFetch.mockReset();
+      mockLookup.mockReset();
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('follows a public redirect after validating the redirected URL', async () => {
+      mockLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+      const finalResponse = { ok: true, status: 200, headers: { get: jest.fn() } } as any;
+      mockFetch
+        .mockResolvedValueOnce({
+          status: 302,
+          headers: {
+            get: jest.fn((name: string) => (name.toLowerCase() === 'location' ? '/final' : null)),
+          },
+        })
+        .mockResolvedValueOnce(finalResponse);
+
+      const result = await fetchWithSsrfGuard('https://example.com/start');
+
+      expect(result).toBe(finalResponse);
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        1,
+        'https://example.com/start',
+        expect.objectContaining({ redirect: 'manual' }),
+      );
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        'https://example.com/final',
+        expect.objectContaining({ redirect: 'manual' }),
+      );
+      expect(mockLookup).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects a private redirect target before fetching it', async () => {
+      mockLookup
+        .mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }])
+        .mockResolvedValueOnce([{ address: '169.254.169.254', family: 4 }]);
+      mockFetch.mockResolvedValueOnce({
+        status: 302,
+        headers: {
+          get: jest.fn((name: string) => (
+            name.toLowerCase() === 'location'
+              ? 'http://169.254.169.254/latest'
+              : null
+          )),
+        },
+      });
+
+      await expect(
+        fetchWithSsrfGuard('https://example.com/start', {}, { allowHttp: true }),
+      ).rejects.toThrow(/blocked address/);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/middleware/src/modules/common/utils/ssrf-guard.ts
+++ b/middleware/src/modules/common/utils/ssrf-guard.ts
@@ -38,6 +38,8 @@ export interface SsrfFetchOptions extends SsrfCheckOptions {
   maxRedirects?: number;
   /** Skip validating the first URL when the caller already did it. Redirect hops are always validated. */
   skipInitialValidation?: boolean;
+  /** Drop caller-supplied headers that could leak secrets when a redirect crosses origins. */
+  dropHeadersOnCrossOriginRedirect?: boolean;
 }
 
 // IPv4 ranges that must never be reachable from outbound fetches.
@@ -113,7 +115,12 @@ export async function fetchWithSsrfGuard(
   init: RequestInit = {},
   opts: SsrfFetchOptions = {},
 ): Promise<Response> {
-  const { maxRedirects = 3, skipInitialValidation = false, ...ssrfOptions } = opts;
+  const {
+    maxRedirects = 3,
+    skipInitialValidation = false,
+    dropHeadersOnCrossOriginRedirect = false,
+    ...ssrfOptions
+  } = opts;
   let currentUrl = url;
   let requestInit: RequestInit = { ...init, redirect: 'manual' };
 
@@ -147,9 +154,16 @@ export async function fetchWithSsrfGuard(
       throw new SsrfError('redirect Location is not a valid URL');
     }
 
+    const previousUrl = currentUrl;
     currentUrl = nextUrl.toString();
     await assertUrlIsPublic(currentUrl, ssrfOptions);
-    requestInit = redirectRequestInit(requestInit, response.status);
+    requestInit = redirectRequestInit(
+      requestInit,
+      response.status,
+      previousUrl,
+      currentUrl,
+      dropHeadersOnCrossOriginRedirect,
+    );
   }
 }
 
@@ -161,13 +175,47 @@ function isRedirectStatus(status: number): boolean {
     || status === 308;
 }
 
-function redirectRequestInit(init: RequestInit, status: number): RequestInit {
+function redirectRequestInit(
+  init: RequestInit,
+  status: number,
+  previousUrl: string,
+  nextUrl: string,
+  dropHeadersOnCrossOriginRedirect: boolean,
+): RequestInit {
   const method = (init.method ?? 'GET').toUpperCase();
+  let nextInit = init;
+
   if (status === 303 || ((status === 301 || status === 302) && method === 'POST')) {
     const { body: _body, ...rest } = init;
-    return { ...rest, method: 'GET', redirect: 'manual' };
+    nextInit = { ...rest, method: 'GET', redirect: 'manual' };
   }
-  return { ...init, redirect: 'manual' };
+
+  if (dropHeadersOnCrossOriginRedirect && originsDiffer(previousUrl, nextUrl)) {
+    nextInit = {
+      ...nextInit,
+      headers: keepNonSecretRedirectHeaders(nextInit.headers),
+    };
+  }
+
+  return { ...nextInit, redirect: 'manual' };
+}
+
+function originsDiffer(previousUrl: string, nextUrl: string): boolean {
+  return new URL(previousUrl).origin !== new URL(nextUrl).origin;
+}
+
+function keepNonSecretRedirectHeaders(headers: HeadersInit | undefined): HeadersInit | undefined {
+  if (!headers) return undefined;
+
+  const safeHeaders = new Set(['accept', 'user-agent']);
+  const kept: Record<string, string> = {};
+  new Headers(headers).forEach((value, key) => {
+    if (safeHeaders.has(key.toLowerCase())) {
+      kept[key] = value;
+    }
+  });
+
+  return kept;
 }
 
 export function isPrivateAddress(ip: string): boolean {

--- a/middleware/src/modules/common/utils/ssrf-guard.ts
+++ b/middleware/src/modules/common/utils/ssrf-guard.ts
@@ -14,8 +14,8 @@ import * as net from 'net';
  *   await assertUrlIsPublic(url);                       // https-only
  *   await assertUrlIsPublic(url, { allowHttp: true });  // widget polling
  *
- * Pair with `redirect: 'manual'` on fetch(); a redirect to a private host
- * would otherwise bypass this check.
+ * Pair with `fetchWithSsrfGuard()` or `redirect: 'manual'` on fetch(); a
+ * redirect to a private host would otherwise bypass this check.
  *
  * TOCTOU note: there is a small window between dns.lookup() and the
  * actual fetch() where DNS could flip. To close it completely we'd need
@@ -31,6 +31,13 @@ import * as net from 'net';
 export interface SsrfCheckOptions {
   /** Allow plain http:// in addition to https://. Default: https-only. */
   allowHttp?: boolean;
+}
+
+export interface SsrfFetchOptions extends SsrfCheckOptions {
+  /** Maximum number of redirects to follow after validating every hop. Default: 3. */
+  maxRedirects?: number;
+  /** Skip validating the first URL when the caller already did it. Redirect hops are always validated. */
+  skipInitialValidation?: boolean;
 }
 
 // IPv4 ranges that must never be reachable from outbound fetches.
@@ -99,6 +106,68 @@ export async function assertUrlIsPublic(
       throw new SsrfError('url points to a blocked address');
     }
   }
+}
+
+export async function fetchWithSsrfGuard(
+  url: string,
+  init: RequestInit = {},
+  opts: SsrfFetchOptions = {},
+): Promise<Response> {
+  const { maxRedirects = 3, skipInitialValidation = false, ...ssrfOptions } = opts;
+  let currentUrl = url;
+  let requestInit: RequestInit = { ...init, redirect: 'manual' };
+
+  if (!skipInitialValidation) {
+    await assertUrlIsPublic(currentUrl, ssrfOptions);
+  }
+
+  for (let redirectCount = 0; ; redirectCount++) {
+    const response = await fetch(currentUrl, {
+      ...requestInit,
+      redirect: 'manual',
+    });
+
+    if (!isRedirectStatus(response.status)) {
+      return response;
+    }
+
+    if (redirectCount >= maxRedirects) {
+      throw new SsrfError(`too many redirects (max ${maxRedirects})`);
+    }
+
+    const location = response.headers.get('location');
+    if (!location) {
+      throw new SsrfError('redirect response missing Location header');
+    }
+
+    let nextUrl: URL;
+    try {
+      nextUrl = new URL(location, currentUrl);
+    } catch {
+      throw new SsrfError('redirect Location is not a valid URL');
+    }
+
+    currentUrl = nextUrl.toString();
+    await assertUrlIsPublic(currentUrl, ssrfOptions);
+    requestInit = redirectRequestInit(requestInit, response.status);
+  }
+}
+
+function isRedirectStatus(status: number): boolean {
+  return status === 301
+    || status === 302
+    || status === 303
+    || status === 307
+    || status === 308;
+}
+
+function redirectRequestInit(init: RequestInit, status: number): RequestInit {
+  const method = (init.method ?? 'GET').toUpperCase();
+  if (status === 303 || ((status === 301 || status === 302) && method === 'POST')) {
+    const { body: _body, ...rest } = init;
+    return { ...rest, method: 'GET', redirect: 'manual' };
+  }
+  return { ...init, redirect: 'manual' };
 }
 
 export function isPrivateAddress(ip: string): boolean {

--- a/middleware/src/modules/content/controllers/widgets.controller.spec.ts
+++ b/middleware/src/modules/content/controllers/widgets.controller.spec.ts
@@ -5,6 +5,10 @@ jest.mock('isomorphic-dompurify', () => ({
   },
 }));
 
+jest.mock('dns/promises', () => ({
+  lookup: jest.fn().mockResolvedValue([{ address: '93.184.216.34', family: 4 }]),
+}));
+
 import { Test, TestingModule } from '@nestjs/testing';
 import { WidgetsController } from './widgets.controller';
 import { ContentService } from '../content.service';
@@ -462,6 +466,23 @@ describe('WidgetsController', () => {
       await expect(
         controller.getRssFeed('https://example.com/rss', '10'),
       ).rejects.toThrow('Failed to fetch RSS feed: HTTP 404');
+    });
+
+    it('should reject redirects instead of following them after SSRF validation', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        status: 302,
+        headers: new Map([['location', 'http://127.0.0.1/rss']]),
+      });
+
+      await expect(
+        controller.getRssFeed('https://example.com/rss', '10'),
+      ).rejects.toThrow('RSS feed redirects are not allowed');
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://example.com/rss',
+        expect.objectContaining({ redirect: 'manual' }),
+      );
     });
 
     it('should throw NotFoundException on network error', async () => {

--- a/middleware/src/modules/content/controllers/widgets.controller.spec.ts
+++ b/middleware/src/modules/content/controllers/widgets.controller.spec.ts
@@ -12,6 +12,7 @@ jest.mock('dns/promises', () => ({
 import { Test, TestingModule } from '@nestjs/testing';
 import { WidgetsController } from './widgets.controller';
 import { ContentService } from '../content.service';
+import { lookup } from 'dns/promises';
 
 describe('WidgetsController', () => {
   let controller: WidgetsController;
@@ -468,8 +469,45 @@ describe('WidgetsController', () => {
       ).rejects.toThrow('Failed to fetch RSS feed: HTTP 404');
     });
 
-    it('should reject redirects instead of following them after SSRF validation', async () => {
-      (global.fetch as jest.Mock).mockResolvedValue({
+    it('should follow public redirects after validating each RSS feed URL', async () => {
+      const rssXml = `<rss><channel>
+        <title>Redirected Feed</title>
+        <item><title>Article 1</title><description>Desc</description></item>
+      </channel></rss>`;
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 301,
+          headers: new Map([['location', 'https://feeds.example.com/rss']]),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: new Map([['content-length', '0']]),
+          text: async () => rssXml,
+        });
+
+      const result = await controller.getRssFeed('https://example.com/rss', '10');
+
+      expect(result.feedTitle).toBe('Redirected Feed');
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        1,
+        'https://example.com/rss',
+        expect.objectContaining({ redirect: 'manual' }),
+      );
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        2,
+        'https://feeds.example.com/rss',
+        expect.objectContaining({ redirect: 'manual' }),
+      );
+    });
+
+    it('should reject private redirect targets before fetching them', async () => {
+      (lookup as jest.Mock)
+        .mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }])
+        .mockResolvedValueOnce([{ address: '127.0.0.1', family: 4 }]);
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
         ok: false,
         status: 302,
         headers: new Map([['location', 'http://127.0.0.1/rss']]),
@@ -477,12 +515,13 @@ describe('WidgetsController', () => {
 
       await expect(
         controller.getRssFeed('https://example.com/rss', '10'),
-      ).rejects.toThrow('RSS feed redirects are not allowed');
+      ).rejects.toThrow('url points to a blocked address');
 
       expect(global.fetch).toHaveBeenCalledWith(
         'https://example.com/rss',
         expect.objectContaining({ redirect: 'manual' }),
       );
+      expect(global.fetch).toHaveBeenCalledTimes(1);
     });
 
     it('should throw NotFoundException on network error', async () => {

--- a/middleware/src/modules/content/controllers/widgets.controller.ts
+++ b/middleware/src/modules/content/controllers/widgets.controller.ts
@@ -21,7 +21,7 @@ import { CreateWidgetDto } from '../dto/create-widget.dto';
 import { PaginationDto } from '../../common/dto/pagination.dto';
 import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 import { parseRssFeed, extractFeedTitle } from '../rss-parser';
-import { assertUrlIsPublic, SsrfError } from '../../common/utils/ssrf-guard';
+import { fetchWithSsrfGuard, SsrfError } from '../../common/utils/ssrf-guard';
 
 /** Maximum response body size from Google Sheets (2 MB). */
 const MAX_SHEET_RESPONSE_BYTES = 2 * 1024 * 1024;
@@ -180,30 +180,22 @@ export class WidgetsController {
       throw new BadRequestException('Only http/https URLs are supported');
     }
 
-    try {
-      await assertUrlIsPublic(feedUrl, { allowHttp: true });
-    } catch (error) {
-      if (error instanceof SsrfError) {
-        throw new BadRequestException(error.message);
-      }
-      throw error;
-    }
-
     const parsedLimit = Math.min(Math.max(parseInt(limit, 10) || 10, 1), 50);
 
     let response: Response;
     try {
-      response = await fetch(feedUrl, {
+      response = await fetchWithSsrfGuard(feedUrl, {
         signal: AbortSignal.timeout(10000),
-        redirect: 'manual',
         headers: { 'User-Agent': 'Vizora/1.0 Digital Signage RSS Reader' },
+      }, {
+        allowHttp: true,
+        maxRedirects: 3,
       });
     } catch (err: any) {
+      if (err instanceof SsrfError) {
+        throw new BadRequestException(err.message);
+      }
       throw new NotFoundException(`Failed to fetch RSS feed: ${err.message || 'timeout or network error'}`);
-    }
-
-    if (response.status >= 300 && response.status < 400) {
-      throw new BadRequestException('RSS feed redirects are not allowed');
     }
 
     if (!response.ok) {

--- a/middleware/src/modules/content/controllers/widgets.controller.ts
+++ b/middleware/src/modules/content/controllers/widgets.controller.ts
@@ -21,6 +21,7 @@ import { CreateWidgetDto } from '../dto/create-widget.dto';
 import { PaginationDto } from '../../common/dto/pagination.dto';
 import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 import { parseRssFeed, extractFeedTitle } from '../rss-parser';
+import { assertUrlIsPublic, SsrfError } from '../../common/utils/ssrf-guard';
 
 /** Maximum response body size from Google Sheets (2 MB). */
 const MAX_SHEET_RESPONSE_BYTES = 2 * 1024 * 1024;
@@ -179,23 +180,13 @@ export class WidgetsController {
       throw new BadRequestException('Only http/https URLs are supported');
     }
 
-    // Block private/reserved IP ranges (SSRF prevention)
-    const { hostname } = parsed;
-    const blockedPatterns = [
-      /^localhost$/i,
-      /^127\./,
-      /^10\./,
-      /^172\.(1[6-9]|2\d|3[01])\./,
-      /^192\.168\./,
-      /^169\.254\./,
-      /^0\./,
-      /^\[::1\]/,
-      /^\[fc/i,
-      /^\[fd/i,
-      /^\[fe80/i,
-    ];
-    if (blockedPatterns.some(p => p.test(hostname))) {
-      throw new BadRequestException('Private or reserved IP addresses are not allowed');
+    try {
+      await assertUrlIsPublic(feedUrl, { allowHttp: true });
+    } catch (error) {
+      if (error instanceof SsrfError) {
+        throw new BadRequestException(error.message);
+      }
+      throw error;
     }
 
     const parsedLimit = Math.min(Math.max(parseInt(limit, 10) || 10, 1), 50);
@@ -204,10 +195,15 @@ export class WidgetsController {
     try {
       response = await fetch(feedUrl, {
         signal: AbortSignal.timeout(10000),
+        redirect: 'manual',
         headers: { 'User-Agent': 'Vizora/1.0 Digital Signage RSS Reader' },
       });
     } catch (err: any) {
       throw new NotFoundException(`Failed to fetch RSS feed: ${err.message || 'timeout or network error'}`);
+    }
+
+    if (response.status >= 300 && response.status < 400) {
+      throw new BadRequestException('RSS feed redirects are not allowed');
     }
 
     if (!response.ok) {

--- a/middleware/src/modules/content/template-rendering.service.spec.ts
+++ b/middleware/src/modules/content/template-rendering.service.spec.ts
@@ -531,7 +531,7 @@ describe('TemplateRenderingService', () => {
       expect(mockCircuitBreaker.executeWithFallback).not.toHaveBeenCalled();
     });
 
-    it('should reject redirects instead of following them after SSRF validation', async () => {
+    it('should follow public redirects after validating each data-source URL', async () => {
       mockCircuitBreaker.executeWithFallback.mockImplementation(async (_name, fn, fallback) => {
         try {
           return await fn();
@@ -539,11 +539,56 @@ describe('TemplateRenderingService', () => {
           return fallback(error as Error);
         }
       });
+      const redirectedData = { items: [{ name: 'Redirected Item' }] };
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 302,
+          statusText: 'Found',
+          headers: { get: jest.fn((name: string) => (name.toLowerCase() === 'location' ? 'https://api.example.com/final' : null)) },
+          json: jest.fn(),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          headers: { get: jest.fn() },
+          json: jest.fn().mockResolvedValue(redirectedData),
+        });
+      const dataSource: DataSourceDto = {
+        type: 'rest_api',
+        url: 'https://api.example.com/data',
+      };
+
+      await expect(service.fetchDataFromSource(dataSource)).resolves.toEqual(redirectedData);
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        1,
+        'https://api.example.com/data',
+        expect.objectContaining({ redirect: 'manual' }),
+      );
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        'https://api.example.com/final',
+        expect.objectContaining({ redirect: 'manual' }),
+      );
+    });
+
+    it('should reject private redirect targets before fetching them', async () => {
+      mockCircuitBreaker.executeWithFallback.mockImplementation(async (_name, fn, fallback) => {
+        try {
+          return await fn();
+        } catch (error) {
+          return fallback(error as Error);
+        }
+      });
+      (lookup as jest.Mock)
+        .mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }])
+        .mockResolvedValueOnce([{ address: '169.254.169.254', family: 4 }]);
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 302,
         statusText: 'Found',
-        headers: { get: jest.fn().mockReturnValue('http://169.254.169.254/latest') },
+        headers: { get: jest.fn((name: string) => (name.toLowerCase() === 'location' ? 'http://169.254.169.254/latest' : null)) },
         json: jest.fn(),
       });
       const dataSource: DataSourceDto = {
@@ -552,12 +597,9 @@ describe('TemplateRenderingService', () => {
       };
 
       await expect(service.fetchDataFromSource(dataSource)).rejects.toThrow(
-        'Template data source redirects are not allowed',
+        'url points to a blocked address',
       );
-      expect(mockFetch).toHaveBeenCalledWith(
-        'https://api.example.com/data',
-        expect.objectContaining({ redirect: 'manual' }),
-      );
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
     it('should fetch data from external URL using circuit breaker', async () => {

--- a/middleware/src/modules/content/template-rendering.service.spec.ts
+++ b/middleware/src/modules/content/template-rendering.service.spec.ts
@@ -532,7 +532,13 @@ describe('TemplateRenderingService', () => {
     });
 
     it('should reject redirects instead of following them after SSRF validation', async () => {
-      mockCircuitBreaker.executeWithFallback.mockImplementation(async (_name, fn) => fn());
+      mockCircuitBreaker.executeWithFallback.mockImplementation(async (_name, fn, fallback) => {
+        try {
+          return await fn();
+        } catch (error) {
+          return fallback(error as Error);
+        }
+      });
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 302,

--- a/middleware/src/modules/content/template-rendering.service.spec.ts
+++ b/middleware/src/modules/content/template-rendering.service.spec.ts
@@ -13,11 +13,16 @@ jest.mock('isomorphic-dompurify', () => ({
   },
 }));
 
+jest.mock('dns/promises', () => ({
+  lookup: jest.fn().mockResolvedValue([{ address: '93.184.216.34', family: 4 }]),
+}));
+
 // Import after mocking
 import * as fs from 'fs';
 import * as path from 'path';
 import { TemplateRenderingService } from './template-rendering.service';
 import { GenericApiDataSource } from './widget-data-sources/generic-api.data-source';
+import { lookup } from 'dns/promises';
 
 // Mock fetch globally
 const mockFetch = jest.fn();
@@ -510,6 +515,42 @@ describe('TemplateRenderingService', () => {
 
       await expect(service.fetchDataFromSource(dataSource)).rejects.toThrow(
         'Cloud metadata endpoints are not allowed',
+      );
+    });
+
+    it('should block hostnames that resolve to private IP addresses', async () => {
+      (lookup as jest.Mock).mockResolvedValueOnce([{ address: '127.0.0.1', family: 4 }]);
+      const dataSource: DataSourceDto = {
+        type: 'rest_api',
+        url: 'https://public-looking.example/data',
+      };
+
+      await expect(service.fetchDataFromSource(dataSource)).rejects.toThrow(
+        'url points to a blocked address',
+      );
+      expect(mockCircuitBreaker.executeWithFallback).not.toHaveBeenCalled();
+    });
+
+    it('should reject redirects instead of following them after SSRF validation', async () => {
+      mockCircuitBreaker.executeWithFallback.mockImplementation(async (_name, fn) => fn());
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 302,
+        statusText: 'Found',
+        headers: { get: jest.fn().mockReturnValue('http://169.254.169.254/latest') },
+        json: jest.fn(),
+      });
+      const dataSource: DataSourceDto = {
+        type: 'rest_api',
+        url: 'https://api.example.com/data',
+      };
+
+      await expect(service.fetchDataFromSource(dataSource)).rejects.toThrow(
+        'Template data source redirects are not allowed',
+      );
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.example.com/data',
+        expect.objectContaining({ redirect: 'manual' }),
       );
     });
 

--- a/middleware/src/modules/content/template-rendering.service.spec.ts
+++ b/middleware/src/modules/content/template-rendering.service.spec.ts
@@ -545,7 +545,7 @@ describe('TemplateRenderingService', () => {
           ok: false,
           status: 302,
           statusText: 'Found',
-          headers: { get: jest.fn((name: string) => (name.toLowerCase() === 'location' ? 'https://api.example.com/final' : null)) },
+          headers: { get: jest.fn((name: string) => (name.toLowerCase() === 'location' ? 'https://api2.example.com/final' : null)) },
           json: jest.fn(),
         })
         .mockResolvedValueOnce({
@@ -558,6 +558,9 @@ describe('TemplateRenderingService', () => {
       const dataSource: DataSourceDto = {
         type: 'rest_api',
         url: 'https://api.example.com/data',
+        headers: {
+          'X-Api-Key': 'secret-value',
+        },
       };
 
       await expect(service.fetchDataFromSource(dataSource)).resolves.toEqual(redirectedData);
@@ -568,8 +571,14 @@ describe('TemplateRenderingService', () => {
       );
       expect(mockFetch).toHaveBeenNthCalledWith(
         2,
-        'https://api.example.com/final',
-        expect.objectContaining({ redirect: 'manual' }),
+        'https://api2.example.com/final',
+        expect.objectContaining({
+          redirect: 'manual',
+          headers: {
+            accept: 'application/json',
+            'user-agent': 'Vizora-Template-Service/1.0',
+          },
+        }),
       );
     });
 
@@ -600,6 +609,39 @@ describe('TemplateRenderingService', () => {
         'url points to a blocked address',
       );
       expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reject HTTPS-to-HTTP redirects in production', async () => {
+      const originalNodeEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+      mockCircuitBreaker.executeWithFallback.mockImplementation(async (_name, fn, fallback) => {
+        try {
+          return await fn();
+        } catch (error) {
+          return fallback(error as Error);
+        }
+      });
+      (lookup as jest.Mock).mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }]);
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 302,
+        statusText: 'Found',
+        headers: { get: jest.fn((name: string) => (name.toLowerCase() === 'location' ? 'http://api.example.com/final' : null)) },
+        json: jest.fn(),
+      });
+      const dataSource: DataSourceDto = {
+        type: 'rest_api',
+        url: 'https://api.example.com/data',
+      };
+
+      try {
+        await expect(service.fetchDataFromSource(dataSource)).rejects.toThrow(
+          'url must use HTTPS',
+        );
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      } finally {
+        process.env.NODE_ENV = originalNodeEnv;
+      }
     });
 
     it('should fetch data from external URL using circuit breaker', async () => {

--- a/middleware/src/modules/content/template-rendering.service.ts
+++ b/middleware/src/modules/content/template-rendering.service.ts
@@ -3,6 +3,7 @@ import * as Handlebars from 'handlebars';
 import DOMPurify from 'isomorphic-dompurify';
 import { CircuitBreakerService } from '../common/services/circuit-breaker.service';
 import { DataSourceDto } from './dto/create-template.dto';
+import { assertUrlIsPublic, SsrfError } from '../common/utils/ssrf-guard';
 
 /**
  * Result of template validation
@@ -246,7 +247,7 @@ export class TemplateRenderingService {
     }
 
     // Block private/internal IPs
-    this.validateExternalUrl(dataSource.url);
+    await this.validateExternalUrl(dataSource.url);
 
     const circuitName = `template-data-${url.hostname}`;
 
@@ -275,8 +276,13 @@ export class TemplateRenderingService {
                 'User-Agent': 'Vizora-Template-Service/1.0',
                 ...safeHeaders,
               },
+              redirect: 'manual',
               signal: controller.signal,
             });
+
+            if (response.status >= 300 && response.status < 400) {
+              throw new Error('Template data source redirects are not allowed');
+            }
 
             if (!response.ok) {
               throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -338,7 +344,7 @@ export class TemplateRenderingService {
   /**
    * Validate URL is not pointing to internal/private resources
    */
-  private validateExternalUrl(urlString: string): void {
+  private async validateExternalUrl(urlString: string): Promise<void> {
     const url = new URL(urlString);
     const hostname = url.hostname.toLowerCase();
 
@@ -386,6 +392,15 @@ export class TemplateRenderingService {
 
     if (metadataHostnames.includes(hostname)) {
       throw new BadRequestException('Cloud metadata endpoints are not allowed');
+    }
+
+    try {
+      await assertUrlIsPublic(urlString, { allowHttp: true });
+    } catch (error) {
+      if (error instanceof SsrfError) {
+        throw new BadRequestException(error.message);
+      }
+      throw error;
     }
   }
 

--- a/middleware/src/modules/content/template-rendering.service.ts
+++ b/middleware/src/modules/content/template-rendering.service.ts
@@ -295,6 +295,9 @@ export class TemplateRenderingService {
           }
         },
         (error) => {
+          if (error?.message === 'Template data source redirects are not allowed') {
+            throw error;
+          }
           this.logger.warn(`Data source fetch failed, using empty data: ${error?.message}`);
           return {};
         },

--- a/middleware/src/modules/content/template-rendering.service.ts
+++ b/middleware/src/modules/content/template-rendering.service.ts
@@ -3,7 +3,7 @@ import * as Handlebars from 'handlebars';
 import DOMPurify from 'isomorphic-dompurify';
 import { CircuitBreakerService } from '../common/services/circuit-breaker.service';
 import { DataSourceDto } from './dto/create-template.dto';
-import { assertUrlIsPublic, SsrfError } from '../common/utils/ssrf-guard';
+import { assertUrlIsPublic, fetchWithSsrfGuard, SsrfError } from '../common/utils/ssrf-guard';
 
 /**
  * Result of template validation
@@ -269,20 +269,19 @@ export class TemplateRenderingService {
                 )
               : {};
 
-            const response = await fetch(dataSource.url!, {
+            const response = await fetchWithSsrfGuard(dataSource.url!, {
               method: dataSource.method || 'GET',
               headers: {
                 'Accept': 'application/json',
                 'User-Agent': 'Vizora-Template-Service/1.0',
                 ...safeHeaders,
               },
-              redirect: 'manual',
               signal: controller.signal,
+            }, {
+              allowHttp: true,
+              maxRedirects: 3,
+              skipInitialValidation: true,
             });
-
-            if (response.status >= 300 && response.status < 400) {
-              throw new Error('Template data source redirects are not allowed');
-            }
 
             if (!response.ok) {
               throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -295,7 +294,7 @@ export class TemplateRenderingService {
           }
         },
         (error) => {
-          if (error?.message === 'Template data source redirects are not allowed') {
+          if (error instanceof SsrfError) {
             throw error;
           }
           this.logger.warn(`Data source fetch failed, using empty data: ${error?.message}`);

--- a/middleware/src/modules/content/template-rendering.service.ts
+++ b/middleware/src/modules/content/template-rendering.service.ts
@@ -278,9 +278,10 @@ export class TemplateRenderingService {
               },
               signal: controller.signal,
             }, {
-              allowHttp: true,
+              allowHttp: process.env.NODE_ENV !== 'production',
               maxRedirects: 3,
               skipInitialValidation: true,
+              dropHeadersOnCrossOriginRedirect: true,
             });
 
             if (!response.ok) {

--- a/middleware/src/modules/content/thumbnail.service.spec.ts
+++ b/middleware/src/modules/content/thumbnail.service.spec.ts
@@ -31,6 +31,7 @@ jest.mock('dns/promises', () => ({
 // Now import the service
 import { ThumbnailService } from './thumbnail.service';
 import sharp from 'sharp';
+import { lookup } from 'dns/promises';
 
 // Mock fetch
 global.fetch = jest.fn();
@@ -182,8 +183,42 @@ describe('ThumbnailService', () => {
       ).rejects.toThrow('Network error');
     });
 
-    it('should reject redirects instead of following them after SSRF validation', async () => {
-      (global.fetch as jest.Mock).mockResolvedValue({
+    it('should follow public redirects after validating each thumbnail URL', async () => {
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          status: 302,
+          headers: {
+            get: jest.fn((name: string) => (name.toLowerCase() === 'location' ? 'https://cdn.example.com/image.jpg' : null)),
+          },
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(100)),
+          headers: {
+            get: jest.fn().mockReturnValue('image/jpeg'),
+          },
+        });
+
+      const result = await service.generateThumbnailFromUrl(contentId, imageUrl);
+
+      expect(result).toBe(`/static/thumbnails/${contentId}.jpg`);
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        1,
+        imageUrl,
+        expect.objectContaining({ redirect: 'manual' }),
+      );
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        2,
+        'https://cdn.example.com/image.jpg',
+        expect.objectContaining({ redirect: 'manual' }),
+      );
+    });
+
+    it('should reject private redirect targets before fetching them', async () => {
+      (lookup as jest.Mock)
+        .mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }])
+        .mockResolvedValueOnce([{ address: '127.0.0.1', family: 4 }]);
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
         status: 302,
         headers: {
           get: jest.fn((name: string) => (name.toLowerCase() === 'location' ? 'http://127.0.0.1/image.jpg' : null)),
@@ -192,7 +227,8 @@ describe('ThumbnailService', () => {
 
       await expect(
         service.generateThumbnailFromUrl(contentId, imageUrl),
-      ).rejects.toThrow('Thumbnail source redirects are not allowed');
+      ).rejects.toThrow('url points to a blocked address');
+      expect(global.fetch).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/middleware/src/modules/content/thumbnail.service.spec.ts
+++ b/middleware/src/modules/content/thumbnail.service.spec.ts
@@ -24,6 +24,10 @@ jest.mock('fs', () => ({
   },
 }));
 
+jest.mock('dns/promises', () => ({
+  lookup: jest.fn().mockResolvedValue([{ address: '93.184.216.34', family: 4 }]),
+}));
+
 // Now import the service
 import { ThumbnailService } from './thumbnail.service';
 import sharp from 'sharp';
@@ -140,7 +144,7 @@ describe('ThumbnailService', () => {
     it('should fetch image from URL and generate thumbnail', async () => {
       const result = await service.generateThumbnailFromUrl(contentId, imageUrl);
 
-      expect(global.fetch).toHaveBeenCalledWith(imageUrl);
+      expect(global.fetch).toHaveBeenCalledWith(imageUrl, expect.objectContaining({ redirect: 'manual' }));
       expect(result).toBe(`/static/thumbnails/${contentId}.jpg`);
     });
 
@@ -176,6 +180,19 @@ describe('ThumbnailService', () => {
       await expect(
         service.generateThumbnailFromUrl(contentId, imageUrl),
       ).rejects.toThrow('Network error');
+    });
+
+    it('should reject redirects instead of following them after SSRF validation', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        status: 302,
+        headers: {
+          get: jest.fn((name: string) => (name.toLowerCase() === 'location' ? 'http://127.0.0.1/image.jpg' : null)),
+        },
+      });
+
+      await expect(
+        service.generateThumbnailFromUrl(contentId, imageUrl),
+      ).rejects.toThrow('Thumbnail source redirects are not allowed');
     });
   });
 

--- a/middleware/src/modules/content/thumbnail.service.ts
+++ b/middleware/src/modules/content/thumbnail.service.ts
@@ -3,6 +3,7 @@ import sharp from 'sharp';
 import { promises as fs } from 'fs';
 import { join } from 'path';
 import { lookup } from 'dns/promises';
+import { assertUrlIsPublic } from '../common/utils/ssrf-guard';
 
 @Injectable()
 export class ThumbnailService {
@@ -33,6 +34,8 @@ export class ThumbnailService {
    * Only allows http/https, blocks private IP ranges and internal hostnames.
    */
   private async validateUrl(imageUrl: string): Promise<void> {
+    await assertUrlIsPublic(imageUrl, { allowHttp: true });
+
     let parsed: URL;
     try {
       parsed = new URL(imageUrl);
@@ -187,7 +190,10 @@ export class ThumbnailService {
 
     try {
       // Fetch image from URL with streaming size check
-      const response = await fetch(imageUrl);
+      const response = await fetch(imageUrl, { redirect: 'manual' });
+      if (response.status >= 300 && response.status < 400) {
+        throw new Error('Thumbnail source redirects are not allowed');
+      }
       const contentLength = parseInt(response.headers.get('content-length') || '0', 10);
       if (contentLength > this.MAX_FILE_SIZE) {
         throw new Error('Image too large for thumbnail generation');

--- a/middleware/src/modules/content/thumbnail.service.ts
+++ b/middleware/src/modules/content/thumbnail.service.ts
@@ -2,7 +2,6 @@ import { Injectable, Logger } from '@nestjs/common';
 import sharp from 'sharp';
 import { promises as fs } from 'fs';
 import { join } from 'path';
-import { lookup } from 'dns/promises';
 import { assertUrlIsPublic } from '../common/utils/ssrf-guard';
 
 @Injectable()
@@ -11,19 +10,6 @@ export class ThumbnailService {
   private readonly THUMBNAIL_DIR = join(process.cwd(), 'static', 'thumbnails');
   private readonly MAX_SIZE = 300; // 300x300 max
   private readonly MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB limit
-
-  /** Blocked internal hostname patterns */
-  private readonly BLOCKED_HOSTNAMES = [
-    'localhost',
-    '0.0.0.0',
-  ];
-
-  /** Blocked hostname suffix patterns (e.g. *.internal, *.local) */
-  private readonly BLOCKED_HOSTNAME_SUFFIXES = [
-    '.internal',
-    '.local',
-    '.localhost',
-  ];
 
   constructor() {
     this.ensureThumbnailDir();
@@ -35,91 +21,6 @@ export class ThumbnailService {
    */
   private async validateUrl(imageUrl: string): Promise<void> {
     await assertUrlIsPublic(imageUrl, { allowHttp: true });
-
-    let parsed: URL;
-    try {
-      parsed = new URL(imageUrl);
-    } catch {
-      throw new Error(`Invalid URL: ${imageUrl}`);
-    }
-
-    // Only allow http and https schemes
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-      throw new Error(`Disallowed URL scheme: ${parsed.protocol}`);
-    }
-
-    const hostname = parsed.hostname.toLowerCase();
-
-    // Block known internal hostnames
-    if (this.BLOCKED_HOSTNAMES.includes(hostname)) {
-      throw new Error(`Blocked internal hostname: ${hostname}`);
-    }
-
-    // Block internal hostname suffixes
-    for (const suffix of this.BLOCKED_HOSTNAME_SUFFIXES) {
-      if (hostname.endsWith(suffix)) {
-        throw new Error(`Blocked internal hostname: ${hostname}`);
-      }
-    }
-
-    // Resolve hostname and check for private IP ranges
-    try {
-      const result = await lookup(hostname, { all: true });
-      const addresses = Array.isArray(result) ? result : [result];
-
-      for (const entry of addresses) {
-        const ip = entry.address;
-        if (this.isPrivateIp(ip)) {
-          throw new Error(`URL resolves to private IP address: ${ip}`);
-        }
-      }
-    } catch (error) {
-      if (error instanceof Error && error.message.startsWith('URL resolves to')) {
-        throw error;
-      }
-      if (error instanceof Error && error.message.startsWith('Blocked internal')) {
-        throw error;
-      }
-      // DNS resolution failure — block the request
-      throw new Error(`Failed to resolve hostname: ${hostname}`);
-    }
-  }
-
-  /**
-   * Check if an IP address is in a private/reserved range.
-   */
-  private isPrivateIp(ip: string): boolean {
-    // IPv6 loopback
-    if (ip === '::1') return true;
-
-    // IPv6 private range fc00::/7
-    if (ip.toLowerCase().startsWith('fc') || ip.toLowerCase().startsWith('fd')) {
-      return true;
-    }
-
-    // IPv4 checks
-    const parts = ip.split('.').map(Number);
-    if (parts.length !== 4 || parts.some(p => isNaN(p))) {
-      // Not a valid IPv4 — may be IPv6; conservatively allow
-      return false;
-    }
-
-    const [a, b] = parts;
-
-    // 127.0.0.0/8 (loopback)
-    if (a === 127) return true;
-    // 10.0.0.0/8 (private)
-    if (a === 10) return true;
-    // 172.16.0.0/12 (private)
-    if (a === 172 && b >= 16 && b <= 31) return true;
-    // 192.168.0.0/16 (private)
-    if (a === 192 && b === 168) return true;
-    // 169.254.0.0/16 (link-local)
-    if (a === 169 && b === 254) return true;
-    // 0.0.0.0
-    if (a === 0 && b === 0 && parts[2] === 0 && parts[3] === 0) return true;
-
-    return false;
   }
 
   private async ensureThumbnailDir() {

--- a/middleware/src/modules/content/thumbnail.service.ts
+++ b/middleware/src/modules/content/thumbnail.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import sharp from 'sharp';
 import { promises as fs } from 'fs';
 import { join } from 'path';
-import { assertUrlIsPublic } from '../common/utils/ssrf-guard';
+import { assertUrlIsPublic, fetchWithSsrfGuard } from '../common/utils/ssrf-guard';
 
 @Injectable()
 export class ThumbnailService {
@@ -91,10 +91,11 @@ export class ThumbnailService {
 
     try {
       // Fetch image from URL with streaming size check
-      const response = await fetch(imageUrl, { redirect: 'manual' });
-      if (response.status >= 300 && response.status < 400) {
-        throw new Error('Thumbnail source redirects are not allowed');
-      }
+      const response = await fetchWithSsrfGuard(imageUrl, {}, {
+        allowHttp: true,
+        maxRedirects: 3,
+        skipInitialValidation: true,
+      });
       const contentLength = parseInt(response.headers.get('content-length') || '0', 10);
       if (contentLength > this.MAX_FILE_SIZE) {
         throw new Error('Image too large for thumbnail generation');

--- a/middleware/src/modules/displays/displays.service.bulk.spec.ts
+++ b/middleware/src/modules/displays/displays.service.bulk.spec.ts
@@ -69,6 +69,7 @@ describe('DisplaysService - Bulk Operations', () => {
   describe('bulkAssignPlaylist', () => {
     it('should assign playlist to multiple displays and notify realtime', async () => {
       mockDb.playlist.findFirst.mockResolvedValue({ id: 'p1', organizationId: 'org-1', items: [] });
+      mockDb.display.count.mockResolvedValue(2);
       mockDb.display.updateMany.mockResolvedValue({ count: 2 });
 
       const result = await service.bulkAssignPlaylist('org-1', ['d1', 'd2'], 'p1');
@@ -87,11 +88,25 @@ describe('DisplaysService - Bulk Operations', () => {
         service.bulkAssignPlaylist('org-1', ['d1'], 'bad-playlist')
       ).rejects.toThrow(NotFoundException);
     });
+
+    it('rejects mixed-organization display IDs before updating or notifying realtime', async () => {
+      mockDb.playlist.findFirst.mockResolvedValue({ id: 'p1', organizationId: 'org-1', items: [] });
+      mockDb.display.count.mockResolvedValue(1);
+      const notifySpy = jest.spyOn(service as any, 'notifyPlaylistUpdate').mockResolvedValue(undefined);
+
+      await expect(
+        service.bulkAssignPlaylist('org-1', ['d1', 'foreign-display'], 'p1')
+      ).rejects.toThrow(NotFoundException);
+
+      expect(mockDb.display.updateMany).not.toHaveBeenCalled();
+      expect(notifySpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('bulkAssignGroup', () => {
     it('should add displays to group', async () => {
       mockDb.displayGroup.findFirst.mockResolvedValue({ id: 'g1', organizationId: 'org-1' });
+      mockDb.display.count.mockResolvedValue(2);
       mockDb.displayGroupMember.createMany.mockResolvedValue({ count: 2 });
 
       const result = await service.bulkAssignGroup('org-1', ['d1', 'd2'], 'g1');
@@ -112,6 +127,17 @@ describe('DisplaysService - Bulk Operations', () => {
       await expect(
         service.bulkAssignGroup('org-1', ['d1'], 'bad-group')
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('rejects mixed-organization display IDs before creating group memberships', async () => {
+      mockDb.displayGroup.findFirst.mockResolvedValue({ id: 'g1', organizationId: 'org-1' });
+      mockDb.display.count.mockResolvedValue(1);
+
+      await expect(
+        service.bulkAssignGroup('org-1', ['d1', 'foreign-display'], 'g1')
+      ).rejects.toThrow(NotFoundException);
+
+      expect(mockDb.displayGroupMember.createMany).not.toHaveBeenCalled();
     });
   });
 });

--- a/middleware/src/modules/displays/displays.service.spec.ts
+++ b/middleware/src/modules/displays/displays.service.spec.ts
@@ -54,6 +54,9 @@ describe('DisplaysService', () => {
         delete: jest.fn(),
         deleteMany: jest.fn(),
       },
+      content: {
+        findFirst: jest.fn(),
+      },
     };
 
     const mockJwtService = {
@@ -792,6 +795,53 @@ describe('DisplaysService', () => {
       await service.resetStalePairingDevices();
 
       expect(databaseService.display.updateMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('pushContent', () => {
+    const mockContent = {
+      id: 'content-123',
+      name: 'Lunch Specials',
+      type: 'image',
+      url: 'minio://org/content.jpg',
+      thumbnail: 'https://example.com/thumb.jpg',
+      mimeType: 'image/jpeg',
+      duration: 10,
+      organizationId: mockOrganizationId,
+    };
+
+    beforeEach(() => {
+      databaseService.display.findFirst.mockResolvedValue(mockDisplay as any);
+      (databaseService as any).content.findFirst.mockResolvedValue(mockContent);
+    });
+
+    it('returns success when realtime accepts the content push', async () => {
+      httpService.post.mockReturnValue(
+        of({ data: { success: true, message: 'Content pushed to device' } } as any),
+      );
+
+      await expect(
+        service.pushContent(mockOrganizationId, mockDisplayId, mockContent.id, 5),
+      ).resolves.toEqual({ success: true, message: 'Content pushed to display' });
+    });
+
+    it('throws ServiceUnavailableException when realtime reports delivery failure', async () => {
+      httpService.post.mockReturnValue(
+        of({ data: { success: false, message: 'Content push failed: no_sockets' } } as any),
+      );
+
+      await expect(
+        service.pushContent(mockOrganizationId, mockDisplayId, mockContent.id, 5),
+      ).rejects.toThrow(ServiceUnavailableException);
+    });
+
+    it('throws ServiceUnavailableException when internal realtime auth is not configured', async () => {
+      delete process.env.INTERNAL_API_SECRET;
+
+      await expect(
+        service.pushContent(mockOrganizationId, mockDisplayId, mockContent.id, 5),
+      ).rejects.toThrow(ServiceUnavailableException);
+      expect(httpService.post).not.toHaveBeenCalled();
     });
   });
 });

--- a/middleware/src/modules/displays/displays.service.spec.ts
+++ b/middleware/src/modules/displays/displays.service.spec.ts
@@ -5,7 +5,7 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { of } from 'rxjs';
 import { DisplaysService } from './displays.service';
 import { DatabaseService } from '../database/database.service';
-import { CircuitBreakerService } from '../common/services/circuit-breaker.service';
+import { CircuitBreakerService, CircuitState } from '../common/services/circuit-breaker.service';
 import { StorageService } from '../storage/storage.service';
 import {
   NotFoundException,
@@ -833,6 +833,36 @@ describe('DisplaysService', () => {
       await expect(
         service.pushContent(mockOrganizationId, mockDisplayId, mockContent.id, 5),
       ).rejects.toThrow(ServiceUnavailableException);
+    });
+
+    it('does not open the shared realtime circuit when realtime returns an application-level delivery failure', async () => {
+      const realCircuitBreaker = new CircuitBreakerService();
+      const serviceWithRealCircuit = new DisplaysService(
+        databaseService,
+        {} as any,
+        httpService,
+        realCircuitBreaker,
+        {
+          healthCheck: jest.fn(),
+          getSignedUrl: jest.fn(),
+          resolveUrl: jest.fn().mockImplementation((url) => url),
+        } as any,
+        { emit: jest.fn() } as any,
+      );
+
+      httpService.post.mockReturnValue(
+        of({ data: { success: false, message: 'Content push failed: no_sockets' } } as any),
+      );
+
+      for (let attempt = 0; attempt < 6; attempt++) {
+        await expect(
+          serviceWithRealCircuit.pushContent(mockOrganizationId, mockDisplayId, mockContent.id, 5),
+        ).rejects.toThrow(ServiceUnavailableException);
+      }
+
+      expect(realCircuitBreaker.getCircuitState('realtime-service')).toBe(CircuitState.CLOSED);
+      expect(realCircuitBreaker.getCircuitStats('realtime-service').recentFailures).toBe(0);
+      expect(httpService.post).toHaveBeenCalledTimes(6);
     });
 
     it('throws ServiceUnavailableException when internal realtime auth is not configured', async () => {

--- a/middleware/src/modules/displays/displays.service.ts
+++ b/middleware/src/modules/displays/displays.service.ts
@@ -537,7 +537,7 @@ export class DisplaysService {
     const url = `${this.realtimeUrl}/api/push/content`;
 
     // Use circuit breaker with fallback
-    await this.circuitBreaker.executeWithFallback(
+    const realtimeResult = await this.circuitBreaker.executeWithFallback(
       'realtime-service',
       async () => {
         const response = await firstValueFrom(
@@ -555,12 +555,8 @@ export class DisplaysService {
             duration,
           }, { headers }),
         );
-        if (response.data?.success === false) {
-          throw new ServiceUnavailableException(
-            response.data.message || 'Realtime service did not deliver content push',
-          );
-        }
         this.logger.log(`Pushed content ${contentId} to display ${displayId} for ${duration} min`);
+        return response.data as { success?: boolean; message?: string };
       },
       (error) => {
         if (error) {
@@ -577,6 +573,12 @@ export class DisplaysService {
       },
       REALTIME_CIRCUIT_CONFIG,
     );
+
+    if (realtimeResult?.success === false) {
+      throw new ServiceUnavailableException(
+        realtimeResult.message || 'Realtime service did not deliver content push',
+      );
+    }
 
     return { success: true, message: 'Content pushed to display' };
   }

--- a/middleware/src/modules/displays/displays.service.ts
+++ b/middleware/src/modules/displays/displays.service.ts
@@ -540,7 +540,7 @@ export class DisplaysService {
     await this.circuitBreaker.executeWithFallback(
       'realtime-service',
       async () => {
-        await firstValueFrom(
+        const response = await firstValueFrom(
           this.httpService.post(url, {
             deviceId: displayId,
             content: {
@@ -555,6 +555,11 @@ export class DisplaysService {
             duration,
           }, { headers }),
         );
+        if (response.data?.success === false) {
+          throw new ServiceUnavailableException(
+            response.data.message || 'Realtime service did not deliver content push',
+          );
+        }
         this.logger.log(`Pushed content ${contentId} to display ${displayId} for ${duration} min`);
       },
       (error) => {
@@ -587,6 +592,7 @@ export class DisplaysService {
   }
 
   async bulkAssignPlaylist(organizationId: string, displayIds: string[], playlistId: string) {
+    const uniqueDisplayIds = [...new Set(displayIds)];
     // Verify playlist belongs to org (include items for realtime notification)
     const playlist = await this.db.playlist.findFirst({
       where: { id: playlistId, organizationId },
@@ -602,16 +608,23 @@ export class DisplaysService {
       throw new NotFoundException('Playlist not found or does not belong to your organization');
     }
 
+    const validDisplayCount = await this.db.display.count({
+      where: { id: { in: uniqueDisplayIds }, organizationId },
+    });
+    if (validDisplayCount !== uniqueDisplayIds.length) {
+      throw new NotFoundException('One or more displays not found');
+    }
+
     const result = await this.db.display.updateMany({
       where: {
-        id: { in: displayIds },
+        id: { in: uniqueDisplayIds },
         organizationId,
       },
       data: { currentPlaylistId: playlistId },
     });
 
     // Notify each device via realtime gateway (fire-and-forget)
-    for (const displayId of displayIds) {
+    for (const displayId of uniqueDisplayIds) {
       this.notifyPlaylistUpdate(displayId, playlist).catch(error => {
         this.logger.error(`Failed to notify realtime for display ${displayId}: ${error.message}`);
       });
@@ -621,6 +634,7 @@ export class DisplaysService {
   }
 
   async bulkAssignGroup(organizationId: string, displayIds: string[], displayGroupId: string) {
+    const uniqueDisplayIds = [...new Set(displayIds)];
     // Verify group belongs to org
     const group = await this.db.displayGroup.findFirst({
       where: { id: displayGroupId, organizationId },
@@ -629,7 +643,14 @@ export class DisplaysService {
       throw new NotFoundException('Display group not found or does not belong to your organization');
     }
 
-    const members = displayIds.map(displayId => ({
+    const validDisplayCount = await this.db.display.count({
+      where: { id: { in: uniqueDisplayIds }, organizationId },
+    });
+    if (validDisplayCount !== uniqueDisplayIds.length) {
+      throw new NotFoundException('One or more displays not found');
+    }
+
+    const members = uniqueDisplayIds.map(displayId => ({
       displayId,
       displayGroupId,
     }));

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -40,10 +40,12 @@
 - [x] Green run: `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="billing|server-api|DisplayClient"` - pass, 7 suites / 81 tests.
 - [x] Review-fix run: `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="displays.service|widgets.controller|thumbnail.service|template-rendering.service"` - pass, 6 suites / 171 tests.
 - [x] Review-fix run: `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="billing|server-api|DisplayClient"` - pass, 7 suites / 83 tests.
+- [x] Redirect follow-up run: `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="ssrf-guard|widgets.controller|thumbnail.service|template-rendering.service|displays.service"` - pass, 7 suites / 218 tests.
 
 **Review gate**
 - [x] Security/tenant/SSRF reviewer: CLEAN for tenant checks and redirect SSRF guards.
 - [x] Customer/performance reviewer: initial findings fixed by keeping realtime `success:false` outside circuit-failure accounting, rethrowing template redirect policy errors from fallback, failing fast on malformed billing redirect responses, and consolidating thumbnail URL validation to the shared SSRF guard.
+- [x] Customer/performance post-fix reviewer found P2 customer breakage from blanket redirect rejection; fixed with bounded redirect following that validates every hop through the shared SSRF guard.
 - [ ] Post-fix re-review.
 
 ---

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -41,11 +41,13 @@
 - [x] Review-fix run: `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="displays.service|widgets.controller|thumbnail.service|template-rendering.service"` - pass, 6 suites / 171 tests.
 - [x] Review-fix run: `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="billing|server-api|DisplayClient"` - pass, 7 suites / 83 tests.
 - [x] Redirect follow-up run: `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="ssrf-guard|widgets.controller|thumbnail.service|template-rendering.service|displays.service"` - pass, 7 suites / 218 tests.
+- [x] Template redirect-secret follow-up run: `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="ssrf-guard|widgets.controller|thumbnail.service|template-rendering.service|displays.service"` - pass, 7 suites / 220 tests.
 
 **Review gate**
 - [x] Security/tenant/SSRF reviewer: CLEAN for tenant checks and redirect SSRF guards.
 - [x] Customer/performance reviewer: initial findings fixed by keeping realtime `success:false` outside circuit-failure accounting, rethrowing template redirect policy errors from fallback, failing fast on malformed billing redirect responses, and consolidating thumbnail URL validation to the shared SSRF guard.
 - [x] Customer/performance post-fix reviewer found P2 customer breakage from blanket redirect rejection; fixed with bounded redirect following that validates every hop through the shared SSRF guard.
+- [x] Security post-fix reviewer found P2 template redirect downgrade/header-leak risk; fixed by enforcing production HTTPS on redirected template URLs and dropping non-safe headers on cross-origin redirects.
 - [ ] Post-fix re-review.
 
 ---

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,8 +1,41 @@
 # Vizora - Task Tracker
 
-## In Progress: Device Token Current-Hash Enforcement (2026-05-31)
+## In Progress: Customer Contract, Security, and Performance Pass 6 (2026-05-31)
+
+**Branch:** `feat/customer-performance-review-6`
+
+**Why now:** PR #128 merged and CI is green, but deploy remains blocked by dirty/diverged prod-local work. The next repo-side slice should fix customer-visible contract failures and small performance/security defects that do not require secrets, customer credentials, live hardware, or production state mutation.
+
+**New primitives introduced:** none. Reuse the existing `ApiClient`, Next `serverFetch`, display push path, realtime push response contract, shared SSRF guard, and display Cache API preload path.
+
+**Hermes-first analysis:** not applicable; this pass does not add business-agent behavior, MCP tools, Hermes skills, AI provider calls, or spend paths.
+
+**Plan/design:** `docs/plans/2026-05-31-customer-contract-security-performance-pass-6.md`
+
+**Selected fix bundle**
+- [ ] Billing checkout/portal responses normalize backend `{ checkoutUrl }` / `{ portalUrl }` to web `{ url }`.
+- [ ] `serverFetch` reads `vizora_auth_token`, forwards auth correctly, and unwraps response envelopes.
+- [ ] Middleware display push-content surfaces realtime `success:false` as failure instead of returning false success.
+- [ ] RSS preview and URL-thumbnail fetches reject redirects after SSRF validation.
+- [ ] Display media preload uses authenticated `/device-content/...` URLs so cache warmup can actually succeed.
+- [ ] Run focused red/green tests.
+- [ ] Run multi-subagent review before broader tests.
+- [ ] Run broader affected tests/builds.
+- [ ] PR, CI, merge.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Analysis feed**
+- [x] Local drift check confirmed billing response mismatch, `serverFetch` cookie/envelope drift, push-content false success, RSS/thumbnail redirect gap, and unauthenticated display preload path still exist after PR #128.
+- [ ] Customer/dashboard subagent review returned and triaged.
+- [ ] Performance subagent review returned and triaged.
+- [ ] Security/reliability subagent review returned and triaged.
+
+---
+
+## Completed: Device Token Current-Hash Enforcement (2026-05-31)
 
 **Branch:** `feat/customer-performance-review-5`
+**PR / merge commit:** #128 / `48e6a229d8cb0557f304629c54ed1b605eba7e2d`
 
 **Why now:** PR #127 merged and CI is green, but deployment remains blocked by dirty/diverged prod-local work. A fresh realtime/display/code review found a P0 auth-boundary gap: signed display JWTs remain accepted after re-pairing or token rotation because middleware and realtime verify signature claims but do not compare the presented token to the current token hash stored on `Display.jwtToken`.
 
@@ -33,8 +66,8 @@
 - [x] Run focused verification.
 - [x] Run multi-subagent review before broad verification.
 - [x] Run broader affected tests/builds.
-- [ ] PR, CI, merge.
-- [ ] Re-check deployment gate; deploy only if prod checkout and runtime token state are safe.
+- [x] PR, CI, merge.
+- [x] Re-check deployment gate; deploy only if prod checkout and runtime token state are safe.
 
 **Runtime-state gate before deploy**
 - [x] Query prod display token-hash coverage: 15 displays total, 15 with `jwtToken`, 0 missing `jwtToken`, 15 active non-pairing, 0 active non-pairing missing `jwtToken`.
@@ -65,6 +98,13 @@
 - [x] Initial parallel `npx nx build @vizora/middleware` collided with simultaneous `@vizora/database:build` copying into `packages/database/dist/generated` on Windows (`EPIPE`, file in use). Serial rerun completed successfully.
 - [x] `npx nx build @vizora/middleware` - pass with existing webpack warnings.
 - [x] `git diff --check origin/main...HEAD` - pass.
+
+**Merge / CI / deployment gate**
+- [x] PR #128 merged after GitHub checks passed: lint, audit, test, build, security, and e2e.
+- [x] GitHub main after merge: `48e6a229d8cb0557f304629c54ed1b605eba7e2d`.
+- [x] Open PRs after merge: none.
+- [x] Production health probe returned `success: true`, database connected at `2026-05-31T14:28:38.620Z`.
+- [x] Production deploy remains blocked: `/opt/vizora/app` is dirty and diverged (`HEAD=bb76aa1838740bff5b58623dfef7a906d44f46a6`, `origin/main=48e6a229d8cb0557f304629c54ed1b605eba7e2d`, `ahead 17, behind 58`). Do not pull/reset/stash/restart services until prod-local work is reconciled.
 
 ---
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -22,8 +22,8 @@
 - [x] Display media preload uses authenticated `/device-content/...` URLs so cache warmup can actually succeed.
 - [x] Run focused red/green tests.
 - [x] Run multi-subagent review before broader tests.
-- [ ] Run post-fix re-review before broader tests.
-- [ ] Run broader affected tests/builds.
+- [x] Run post-fix re-review before broader tests.
+- [x] Run broader affected tests/builds.
 - [ ] PR, CI, merge.
 - [ ] Re-check deployment gate; deploy only if prod checkout is safe.
 
@@ -48,7 +48,17 @@
 - [x] Customer/performance reviewer: initial findings fixed by keeping realtime `success:false` outside circuit-failure accounting, rethrowing template redirect policy errors from fallback, failing fast on malformed billing redirect responses, and consolidating thumbnail URL validation to the shared SSRF guard.
 - [x] Customer/performance post-fix reviewer found P2 customer breakage from blanket redirect rejection; fixed with bounded redirect following that validates every hop through the shared SSRF guard.
 - [x] Security post-fix reviewer found P2 template redirect downgrade/header-leak risk; fixed by enforcing production HTTPS on redirected template URLs and dropping non-safe headers on cross-origin redirects.
-- [ ] Post-fix re-review.
+- [x] Post-fix security re-review: CLEAN. Residual risks: documented DNS lookup-to-fetch TOCTOU remains, and billing redirect URLs still trust middleware/provider responses.
+- [x] Post-fix customer/performance re-review: CLEAN. Residual risk: template APIs that require custom headers after cross-origin redirects must use the final URL directly or a same-origin redirect.
+
+**Broader verification**
+- [x] `pnpm --filter @vizora/middleware test -- --runInBand` - pass, 143 suites / 2813 tests.
+- [x] `pnpm --filter @vizora/web test -- --runInBand` - pass, 92 suites / 942 tests; existing React `act(...)`, jsdom navigation, and intentional negative-path console warnings remain.
+- [x] `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` - pass.
+- [x] `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` - pass.
+- [x] `npx nx build @vizora/middleware` - pass with existing webpack warnings.
+- [x] `NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 BACKEND_URL=http://localhost:3000 npx nx build @vizora/web` - pass with existing Next middleware/proxy deprecation and TS project-reference warnings.
+- [x] `git diff --check origin/main...HEAD` - pass.
 
 ---
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -13,22 +13,38 @@
 **Plan/design:** `docs/plans/2026-05-31-customer-contract-security-performance-pass-6.md`
 
 **Selected fix bundle**
-- [ ] Billing checkout/portal responses normalize backend `{ checkoutUrl }` / `{ portalUrl }` to web `{ url }`.
-- [ ] `serverFetch` reads `vizora_auth_token`, forwards auth correctly, and unwraps response envelopes.
-- [ ] Middleware display push-content surfaces realtime `success:false` as failure instead of returning false success.
-- [ ] RSS preview and URL-thumbnail fetches reject redirects after SSRF validation.
-- [ ] Display media preload uses authenticated `/device-content/...` URLs so cache warmup can actually succeed.
-- [ ] Run focused red/green tests.
-- [ ] Run multi-subagent review before broader tests.
+- [x] Billing checkout/portal responses normalize backend `{ checkoutUrl }` / `{ portalUrl }` to web `{ url }`.
+- [x] `serverFetch` reads `vizora_auth_token`, forwards auth correctly, and unwraps response envelopes.
+- [x] Middleware display push-content surfaces realtime `success:false` as failure instead of returning false success.
+- [x] Bulk playlist assignment rejects mixed-organization display IDs before DB update or realtime notification.
+- [x] Bulk group assignment rejects mixed-organization display IDs before membership creation.
+- [x] RSS preview, template data sources, and URL-thumbnail fetches reject redirects after SSRF validation.
+- [x] Display media preload uses authenticated `/device-content/...` URLs so cache warmup can actually succeed.
+- [x] Run focused red/green tests.
+- [x] Run multi-subagent review before broader tests.
+- [ ] Run post-fix re-review before broader tests.
 - [ ] Run broader affected tests/builds.
 - [ ] PR, CI, merge.
 - [ ] Re-check deployment gate; deploy only if prod checkout is safe.
 
 **Analysis feed**
 - [x] Local drift check confirmed billing response mismatch, `serverFetch` cookie/envelope drift, push-content false success, RSS/thumbnail redirect gap, and unauthenticated display preload path still exist after PR #128.
-- [ ] Customer/dashboard subagent review returned and triaged.
-- [ ] Performance subagent review returned and triaged.
-- [ ] Security/reliability subagent review returned and triaged.
+- [x] Customer/dashboard subagent review returned and triaged. In-scope: billing response drift. Deferred: pairing UX canonicalization, content rename `title`/`name`, overnight schedules, 403 handling, conflict warnings, storage estimates, proof-of-play UI, notification pagination.
+- [x] Performance subagent review returned and triaged. In-scope: authenticated display preload. Deferred: streaming upload/direct-to-storage design, dashboard summary endpoint, dashboard-only realtime rooms, media metadata cache, pairing-key index, summary list endpoints.
+- [x] Security/reliability subagent review returned and triaged. In-scope: cross-tenant bulk playlist/group assignment and template data-source SSRF redirect/DNS guard. Deferred: active schedule playback path and REST heartbeat ID contract.
+
+**Focused verification**
+- [x] Red run: `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="billing|server-api|DisplayClient"` failed on backend-shaped billing responses, missing `serverFetch` auth/envelope unwrap, and unauthenticated display preload.
+- [x] Red run: `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="displays.service|widgets.controller|thumbnail.service|template-rendering.service"` failed on push-content false success, mixed-org bulk operations, and redirect-following SSRF surfaces.
+- [x] Green run: `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="displays.service|widgets.controller|thumbnail.service|template-rendering.service"` - pass, 6 suites / 170 tests.
+- [x] Green run: `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="billing|server-api|DisplayClient"` - pass, 7 suites / 81 tests.
+- [x] Review-fix run: `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="displays.service|widgets.controller|thumbnail.service|template-rendering.service"` - pass, 6 suites / 171 tests.
+- [x] Review-fix run: `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="billing|server-api|DisplayClient"` - pass, 7 suites / 83 tests.
+
+**Review gate**
+- [x] Security/tenant/SSRF reviewer: CLEAN for tenant checks and redirect SSRF guards.
+- [x] Customer/performance reviewer: initial findings fixed by keeping realtime `success:false` outside circuit-failure accounting, rethrowing template redirect policy errors from fallback, failing fast on malformed billing redirect responses, and consolidating thumbnail URL validation to the shared SSRF guard.
+- [ ] Post-fix re-review.
 
 ---
 

--- a/web/src/app/display/DisplayClient.tsx
+++ b/web/src/app/display/DisplayClient.tsx
@@ -13,6 +13,31 @@ import { StatusBar } from './components/StatusBar';
 import { FullscreenButton } from './components/FullscreenButton';
 import { redactSensitiveUrl } from './lib/redact-sensitive-url';
 
+function authenticateDisplayContentUrl(url: string, token?: string): string {
+  if (!token || !url) return url;
+  try {
+    const baseOrigin = typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
+    const parsed = new URL(url, baseOrigin);
+    const apiOrigin = process.env.NEXT_PUBLIC_API_URL
+      ? new URL(process.env.NEXT_PUBLIC_API_URL).origin
+      : baseOrigin;
+    const isDeviceContentPath =
+      /^\/(?:api\/v1\/)?device-content\/[^/]+\/file$/.test(parsed.pathname);
+
+    if (!new Set([baseOrigin, apiOrigin]).has(parsed.origin) || !isDeviceContentPath) {
+      return url;
+    }
+
+    parsed.searchParams.set('token', token);
+    if (/^[a-z][a-z\d+\-.]*:/i.test(url)) {
+      return parsed.toString();
+    }
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return url;
+  }
+}
+
 export function DisplayClient() {
   const [state, setState] = useState<DisplayState>('LOADING');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -55,10 +80,10 @@ export function DisplayClient() {
     const urls = playlist.items
       .slice(0, 5)
       .filter((item) => item.content && (item.content.type === 'image' || item.content.type === 'video'))
-      .map((item) => item.content!.url)
+      .map((item) => authenticateDisplayContentUrl(item.content!.url, credentials?.deviceToken))
       .filter(Boolean);
     if (urls.length > 0) preloadItems(urls);
-  }, [player, preloadItems]);
+  }, [credentials?.deviceToken, player, preloadItems]);
 
   const handleCommand = useCallback((command: DeviceCommand) => {
     switch (command.type) {

--- a/web/src/app/display/__tests__/DisplayClient.test.tsx
+++ b/web/src/app/display/__tests__/DisplayClient.test.tsx
@@ -1,0 +1,111 @@
+import { render, waitFor } from '@testing-library/react';
+import { DisplayClient } from '../DisplayClient';
+import type { Playlist } from '../lib/types';
+
+const preloadItems = jest.fn();
+const updatePlaylist = jest.fn();
+let capturedPlaylistUpdate: ((playlist: Playlist) => void) | undefined;
+
+jest.mock('../hooks/useBrowserCache', () => ({
+  useBrowserCache: () => ({ preloadItems }),
+}));
+
+jest.mock('../hooks/usePairing', () => ({
+  usePairing: () => ({
+    pairingCode: null,
+    qrCode: null,
+    credentials: {
+      deviceToken: 'device-token-123',
+      deviceId: 'display-1',
+      organizationId: 'org-1',
+    },
+    isPairing: false,
+    error: null,
+    requestPairingCode: jest.fn(),
+    resetPairing: jest.fn(),
+    updateDeviceToken: jest.fn(),
+  }),
+  clearCredentials: jest.fn(),
+}));
+
+jest.mock('../hooks/useDeviceConnection', () => ({
+  useDeviceConnection: (options: any) => {
+    capturedPlaylistUpdate = options.onPlaylistUpdate;
+    return {
+      status: 'connected',
+      emitImpression: jest.fn(),
+      emitContentError: jest.fn(),
+    };
+  },
+}));
+
+jest.mock('../hooks/usePlaylistPlayer', () => ({
+  usePlaylistPlayer: () => ({
+    updatePlaylist,
+    pushContent: jest.fn(),
+    currentItem: null,
+    temporaryContent: null,
+    currentContentId: null,
+    handleVideoEnded: jest.fn(),
+  }),
+}));
+
+jest.mock('../hooks/useFullscreen', () => ({
+  useFullscreen: () => ({
+    isFullscreen: false,
+    toggleFullscreen: jest.fn(),
+  }),
+}));
+
+jest.mock('../components/ContentScreen', () => ({
+  ContentScreen: () => <div data-testid="content-screen" />,
+}));
+
+jest.mock('../components/StatusBar', () => ({
+  StatusBar: () => <div data-testid="status-bar" />,
+}));
+
+jest.mock('../components/FullscreenButton', () => ({
+  FullscreenButton: () => <button type="button">fullscreen</button>,
+}));
+
+describe('DisplayClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedPlaylistUpdate = undefined;
+    Object.defineProperty(window, 'location', {
+      value: new URL('https://display.example.test/display'),
+      writable: true,
+    });
+  });
+
+  it('preloads authenticated device-content URLs after playlist updates', async () => {
+    render(<DisplayClient />);
+
+    await waitFor(() => expect(capturedPlaylistUpdate).toBeDefined());
+
+    capturedPlaylistUpdate?.({
+      id: 'playlist-1',
+      name: 'Main',
+      items: [
+        {
+          id: 'item-1',
+          contentId: 'content-1',
+          duration: 10,
+          order: 0,
+          content: {
+            id: 'content-1',
+            name: 'Video',
+            type: 'video',
+            url: '/api/v1/device-content/content-1/file',
+          },
+        },
+      ],
+    });
+
+    expect(updatePlaylist).toHaveBeenCalled();
+    expect(preloadItems).toHaveBeenCalledWith([
+      '/api/v1/device-content/content-1/file?token=device-token-123',
+    ]);
+  });
+});

--- a/web/src/lib/__tests__/server-api.test.ts
+++ b/web/src/lib/__tests__/server-api.test.ts
@@ -1,0 +1,64 @@
+import { cookies } from 'next/headers';
+import { serverFetch } from '../server-api';
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(),
+}));
+
+describe('serverFetch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+    (cookies as jest.Mock).mockResolvedValue({
+      get: jest.fn((name: string) =>
+        name === 'vizora_auth_token' ? { value: 'server-cookie-token' } : undefined,
+      ),
+    });
+  });
+
+  it('forwards the httpOnly auth cookie to middleware during SSR', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, data: { ok: true } }),
+    });
+
+    await serverFetch('/admin/stats');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/admin/stats'),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer server-cookie-token',
+          Cookie: 'vizora_auth_token=server-cookie-token',
+        }),
+      }),
+    );
+  });
+
+  it('unwraps middleware response envelopes for server components', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: { data: [{ id: 'org-1' }], total: 1 },
+        meta: { requestId: 'req-1' },
+      }),
+    });
+
+    await expect(serverFetch('/admin/organizations')).resolves.toEqual({
+      data: [{ id: 'org-1' }],
+      total: 1,
+    });
+  });
+
+  it('includes backend error messages when SSR API calls fail', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+      json: async () => ({ message: 'Admins only' }),
+    });
+
+    await expect(serverFetch('/admin/stats')).rejects.toThrow('Admins only');
+  });
+});

--- a/web/src/lib/api/__tests__/billing.test.ts
+++ b/web/src/lib/api/__tests__/billing.test.ts
@@ -48,4 +48,38 @@ describe('billing api methods', () => {
       url: 'https://billing.stripe.com/session',
     });
   });
+
+  it('throws a clear error when checkout response has no redirect URL', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          sessionId: 'cs_test_123',
+        },
+      }),
+    });
+
+    const client = new ApiClient('/api/v1');
+
+    await expect(client.createCheckout('basic', 'monthly')).rejects.toThrow(
+      'Billing checkout response did not include a redirect URL',
+    );
+  });
+
+  it('throws a clear error when portal response has no redirect URL', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {},
+      }),
+    });
+
+    const client = new ApiClient('/api/v1');
+
+    await expect(client.getBillingPortalUrl('https://app.example.test/billing')).rejects.toThrow(
+      'Billing portal response did not include a redirect URL',
+    );
+  });
 });

--- a/web/src/lib/api/__tests__/billing.test.ts
+++ b/web/src/lib/api/__tests__/billing.test.ts
@@ -1,0 +1,51 @@
+import { ApiClient } from '../client';
+import '../billing';
+
+describe('billing api methods', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      value: 'vizora_csrf_token=test-csrf',
+    });
+    global.fetch = jest.fn();
+  });
+
+  it('normalizes checkoutUrl responses to the url property used by billing pages', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          checkoutUrl: 'https://checkout.stripe.com/session',
+          sessionId: 'cs_test_123',
+        },
+      }),
+    });
+
+    const client = new ApiClient('/api/v1');
+
+    await expect(client.createCheckout('basic', 'monthly')).resolves.toEqual({
+      url: 'https://checkout.stripe.com/session',
+      sessionId: 'cs_test_123',
+    });
+  });
+
+  it('normalizes portalUrl responses to the url property used by billing pages', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          portalUrl: 'https://billing.stripe.com/session',
+        },
+      }),
+    });
+
+    const client = new ApiClient('/api/v1');
+
+    await expect(client.getBillingPortalUrl('https://app.example.test/billing')).resolves.toEqual({
+      url: 'https://billing.stripe.com/session',
+    });
+  });
+});

--- a/web/src/lib/api/billing.ts
+++ b/web/src/lib/api/billing.ts
@@ -63,9 +63,13 @@ ApiClient.prototype.createCheckout = async function (planId: string, interval: '
     body: JSON.stringify({ planId, interval }),
   });
   const { checkoutUrl, ...rest } = response;
+  const url = response.url ?? checkoutUrl;
+  if (!url) {
+    throw new Error('Billing checkout response did not include a redirect URL');
+  }
   return {
     ...rest,
-    url: response.url ?? checkoutUrl ?? '',
+    url,
   };
 };
 
@@ -83,8 +87,12 @@ ApiClient.prototype.getBillingPortalUrl = async function (returnUrl: string): Pr
   const response = await this.request<BillingPortalResponse & { portalUrl?: string }>(
     `/billing/portal?returnUrl=${encodeURIComponent(returnUrl)}`,
   );
+  const url = response.url ?? response.portalUrl;
+  if (!url) {
+    throw new Error('Billing portal response did not include a redirect URL');
+  }
   return {
-    url: response.url ?? response.portalUrl ?? '',
+    url,
   };
 };
 

--- a/web/src/lib/api/billing.ts
+++ b/web/src/lib/api/billing.ts
@@ -58,10 +58,15 @@ ApiClient.prototype.getQuotaUsage = async function (): Promise<QuotaUsage> {
 };
 
 ApiClient.prototype.createCheckout = async function (planId: string, interval: 'monthly' | 'yearly'): Promise<CheckoutResponse> {
-  return this.request<CheckoutResponse>('/billing/checkout', {
+  const response = await this.request<CheckoutResponse & { checkoutUrl?: string }>('/billing/checkout', {
     method: 'POST',
     body: JSON.stringify({ planId, interval }),
   });
+  const { checkoutUrl, ...rest } = response;
+  return {
+    ...rest,
+    url: response.url ?? checkoutUrl ?? '',
+  };
 };
 
 ApiClient.prototype.cancelSubscription = async function (immediately = false): Promise<void> {
@@ -75,7 +80,12 @@ ApiClient.prototype.reactivateSubscription = async function (): Promise<void> {
 };
 
 ApiClient.prototype.getBillingPortalUrl = async function (returnUrl: string): Promise<BillingPortalResponse> {
-  return this.request<BillingPortalResponse>(`/billing/portal?returnUrl=${encodeURIComponent(returnUrl)}`);
+  const response = await this.request<BillingPortalResponse & { portalUrl?: string }>(
+    `/billing/portal?returnUrl=${encodeURIComponent(returnUrl)}`,
+  );
+  return {
+    url: response.url ?? response.portalUrl ?? '',
+  };
 };
 
 ApiClient.prototype.getInvoices = async function (limit?: number): Promise<Invoice[]> {

--- a/web/src/lib/server-api.ts
+++ b/web/src/lib/server-api.ts
@@ -4,21 +4,32 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000/a
 
 export async function serverFetch<T>(path: string, options?: RequestInit): Promise<T> {
   const cookieStore = await cookies();
-  const token = cookieStore.get('token')?.value;
+  const token = cookieStore.get('vizora_auth_token')?.value;
 
   const res = await fetch(`${API_BASE_URL}${path}`, {
     ...options,
     headers: {
       'Content-Type': 'application/json',
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(token ? { Cookie: `vizora_auth_token=${token}` } : {}),
       ...options?.headers,
     },
     cache: options?.cache || 'no-store',
   });
 
+  const body = await res.json().catch(() => null);
+
   if (!res.ok) {
-    throw new Error(`API error: ${res.status} ${res.statusText}`);
+    const message =
+      body && typeof body === 'object' && 'message' in body
+        ? String((body as { message: unknown }).message)
+        : `API error: ${res.status} ${res.statusText}`;
+    throw new Error(message);
   }
 
-  return res.json();
+  if (body && typeof body === 'object' && 'success' in body && 'data' in body) {
+    return (body as { data: T }).data;
+  }
+
+  return body as T;
 }


### PR DESCRIPTION
## Summary
- normalize billing checkout/portal redirect contracts and fail clearly when redirect URLs are missing
- fix Next serverFetch cookie/envelope handling and authenticated display media preload URLs
- surface realtime content-push delivery failures without poisoning the shared realtime circuit
- reject mixed-org bulk playlist/group display IDs before writes or realtime notifications
- add bounded SSRF-safe redirect following for RSS/template/thumbnail fetches, with production HTTPS and cross-origin header protections for template data sources

## Review gates
- Security/tenant/SSRF review: CLEAN after follow-ups
- Customer/performance review: CLEAN after follow-ups
- Residual risks: documented DNS lookup-to-fetch TOCTOU remains; billing redirect URLs still trust middleware/provider responses; template APIs needing custom headers after cross-origin redirects must use the final URL or same-origin redirect

## Verification
- `pnpm --filter @vizora/middleware test -- --runInBand` - pass, 143 suites / 2813 tests
- `pnpm --filter @vizora/web test -- --runInBand` - pass, 92 suites / 942 tests
- `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` - pass
- `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` - pass
- `npx nx build @vizora/middleware` - pass with existing webpack warnings
- `NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 BACKEND_URL=http://localhost:3000 npx nx build @vizora/web` - pass with existing Next warnings
- `git diff --check origin/main...HEAD` - pass