### PR TITLE
fix(web): harden dashboard contract handling

### DIFF
--- a/docs/plans/2026-05-31-dashboard-contract-readiness-pass-8.md
+++ b/docs/plans/2026-05-31-dashboard-contract-readiness-pass-8.md
@@ -1,0 +1,96 @@
+# Dashboard Contract Readiness Pass 8
+
+**Date:** 2026-05-31  
+**Branch:** `feat/customer-dashboard-improvements-8`
+
+## Goal
+
+Fix bounded customer-visible dashboard contract failures found during the
+post-merge customer dashboard and performance review. This pass intentionally
+targets correctness defects that can be verified with focused unit tests and do
+not require secrets, production state mutation, payment-provider setup, live
+hardware, or deployment.
+
+**New primitives introduced:** none. Reuse the existing web `ApiClient`,
+billing module, dashboard pages, content API wrappers, and schedules/dashboard
+client components.
+
+**Hermes-first analysis:** not applicable. This pass does not add or change
+business-agent behavior, MCP tools, Hermes skills, AI provider calls, or spend
+paths.
+
+## Customer Dashboard Improvement List
+
+1. Billing correctness: prices are stored by the backend in minor units, but the
+   dashboard can render them as major units. Yearly display prices are also
+   computed client-side instead of using backend canonical plan prices.
+2. Billing trial state: the backend emits `subscriptionStatus: "trial"`, while
+   parts of the billing dashboard look for `trialing`.
+3. API auth handling: the browser client treats `403 Forbidden` like an expired
+   session, clearing valid auth and redirecting customers away from dashboard
+   pages.
+4. Content rename: the web client sends `title` to the strict middleware update
+   DTO, while the middleware accepts `name`.
+5. Schedules loading: partial schedule/reference-data failures are silently
+   rendered as empty or incomplete setup states.
+6. Dashboard activity: device-status initialization updates count cards but can
+   leave recent activity stale until a separate content/playlist refresh.
+7. Pairing UX: dashboard and help copy describe inconsistent code direction
+   between display client and dashboard.
+8. First-run checklist: onboarding disappears after the first device even if
+   content, playlist, and schedule milestones are incomplete.
+9. Advanced controls: customer pages expose emergency/fleet/moderation actions
+   too early in the main onboarding surface.
+10. Runtime performance: dashboard shell can create multiple Socket.IO
+    connections per route, overview pages fetch full paginated lists, and list
+    endpoints return detail-sized payloads.
+11. Content upload performance: bulk upload can overload middleware memory
+    before the larger direct-to-storage redesign.
+
+## Selected Fix Bundle
+
+- Keep auth on `403`, redirect only on `401`, and throw status-bearing
+  `ApiError` instances from JSON/FormData requests.
+- Pass billing interval through `GET /billing/plans`, refetch plans when the
+  interval toggle changes, and render minor-unit prices as customer-visible
+  major-unit prices.
+- Use `trial` consistently in billing page/status UI.
+- Map content update payloads from web `title` to middleware `name`.
+- Surface schedule partial-load failures with an error banner instead of a false
+  empty state.
+- Rebuild dashboard recent activity when device-status context initializes.
+
+## Verification Plan
+
+1. Add failing focused tests for each contract defect.
+2. Implement the smallest code changes needed to pass those tests.
+3. Run focused web and middleware tests.
+4. Run multi-subagent code review before broader tests.
+5. Run relevant broader tests/build/type checks.
+6. Open PR, wait for CI, merge if green.
+7. Re-check production deployment gate; do not deploy over dirty/diverged prod
+   work without a reviewed reconciliation path.
+
+## Review Results
+
+- API/security reviewer initially found one residual contract bug:
+  `GET /billing/plans?interval=` still behaved like yearly. Fixed by rejecting
+  present-but-empty interval query values in the billing controller.
+- Customer/runtime reviewer returned CLEAN after the stale yearly-card, recent
+  activity, and interval-validation fixes.
+- API/security re-review returned CLEAN after the empty-interval fix.
+
+## Verification Results
+
+- Focused web tests passed: 9 suites / 113 tests.
+- Focused billing controller tests passed: 1 suite / 24 tests.
+- Full web Jest passed: 94 suites / 953 tests. Existing React `act(...)`
+  warnings still appear in several suites.
+- Full middleware Jest passed: 143 suites / 2824 tests.
+- Middleware and web TypeScript checks passed.
+- Middleware build passed with existing webpack warnings.
+- Web production build passed when required production CSP variables were set
+  for the local verification build.
+- Browser smoke passed against local `next start` with Playwright-mocked API
+  data for desktop/mobile billing plans, yearly-plan failure, and schedules
+  partial-load error visibility. Screenshots are in `test-results/pass8-browser/`.

--- a/middleware/src/modules/billing/billing.controller.spec.ts
+++ b/middleware/src/modules/billing/billing.controller.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
 import { BillingController } from './billing.controller';
 import { BillingService } from './billing.service';
 
@@ -116,7 +117,11 @@ describe('BillingController', () => {
       const result = await controller.getPlans(organizationId);
 
       expect(result).toEqual(mockPlans);
-      expect(mockBillingService.getPlans).toHaveBeenCalledWith(organizationId, undefined);
+      expect(mockBillingService.getPlans).toHaveBeenCalledWith(
+        organizationId,
+        undefined,
+        undefined,
+      );
     });
 
     it('should pass country parameter to service', async () => {
@@ -124,7 +129,35 @@ describe('BillingController', () => {
 
       await controller.getPlans(organizationId, 'IN');
 
-      expect(mockBillingService.getPlans).toHaveBeenCalledWith(organizationId, 'IN');
+      expect(mockBillingService.getPlans).toHaveBeenCalledWith(organizationId, 'IN', undefined);
+    });
+
+    it('should pass interval parameter to service', async () => {
+      mockBillingService.getPlans.mockResolvedValue([
+        { ...mockPlans[0], interval: 'yearly', price: 29000 },
+      ]);
+
+      await (controller.getPlans as any)(organizationId, undefined, 'yearly');
+
+      expect(mockBillingService.getPlans).toHaveBeenCalledWith(
+        organizationId,
+        undefined,
+        'yearly',
+      );
+    });
+
+    it('should reject invalid interval values', async () => {
+      await expect((controller.getPlans as any)(organizationId, undefined, 'weekly')).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(mockBillingService.getPlans).not.toHaveBeenCalled();
+    });
+
+    it('should reject empty interval query values', async () => {
+      await expect((controller.getPlans as any)(organizationId, undefined, '')).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(mockBillingService.getPlans).not.toHaveBeenCalled();
     });
 
     it('should return India-specific plans when country is IN', async () => {

--- a/middleware/src/modules/billing/billing.controller.ts
+++ b/middleware/src/modules/billing/billing.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Controller,
   Get,
   Post,
@@ -16,6 +17,8 @@ import { BillingService } from './billing.service';
 import { CreateCheckoutDto } from './dto/create-checkout.dto';
 import { UpdateSubscriptionDto } from './dto/update-subscription.dto';
 
+type BillingInterval = 'monthly' | 'yearly';
+
 @Controller('billing')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class BillingController {
@@ -30,8 +33,16 @@ export class BillingController {
   async getPlans(
     @CurrentUser('organizationId') organizationId: string,
     @Query('country') country?: string,
+    @Query('interval') interval?: string,
   ) {
-    return this.billingService.getPlans(organizationId, country);
+    if (interval !== undefined && interval !== 'monthly' && interval !== 'yearly') {
+      throw new BadRequestException('Invalid billing interval');
+    }
+    return this.billingService.getPlans(
+      organizationId,
+      country,
+      interval as BillingInterval | undefined,
+    );
   }
 
   @Post('checkout')

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,8 +1,88 @@
 # Vizora - Task Tracker
 
-## In Progress: Device Content Streaming Performance Pass 7 (2026-05-31)
+## In Progress: Dashboard Contract Readiness Pass 8 (2026-05-31)
+
+**Branch:** `feat/customer-dashboard-improvements-8`
+
+**Why now:** After PR #130 merged, the next highest-value repo-side customer
+readiness work is a bounded set of dashboard contract defects found by the
+customer UX, performance, and reliability reviews. These affect billing accuracy,
+auth behavior, content rename, schedule load failure visibility, and dashboard
+activity freshness without requiring secrets, live hardware, or production state
+mutation.
+
+**New primitives introduced:** none. Reuse the existing web `ApiClient`,
+billing module, content API wrapper, schedules page, and dashboard overview.
+
+**Hermes-first analysis:** not applicable; this pass does not add business-agent
+behavior, MCP tools, Hermes skills, AI provider calls, or spend paths.
+
+**Plan/design:** `docs/plans/2026-05-31-dashboard-contract-readiness-pass-8.md`
+
+**Plan**
+- [x] Reconcile post-PR #130 tracker state and create fresh branch from `origin/main`.
+- [x] Run multi-subagent customer UX, performance, and reliability analysis.
+- [x] Write plan/design and customer-dashboard improvement list.
+- [x] Add failing focused tests for the selected contract defects.
+- [x] Implement bounded fixes.
+- [x] Run focused web/middleware tests.
+- [x] Run multi-subagent code review before broader tests.
+- [x] Run broader affected tests/builds/typecheck.
+- [ ] PR, CI, merge.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Analysis feed**
+- [x] Customer UX review prioritized billing display/trial correctness, pairing guidance,
+  first-run checklist, schedule prerequisites, advanced control exposure, filter-empty states,
+  and overloaded settings.
+- [x] Performance review prioritized duplicate dashboard sockets, full-list overview fetches,
+  detail-sized list payloads, unbounded content library rendering, playlist/schedule reference
+  fetch fan-out, and upload-memory pressure.
+- [x] Reliability review prioritized 403 logout behavior, billing interval drift, trial status
+  naming, content rename payload drift, schedule partial-load silence, and stale dashboard
+  recent activity.
+
+**Selected fix bundle**
+- [x] Keep auth on `403`, redirect only on `401`, and throw status-bearing `ApiError` objects.
+- [x] Pass billing interval through plans API and render backend minor-unit prices correctly.
+- [x] Use `trial` consistently in billing page/status UI.
+- [x] Map content rename payloads from web `title` to middleware `name`.
+- [x] Surface schedule partial-load failures with an error banner.
+- [x] Rebuild dashboard recent activity when device-status context initializes.
+
+**Review / verification**
+- [x] API/security reviewer initially found `GET /billing/plans?interval=` still bypassed validation;
+  fixed by rejecting present-but-empty interval query values and adding controller coverage.
+- [x] Customer/runtime reviewer: CLEAN after yearly-fetch failure, recent activity, and interval
+  validation fixes.
+- [x] API/security re-review: CLEAN after empty-interval fix.
+- [x] Focused web suite:
+  `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="api/__tests__/(client|billing|content)|billing|schedules-page|dashboard-page"` -
+  pass, 9 suites / 113 tests.
+- [x] Focused middleware billing controller:
+  `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=billing.controller` -
+  pass, 1 suite / 24 tests.
+- [x] Full web Jest:
+  `pnpm --filter @vizora/web test -- --runInBand` - pass, 94 suites / 953 tests
+  (pre-existing React `act(...)` warnings still appear in several suites).
+- [x] Full middleware Jest:
+  `pnpm --filter @vizora/middleware test -- --runInBand` - pass, 143 suites / 2824 tests.
+- [x] Type checks:
+  `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` and
+  `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` - pass.
+- [x] Builds:
+  `npx nx build @vizora/middleware` - pass with existing webpack warnings;
+  `$env:NEXT_PUBLIC_SOCKET_URL='http://localhost:3002'; $env:NEXT_PUBLIC_API_URL='http://localhost:3000'; $env:BACKEND_URL='http://localhost:3000'; npx nx build @vizora/web` - pass.
+- [x] Browser smoke: local production `next start` plus Playwright-mocked API verified desktop/mobile
+  billing plan pricing, yearly refetch, no stale monthly cards after yearly failure, and schedules
+  partial-load permission banner. Screenshots saved under `test-results/pass8-browser/`.
+
+---
+
+## Completed: Device Content Streaming Performance Pass 7 (2026-05-31)
 
 **Branch:** `feat/content-streaming-performance-7`
+**PR / merge commit:** #130 / `c617cef6cc6b44e29bb8ef19c04f3a7071532809`
 
 **Why now:** Customer display playback is a hot path and the middleware device-content route repeats
 device-token DB validation, content DB lookup, and MinIO metadata lookup for every video byte-range
@@ -26,8 +106,8 @@ Hermes skills, AI provider calls, or spend paths.
 - [x] Run focused middleware tests.
 - [x] Run multi-subagent code review before broader tests.
 - [x] Run broader affected tests/builds/typecheck.
-- [ ] PR, CI, merge.
-- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+- [x] PR, CI, merge.
+- [x] Re-check deployment gate; deploy only if prod checkout is safe.
 
 **Baseline evidence**
 - [x] Code inspection: `DeviceContentController.serveFile` calls `verifyCurrentDeviceToken`,
@@ -81,6 +161,10 @@ Hermes skills, AI provider calls, or spend paths.
 - [x] Branch commit created: `perf(middleware): cache device content streaming lookups`.
 - [x] PR #130 opened and mergeable.
 - [x] GitHub CI green at first pushed head: audit, lint, test, build, security, and e2e passed.
+- [x] PR #130 merged after final CI green at head `7846dafa0c91ca9f804f4d62613127f67626ab9c`;
+  merge commit `c617cef6cc6b44e29bb8ef19c04f3a7071532809`.
+- [x] Deployment gate checked after merge: production health OK, core PM2 services online, but
+  `/opt/vizora/app` is dirty and diverged (`ahead 17, behind 66`), so deploy was not attempted.
 
 ---
 

--- a/web/src/app/dashboard/__tests__/dashboard-page.test.tsx
+++ b/web/src/app/dashboard/__tests__/dashboard-page.test.tsx
@@ -25,11 +25,14 @@ jest.mock('@/lib/api', () => ({
   },
 }));
 
-const stableDeviceStatuses = {};
+let mockDeviceStatusContext = {
+  deviceStatuses: {},
+  isInitialized: true,
+};
 jest.mock('@/lib/context/DeviceStatusContext', () => ({
   useDeviceStatus: () => ({
-    deviceStatuses: stableDeviceStatuses,
-    isInitialized: true,
+    deviceStatuses: mockDeviceStatusContext.deviceStatuses,
+    isInitialized: mockDeviceStatusContext.isInitialized,
   }),
 }));
 
@@ -49,6 +52,10 @@ jest.mock('@/components/Tooltip', () => ({
 describe('DashboardClient', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockDeviceStatusContext = {
+      deviceStatuses: {},
+      isInitialized: true,
+    };
   });
 
   it('renders dashboard overview heading', () => {
@@ -130,5 +137,60 @@ describe('DashboardClient', () => {
     });
     expect(screen.getByText('Content Items').parentElement?.parentElement).toHaveTextContent('2');
     expect(screen.getByText('Playlists').parentElement?.parentElement).toHaveTextContent('1');
+  });
+
+  it('refreshes recent activity after a partial content refresh succeeds', async () => {
+    (apiClient.getContent as jest.Mock).mockResolvedValueOnce({
+      data: [{
+        id: 'c-new',
+        title: 'Updated Menu',
+        type: 'image',
+        status: 'ready',
+        createdAt: '2026-05-31T12:00:00.000Z',
+      }],
+      meta: { page: 1, limit: 100, total: 1, totalPages: 1 },
+    });
+    (apiClient.getPlaylists as jest.Mock).mockRejectedValueOnce(new Error('playlists unavailable'));
+
+    render(<DashboardClient initialContent={[]} initialPlaylists={[]} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Some dashboard data could not refresh')).toBeInTheDocument();
+      expect(screen.getByText('Updated Menu')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Content Items').parentElement?.parentElement).toHaveTextContent('1');
+  });
+
+  it('adds device status entries to recent activity after device context initializes', async () => {
+    mockDeviceStatusContext = {
+      deviceStatuses: {},
+      isInitialized: false,
+    };
+
+    const { rerender } = render(<DashboardClient initialContent={[]} initialPlaylists={[]} />);
+
+    expect(screen.getByText('No recent activity yet')).toBeInTheDocument();
+
+    mockDeviceStatusContext = {
+      isInitialized: true,
+      deviceStatuses: {
+        'device-1': {
+          id: 'device-1',
+          status: 'online',
+          metadata: {
+            nickname: 'Lobby Display',
+            location: 'Front Desk',
+            lastSeen: '2026-05-31T12:00:00.000Z',
+          },
+        },
+      },
+    };
+
+    rerender(<DashboardClient initialContent={[]} initialPlaylists={[]} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Lobby Display')).toBeInTheDocument();
+      expect(screen.getByText(/online.*Front Desk/)).toBeInTheDocument();
+    });
   });
 });

--- a/web/src/app/dashboard/page-client.tsx
+++ b/web/src/app/dashboard/page-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { apiClient } from '@/lib/api';
 import { fetchAllPaginated } from '@/lib/api/pagination';
@@ -34,11 +34,17 @@ export default function DashboardClient({ initialContent, initialPlaylists }: Da
  const [recentActivity, setRecentActivity] = useState<any[]>([]);
  const [loading, setLoading] = useState(false);
  const [error, setError] = useState<string | null>(null);
+ const activityContentRef = useRef(initialContent);
+ const activityPlaylistsRef = useRef(initialPlaylists);
+ const deviceStatusesRef = useRef(deviceStatuses);
+ deviceStatusesRef.current = deviceStatuses;
 
  // Initialize stats from server-fetched data
  useEffect(() => {
  const content = initialContent;
  const playlists = initialPlaylists;
+ activityContentRef.current = content;
+ activityPlaylistsRef.current = playlists;
 
  setStats(prev => ({
  ...prev,
@@ -52,7 +58,7 @@ export default function DashboardClient({ initialContent, initialPlaylists }: Da
  },
  }));
 
- buildRecentActivity(content, playlists);
+ buildRecentActivity(content, playlists, deviceStatusesRef.current);
  }, [initialContent, initialPlaylists]);
 
  useEffect(() => {
@@ -71,10 +77,11 @@ export default function DashboardClient({ initialContent, initialPlaylists }: Da
  online: devicesList.filter(d => d.status === 'online').length,
  },
  }));
+ buildRecentActivity(activityContentRef.current, activityPlaylistsRef.current, deviceStatuses);
  }, [deviceStatuses, isInitialized]);
 
- const buildRecentActivity = (content: any[], playlists: any[]) => {
- const devicesList = Object.values(deviceStatuses);
+ const buildRecentActivity = (content: any[], playlists: any[], statuses = deviceStatuses) => {
+ const devicesList = Object.values(statuses);
  const activity = [
  ...devicesList.slice(0, 3).map((d: any) => ({
  type: 'device',
@@ -121,6 +128,8 @@ export default function DashboardClient({ initialContent, initialPlaylists }: Da
 
  const content = results[0].status === 'fulfilled' ? results[0].value : null;
  const playlists = results[1].status === 'fulfilled' ? results[1].value : null;
+ if (content) activityContentRef.current = content;
+ if (playlists) activityPlaylistsRef.current = playlists;
 
  results.forEach((result, index) => {
  if (result.status === 'rejected') {
@@ -150,8 +159,15 @@ export default function DashboardClient({ initialContent, initialPlaylists }: Da
  : {}),
  }));
 
+ if (content || playlists) {
+ buildRecentActivity(
+ activityContentRef.current,
+ activityPlaylistsRef.current,
+ deviceStatusesRef.current,
+ );
+ }
+
  if (content && playlists) {
- buildRecentActivity(content, playlists);
  setError(null);
  } else {
  setError('Some dashboard data could not refresh');

--- a/web/src/app/dashboard/schedules/__tests__/schedules-page.test.tsx
+++ b/web/src/app/dashboard/schedules/__tests__/schedules-page.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { ApiError } from '@/lib/error-handler';
 import SchedulesClient from '../page-client';
 
 const mockGetSchedules = jest.fn();
@@ -46,7 +47,14 @@ jest.mock('@/components/LoadingSpinner', () => {
 });
 
 jest.mock('@/components/EmptyState', () => {
-  return function MockEmpty({ title }: any) { return <div data-testid="empty-state">{title || 'No items'}</div>; };
+  return function MockEmpty({ title, description }: any) {
+    return (
+      <div data-testid="empty-state">
+        <span>{title || 'No items'}</span>
+        {description && <span>{description}</span>}
+      </div>
+    );
+  };
 });
 
 jest.mock('@/components/Modal', () => {
@@ -196,6 +204,22 @@ describe('SchedulesClient', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
     });
+    expect(screen.getByText('Some schedule data could not load')).toBeInTheDocument();
+    expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
+  });
+
+  it('surfaces permission-specific messages for partial schedule load failures', async () => {
+    mockGetDisplays.mockRejectedValue(
+      new ApiError(403, 'Forbidden', 'You do not have permission to access this resource.'),
+    );
+
+    render(<SchedulesClient />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('Some schedule data could not load')).toBeInTheDocument();
+    expect(screen.getByText(/do not have permission/i)).toBeInTheDocument();
   });
 
   it('fetches playlists for schedule form', async () => {

--- a/web/src/app/dashboard/schedules/page-client.tsx
+++ b/web/src/app/dashboard/schedules/page-client.tsx
@@ -16,6 +16,7 @@ import { useToast } from '@/lib/hooks/useToast';
 import { useRealtimeEvents } from '@/lib/hooks';
 import { Icon } from '@/theme/icons';
 import { format } from 'date-fns';
+import { isApiError } from '@/lib/error-handler';
 
 interface Schedule {
  id: string;
@@ -82,6 +83,16 @@ const calculateDuration = (startTime?: number | string, endTime?: number | strin
  return duration;
 };
 
+const getLoadFailureMessage = (reason: unknown): string => {
+ if (isApiError(reason)) {
+ return reason.userMessage;
+ }
+ if (reason instanceof Error) {
+ return reason.message;
+ }
+ return 'Request failed';
+};
+
 export default function SchedulesClient() {
  const toast = useToast();
  const [schedules, setSchedules] = useState<Schedule[]>([]);
@@ -95,6 +106,7 @@ export default function SchedulesClient() {
  const [displayGroups, setDisplayGroups] = useState<any[]>([]);
  const [conflictWarnings, setConflictWarnings] = useState<any[]>([]);
  const [viewMode, setViewMode] = useState<'list' | 'calendar'>('list');
+ const [loadError, setLoadError] = useState<string | null>(null);
 
  // Modal states
  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
@@ -130,6 +142,7 @@ export default function SchedulesClient() {
  const loadData = async () => {
  try {
  setLoading(true);
+ setLoadError(null);
  const [schedulesRes, devicesRes, playlistsRes, groupsRes] = await Promise.allSettled([
  fetchAllPaginated((params) => apiClient.getSchedules(params)),
  fetchAllPaginated((params) => apiClient.getDisplays(params)),
@@ -168,7 +181,23 @@ export default function SchedulesClient() {
  if (groupsRes?.status === 'fulfilled') {
  setDisplayGroups(groupsRes.value || []);
  }
+ const failedResults = [
+ schedulesRes.status === 'rejected' ? { source: 'schedules', reason: schedulesRes.reason } : null,
+ devicesRes.status === 'rejected' ? { source: 'devices', reason: devicesRes.reason } : null,
+ playlistsRes.status === 'rejected' ? { source: 'playlists', reason: playlistsRes.reason } : null,
+ groupsRes.status === 'rejected' ? { source: 'device groups', reason: groupsRes.reason } : null,
+ ].filter(Boolean) as Array<{ source: string; reason: unknown }>;
+ const failedSources = failedResults.map((failure) => failure.source);
+ if (failedSources.length > 0) {
+ const messages = Array.from(
+ new Set(failedResults.map((failure) => getLoadFailureMessage(failure.reason))),
+ );
+ setLoadError(
+ `Some schedule data could not load (${failedSources.join(', ')}): ${messages.join('; ')}`,
+ );
+ }
  } catch (error: any) {
+ setLoadError(error.message || 'Failed to load schedule data');
  toast.error(error.message || 'Failed to load data');
  } finally {
  setLoading(false);
@@ -473,6 +502,18 @@ export default function SchedulesClient() {
  </div>
  </div>
 
+ {loadError && (
+ <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 flex items-start gap-3">
+ <Icon name="error" size="lg" className="text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" />
+ <div>
+ <h3 className="text-sm font-semibold text-red-900 dark:text-red-100">
+ Some schedule data could not load
+ </h3>
+ <p className="text-sm text-red-700 dark:text-red-300 mt-1">{loadError}</p>
+ </div>
+ </div>
+ )}
+
  {/* Content Area */}
  {viewMode === 'calendar' ? (
  <ScheduleCalendar
@@ -491,7 +532,7 @@ export default function SchedulesClient() {
  setIsCreateModalOpen(true);
  }}
  />
- ) : schedules.length === 0 ? (
+ ) : schedules.length === 0 && !loadError ? (
  <EmptyState
  icon="schedules"
  title="No schedules yet"

--- a/web/src/app/dashboard/settings/billing/__tests__/billing-page.test.tsx
+++ b/web/src/app/dashboard/settings/billing/__tests__/billing-page.test.tsx
@@ -151,10 +151,10 @@ describe('BillingPage', () => {
     });
   });
 
-  it('shows trial end date for trialing subscriptions', async () => {
+  it('shows trial end date for trial subscriptions', async () => {
     (apiClient.getSubscriptionStatus as jest.Mock).mockResolvedValue({
       ...mockSubscription,
-      subscriptionStatus: 'trialing',
+      subscriptionStatus: 'trial',
       trialEndsAt: '2026-02-20T00:00:00.000Z',
     });
 

--- a/web/src/app/dashboard/settings/billing/__tests__/components.test.tsx
+++ b/web/src/app/dashboard/settings/billing/__tests__/components.test.tsx
@@ -11,8 +11,8 @@ describe('StatusBadge', () => {
     expect(screen.getByText('Active')).toHaveClass('bg-green-500/10');
   });
 
-  it('renders trialing status correctly', () => {
-    render(<StatusBadge status="trialing" />);
+  it('renders trial status correctly', () => {
+    render(<StatusBadge status="trial" />);
     expect(screen.getByText('Trial')).toBeInTheDocument();
     expect(screen.getByText('Trial')).toHaveClass('bg-[#00B4D8]/10');
   });
@@ -107,7 +107,7 @@ describe('PlanCard', () => {
     id: 'pro',
     name: 'Pro',
     screenQuota: 25,
-    price: 99,
+    price: 9900,
     currency: 'USD',
     interval: 'monthly',
     features: ['25 screens', 'Priority support', 'API access'],
@@ -131,7 +131,7 @@ describe('PlanCard', () => {
   });
 
   it('formats INR price correctly', () => {
-    const inrPlan = { ...mockPlan, price: 7999, currency: 'INR' };
+    const inrPlan = { ...mockPlan, price: 799900, currency: 'INR' };
     render(<PlanCard plan={inrPlan} onSelect={mockOnSelect} isCurrentPlan={false} />);
     expect(screen.getByText(/7,999/)).toBeInTheDocument();
   });

--- a/web/src/app/dashboard/settings/billing/__tests__/plans-page.test.tsx
+++ b/web/src/app/dashboard/settings/billing/__tests__/plans-page.test.tsx
@@ -45,7 +45,7 @@ describe('PlansPage', () => {
       id: 'basic',
       name: 'Basic',
       screenQuota: 5,
-      price: 29,
+      price: 2900,
       currency: 'USD',
       interval: 'monthly',
       features: ['5 screens', 'Email support', 'Basic analytics'],
@@ -55,7 +55,7 @@ describe('PlansPage', () => {
       id: 'pro',
       name: 'Pro',
       screenQuota: 25,
-      price: 99,
+      price: 9900,
       currency: 'USD',
       interval: 'monthly',
       features: ['25 screens', 'Priority support', 'Advanced analytics', 'API access'],
@@ -191,15 +191,24 @@ describe('PlansPage', () => {
     });
   });
 
-  it('shows save 20% badge on yearly toggle', async () => {
+  it('shows annual pricing badge on yearly toggle', async () => {
     render(<PlansPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('Save 20%')).toBeInTheDocument();
+      expect(screen.getByText('Annual pricing')).toBeInTheDocument();
     });
   });
 
   it('updates prices when switching to yearly billing', async () => {
+    (apiClient.getPlans as jest.Mock)
+      .mockResolvedValueOnce(mockPlans)
+      .mockResolvedValueOnce([
+        { ...mockPlans[0], interval: 'yearly' },
+        { ...mockPlans[1], price: 29000, interval: 'yearly' },
+        { ...mockPlans[2], price: 99000, interval: 'yearly' },
+        { ...mockPlans[3], interval: 'yearly' },
+      ]);
+
     render(<PlansPage />);
 
     await waitFor(() => {
@@ -210,8 +219,36 @@ describe('PlansPage', () => {
     fireEvent.click(screen.getByRole('button', { name: /Yearly/ }));
 
     await waitFor(() => {
-      // 29 * 12 * 0.8 = 278.4 rounded to 278
-      expect(screen.getByText('$278.00')).toBeInTheDocument();
+      expect(apiClient.getPlans).toHaveBeenLastCalledWith(undefined, 'yearly');
+      expect(screen.getByText('$290.00')).toBeInTheDocument();
+    });
+  });
+
+  it('does not show stale monthly cards after yearly plans fail to load', async () => {
+    (apiClient.getPlans as jest.Mock)
+      .mockResolvedValueOnce(mockPlans)
+      .mockRejectedValueOnce(new Error('yearly unavailable'));
+
+    render(<PlansPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('$29.00')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Yearly/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Unable to load\s+yearly\s+plans/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText('$29.00')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Select Plan' })).not.toBeInTheDocument();
+  });
+
+  it('requests monthly plans on first load', async () => {
+    render(<PlansPage />);
+
+    await waitFor(() => {
+      expect(apiClient.getPlans).toHaveBeenCalledWith(undefined, 'monthly');
     });
   });
 

--- a/web/src/app/dashboard/settings/billing/components/plan-card.tsx
+++ b/web/src/app/dashboard/settings/billing/components/plan-card.tsx
@@ -14,20 +14,21 @@ interface PlanCardProps {
 
 export function PlanCard({ plan, onSelect, onContactSales, isCurrentPlan, isLoading }: PlanCardProps) {
   const formatPrice = (price: number, currency: string) => {
+    const majorUnits = price / 100;
     if (currency === 'INR' || currency === 'inr') {
       return new Intl.NumberFormat('en-IN', {
         style: 'currency',
         currency: 'INR',
         minimumFractionDigits: 0,
         maximumFractionDigits: 0,
-      }).format(price);
+      }).format(majorUnits);
     }
     return new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: currency.toUpperCase(),
       minimumFractionDigits: 2,
       maximumFractionDigits: 2,
-    }).format(price);
+    }).format(majorUnits);
   };
 
   const isEnterprise = plan.name.toLowerCase() === 'enterprise';

--- a/web/src/app/dashboard/settings/billing/components/status-badge.tsx
+++ b/web/src/app/dashboard/settings/billing/components/status-badge.tsx
@@ -6,6 +6,7 @@ interface StatusBadgeProps {
 
 const statusConfig: Record<string, { bg: string; text: string; label: string }> = {
   active: { bg: 'bg-green-500/10', text: 'text-green-500', label: 'Active' },
+  trial: { bg: 'bg-[#00B4D8]/10', text: 'text-[#00B4D8]', label: 'Trial' },
   trialing: { bg: 'bg-[#00B4D8]/10', text: 'text-[#00B4D8]', label: 'Trial' },
   past_due: { bg: 'bg-yellow-500/10', text: 'text-yellow-500', label: 'Past Due' },
   canceled: { bg: 'bg-[var(--surface-hover)]', text: 'text-[var(--foreground-tertiary)]', label: 'Canceled' },

--- a/web/src/app/dashboard/settings/billing/page.tsx
+++ b/web/src/app/dashboard/settings/billing/page.tsx
@@ -115,7 +115,7 @@ export default function BillingPage() {
  });
  };
 
- const isTrialing = subscription?.subscriptionStatus === 'trialing';
+ const isTrialing = subscription?.subscriptionStatus === 'trial';
  const isCanceled = subscription?.cancelAtPeriodEnd;
  const isPaidPlan = subscription?.subscriptionTier !== 'free' && subscription?.subscriptionTier !== 'Free';
 

--- a/web/src/app/dashboard/settings/billing/plans/page.tsx
+++ b/web/src/app/dashboard/settings/billing/plans/page.tsx
@@ -17,17 +17,21 @@ export default function PlansPage() {
  const [loading, setLoading] = useState(true);
  const [checkoutLoading, setCheckoutLoading] = useState<string | null>(null);
  const [billingInterval, setBillingInterval] = useState<'monthly' | 'yearly'>('monthly');
+ const [plansError, setPlansError] = useState<string | null>(null);
 
  useEffect(() => {
- loadPlans();
- }, []);
+ loadPlans(billingInterval);
+ }, [billingInterval]);
 
- const loadPlans = async () => {
+ const loadPlans = async (interval: 'monthly' | 'yearly') => {
  try {
  setLoading(true);
- const planData = await apiClient.getPlans();
+ setPlansError(null);
+ setPlans([]);
+ const planData = await apiClient.getPlans(undefined, interval);
  setPlans(planData);
  } catch (error: any) {
+ setPlansError(error.message || `Unable to load ${interval} plans`);
  toast.error(error.message || 'Failed to load plans');
  } finally {
  setLoading(false);
@@ -41,7 +45,8 @@ export default function PlansPage() {
 
  try {
  setCheckoutLoading(plan.id);
- const { url } = await apiClient.createCheckout(plan.id, billingInterval);
+ const checkoutInterval = plan.interval === 'yearly' ? 'yearly' : 'monthly';
+ const { url } = await apiClient.createCheckout(plan.id, checkoutInterval);
  window.location.href = url;
  } catch (error: any) {
  toast.error(error.message || 'Failed to start checkout');
@@ -59,13 +64,6 @@ export default function PlansPage() {
      // Clipboard failed, show modal as fallback
    }
    setShowContactModal(true);
- };
-
- // Calculate yearly savings
- const getYearlySavings = (plan: Plan) => {
- if (plan.interval !== 'monthly' || plan.price === 0) return 0;
- // Assuming 20% discount for yearly
- return Math.round(plan.price * 12 * 0.2);
  };
 
  if (loading) {
@@ -134,36 +132,29 @@ export default function PlansPage() {
  >
  Yearly
  <span className="bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300 text-xs px-2 py-0.5 rounded-full">
- Save 20%
+ Annual pricing
  </span>
  </button>
  </div>
  </div>
 
  {/* Plans Grid */}
+ {plansError && (
+ <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300">
+ Unable to load {billingInterval} plans. Please try again.
+ </div>
+ )}
  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
- {plans.map((plan) => {
- // Adjust price for yearly billing
- const displayPlan = {
- ...plan,
- price:
- billingInterval === 'yearly' && plan.price > 0
- ? Math.round(plan.price * 12 * 0.8) // 20% discount
- : plan.price,
- interval: billingInterval,
- };
-
- return (
+ {plans.map((plan) => (
  <PlanCard
  key={plan.id}
- plan={displayPlan}
+ plan={plan}
  onSelect={() => handleSelectPlan(plan)}
  onContactSales={handleContactSales}
  isCurrentPlan={plan.isCurrent}
  isLoading={checkoutLoading === plan.id}
  />
- );
- })}
+ ))}
  </div>
 
  {/* FAQ Section */}

--- a/web/src/lib/api/__tests__/billing.test.ts
+++ b/web/src/lib/api/__tests__/billing.test.ts
@@ -82,4 +82,42 @@ describe('billing api methods', () => {
       'Billing portal response did not include a redirect URL',
     );
   });
+
+  it('passes country and interval query params when fetching plans', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: [],
+      }),
+    });
+
+    const client = new ApiClient('/api/v1');
+
+    await client.getPlans('IN', 'yearly');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/v1/billing/plans?country=IN&interval=yearly',
+      expect.objectContaining({ credentials: 'include' }),
+    );
+  });
+
+  it('passes interval without country when fetching plans', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: [],
+      }),
+    });
+
+    const client = new ApiClient('/api/v1');
+
+    await client.getPlans(undefined, 'yearly');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/v1/billing/plans?interval=yearly',
+      expect.objectContaining({ credentials: 'include' }),
+    );
+  });
 });

--- a/web/src/lib/api/__tests__/client.test.ts
+++ b/web/src/lib/api/__tests__/client.test.ts
@@ -1,0 +1,68 @@
+import { ApiError } from '@/lib/error-handler';
+import { ApiClient } from '../client';
+
+describe('ApiClient auth error handling', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      value: 'vizora_csrf_token=test-csrf',
+    });
+    global.fetch = jest.fn();
+  });
+
+  it('preserves authenticated state and throws ApiError for 403 responses', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+      json: async () => ({ message: 'Forbidden resource' }),
+    });
+
+    const client = new ApiClient('/api/v1');
+    client.setAuthenticated(true);
+
+    await expect(client.request('/admin-only')).rejects.toMatchObject({
+      name: 'ApiError',
+      statusCode: 403,
+      message: 'Forbidden resource',
+      userMessage: 'You do not have permission to access this resource.',
+    });
+    expect(client.isAuthenticated).toBe(true);
+  });
+
+  it('clears authenticated state for 401 responses', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      json: async () => ({ message: 'Session expired' }),
+    });
+
+    const client = new ApiClient('/api/v1');
+    client.setAuthenticated(true);
+
+    await expect(client.request('/dashboard-data')).rejects.toBeInstanceOf(ApiError);
+    expect(client.isAuthenticated).toBe(false);
+  });
+
+  it('preserves authenticated state and throws ApiError for FormData 403 responses', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+      json: async () => ({ message: 'Upload forbidden' }),
+    });
+
+    const client = new ApiClient('/api/v1');
+    client.setAuthenticated(true);
+
+    await expect(client.requestFormData('/content/upload', new FormData())).rejects.toMatchObject({
+      name: 'ApiError',
+      statusCode: 403,
+      message: 'Upload forbidden',
+      userMessage: 'You do not have permission to access this resource.',
+    });
+    expect(client.isAuthenticated).toBe(true);
+  });
+});

--- a/web/src/lib/api/__tests__/content.test.ts
+++ b/web/src/lib/api/__tests__/content.test.ts
@@ -1,0 +1,23 @@
+import { ApiClient } from '../client';
+import '../content';
+
+describe('content api methods', () => {
+  it('maps web title updates to the middleware name field', async () => {
+    const client = new ApiClient('/api/v1');
+    const requestSpy = jest.spyOn(client, 'request').mockResolvedValue({
+      id: 'content-1',
+      title: 'Lobby Menu',
+    } as any);
+
+    await client.updateContent('content-1', { title: 'Lobby Menu', metadata: { section: 'front' } });
+
+    expect(requestSpy).toHaveBeenCalledWith(
+      '/content/content-1',
+      expect.objectContaining({ method: 'PATCH' }),
+    );
+    expect(JSON.parse((requestSpy.mock.calls[0][1] as RequestInit).body as string)).toEqual({
+      name: 'Lobby Menu',
+      metadata: { section: 'front' },
+    });
+  });
+});

--- a/web/src/lib/api/billing.ts
+++ b/web/src/lib/api/billing.ts
@@ -15,7 +15,7 @@ declare module './client' {
     revokeApiKey(id: string): Promise<void>;
     // Billing
     getSubscriptionStatus(): Promise<SubscriptionStatus>;
-    getPlans(country?: string): Promise<Plan[]>;
+    getPlans(country?: string, interval?: 'monthly' | 'yearly'): Promise<Plan[]>;
     getQuotaUsage(): Promise<QuotaUsage>;
     createCheckout(planId: string, interval: 'monthly' | 'yearly'): Promise<CheckoutResponse>;
     cancelSubscription(immediately?: boolean): Promise<void>;
@@ -48,9 +48,15 @@ ApiClient.prototype.getSubscriptionStatus = async function (): Promise<Subscript
   return this.request<SubscriptionStatus>('/billing/subscription');
 };
 
-ApiClient.prototype.getPlans = async function (country?: string): Promise<Plan[]> {
-  const params = country ? `?country=${country}` : '';
-  return this.request<Plan[]>(`/billing/plans${params}`);
+ApiClient.prototype.getPlans = async function (
+  country?: string,
+  interval?: 'monthly' | 'yearly',
+): Promise<Plan[]> {
+  const params = new URLSearchParams();
+  if (country) params.set('country', country);
+  if (interval) params.set('interval', interval);
+  const query = params.toString();
+  return this.request<Plan[]>(`/billing/plans${query ? `?${query}` : ''}`);
 };
 
 ApiClient.prototype.getQuotaUsage = async function (): Promise<QuotaUsage> {

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -2,6 +2,7 @@
 // Uses httpOnly cookies for secure JWT token storage
 
 import { devLog, devWarn } from '../logger';
+import { ApiError } from '../error-handler';
 
 // Use relative URL '/api' so requests go through the Next.js rewrite proxy,
 // keeping cookies same-origin. Only fall back to absolute URL for SSR or
@@ -83,6 +84,44 @@ export interface ScheduleData {
 
 // CSRF cookie name (must match backend)
 const CSRF_COOKIE_NAME = 'vizora_csrf_token';
+
+function getUserMessageForStatus(statusCode: number, errorMessage: string): string {
+  switch (statusCode) {
+    case 400:
+      return 'Invalid request. Please check your input.';
+    case 401:
+      return 'Your session has expired. Please log in again.';
+    case 403:
+      return 'You do not have permission to access this resource.';
+    case 404:
+      return 'The requested resource was not found.';
+    case 409:
+      return errorMessage;
+    case 422:
+      return 'Please check your input and try again.';
+    case 429:
+      return 'Too many requests. Please wait a moment and try again.';
+    case 500:
+      return 'A server error occurred. Please try again later.';
+    case 502:
+    case 503:
+      return 'The service is temporarily unavailable. Please try again later.';
+    default:
+      return errorMessage;
+  }
+}
+
+async function buildApiError(response: Response, fallbackMessage: string): Promise<ApiError> {
+  const errorData = await response.json().catch(() => ({ message: fallbackMessage }));
+  const message = Array.isArray(errorData?.message)
+    ? errorData.message.join(', ')
+    : errorData?.message || `HTTP ${response.status}`;
+  return new ApiError(
+    response.status,
+    message,
+    getUserMessageForStatus(response.status, message),
+  );
+}
 
 /**
  * Get CSRF token from cookie
@@ -211,8 +250,9 @@ export class ApiClient {
         if (process.env.NODE_ENV === 'development') {
           console.error(`[API] Request failed with status ${response.status}`);
         }
-        // Handle authentication errors
-        if (response.status === 401 || response.status === 403) {
+        // Handle expired/invalid sessions. A 403 is a permission boundary,
+        // not proof that the user's auth cookie is invalid.
+        if (response.status === 401) {
           this.isAuthenticated = false;
           if (typeof window !== 'undefined') {
             // Only redirect from protected routes (dashboard, admin), not public pages
@@ -223,8 +263,7 @@ export class ApiClient {
           }
         }
 
-        const error = await response.json().catch(() => ({ message: 'Request failed' }));
-        throw new Error(error.message || `HTTP ${response.status}`);
+        throw await buildApiError(response, 'Request failed');
       }
 
       const data = await response.json();
@@ -286,11 +325,10 @@ export class ApiClient {
       clearTimeout(timeoutId);
 
       if (!response.ok) {
-        if (response.status === 401 || response.status === 403) {
+        if (response.status === 401) {
           this.isAuthenticated = false;
         }
-        const error = await response.json().catch(() => ({ message: 'Upload failed' }));
-        throw new Error(error.message || `HTTP ${response.status}`);
+        throw await buildApiError(response, 'Upload failed');
       }
 
       const data = await response.json();

--- a/web/src/lib/api/content.ts
+++ b/web/src/lib/api/content.ts
@@ -142,9 +142,15 @@ ApiClient.prototype.updateContent = async function (
   id: string,
   data: Partial<{ title: string; metadata?: Record<string, unknown> }>
 ): Promise<Content> {
+  const { title, ...rest } = data;
+  const payload = {
+    ...rest,
+    ...(title !== undefined ? { name: title } : {}),
+  };
+
   return this.request<Content>(`/content/${id}`, {
     method: 'PATCH',
-    body: JSON.stringify(data),
+    body: JSON.stringify(payload),
   });
 };
 


### PR DESCRIPTION
## Summary
- preserve dashboard auth on 403 while still redirecting only on true 401 session expiry
- align billing plans with backend canonical intervals/prices and validate invalid interval query values
- fix customer-visible dashboard contract drift in trial status, content rename payloads, schedules partial-load errors, and recent activity freshness

## Reviews
- API/security reviewer: initial `interval=` finding fixed; final re-review CLEAN
- Customer/runtime reviewer: CLEAN

## Tests
- `pnpm --filter @vizora/web test -- --runInBand --testPathPattern=api/__tests__/(client|billing|content)|billing|schedules-page|dashboard-page` - pass, 9 suites / 113 tests
- `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=billing.controller` - pass, 1 suite / 24 tests
- `pnpm --filter @vizora/web test -- --runInBand` - pass, 94 suites / 953 tests
- `pnpm --filter @vizora/middleware test -- --runInBand` - pass, 143 suites / 2824 tests
- `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` - pass
- `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` - pass
- `npx nx build @vizora/middleware` - pass with existing webpack warnings
- `NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000 BACKEND_URL=http://localhost:3000 npx nx build @vizora/web` - pass
- Browser smoke with local `next start` + Playwright-mocked API - pass; screenshots in ignored `test-results/pass8-browser/`

## Deploy
- Not deployed by this PR. Production deploy gate still requires reconciling the dirty/diverged prod checkout before pulling/restarting services.