### PR TITLE
perf(middleware): cache device content streaming lookups

### DIFF
--- a/docs/plans/2026-05-31-device-content-streaming-performance-pass-7.md
+++ b/docs/plans/2026-05-31-device-content-streaming-performance-pass-7.md
@@ -1,0 +1,84 @@
+# Device Content Streaming Performance Pass 7
+
+## Context
+
+Customer display playback is a hot path. The current `GET /api/v1/device-content/:id/file`
+handler performs device-token verification, a display current-token DB lookup, a content DB
+lookup, and a MinIO metadata lookup on every full-object or byte-range request. Video playback
+typically emits clusters of range requests for the same token/content/object, so the path repeats
+auth and metadata work inside the same playback burst.
+
+Production deploy remains blocked by dirty/diverged prod-local work, so this pass is repo-side
+only until the deployment gate is safe.
+
+## New primitives introduced
+
+Small in-process TTL caches inside `DeviceContentController` only:
+
+- verified current device-token payload cache keyed by SHA-256 token hash
+- tenant-scoped content row cache keyed by `organizationId:contentId`
+- MinIO object metadata cache keyed by object key
+
+No schema, env vars, external cache, queue, storage topology, or parallel streaming substrate.
+
+## Hermes-first analysis
+
+Not applicable. This pass does not add business-agent behavior, MCP tools, Hermes skills,
+AI/provider calls, spend paths, or customer-lifecycle/support automation.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Device media streaming | none applicable | Use existing NestJS controller/storage path; Hermes is not in request serving. |
+| Middleware request caching | none applicable | Build locally as bounded in-process cache around existing controller calls. |
+
+Awesome-Hermes ecosystem check: no relevant runtime serving/cache primitive applies to this
+middleware hot path.
+
+## Design
+
+1. Keep the existing device JWT and tenant boundaries. The auth cache only stores a result after
+   `verifyCurrentDeviceToken` has validated signature, token shape, display org, disabled state,
+   and current stored token hash.
+2. Keep TTLs short to bound stale-token and stale-content exposure:
+   - device auth cache: 5 seconds, capped by JWT `exp` when present
+   - content row cache: 10 seconds
+   - object metadata cache: 10 seconds
+3. Keep MinIO availability checked on every request before opening a stream. Cached metadata must
+   not mask a storage outage.
+4. Do not cache misses or errors. Disabled/stale/missing tokens, missing content, missing metadata,
+   oversized files, and stream failures remain uncached.
+5. Keep successful full/range media responses `Cache-Control: private, no-store`. The media URL is
+   stable (`/device-content/:id/file?token=...`), so browser/device `max-age` could bypass server
+   auth and content checks after token rotation, display disable, or content replacement. Versioned
+   media URLs or validator-based 304 handling are deferred to a separate design.
+6. If a cached content row or cached object metadata leads to a pre-header MinIO stream-acquisition
+   failure, invalidate the relevant content/metadata cache entries and retry once with fresh DB and
+   metadata lookups. This prevents a normal file replacement from becoming a transient playback
+   failure when the old object was deleted after being cached.
+7. Add max-entry limits and opportunistic pruning so one process cannot grow caches without bound.
+
+## Verification plan
+
+- Add focused unit tests that first fail on repeated range requests doing duplicate auth/content/
+  metadata work.
+- Assert cache expiry rechecks the display token hash before accepting a rotated/stale token.
+- Assert successful full/range responses remain `private, no-store` and 416 remains `no-store`.
+- Assert stale cached object keys are invalidated and retried once before response headers are sent.
+- Add a concurrent same-token/same-content range-request test if the implementation includes
+  in-flight request coalescing.
+- Run focused middleware tests for `device-content.controller`.
+- Run at least two subagent reviews before broader tests.
+- Run broader middleware tests/build/typecheck if reviews are clean or after fixes.
+
+## Residual risks
+
+- A token revoked or display disabled immediately after a successful request may remain accepted by
+  that middleware worker for up to 5 seconds.
+- Content URL or object metadata replacement may remain stale for up to 10 seconds on the worker
+  that cached it, unless the old object disappears before stream acquisition, in which case the
+  controller retries after invalidating the cached row/metadata.
+- The route's authorization model remains the pre-existing org-scoped device-token model: a current
+  device token can request content by ID within its organization. This pass does not add playlist,
+  schedule, active-status, or assignment-level authorization.
+- Caches are per-process; this improves burst behavior without introducing cross-process coherence
+  or new infrastructure.

--- a/middleware/src/modules/content/content.service.spec.ts
+++ b/middleware/src/modules/content/content.service.spec.ts
@@ -252,6 +252,35 @@ describe('ContentService', () => {
     });
   });
 
+  describe('findByIdForDevice', () => {
+    it('selects only fields needed by the device file-serving path', async () => {
+      mockDatabaseService.content.findFirst.mockResolvedValue({
+        id: 'content-123',
+        organizationId: 'org-123',
+        url: 'minio://org-123/uploads/test.jpg',
+        mimeType: 'image/jpeg',
+      });
+
+      const result = await service.findByIdForDevice('content-123', 'org-123');
+
+      expect(result).toEqual({
+        id: 'content-123',
+        organizationId: 'org-123',
+        url: 'minio://org-123/uploads/test.jpg',
+        mimeType: 'image/jpeg',
+      });
+      expect(mockDatabaseService.content.findFirst).toHaveBeenCalledWith({
+        where: { id: 'content-123', organizationId: 'org-123' },
+        select: {
+          id: true,
+          organizationId: true,
+          url: true,
+          mimeType: true,
+        },
+      });
+    });
+  });
+
   describe('getResolvedLayout', () => {
     it('emits display-compatible resolvedPlaylist and resolvedContent zone fields', async () => {
       mockDatabaseService.content.findFirst.mockResolvedValue({

--- a/middleware/src/modules/content/content.service.ts
+++ b/middleware/src/modules/content/content.service.ts
@@ -206,6 +206,12 @@ export class ContentService {
   async findByIdForDevice(id: string, organizationId: string) {
     const content = await this.db.content.findFirst({
       where: { id, organizationId },
+      select: {
+        id: true,
+        organizationId: true,
+        url: true,
+        mimeType: true,
+      },
     });
     return content;
   }

--- a/middleware/src/modules/content/device-content.controller.spec.ts
+++ b/middleware/src/modules/content/device-content.controller.spec.ts
@@ -36,6 +36,16 @@ describe('DeviceContentController', () => {
   const hashToken = (token: string) =>
     createHash('sha256').update(token).digest('hex');
 
+  const createDeferred = <T>() => {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+  };
+
   const validDevicePayload = {
     sub: deviceId,
     deviceIdentifier: 'DEVICE-001',
@@ -91,6 +101,10 @@ describe('DeviceContentController', () => {
     }).compile();
 
     controller = module.get<DeviceContentController>(DeviceContentController);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('should be defined', () => {
@@ -167,6 +181,7 @@ describe('DeviceContentController', () => {
           'Content-Type': 'image/jpeg',
           'Accept-Ranges': 'bytes',
           'Content-Length': String(buffer.length),
+          'Cache-Control': 'private, no-store',
         }),
       );
       expect(mockStorageService.getObject).toHaveBeenCalledWith(objectKey);
@@ -473,6 +488,7 @@ describe('DeviceContentController', () => {
         expect.objectContaining({
           'Content-Length': '4',
           'Content-Range': 'bytes 5-8/12',
+          'Cache-Control': 'private, no-store',
         }),
       );
       expect(mockStorageService.getObjectRange).toHaveBeenCalledWith(
@@ -482,6 +498,347 @@ describe('DeviceContentController', () => {
       );
       expect(mockStorageService.getObject).not.toHaveBeenCalled();
       expect(res.getBody().toString()).toBe('rang');
+    });
+
+    it('should reuse auth, content, and object metadata during a range-request burst', async () => {
+      const now = 1_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+
+      const firstReq = createMockRequest('valid-device-token');
+      firstReq.headers.range = 'bytes=0-3';
+      const firstRes = createMockResponse();
+      const secondReq = createMockRequest('valid-device-token');
+      secondReq.headers.range = 'bytes=4-7';
+      const secondRes = createMockResponse();
+
+      mockJwtService.verify.mockReturnValue({
+        ...validDevicePayload,
+        exp: Math.floor((now + 60_000) / 1000),
+      } as any);
+      mockContentService.findByIdForDevice.mockResolvedValue(mockContent as any);
+      mockStorageService.getFileMetadata.mockResolvedValue({
+        size: 12,
+        lastModified: new Date('2026-05-31T00:00:00.000Z'),
+        contentType: 'image/jpeg',
+      });
+      mockStorageService.getObjectRange
+        .mockResolvedValueOnce(Readable.from(['abcd']))
+        .mockResolvedValueOnce(Readable.from(['efgh']));
+
+      await controller.serveFile(contentId, firstReq, firstRes);
+      await controller.serveFile(contentId, secondReq, secondRes);
+
+      expect(mockJwtService.verify).toHaveBeenCalledTimes(1);
+      expect(mockDatabaseService.display.findUnique).toHaveBeenCalledTimes(1);
+      expect(mockContentService.findByIdForDevice).toHaveBeenCalledTimes(1);
+      expect(mockStorageService.getFileMetadata).toHaveBeenCalledTimes(1);
+      expect(mockStorageService.getObjectRange).toHaveBeenCalledTimes(2);
+      expect(mockStorageService.getObjectRange).toHaveBeenNthCalledWith(1, objectKey, 0, 4);
+      expect(mockStorageService.getObjectRange).toHaveBeenNthCalledWith(2, objectKey, 4, 4);
+      expect(firstRes.getBody().toString()).toBe('abcd');
+      expect(secondRes.getBody().toString()).toBe('efgh');
+    });
+
+    it('should coalesce concurrent auth, content, and metadata loads during a range-request burst', async () => {
+      const now = 1_500_000;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+      const displayDeferred = createDeferred<any>();
+      const contentDeferred = createDeferred<any>();
+      const metadataDeferred = createDeferred<any>();
+
+      const firstReq = createMockRequest('valid-device-token');
+      firstReq.headers.range = 'bytes=0-3';
+      const firstRes = createMockResponse();
+      const secondReq = createMockRequest('valid-device-token');
+      secondReq.headers.range = 'bytes=4-7';
+      const secondRes = createMockResponse();
+
+      mockJwtService.verify.mockReturnValue(validDevicePayload);
+      mockDatabaseService.display.findUnique.mockReturnValue(displayDeferred.promise);
+      mockContentService.findByIdForDevice.mockReturnValue(contentDeferred.promise);
+      mockStorageService.getFileMetadata.mockReturnValue(metadataDeferred.promise);
+      mockStorageService.getObjectRange
+        .mockResolvedValueOnce(Readable.from(['abcd']))
+        .mockResolvedValueOnce(Readable.from(['efgh']));
+
+      const firstPromise = controller.serveFile(contentId, firstReq, firstRes);
+      const secondPromise = controller.serveFile(contentId, secondReq, secondRes);
+
+      await Promise.resolve();
+      expect(mockJwtService.verify).toHaveBeenCalledTimes(1);
+      expect(mockDatabaseService.display.findUnique).toHaveBeenCalledTimes(1);
+
+      displayDeferred.resolve({
+        id: deviceId,
+        organizationId,
+        isDisabled: false,
+        jwtToken: hashToken('valid-device-token'),
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(mockContentService.findByIdForDevice).toHaveBeenCalledTimes(1);
+
+      contentDeferred.resolve(mockContent);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(mockStorageService.getFileMetadata).toHaveBeenCalledTimes(1);
+
+      metadataDeferred.resolve({
+        size: 12,
+        lastModified: new Date('2026-05-31T00:00:00.000Z'),
+        contentType: 'image/jpeg',
+      });
+
+      await Promise.all([firstPromise, secondPromise]);
+
+      expect(mockStorageService.getObjectRange).toHaveBeenCalledTimes(2);
+      expect(mockStorageService.getObjectRange).toHaveBeenNthCalledWith(1, objectKey, 0, 4);
+      expect(mockStorageService.getObjectRange).toHaveBeenNthCalledWith(2, objectKey, 4, 4);
+      expect(firstRes.getBody().toString()).toBe('abcd');
+      expect(secondRes.getBody().toString()).toBe('efgh');
+    });
+
+    it('should recheck the current display token hash after the auth cache expires', async () => {
+      const now = 2_000_000;
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(now);
+      const req = createMockRequest('valid-device-token');
+      req.headers.range = 'bytes=0-3';
+      const firstRes = createMockResponse();
+      const secondRes = createMockResponse();
+
+      mockJwtService.verify.mockReturnValue(validDevicePayload);
+      mockDatabaseService.display.findUnique
+        .mockResolvedValueOnce({
+          id: deviceId,
+          organizationId,
+          isDisabled: false,
+          jwtToken: hashToken('valid-device-token'),
+        })
+        .mockResolvedValueOnce({
+          id: deviceId,
+          organizationId,
+          isDisabled: false,
+          jwtToken: hashToken('rotated-device-token'),
+        });
+      mockContentService.findByIdForDevice.mockResolvedValue(mockContent as any);
+      mockStorageService.getFileMetadata.mockResolvedValue({
+        size: 12,
+        lastModified: new Date('2026-05-31T00:00:00.000Z'),
+        contentType: 'image/jpeg',
+      });
+      mockStorageService.getObjectRange.mockResolvedValue(Readable.from(['abcd']));
+
+      await controller.serveFile(contentId, req, firstRes);
+
+      nowSpy.mockReturnValue(now + 5_001);
+      await expect(controller.serveFile(contentId, req, secondRes)).rejects.toThrow(
+        UnauthorizedException,
+      );
+
+      expect(mockJwtService.verify).toHaveBeenCalledTimes(2);
+      expect(mockDatabaseService.display.findUnique).toHaveBeenCalledTimes(2);
+      expect(mockStorageService.getObjectRange).toHaveBeenCalledTimes(1);
+    });
+
+    it('should invalidate cached content and metadata and retry once when a cached object key is stale', async () => {
+      const now = 3_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+
+      const firstReq = createMockRequest('valid-device-token');
+      firstReq.headers.range = 'bytes=0-3';
+      const firstRes = createMockResponse();
+      const secondReq = createMockRequest('valid-device-token');
+      secondReq.headers.range = 'bytes=0-2';
+      const secondRes = createMockResponse();
+      const replacementObjectKey = `${organizationId}/uploads/replacement-image.jpg`;
+
+      mockJwtService.verify.mockReturnValue(validDevicePayload);
+      mockContentService.findByIdForDevice
+        .mockResolvedValueOnce(mockContent as any)
+        .mockResolvedValueOnce({
+          ...mockContent,
+          url: `minio://${replacementObjectKey}`,
+        } as any);
+      mockStorageService.getFileMetadata
+        .mockResolvedValueOnce({
+          size: 12,
+          lastModified: new Date('2026-05-31T00:00:00.000Z'),
+          contentType: 'image/jpeg',
+        })
+        .mockResolvedValueOnce({
+          size: 9,
+          lastModified: new Date('2026-05-31T00:00:10.000Z'),
+          contentType: 'image/jpeg',
+        });
+      mockStorageService.getObjectRange
+        .mockResolvedValueOnce(Readable.from(['old!']))
+        .mockRejectedValueOnce(new Error('Not Found'))
+        .mockResolvedValueOnce(Readable.from(['new']));
+
+      await controller.serveFile(contentId, firstReq, firstRes);
+      await controller.serveFile(contentId, secondReq, secondRes);
+
+      expect(mockContentService.findByIdForDevice).toHaveBeenCalledTimes(2);
+      expect(mockStorageService.getFileMetadata).toHaveBeenCalledTimes(2);
+      expect(mockStorageService.getObjectRange).toHaveBeenNthCalledWith(1, objectKey, 0, 4);
+      expect(mockStorageService.getObjectRange).toHaveBeenNthCalledWith(2, objectKey, 0, 3);
+      expect(mockStorageService.getObjectRange).toHaveBeenNthCalledWith(3, replacementObjectKey, 0, 3);
+      expect(secondRes.status).toHaveBeenCalledWith(206);
+      expect(secondRes.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'Content-Length': '3',
+          'Content-Range': 'bytes 0-2/9',
+          'Cache-Control': 'private, no-store',
+        }),
+      );
+      expect(firstRes.getBody().toString()).toBe('old!');
+      expect(secondRes.getBody().toString()).toBe('new');
+    });
+
+    it('should let one stale cached object miss refresh a concurrent range burst', async () => {
+      const now = 3_500_000;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+
+      const firstReq = createMockRequest('valid-device-token');
+      firstReq.headers.range = 'bytes=0-3';
+      const firstRes = createMockResponse();
+      const secondReq = createMockRequest('valid-device-token');
+      secondReq.headers.range = 'bytes=0-2';
+      const secondRes = createMockResponse();
+      const thirdReq = createMockRequest('valid-device-token');
+      thirdReq.headers.range = 'bytes=3-5';
+      const thirdRes = createMockResponse();
+      const replacementObjectKey = `${organizationId}/uploads/replacement-image.jpg`;
+
+      mockJwtService.verify.mockReturnValue(validDevicePayload);
+      mockContentService.findByIdForDevice
+        .mockResolvedValueOnce(mockContent as any)
+        .mockResolvedValueOnce({
+          ...mockContent,
+          url: `minio://${replacementObjectKey}`,
+        } as any);
+      mockStorageService.getFileMetadata
+        .mockResolvedValueOnce({
+          size: 12,
+          lastModified: new Date('2026-05-31T00:00:00.000Z'),
+          contentType: 'image/jpeg',
+        })
+        .mockResolvedValueOnce({
+          size: 9,
+          lastModified: new Date('2026-05-31T00:00:10.000Z'),
+          contentType: 'image/jpeg',
+        });
+      mockStorageService.getObjectRange
+        .mockResolvedValueOnce(Readable.from(['old!']))
+        .mockRejectedValueOnce(new Error('Not Found'))
+        .mockResolvedValueOnce(Readable.from(['new']))
+        .mockResolvedValueOnce(Readable.from(['est']));
+
+      await controller.serveFile(contentId, firstReq, firstRes);
+      await Promise.all([
+        controller.serveFile(contentId, secondReq, secondRes),
+        controller.serveFile(contentId, thirdReq, thirdRes),
+      ]);
+
+      expect(mockContentService.findByIdForDevice).toHaveBeenCalledTimes(2);
+      expect(mockStorageService.getFileMetadata).toHaveBeenCalledTimes(2);
+      const oldObjectCalls = mockStorageService.getObjectRange.mock.calls.filter(
+        ([calledObjectKey]) => calledObjectKey === objectKey,
+      );
+      const replacementObjectCalls = mockStorageService.getObjectRange.mock.calls.filter(
+        ([calledObjectKey]) => calledObjectKey === replacementObjectKey,
+      );
+      expect(oldObjectCalls).toHaveLength(2);
+      expect(replacementObjectCalls).toHaveLength(2);
+      expect(secondRes.getBody().toString()).toBe('new');
+      expect(thirdRes.getBody().toString()).toBe('est');
+    });
+
+    it('should evict cached content and retry fresh when cached object metadata disappears', async () => {
+      const now = 3_750_000;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+
+      const firstReq = createMockRequest('valid-device-token');
+      firstReq.headers.range = 'bytes=0-2';
+      const firstRes = createMockResponse();
+      const secondReq = createMockRequest('valid-device-token');
+      secondReq.headers.range = 'bytes=0-2';
+      const secondRes = createMockResponse();
+      const replacementObjectKey = `${organizationId}/uploads/replacement-image.jpg`;
+
+      mockJwtService.verify.mockReturnValue(validDevicePayload);
+      mockContentService.findByIdForDevice
+        .mockResolvedValueOnce(mockContent as any)
+        .mockResolvedValueOnce({
+          ...mockContent,
+          url: `minio://${replacementObjectKey}`,
+        } as any);
+      mockStorageService.getFileMetadata
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          size: 9,
+          lastModified: new Date('2026-05-31T00:00:10.000Z'),
+          contentType: 'image/jpeg',
+        });
+      mockStorageService.getObjectRange.mockResolvedValueOnce(Readable.from(['new']));
+
+      await expect(controller.serveFile(contentId, firstReq, firstRes)).rejects.toThrow(
+        NotFoundException,
+      );
+      await controller.serveFile(contentId, secondReq, secondRes);
+
+      expect(mockContentService.findByIdForDevice).toHaveBeenCalledTimes(2);
+      expect(mockStorageService.getFileMetadata).toHaveBeenCalledTimes(2);
+      expect(mockStorageService.getObjectRange).toHaveBeenCalledWith(
+        replacementObjectKey,
+        0,
+        3,
+      );
+      expect(secondRes.getBody().toString()).toBe('new');
+    });
+
+    it('should retry in the same request when cached-row metadata is missing after a storage outage', async () => {
+      const now = 3_875_000;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+
+      const outageReq = createMockRequest('valid-device-token');
+      outageReq.headers.range = 'bytes=0-2';
+      const outageRes = createMockResponse();
+      const retryReq = createMockRequest('valid-device-token');
+      retryReq.headers.range = 'bytes=0-2';
+      const retryRes = createMockResponse();
+      const replacementObjectKey = `${organizationId}/uploads/replacement-image.jpg`;
+
+      mockJwtService.verify.mockReturnValue(validDevicePayload);
+      mockContentService.findByIdForDevice
+        .mockResolvedValueOnce(mockContent as any)
+        .mockResolvedValueOnce({
+          ...mockContent,
+          url: `minio://${replacementObjectKey}`,
+        } as any);
+      mockStorageService.isMinioAvailable
+        .mockReturnValueOnce(false)
+        .mockReturnValue(true);
+      mockStorageService.getFileMetadata
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          size: 9,
+          lastModified: new Date('2026-05-31T00:00:10.000Z'),
+          contentType: 'image/jpeg',
+        });
+      mockStorageService.getObjectRange.mockResolvedValueOnce(Readable.from(['new']));
+
+      await expect(controller.serveFile(contentId, outageReq, outageRes)).rejects.toThrow(
+        BadRequestException,
+      );
+      await controller.serveFile(contentId, retryReq, retryRes);
+
+      expect(mockContentService.findByIdForDevice).toHaveBeenCalledTimes(2);
+      expect(mockStorageService.getFileMetadata).toHaveBeenCalledTimes(2);
+      expect(mockStorageService.getObjectRange).toHaveBeenCalledWith(
+        replacementObjectKey,
+        0,
+        3,
+      );
+      expect(retryRes.getBody().toString()).toBe('new');
     });
 
     it('should serve suffix byte ranges', async () => {

--- a/middleware/src/modules/content/device-content.controller.ts
+++ b/middleware/src/modules/content/device-content.controller.ts
@@ -21,12 +21,64 @@ import { StorageService } from '../storage/storage.service';
 import { DatabaseService } from '../database/database.service';
 import { pipeline } from 'node:stream/promises';
 import {
+  DeviceJwtPayload,
   getDeviceTokenFromRequest,
+  hashDeviceToken,
   verifyCurrentDeviceToken,
 } from '../common/device-token-auth.util';
 
 const MINIO_URL_PREFIX = 'minio://';
 const MAX_DEVICE_CONTENT_FILE_SIZE = 100 * 1024 * 1024;
+const DEVICE_TOKEN_AUTH_CACHE_TTL_MS = 5_000;
+const DEVICE_CONTENT_CACHE_TTL_MS = 10_000;
+const DEVICE_OBJECT_METADATA_CACHE_TTL_MS = 10_000;
+const DEVICE_TOKEN_AUTH_CACHE_MAX_ENTRIES = 1_000;
+const DEVICE_CONTENT_CACHE_MAX_ENTRIES = 1_000;
+const DEVICE_OBJECT_METADATA_CACHE_MAX_ENTRIES = 1_000;
+const SUCCESSFUL_MEDIA_CACHE_CONTROL = 'private, no-store';
+
+type DeviceContentRecord = NonNullable<
+  Awaited<ReturnType<ContentService['findByIdForDevice']>>
+>;
+
+type ObjectMetadata = NonNullable<
+  Awaited<ReturnType<StorageService['getFileMetadata']>>
+>;
+
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+interface CachedDeviceAuth {
+  payload: DeviceJwtPayload;
+  tokenHash: string;
+}
+
+interface CachedLookup<T> {
+  value: T;
+  cacheHit: boolean;
+  cacheKey: string;
+}
+
+interface ResolvedMinioContent {
+  kind: 'minio';
+  objectKey: string;
+  contentCacheKey: string;
+  contentCacheHit: boolean;
+  metadataCacheKey: string;
+  metadataCacheHit: boolean;
+  mimeType: string;
+  metadata: ObjectMetadata;
+  range: RangeParseResult;
+}
+
+interface ResolvedRedirectContent {
+  kind: 'redirect';
+  url: string;
+}
+
+type ResolvedDeviceContent = ResolvedMinioContent | ResolvedRedirectContent;
 
 interface ByteRange {
   start: number;
@@ -46,6 +98,13 @@ type RangeParseResult =
 @Controller('device-content')
 export class DeviceContentController {
   private readonly logger = new Logger(DeviceContentController.name);
+  private readonly deviceAuthCache = new Map<string, CacheEntry<CachedDeviceAuth>>();
+  private readonly deviceAuthLoads = new Map<string, Promise<CachedDeviceAuth>>();
+  private readonly contentCache = new Map<string, CacheEntry<DeviceContentRecord>>();
+  private readonly contentLoads = new Map<string, Promise<DeviceContentRecord | null>>();
+  private readonly objectMetadataCache = new Map<string, CacheEntry<ObjectMetadata>>();
+  private readonly objectMetadataLoads = new Map<string, Promise<ObjectMetadata | null>>();
+  private readonly cachedObjectOpenLocks = new Map<string, Promise<void>>();
 
   constructor(
     private readonly contentService: ContentService,
@@ -107,6 +166,407 @@ export class DeviceContentController {
     };
   }
 
+  private getCacheValue<T>(cache: Map<string, CacheEntry<T>>, key: string): T | null {
+    const entry = cache.get(key);
+    if (!entry) {
+      return null;
+    }
+
+    if (entry.expiresAt <= Date.now()) {
+      cache.delete(key);
+      return null;
+    }
+
+    return entry.value;
+  }
+
+  private setCacheValue<T>(
+    cache: Map<string, CacheEntry<T>>,
+    key: string,
+    value: T,
+    expiresAt: number,
+    maxEntries: number,
+  ): void {
+    const now = Date.now();
+    if (expiresAt <= now) {
+      cache.delete(key);
+      return;
+    }
+
+    if (!cache.has(key) && cache.size >= maxEntries) {
+      for (const [cacheKey, entry] of cache) {
+        if (entry.expiresAt <= now) {
+          cache.delete(cacheKey);
+        }
+      }
+    }
+
+    while (!cache.has(key) && cache.size >= maxEntries) {
+      const oldestKey = cache.keys().next().value as string | undefined;
+      if (!oldestKey) {
+        break;
+      }
+      cache.delete(oldestKey);
+    }
+
+    cache.set(key, { value, expiresAt });
+  }
+
+  private getAuthCacheExpiresAt(payload: DeviceJwtPayload, now: number): number {
+    const exp = (payload as DeviceJwtPayload & { exp?: unknown }).exp;
+    const ttlExpiresAt = now + DEVICE_TOKEN_AUTH_CACHE_TTL_MS;
+    if (typeof exp !== 'number' || !Number.isFinite(exp)) {
+      return ttlExpiresAt;
+    }
+
+    return Math.min(ttlExpiresAt, exp * 1000);
+  }
+
+  private async verifyDeviceTokenCached(req: Request): Promise<CachedLookup<CachedDeviceAuth>> {
+    const token = getDeviceTokenFromRequest(req, { allowQueryToken: true });
+    const tokenHash = hashDeviceToken(token);
+    const cached = this.getCacheValue(this.deviceAuthCache, tokenHash);
+    if (cached) {
+      return { value: cached, cacheHit: true, cacheKey: tokenHash };
+    }
+
+    let load = this.deviceAuthLoads.get(tokenHash);
+    if (!load) {
+      load = verifyCurrentDeviceToken({
+        jwtService: this.jwtService,
+        databaseService: this.databaseService,
+        token,
+      }).then(({ payload, tokenHash: verifiedHash }) => ({
+        payload,
+        tokenHash: verifiedHash,
+      }));
+      this.deviceAuthLoads.set(tokenHash, load);
+    }
+
+    try {
+      const value = await load;
+      this.setCacheValue(
+        this.deviceAuthCache,
+        tokenHash,
+        value,
+        this.getAuthCacheExpiresAt(value.payload, Date.now()),
+        DEVICE_TOKEN_AUTH_CACHE_MAX_ENTRIES,
+      );
+      return { value, cacheHit: false, cacheKey: tokenHash };
+    } finally {
+      if (this.deviceAuthLoads.get(tokenHash) === load) {
+        this.deviceAuthLoads.delete(tokenHash);
+      }
+    }
+  }
+
+  private async getContentForDeviceCached(
+    id: string,
+    organizationId: string,
+  ): Promise<CachedLookup<DeviceContentRecord | null>> {
+    const cacheKey = `${organizationId}:${id}`;
+    const cached = this.getCacheValue(this.contentCache, cacheKey);
+    if (cached) {
+      return { value: cached, cacheHit: true, cacheKey };
+    }
+
+    let load = this.contentLoads.get(cacheKey);
+    if (!load) {
+      load = this.contentService.findByIdForDevice(id, organizationId);
+      this.contentLoads.set(cacheKey, load);
+    }
+
+    try {
+      const value = await load;
+      if (value && value.url) {
+        this.setCacheValue(
+          this.contentCache,
+          cacheKey,
+          value,
+          Date.now() + DEVICE_CONTENT_CACHE_TTL_MS,
+          DEVICE_CONTENT_CACHE_MAX_ENTRIES,
+        );
+      }
+      return { value, cacheHit: false, cacheKey };
+    } finally {
+      if (this.contentLoads.get(cacheKey) === load) {
+        this.contentLoads.delete(cacheKey);
+      }
+    }
+  }
+
+  private async getObjectMetadataCached(
+    objectKey: string,
+  ): Promise<CachedLookup<ObjectMetadata | null>> {
+    const cached = this.getCacheValue(this.objectMetadataCache, objectKey);
+    if (cached) {
+      return { value: cached, cacheHit: true, cacheKey: objectKey };
+    }
+
+    let load = this.objectMetadataLoads.get(objectKey);
+    if (!load) {
+      load = this.storageService.getFileMetadata(objectKey);
+      this.objectMetadataLoads.set(objectKey, load);
+    }
+
+    try {
+      const value = await load;
+      if (value) {
+        this.setCacheValue(
+          this.objectMetadataCache,
+          objectKey,
+          value,
+          Date.now() + DEVICE_OBJECT_METADATA_CACHE_TTL_MS,
+          DEVICE_OBJECT_METADATA_CACHE_MAX_ENTRIES,
+        );
+      }
+      return { value, cacheHit: false, cacheKey: objectKey };
+    } finally {
+      if (this.objectMetadataLoads.get(objectKey) === load) {
+        this.objectMetadataLoads.delete(objectKey);
+      }
+    }
+  }
+
+  private async resolveDeviceContent(
+    id: string,
+    organizationId: string,
+    req: Request,
+    allowCachedMetadataMissRetry = true,
+  ): Promise<ResolvedDeviceContent> {
+    const contentLookup = await this.getContentForDeviceCached(id, organizationId);
+    const content = contentLookup.value;
+
+    if (!content || !content.url) {
+      throw new NotFoundException('Content not found');
+    }
+
+    if (!content.url.startsWith(MINIO_URL_PREFIX)) {
+      return { kind: 'redirect', url: content.url };
+    }
+
+    const objectKey = content.url.substring(MINIO_URL_PREFIX.length);
+    if (!objectKey.startsWith(`${organizationId}/`)) {
+      throw new NotFoundException('Content file not found');
+    }
+
+    if (!this.storageService.isMinioAvailable()) {
+      throw new BadRequestException('Storage service is currently unavailable');
+    }
+
+    const metadataLookup = await this.getObjectMetadataCached(objectKey);
+    const metadata = metadataLookup.value;
+    if (!metadata) {
+      this.contentCache.delete(contentLookup.cacheKey);
+      this.objectMetadataCache.delete(metadataLookup.cacheKey);
+      if (allowCachedMetadataMissRetry && contentLookup.cacheHit) {
+        return this.resolveDeviceContent(id, organizationId, req, false);
+      }
+      throw new NotFoundException('Content file not found');
+    }
+
+    if (metadata.size > MAX_DEVICE_CONTENT_FILE_SIZE) {
+      throw new BadRequestException('Content file exceeds maximum size limit (100MB)');
+    }
+
+    return {
+      kind: 'minio',
+      objectKey,
+      contentCacheKey: contentLookup.cacheKey,
+      contentCacheHit: contentLookup.cacheHit,
+      metadataCacheKey: metadataLookup.cacheKey,
+      metadataCacheHit: metadataLookup.cacheHit,
+      mimeType: content.mimeType || metadata.contentType || 'application/octet-stream',
+      metadata,
+      range: this.parseRangeHeader(req.headers.range, metadata.size),
+    };
+  }
+
+  private invalidateCachedMediaContext(context: ResolvedMinioContent): void {
+    this.contentCache.delete(context.contentCacheKey);
+    this.objectMetadataCache.delete(context.metadataCacheKey);
+  }
+
+  private isLikelyMissingObjectError(error: unknown): boolean {
+    const code =
+      error && typeof error === 'object' && 'code' in error
+        ? String((error as { code?: unknown }).code)
+        : '';
+    const message = error instanceof Error ? error.message : String(error);
+    return (
+      /^(NoSuchKey|NoSuchObject|NotFound)$/i.test(code) ||
+      /not found|no such key|specified key does not exist/i.test(message)
+    );
+  }
+
+  private shouldRetryStaleCachedObject(
+    context: ResolvedMinioContent,
+    error: unknown,
+  ): boolean {
+    return (
+      (context.contentCacheHit || context.metadataCacheHit) &&
+      this.isLikelyMissingObjectError(error)
+    );
+  }
+
+  private isCachedMediaContextStillCurrent(context: ResolvedMinioContent): boolean {
+    if (context.contentCacheHit) {
+      const cachedContent = this.getCacheValue(this.contentCache, context.contentCacheKey);
+      if (
+        !cachedContent ||
+        cachedContent.url !== `${MINIO_URL_PREFIX}${context.objectKey}`
+      ) {
+        return false;
+      }
+    }
+
+    if (context.metadataCacheHit) {
+      const cachedMetadata = this.getCacheValue(
+        this.objectMetadataCache,
+        context.metadataCacheKey,
+      );
+      if (!cachedMetadata) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private async withCachedObjectOpenLock<T>(
+    objectKey: string,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    const previous = this.cachedObjectOpenLocks.get(objectKey) ?? Promise.resolve();
+    let release: () => void = () => undefined;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const queued = previous.catch(() => undefined).then(() => current);
+    this.cachedObjectOpenLocks.set(objectKey, queued);
+
+    await previous.catch(() => undefined);
+    try {
+      return await fn();
+    } finally {
+      release();
+      if (this.cachedObjectOpenLocks.get(objectKey) === queued) {
+        this.cachedObjectOpenLocks.delete(objectKey);
+      }
+    }
+  }
+
+  private async openMinioStream(context: ResolvedMinioContent): Promise<NodeJS.ReadableStream> {
+    if (context.range.kind === 'range') {
+      const length = context.range.range.end - context.range.range.start + 1;
+      return this.storageService.getObjectRange(
+        context.objectKey,
+        context.range.range.start,
+        length,
+      );
+    }
+
+    return this.storageService.getObject(context.objectKey);
+  }
+
+  private async openMinioStreamWithStaleRecovery(
+    id: string,
+    organizationId: string,
+    req: Request,
+    context: ResolvedMinioContent,
+  ): Promise<{ resolved: ResolvedDeviceContent; stream: NodeJS.ReadableStream | null }> {
+    const openWithRetry = async (
+      current: ResolvedMinioContent,
+    ): Promise<{ resolved: ResolvedDeviceContent; stream: NodeJS.ReadableStream | null }> => {
+      try {
+        return { resolved: current, stream: await this.openMinioStream(current) };
+      } catch (error) {
+        if (!this.shouldRetryStaleCachedObject(current, error)) {
+          throw error;
+        }
+
+        this.invalidateCachedMediaContext(current);
+        const refreshed = await this.resolveDeviceContent(id, organizationId, req);
+        if (refreshed.kind !== 'minio' || refreshed.range.kind === 'unsatisfiable') {
+          return { resolved: refreshed, stream: null };
+        }
+
+        return {
+          resolved: refreshed,
+          stream: await this.openMinioStream(refreshed),
+        };
+      }
+    };
+
+    if (!context.contentCacheHit && !context.metadataCacheHit) {
+      return openWithRetry(context);
+    }
+
+    return this.withCachedObjectOpenLock(context.objectKey, async () => {
+      if (!this.isCachedMediaContextStillCurrent(context)) {
+        const refreshed = await this.resolveDeviceContent(id, organizationId, req);
+        if (refreshed.kind !== 'minio' || refreshed.range.kind === 'unsatisfiable') {
+          return { resolved: refreshed, stream: null };
+        }
+        return openWithRetry(refreshed);
+      }
+
+      return openWithRetry(context);
+    });
+  }
+
+  private async writeResolvedContent(
+    resolved: ResolvedDeviceContent,
+    stream: NodeJS.ReadableStream | null,
+    res: Response,
+  ): Promise<void> {
+    if (resolved.kind === 'redirect') {
+      res.set('Cross-Origin-Resource-Policy', 'cross-origin');
+      res.redirect(resolved.url);
+      return;
+    }
+
+    if (resolved.range.kind === 'unsatisfiable') {
+      res.status(416);
+      res.set({
+        'Accept-Ranges': 'bytes',
+        'Content-Range': `bytes */${resolved.metadata.size}`,
+        'Cache-Control': 'no-store',
+        'Cross-Origin-Resource-Policy': 'cross-origin',
+      });
+      res.end();
+      return;
+    }
+
+    if (!stream) {
+      throw new InternalServerErrorException('Content stream was not opened');
+    }
+
+    if (resolved.range.kind === 'range') {
+      const length = resolved.range.range.end - resolved.range.range.start + 1;
+      res.status(206);
+      res.set({
+        'Content-Type': resolved.mimeType,
+        'Accept-Ranges': 'bytes',
+        'Content-Length': String(length),
+        'Content-Range': `bytes ${resolved.range.range.start}-${resolved.range.range.end}/${resolved.metadata.size}`,
+        'Cache-Control': SUCCESSFUL_MEDIA_CACHE_CONTROL,
+        'Cross-Origin-Resource-Policy': 'cross-origin',
+      });
+      await this.streamToResponse(stream, res);
+      return;
+    }
+
+    res.set({
+      'Content-Type': resolved.mimeType,
+      'Accept-Ranges': 'bytes',
+      'Content-Length': String(resolved.metadata.size),
+      'Cache-Control': SUCCESSFUL_MEDIA_CACHE_CONTROL,
+      'Cross-Origin-Resource-Policy': 'cross-origin',
+    });
+    await this.streamToResponse(stream, res);
+  }
+
   private async streamToResponse(stream: NodeJS.ReadableStream, res: Response): Promise<void> {
     try {
       await pipeline(stream, res);
@@ -144,90 +604,25 @@ export class DeviceContentController {
     // Device JWT is mandatory — throws UnauthorizedException if missing/invalid.
     // Verify it BEFORE the DB query so an unauth caller can't probe content
     // IDs for existence via timing or DB error patterns.
-    const { payload: devicePayload } = await verifyCurrentDeviceToken({
-      jwtService: this.jwtService,
-      databaseService: this.databaseService,
-      token: getDeviceTokenFromRequest(req, { allowQueryToken: true }),
-    });
-
-    const content = await this.contentService.findByIdForDevice(
+    const { value: deviceAuth } = await this.verifyDeviceTokenCached(req);
+    let resolved = await this.resolveDeviceContent(
       id,
-      devicePayload.organizationId,
+      deviceAuth.payload.organizationId,
+      req,
     );
+    let stream: NodeJS.ReadableStream | null = null;
 
-    if (!content || !content.url) {
-      throw new NotFoundException('Content not found');
+    if (resolved.kind === 'minio' && resolved.range.kind !== 'unsatisfiable') {
+      const opened = await this.openMinioStreamWithStaleRecovery(
+        id,
+        deviceAuth.payload.organizationId,
+        req,
+        resolved,
+      );
+      resolved = opened.resolved;
+      stream = opened.stream;
     }
 
-    if (content.url.startsWith(MINIO_URL_PREFIX)) {
-      const objectKey = content.url.substring(MINIO_URL_PREFIX.length);
-      if (!objectKey.startsWith(`${devicePayload.organizationId}/`)) {
-        throw new NotFoundException('Content file not found');
-      }
-
-      if (!this.storageService.isMinioAvailable()) {
-        throw new BadRequestException('Storage service is currently unavailable');
-      }
-
-      const metadata = await this.storageService.getFileMetadata(objectKey);
-      if (!metadata) {
-        throw new NotFoundException('Content file not found');
-      }
-
-      if (metadata.size > MAX_DEVICE_CONTENT_FILE_SIZE) {
-        throw new BadRequestException('Content file exceeds maximum size limit (100MB)');
-      }
-
-      const mimeType = content.mimeType || metadata.contentType || 'application/octet-stream';
-      const range = this.parseRangeHeader(req.headers.range, metadata.size);
-
-      if (range.kind === 'unsatisfiable') {
-        res.status(416);
-        res.set({
-          'Accept-Ranges': 'bytes',
-          'Content-Range': `bytes */${metadata.size}`,
-          'Cache-Control': 'no-store',
-          'Cross-Origin-Resource-Policy': 'cross-origin',
-        });
-        res.end();
-        return;
-      }
-
-      if (range.kind === 'range') {
-        const length = range.range.end - range.range.start + 1;
-        const stream = await this.storageService.getObjectRange(
-          objectKey,
-          range.range.start,
-          length,
-        );
-        res.status(206);
-        res.set({
-          'Content-Type': mimeType,
-          'Accept-Ranges': 'bytes',
-          'Content-Length': String(length),
-          'Content-Range': `bytes ${range.range.start}-${range.range.end}/${metadata.size}`,
-          'Cache-Control': 'private, no-store',
-          'Cross-Origin-Resource-Policy': 'cross-origin',
-        });
-        await this.streamToResponse(stream, res);
-        return;
-      }
-
-      const stream = await this.storageService.getObject(objectKey);
-      res.set({
-        'Content-Type': mimeType,
-        'Accept-Ranges': 'bytes',
-        'Content-Length': String(metadata.size),
-        'Cache-Control': 'private, no-store',
-        'Cross-Origin-Resource-Policy': 'cross-origin',
-      });
-      await this.streamToResponse(stream, res);
-      return;
-    }
-
-    // For non-MinIO URLs, redirect (CORP header on redirect itself)
-    res.set('Cross-Origin-Resource-Policy', 'cross-origin');
-    res.redirect(content.url);
-    return;
+    await this.writeResolvedContent(resolved, stream, res);
   }
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,8 +1,93 @@
 # Vizora - Task Tracker
 
-## In Progress: Customer Contract, Security, and Performance Pass 6 (2026-05-31)
+## In Progress: Device Content Streaming Performance Pass 7 (2026-05-31)
+
+**Branch:** `feat/content-streaming-performance-7`
+
+**Why now:** Customer display playback is a hot path and the middleware device-content route repeats
+device-token DB validation, content DB lookup, and MinIO metadata lookup for every video byte-range
+request. This is repo-side, customer-visible performance work that does not require secrets,
+production state mutation, or live hardware.
+
+**New primitives introduced:** small in-process TTL caches inside `DeviceContentController` for
+verified current device-token payloads, tenant-scoped content rows, and MinIO object metadata.
+
+**Hermes-first analysis:** not applicable; this pass does not add business-agent behavior, MCP tools,
+Hermes skills, AI provider calls, or spend paths.
+
+**Plan/design:** `docs/plans/2026-05-31-device-content-streaming-performance-pass-7.md`
+
+**Plan**
+- [x] Create fresh branch from merged `origin/main`.
+- [x] Write plan/design and tracker section.
+- [x] Run multi-subagent design review before tests.
+- [x] Add failing focused tests for duplicate range-request work and cache headers.
+- [x] Implement bounded short-TTL auth/content/metadata caches on the existing controller path.
+- [x] Run focused middleware tests.
+- [x] Run multi-subagent code review before broader tests.
+- [x] Run broader affected tests/builds/typecheck.
+- [ ] PR, CI, merge.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Baseline evidence**
+- [x] Code inspection: `DeviceContentController.serveFile` calls `verifyCurrentDeviceToken`,
+  `contentService.findByIdForDevice`, and `storageService.getFileMetadata` on every request before
+  selecting full/range streaming.
+- [x] Existing response headers use `Cache-Control: private, no-store` on successful media responses,
+  preventing short browser/device cache reuse.
+
+**Design review gate**
+- [x] Customer/performance reviewer found a blocking design problem with `private, max-age=30` on
+  stable media URLs; revised design keeps successful media responses `private, no-store`.
+- [x] Customer/performance reviewer found a stale-content replacement failure mode; revised design
+  invalidates cached content/metadata and retries once on pre-header MinIO stream-acquisition failure.
+- [x] Security/tenant reviewer found the same response-cache stale-auth risk and called out the
+  pre-existing org-scoped content authorization model; revised docs make that boundary explicit.
+- [x] Security/tenant reviewer accepted a 5s server-side auth cache if populated only after full
+  current-token validation and capped by JWT `exp`.
+
+**Focused verification**
+- [x] Red run: `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=device-content.controller`
+  failed on duplicate JWT/content/metadata calls and missing stale-object retry.
+- [x] Green run: `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=device-content.controller`
+  passed, 1 suite / 30 tests.
+- [x] Code review found concurrent stale-object misses could poison the shared MinIO range circuit;
+  fixed by serializing cached-object stream acquisition per old object key and re-resolving waiters
+  after invalidation.
+- [x] Code review found metadata-miss replacement could transiently 404 for the content-cache TTL;
+  fixed by evicting cached content/metadata on metadata miss and retrying cached rows once.
+- [x] Code review found the content cache stored full rows; fixed `findByIdForDevice` to select only
+  `id`, `organizationId`, `url`, and `mimeType`.
+- [x] Review-fix run: `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="device-content.controller|content.service"`
+  passed, 2 suites / 130 tests.
+- [x] Post-review low coverage fix: added direct same-request cached-row metadata-miss retry coverage.
+- [x] Post-review focused run: `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="device-content.controller|content.service"`
+  passed, 2 suites / 131 tests.
+
+**Review gate**
+- [x] Security/runtime re-review: CLEAN; verified metadata-miss retry, narrow content query, stale old-key lock,
+  token-exp auth-cache cap, org cache keying, and no browser `max-age`.
+- [x] Playback/performance re-review: CLEAN; verified pending-load coalescing, stale old-key retry/circuit fix,
+  no-store behavior, and that only stream acquisition is serialized, not response body transfer.
+
+**Broader verification**
+- [x] `pnpm --filter @vizora/middleware test -- --runInBand` - pass, 143 suites / 2821 tests.
+- [x] `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` - pass.
+- [x] `npx nx build @vizora/middleware` - pass with existing webpack warnings; Nx reported
+  `@vizora/database:build` as flaky after successful completion.
+- [x] `git diff --check` - pass with expected LF-to-CRLF warnings only.
+
+**PR / CI**
+- [x] Branch commit created: `perf(middleware): cache device content streaming lookups`.
+- [x] PR #130 opened and mergeable.
+- [x] GitHub CI green at first pushed head: audit, lint, test, build, security, and e2e passed.
+
+---
+
+## Completed: Customer Contract, Security, and Performance Pass 6 (2026-05-31)
 
 **Branch:** `feat/customer-performance-review-6`
+**PR / merge commit:** #129 / `8805aa90ea2fb04df907c71ceb5a11d723e22bea`
 
 **Why now:** PR #128 merged and CI is green, but deploy remains blocked by dirty/diverged prod-local work. The next repo-side slice should fix customer-visible contract failures and small performance/security defects that do not require secrets, customer credentials, live hardware, or production state mutation.
 
@@ -24,8 +109,8 @@
 - [x] Run multi-subagent review before broader tests.
 - [x] Run post-fix re-review before broader tests.
 - [x] Run broader affected tests/builds.
-- [ ] PR, CI, merge.
-- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+- [x] PR, CI, merge.
+- [x] Re-check deployment gate; deploy only if prod checkout is safe.
 
 **Analysis feed**
 - [x] Local drift check confirmed billing response mismatch, `serverFetch` cookie/envelope drift, push-content false success, RSS/thumbnail redirect gap, and unauthenticated display preload path still exist after PR #128.
@@ -59,6 +144,16 @@
 - [x] `npx nx build @vizora/middleware` - pass with existing webpack warnings.
 - [x] `NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 BACKEND_URL=http://localhost:3000 npx nx build @vizora/web` - pass with existing Next middleware/proxy deprecation and TS project-reference warnings.
 - [x] `git diff --check origin/main...HEAD` - pass.
+
+**Merge / CI / deployment gate**
+- [x] PR #129 merged after GitHub checks passed: lint, audit, test, build, security, and e2e.
+- [x] GitHub main after merge: `8805aa90ea2fb04df907c71ceb5a11d723e22bea`.
+- [x] Open PRs after merge: none.
+- [x] Production health probe returned `success: true`, database connected at `2026-05-31T15:33:14.762Z`.
+- [x] Production deploy remains blocked: `/opt/vizora/app` is dirty and diverged
+  (`HEAD=bb76aa1838740bff5b58623dfef7a906d44f46a6`, `origin/main=8805aa90ea2fb04df907c71ceb5a11d723e22bea`,
+  `ahead 17, behind 65`). Do not pull/reset/stash/restart services until prod-local work is
+  reconciled.
 
 ---
 


### PR DESCRIPTION
## Summary
- add short per-worker caches for verified device auth, tenant-scoped content rows, and MinIO object metadata on `/device-content/:id/file`
- keep successful media responses `private, no-store` while coalescing duplicate JWT/DB/stat work during range bursts
- add stale replacement recovery for cached old object keys, including concurrent range bursts and metadata-miss retry
- narrow `findByIdForDevice` to the fields needed by device file serving

## Tests
- `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=device-content.controller|content.service`
- `pnpm --filter @vizora/middleware test -- --runInBand`
- `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
- `npx nx build @vizora/middleware`
- `git diff --check`

## Reviews
- design review: security/runtime + customer/performance
- code review: security/runtime + playback/performance, final re-review CLEAN

## Deployment
- not deployed. Production checkout remains dirty/diverged and must be reconciled before pull/restart/deploy.