### PR TITLE
perf: harden display playback and recovery

### DIFF
--- a/display/src/electron/device-client.spec.ts
+++ b/display/src/electron/device-client.spec.ts
@@ -743,6 +743,32 @@ describe('DeviceClient', () => {
       expect(mockSocket.disconnect).toHaveBeenCalled();
       expect(mockConfig.onPairingRequired).toHaveBeenCalled();
     });
+
+    it('should clear token and re-enter pairing when connect_error reports missing device', () => {
+      client.connect('stale-token');
+
+      const errorCall = mockSocket.on.mock.calls.find((call: any[]) => call[0] === 'connect_error');
+      expect(errorCall).toBeDefined();
+
+      errorCall![1]({ message: 'device_not_found' });
+
+      expect(mockStore.delete).toHaveBeenCalledWith('deviceToken');
+      expect(mockSocket.disconnect).toHaveBeenCalled();
+      expect(mockConfig.onPairingRequired).toHaveBeenCalled();
+    });
+
+    it('should clear token and re-enter pairing when socket error reports stale token', () => {
+      client.connect('stale-token');
+
+      const errorCall = mockSocket.on.mock.calls.find((call: any[]) => call[0] === 'error');
+      expect(errorCall).toBeDefined();
+
+      errorCall![1]({ message: 'device_token_stale' });
+
+      expect(mockStore.delete).toHaveBeenCalledWith('deviceToken');
+      expect(mockSocket.disconnect).toHaveBeenCalled();
+      expect(mockConfig.onPairingRequired).toHaveBeenCalled();
+    });
   });
 
   describe('disconnect', () => {

--- a/display/src/electron/device-client.ts
+++ b/display/src/electron/device-client.ts
@@ -12,12 +12,33 @@ interface DeviceClientConfig {
 
 type SocketAck = (response?: { ok: boolean; error?: string }) => void;
 const SELF_TERMINATING_COMMAND_ACK_FLUSH_MS = 500;
+const TERMINAL_DEVICE_AUTH_ERRORS = [
+  'unauthorized',
+  'invalid token',
+  'device_token_stale',
+  'device_not_found',
+];
 
 function unwrapResponseEnvelope<T>(parsed: T | { data?: T }): T {
   if (parsed && typeof parsed === 'object' && 'data' in parsed && (parsed as any).data !== undefined) {
     return (parsed as any).data as T;
   }
   return parsed as T;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (error && typeof error === 'object' && 'message' in error) {
+    return String((error as { message?: unknown }).message ?? '');
+  }
+  return '';
+}
+
+function isTerminalDeviceAuthError(error: unknown): boolean {
+  const message = getErrorMessage(error).toLowerCase();
+  return TERMINAL_DEVICE_AUTH_ERRORS.some((term) => message.includes(term));
 }
 
 export class DeviceClient {
@@ -86,6 +107,14 @@ export class DeviceClient {
         fs.unlinkSync(stateFile);
       } catch {}
     }
+  }
+
+  private clearTokenAndRequestPairing(reason: string): void {
+    console.log(`[DeviceClient] Token rejected (${reason}), clearing and re-entering pairing`);
+    this.deviceToken = null;
+    this.store?.delete('deviceToken');
+    this.socket?.disconnect();
+    this.config.onPairingRequired();
   }
 
   async requestPairingCode(): Promise<any> {
@@ -284,12 +313,8 @@ export class DeviceClient {
 
     this.socket.on('connect_error', (error) => {
       console.error('[DeviceClient] Connection error:', error.message);
-      if (error.message.includes('unauthorized') || error.message.includes('invalid token')) {
-        console.log('[DeviceClient] Token rejected, clearing and re-entering pairing');
-        this.deviceToken = null;
-        this.store?.delete('deviceToken');
-        this.socket?.disconnect();
-        this.config.onPairingRequired();
+      if (isTerminalDeviceAuthError(error)) {
+        this.clearTokenAndRequestPairing(getErrorMessage(error));
       }
     });
 
@@ -382,6 +407,10 @@ export class DeviceClient {
 
     this.socket.on('error', (error) => {
       console.error('[DeviceClient] Socket error:', error);
+      if (isTerminalDeviceAuthError(error)) {
+        this.clearTokenAndRequestPairing(getErrorMessage(error));
+        return;
+      }
       this.config.onError(error);
     });
   }

--- a/docs/plans/2026-05-31-performance-readiness-pass-9.md
+++ b/docs/plans/2026-05-31-performance-readiness-pass-9.md
@@ -1,0 +1,72 @@
+# Performance Readiness Pass 9 Plan
+
+**Goal:** Fix a bounded set of customer-critical playback, pairing, and display recovery defects found by the pass 9 performance reviewers.
+
+**Architecture:** Keep the work inside existing Vizora-native surfaces: `DeviceContentController`, realtime `DeviceGateway`, browser display hooks, and Electron display client. This pass intentionally avoids new infrastructure, new queues, new tables, and new agent/Hermes paths.
+
+**Tech Stack:** NestJS middleware, Socket.IO realtime gateway, Next.js display client, Electron display client, Jest.
+
+---
+
+## Scope
+
+**New primitives introduced:** none. The only new code should be small helper methods/constants inside existing modules.
+
+**Hermes-first analysis:** not applicable to the selected implementation because this pass does not add business agents, MCP tools, Hermes skills, AI provider calls, or spend paths.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Device playback HTTP caching/ranges | none applicable | Build in existing middleware controller |
+| Realtime heartbeat persistence | none applicable | Build in existing realtime gateway |
+| Display pairing/token recovery | none applicable | Build in existing display clients |
+
+Awesome-Hermes ecosystem verdict: not applicable; these are first-party runtime correctness/performance paths, not agent skills.
+
+## Reviewer Findings
+
+- Middleware/storage reviewer found large upload buffering, unsupported multi-range behavior, missing conditional validators, unbounded template data-source reads, and template refresh overlap risk.
+- Pairing/realtime reviewer found stale Postgres heartbeats causing false offline status, `clear_cache` unpairing browser displays, and stale-token errors not resetting display clients.
+- Frontend/dashboard reviewer found large content library all-fetching/rendering, bulk upload memory pressure, duplicate dashboard sockets, playlist index eager builder load, dashboard overview count fan-out, and pairing help copy drift.
+
+## Selected Fix Bundle
+
+This PR will fix the bounded items with tight regression coverage:
+
+1. Device media requests reject unsupported multi-range headers with `416` instead of streaming the full object.
+2. Device media responses set validators (`ETag`, `Last-Modified`) and honor authenticated `If-None-Match` / `If-Modified-Since` by returning `304` before opening a MinIO stream.
+3. Device media successful responses use `private, no-cache` so displays can revalidate without serving stale protected media blindly.
+4. Realtime heartbeat handling refreshes Postgres `lastHeartbeat` on a throttle while preserving the existing Redis-fast path.
+5. Realtime stale-status cleanup treats `deviceSockets` keys as device IDs.
+6. Browser display `clear_cache` clears the browser media cache without deleting pairing credentials.
+7. Browser and Electron displays treat server `device_token_stale` / `device_not_found` socket errors as terminal pairing errors and reset stored device tokens.
+
+## Deferred Follow-Ups
+
+These are important but too large for this PR:
+
+- Disk-backed/streaming upload pipeline and per-type frontend upload caps.
+- Server-backed content library pagination/search and thumbnail virtualization/lazy loading.
+- Shared dashboard socket provider to collapse duplicate Socket.IO clients.
+- Playlist index summary payload and removal of dead builder-modal code.
+- Dashboard overview summary/read-model endpoint.
+- Pairing help copy update.
+- Template/widget data-source response caps and template refresh overlap guard.
+- Single-display queued push response contract.
+- Electron media cache invalidation for replaced content.
+
+## Verification Plan
+
+Focused tests:
+
+- `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=device-content.controller`
+- `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern=device.gateway`
+- `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="display"`
+- `pnpm --filter @vizora/display test -- --runInBand device-client.spec.ts`
+
+Broader checks after subagent code review:
+
+- Middleware, realtime, web, and display type checks/builds where affected.
+- `git diff --check`.
+- PR CI before merge.
+
+Deployment remains blocked unless the production checkout is clean/safe after merge.

--- a/middleware/src/modules/content/device-content.controller.spec.ts
+++ b/middleware/src/modules/content/device-content.controller.spec.ts
@@ -181,7 +181,9 @@ describe('DeviceContentController', () => {
           'Content-Type': 'image/jpeg',
           'Accept-Ranges': 'bytes',
           'Content-Length': String(buffer.length),
-          'Cache-Control': 'private, no-store',
+          'Cache-Control': 'private, no-cache',
+          ETag: expect.stringMatching(/^W\/".+"$/),
+          'Last-Modified': 'Sun, 31 May 2026 00:00:00 GMT',
         }),
       );
       expect(mockStorageService.getObject).toHaveBeenCalledWith(objectKey);
@@ -488,7 +490,13 @@ describe('DeviceContentController', () => {
         expect.objectContaining({
           'Content-Length': '4',
           'Content-Range': 'bytes 5-8/12',
-          'Cache-Control': 'private, no-store',
+          'Cache-Control': 'private, no-cache',
+          'Last-Modified': 'Sun, 31 May 2026 00:00:00 GMT',
+        }),
+      );
+      expect(res.set).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          ETag: expect.any(String),
         }),
       );
       expect(mockStorageService.getObjectRange).toHaveBeenCalledWith(
@@ -686,7 +694,7 @@ describe('DeviceContentController', () => {
         expect.objectContaining({
           'Content-Length': '3',
           'Content-Range': 'bytes 0-2/9',
-          'Cache-Control': 'private, no-store',
+          'Cache-Control': 'private, no-cache',
         }),
       );
       expect(firstRes.getBody().toString()).toBe('old!');
@@ -893,16 +901,14 @@ describe('DeviceContentController', () => {
           'Cache-Control': 'no-store',
         }),
       );
-      expect(res.set).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          'Cache-Control': 'private, no-store',
-        }),
-      );
+      expect(res.set).not.toHaveBeenCalledWith(expect.objectContaining({
+        'Cache-Control': 'private, no-cache',
+      }));
       expect(mockStorageService.getObject).not.toHaveBeenCalled();
       expect(mockStorageService.getObjectRange).not.toHaveBeenCalled();
     });
 
-    it('should ignore unsupported multi-range headers and stream the full object', async () => {
+    it('should reject unsupported multi-range headers without opening a stream', async () => {
       const req = createMockRequest('valid-device-token');
       req.headers.range = 'bytes=0-2,5-8';
       const res = createMockResponse();
@@ -914,14 +920,127 @@ describe('DeviceContentController', () => {
         lastModified: new Date('2026-05-31T00:00:00.000Z'),
         contentType: 'image/jpeg',
       });
-      mockStorageService.getObject.mockResolvedValue(Readable.from(['full-response']));
 
       await controller.serveFile(contentId, req, res);
 
-      expect(res.status).not.toHaveBeenCalledWith(416);
+      expect(res.status).toHaveBeenCalledWith(416);
+      expect(res.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'Accept-Ranges': 'bytes',
+          'Content-Range': 'bytes */12',
+          'Cache-Control': 'no-store',
+        }),
+      );
       expect(mockStorageService.getObjectRange).not.toHaveBeenCalled();
-      expect(mockStorageService.getObject).toHaveBeenCalledWith(objectKey);
-      expect(res.getBody().toString()).toBe('full-response');
+      expect(mockStorageService.getObject).not.toHaveBeenCalled();
+      expect(res.getBody().toString()).toBe('');
+    });
+
+    it('should return 304 for a matching If-None-Match before opening MinIO stream', async () => {
+      const lastModified = new Date('2026-05-31T00:00:00.000Z');
+      const etag = `W/"${createHash('sha256')
+        .update(`${objectKey}:12:${lastModified.getTime()}`)
+        .digest('base64url')}"`;
+      const req = createMockRequest('valid-device-token');
+      req.headers['if-none-match'] = etag;
+      const res = createMockResponse();
+
+      mockContentService.findByIdForDevice.mockResolvedValue(mockContent as any);
+      mockJwtService.verify.mockReturnValue(validDevicePayload);
+      mockStorageService.getFileMetadata.mockResolvedValue({
+        size: 12,
+        lastModified,
+        contentType: 'image/jpeg',
+      });
+
+      await controller.serveFile(contentId, req, res);
+
+      expect(res.status).toHaveBeenCalledWith(304);
+      expect(res.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ETag: etag,
+          'Last-Modified': 'Sun, 31 May 2026 00:00:00 GMT',
+          'Cache-Control': 'private, no-cache',
+          'Accept-Ranges': 'bytes',
+        }),
+      );
+      expect(mockStorageService.getObject).not.toHaveBeenCalled();
+      expect(mockStorageService.getObjectRange).not.toHaveBeenCalled();
+      expect(res.getBody().toString()).toBe('');
+    });
+
+    it('should return 304 for an unchanged If-Modified-Since before opening MinIO stream', async () => {
+      const req = createMockRequest('valid-device-token');
+      req.headers['if-modified-since'] = 'Sun, 31 May 2026 00:00:30 GMT';
+      const res = createMockResponse();
+
+      mockContentService.findByIdForDevice.mockResolvedValue(mockContent as any);
+      mockJwtService.verify.mockReturnValue(validDevicePayload);
+      mockStorageService.getFileMetadata.mockResolvedValue({
+        size: 12,
+        lastModified: new Date('2026-05-31T00:00:00.000Z'),
+        contentType: 'image/jpeg',
+      });
+
+      await controller.serveFile(contentId, req, res);
+
+      expect(res.status).toHaveBeenCalledWith(304);
+      expect(res.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'Last-Modified': 'Sun, 31 May 2026 00:00:00 GMT',
+          'Cache-Control': 'private, no-cache',
+        }),
+      );
+      expect(mockStorageService.getObject).not.toHaveBeenCalled();
+      expect(mockStorageService.getObjectRange).not.toHaveBeenCalled();
+    });
+
+    it('should refresh stale cached objects instead of returning 304 from cached validators', async () => {
+      const now = 4_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+
+      const firstReq = createMockRequest('valid-device-token');
+      const firstRes = createMockResponse();
+      const firstLastModified = new Date('2026-05-31T00:00:00.000Z');
+      const firstEtag = `W/"${createHash('sha256')
+        .update(`${objectKey}:12:${firstLastModified.getTime()}`)
+        .digest('base64url')}"`;
+      const secondReq = createMockRequest('valid-device-token');
+      secondReq.headers['if-none-match'] = firstEtag;
+      const secondRes = createMockResponse();
+      const replacementObjectKey = `${organizationId}/uploads/replacement-image.jpg`;
+
+      mockJwtService.verify.mockReturnValue(validDevicePayload);
+      mockContentService.findByIdForDevice
+        .mockResolvedValueOnce(mockContent as any)
+        .mockResolvedValueOnce({
+          ...mockContent,
+          url: `minio://${replacementObjectKey}`,
+        } as any);
+      mockStorageService.getFileMetadata
+        .mockResolvedValueOnce({
+          size: 12,
+          lastModified: firstLastModified,
+          contentType: 'image/jpeg',
+        })
+        .mockResolvedValueOnce({
+          size: 9,
+          lastModified: new Date('2026-05-31T00:00:10.000Z'),
+          contentType: 'image/jpeg',
+        });
+      mockStorageService.getObject
+        .mockResolvedValueOnce(Readable.from(['old']))
+        .mockRejectedValueOnce(new Error('Not Found'))
+        .mockResolvedValueOnce(Readable.from(['new']));
+
+      await controller.serveFile(contentId, firstReq, firstRes);
+      await controller.serveFile(contentId, secondReq, secondRes);
+
+      expect(secondRes.status).not.toHaveBeenCalledWith(304);
+      expect(mockContentService.findByIdForDevice).toHaveBeenCalledTimes(2);
+      expect(mockStorageService.getObject).toHaveBeenNthCalledWith(2, objectKey);
+      expect(mockStorageService.getObject).toHaveBeenNthCalledWith(3, replacementObjectKey);
+      expect(secondRes.getBody().toString()).toBe('new');
     });
 
     it('should clear media headers and return 500 when streaming fails before headers are sent', async () => {
@@ -949,6 +1068,8 @@ describe('DeviceContentController', () => {
       expect(res.removeHeader).toHaveBeenCalledWith('Content-Type');
       expect(res.removeHeader).toHaveBeenCalledWith('Content-Length');
       expect(res.removeHeader).toHaveBeenCalledWith('Cache-Control');
+      expect(res.removeHeader).toHaveBeenCalledWith('ETag');
+      expect(res.removeHeader).toHaveBeenCalledWith('Last-Modified');
       expect(res.removeHeader).toHaveBeenCalledWith('Cross-Origin-Resource-Policy');
     });
 

--- a/middleware/src/modules/content/device-content.controller.ts
+++ b/middleware/src/modules/content/device-content.controller.ts
@@ -10,6 +10,7 @@ import {
   InternalServerErrorException,
   Logger,
 } from '@nestjs/common';
+import { createHash } from 'node:crypto';
 import { ParseIdPipe } from '../common/pipes/parse-id.pipe';
 import type { Request, Response } from 'express';
 import { JwtService } from '@nestjs/jwt';
@@ -35,7 +36,7 @@ const DEVICE_OBJECT_METADATA_CACHE_TTL_MS = 10_000;
 const DEVICE_TOKEN_AUTH_CACHE_MAX_ENTRIES = 1_000;
 const DEVICE_CONTENT_CACHE_MAX_ENTRIES = 1_000;
 const DEVICE_OBJECT_METADATA_CACHE_MAX_ENTRIES = 1_000;
-const SUCCESSFUL_MEDIA_CACHE_CONTROL = 'private, no-store';
+const SUCCESSFUL_MEDIA_CACHE_CONTROL = 'private, no-cache';
 
 type DeviceContentRecord = NonNullable<
   Awaited<ReturnType<ContentService['findByIdForDevice']>>
@@ -119,7 +120,7 @@ export class DeviceContentController {
     }
 
     if (rangeHeader.includes(',')) {
-      return { kind: 'none' };
+      return { kind: 'unsatisfiable' };
     }
 
     const match = /^bytes=(\d*)-(\d*)$/.exec(rangeHeader.trim());
@@ -543,6 +544,7 @@ export class DeviceContentController {
     }
 
     if (resolved.range.kind === 'range') {
+      const validators = this.getMediaValidators(resolved);
       const length = resolved.range.range.end - resolved.range.range.start + 1;
       res.status(206);
       res.set({
@@ -551,20 +553,83 @@ export class DeviceContentController {
         'Content-Length': String(length),
         'Content-Range': `bytes ${resolved.range.range.start}-${resolved.range.range.end}/${resolved.metadata.size}`,
         'Cache-Control': SUCCESSFUL_MEDIA_CACHE_CONTROL,
+        'Last-Modified': validators.lastModified,
         'Cross-Origin-Resource-Policy': 'cross-origin',
       });
       await this.streamToResponse(stream, res);
       return;
     }
 
+    const validators = this.getMediaValidators(resolved);
     res.set({
       'Content-Type': resolved.mimeType,
       'Accept-Ranges': 'bytes',
       'Content-Length': String(resolved.metadata.size),
       'Cache-Control': SUCCESSFUL_MEDIA_CACHE_CONTROL,
+      ETag: validators.etag,
+      'Last-Modified': validators.lastModified,
       'Cross-Origin-Resource-Policy': 'cross-origin',
     });
     await this.streamToResponse(stream, res);
+  }
+
+  private getMediaValidators(resolved: ResolvedMinioContent): {
+    etag: string;
+    lastModified: string;
+    lastModifiedTime: number;
+  } {
+    const lastModifiedTime = resolved.metadata.lastModified.getTime();
+    const digest = createHash('sha256')
+      .update(`${resolved.objectKey}:${resolved.metadata.size}:${lastModifiedTime}`)
+      .digest('base64url');
+
+    return {
+      etag: `W/"${digest}"`,
+      lastModified: resolved.metadata.lastModified.toUTCString(),
+      lastModifiedTime,
+    };
+  }
+
+  private getHeaderValue(req: Request, name: string): string | undefined {
+    const value = req.headers[name.toLowerCase()];
+    if (Array.isArray(value)) {
+      return value.join(',');
+    }
+    return typeof value === 'string' ? value : undefined;
+  }
+
+  private isClientCacheFresh(req: Request, resolved: ResolvedMinioContent): boolean {
+    const validators = this.getMediaValidators(resolved);
+    const ifNoneMatch = this.getHeaderValue(req, 'if-none-match');
+    if (ifNoneMatch) {
+      const requestedEtags = ifNoneMatch.split(',').map((tag) => tag.trim());
+      return requestedEtags.includes('*') || requestedEtags.includes(validators.etag);
+    }
+
+    const ifModifiedSince = this.getHeaderValue(req, 'if-modified-since');
+    if (!ifModifiedSince) {
+      return false;
+    }
+
+    const sinceTime = Date.parse(ifModifiedSince);
+    if (!Number.isFinite(sinceTime)) {
+      return false;
+    }
+
+    return Math.floor(validators.lastModifiedTime / 1000) * 1000 <= sinceTime;
+  }
+
+  private writeNotModified(resolved: ResolvedMinioContent, res: Response): void {
+    const validators = this.getMediaValidators(resolved);
+    res.status(304);
+    res.set({
+      'Accept-Ranges': 'bytes',
+      'Cache-Control': SUCCESSFUL_MEDIA_CACHE_CONTROL,
+      ETag: validators.etag,
+      'Last-Modified': validators.lastModified,
+      'Cross-Origin-Resource-Policy': 'cross-origin',
+    });
+    res.end();
   }
 
   private async streamToResponse(stream: NodeJS.ReadableStream, res: Response): Promise<void> {
@@ -580,6 +645,8 @@ export class DeviceContentController {
         res.removeHeader('Content-Range');
         res.removeHeader('Accept-Ranges');
         res.removeHeader('Cache-Control');
+        res.removeHeader('ETag');
+        res.removeHeader('Last-Modified');
         res.removeHeader('Cross-Origin-Resource-Policy');
         throw new InternalServerErrorException('Failed to stream content file');
       }
@@ -611,6 +678,17 @@ export class DeviceContentController {
       req,
     );
     let stream: NodeJS.ReadableStream | null = null;
+
+    if (
+      resolved.kind === 'minio' &&
+      resolved.range.kind !== 'unsatisfiable' &&
+      !resolved.contentCacheHit &&
+      !resolved.metadataCacheHit &&
+      this.isClientCacheFresh(req, resolved)
+    ) {
+      this.writeNotModified(resolved, res);
+      return;
+    }
 
     if (resolved.kind === 'minio' && resolved.range.kind !== 'unsatisfiable') {
       const opened = await this.openMinioStreamWithStaleRecovery(

--- a/realtime/src/gateways/device.gateway.spec.ts
+++ b/realtime/src/gateways/device.gateway.spec.ts
@@ -122,6 +122,7 @@ describe('DeviceGateway', () => {
     emit: options.emit ?? jest.fn((_event: string, _data: any, ackCb?: () => void) => {
       if (ackCb) ackCb();
     }),
+    disconnect: jest.fn(),
   });
 
   // Mock socket that auto-invokes ack callbacks on emit
@@ -180,6 +181,7 @@ describe('DeviceGateway', () => {
     mockServer.in.mockReturnValue({
       fetchSockets: jest.fn().mockResolvedValue([mockRemoteSocket]),
     });
+    mockServer.sockets.sockets.clear();
     // Use fake timers to prevent setInterval leaks
     jest.useFakeTimers();
 
@@ -206,6 +208,7 @@ describe('DeviceGateway', () => {
 
     // Assign mock server
     (gateway as any).server = mockServer;
+    mockServer.sockets.sockets.set('remote-socket-1', mockRemoteSocket);
     (gateway as any).deviceSockets.set('device-1', 'remote-socket-1');
   });
 
@@ -748,6 +751,11 @@ describe('DeviceGateway', () => {
   });
 
   describe('handleHeartbeat', () => {
+    beforeEach(() => {
+      mockServer.sockets.sockets.set('socket-1', {});
+      (gateway as any).deviceSockets.set('device-1', 'socket-1');
+    });
+
     it('should process heartbeat and return success', async () => {
       const client = createMockSocket();
       const data = {
@@ -825,6 +833,9 @@ describe('DeviceGateway', () => {
 
       expect(result.success).toBe(true);
       expect(result.data.commands).toEqual([]);
+      expect(mockRedisService.setDeviceStatus).not.toHaveBeenCalled();
+      expect(mockDatabaseService.display.updateMany).not.toHaveBeenCalled();
+      expect(mockHeartbeatService.processHeartbeat).not.toHaveBeenCalled();
       expect(mockRedisService.getPendingPlaylist).not.toHaveBeenCalled();
       expect(mockRedisService.getDeviceCommands).not.toHaveBeenCalled();
     });
@@ -893,17 +904,25 @@ describe('DeviceGateway', () => {
       expect(mockRedisService.getPendingPlaylist).not.toHaveBeenCalled();
     });
 
-    it('should not write to DB when status has not changed', async () => {
-      // Pre-set the status cache to 'online'
-      (gateway as any).deviceStatusCache.set('device-1', 'online');
+    it('should throttle PostgreSQL heartbeat refreshes while status remains online', async () => {
+      (gateway as any).deviceStatusCache.set('device-1', 'offline');
 
       const client = createMockSocket();
       const data = {};
 
       await gateway.handleHeartbeat(client as any, data as any);
 
-      // DB update should NOT be called since status hasn't changed
+      expect(mockDatabaseService.display.updateMany).toHaveBeenCalledTimes(1);
+
+      mockDatabaseService.display.updateMany.mockClear();
+      await gateway.handleHeartbeat(client as any, data as any);
+
       expect(mockDatabaseService.display.updateMany).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(61_000);
+      await gateway.handleHeartbeat(client as any, data as any);
+
+      expect(mockDatabaseService.display.updateMany).toHaveBeenCalledTimes(1);
     });
 
     it('should write to DB when status transitions from offline to online', async () => {
@@ -917,6 +936,32 @@ describe('DeviceGateway', () => {
 
       // DB update SHOULD be called because status changed
       expect(mockDatabaseService.display.updateMany).toHaveBeenCalled();
+    });
+
+    it('should keep active device status cache entries when cleaning stale sockets', () => {
+      (gateway as any).deviceSockets.clear();
+      (gateway as any).deviceSockets.set('device-1', 'socket-1');
+      mockServer.sockets.sockets.set('socket-1', {});
+      (gateway as any).deviceStatusCache.set('device-1', 'online');
+      (gateway as any).deviceStatusCache.set('device-stale', 'online');
+
+      (gateway as any).cleanupStaleEntries();
+
+      expect((gateway as any).deviceStatusCache.get('device-1')).toBe('online');
+      expect((gateway as any).deviceStatusCache.has('device-stale')).toBe(false);
+    });
+
+    it('should remove status cache entries whose socket map entry is gone', () => {
+      (gateway as any).deviceSockets.clear();
+      (gateway as any).deviceSockets.set('device-1', 'missing-socket');
+      (gateway as any).deviceStatusCache.set('device-1', 'online');
+      (gateway as any).lastHeartbeatDbWrites.set('device-1', Date.now());
+
+      (gateway as any).cleanupStaleEntries();
+
+      expect((gateway as any).deviceSockets.has('device-1')).toBe(false);
+      expect((gateway as any).deviceStatusCache.has('device-1')).toBe(false);
+      expect((gateway as any).lastHeartbeatDbWrites.has('device-1')).toBe(false);
     });
 
     it('should return error response on failure', async () => {

--- a/realtime/src/gateways/device.gateway.ts
+++ b/realtime/src/gateways/device.gateway.ts
@@ -87,6 +87,7 @@ type PendingCommandDeliveryResult = {
 const HEARTBEAT_REPLAY_BASE_DELAY_MS = 15000;
 const HEARTBEAT_REPLAY_MAX_DELAY_MS = 300000;
 const HEARTBEAT_REPLAY_MAX_FAILURES = 5;
+const HEARTBEAT_DB_REFRESH_INTERVAL_MS = 60_000;
 
 @WebSocketGateway({
   cors: {
@@ -110,6 +111,7 @@ export class DeviceGateway
 
   // 2.1: In-memory device status cache to avoid redundant DB writes
   private readonly deviceStatusCache: Map<string, string> = new Map();
+  private readonly lastHeartbeatDbWrites: Map<string, number> = new Map();
 
   // 2.4: Connection rate limiting per IP
   private readonly connectionAttempts: Map<string, { count: number; resetAt: number }> = new Map();
@@ -223,6 +225,7 @@ export class DeviceGateway
     client.disconnect?.(true);
     if (this.isActiveDeviceSocket(client, deviceId)) {
       this.deviceSockets.delete(deviceId);
+      this.lastHeartbeatDbWrites.delete(deviceId);
     }
     return false;
   }
@@ -300,6 +303,7 @@ export class DeviceGateway
     const socket = this.server?.sockets?.sockets?.get(socketId);
     if (!socket) {
       this.deviceSockets.delete(deviceId);
+      this.lastHeartbeatDbWrites.delete(deviceId);
       return false;
     }
 
@@ -510,14 +514,19 @@ export class DeviceGateway
    */
   private cleanupStaleEntries(): void {
     const activeDeviceIds = new Set<string>();
-    for (const [, deviceId] of this.deviceSockets) {
-      activeDeviceIds.add(deviceId);
+    for (const [deviceId, socketId] of this.deviceSockets) {
+      if (this.server?.sockets?.sockets?.has(socketId)) {
+        activeDeviceIds.add(deviceId);
+      } else {
+        this.deviceSockets.delete(deviceId);
+      }
     }
 
     let cleaned = 0;
     for (const deviceId of this.deviceStatusCache.keys()) {
       if (!activeDeviceIds.has(deviceId)) {
         this.deviceStatusCache.delete(deviceId);
+        this.lastHeartbeatDbWrites.delete(deviceId);
         cleaned++;
       }
     }
@@ -895,6 +904,7 @@ export class DeviceGateway
             lastHeartbeat: new Date(),
           },
         });
+        this.lastHeartbeatDbWrites.set(deviceId, Date.now());
       } catch (dbError: unknown) {
         const errorMessage = dbError instanceof Error ? dbError.message : 'Unknown error';
         this.logger.warn(`Failed to update database for device ${deviceId}: ${errorMessage}`);
@@ -1154,6 +1164,7 @@ export class DeviceGateway
           return;
         }
         this.deviceSockets.delete(deviceId);
+        this.lastHeartbeatDbWrites.delete(deviceId);
 
         // Update status in Redis
         await this.redisService.setDeviceStatus(deviceId, {
@@ -1239,6 +1250,13 @@ export class DeviceGateway
     const startTime = Date.now();
 
     try {
+      if (!this.isActiveDeviceSocket(client, deviceId)) {
+        return createSuccessResponse({
+          nextHeartbeatIn: 15000,
+          commands: [],
+        });
+      }
+
       // Update heartbeat in Redis (cheap, always do this)
       await this.redisService.setDeviceStatus(deviceId, {
         status: 'online',
@@ -1249,9 +1267,15 @@ export class DeviceGateway
         currentContent: data.currentContent,
       });
 
-      // 2.1: Only write to DB when status transitions (e.g., offline -> online)
+      // Keep Redis as the fast heartbeat path, but refresh Postgres often
+      // enough that middleware's offline scanner does not see live devices as stale.
       const previousStatus = this.deviceStatusCache.get(deviceId);
-      if (previousStatus !== 'online') {
+      const lastHeartbeatDbWrite = this.lastHeartbeatDbWrites.get(deviceId) ?? 0;
+      const shouldWriteHeartbeatToDb =
+        previousStatus !== 'online' ||
+        Date.now() - lastHeartbeatDbWrite >= HEARTBEAT_DB_REFRESH_INTERVAL_MS;
+
+      if (shouldWriteHeartbeatToDb) {
         try {
           // updateMany — silently no-ops if the row was deleted between
           // the device's JWT issuance and this heartbeat (test sockets,
@@ -1264,6 +1288,7 @@ export class DeviceGateway
               lastHeartbeat: new Date(),
             },
           });
+          this.lastHeartbeatDbWrites.set(deviceId, Date.now());
         } catch (dbError: unknown) {
           const errorMessage = dbError instanceof Error ? dbError.message : 'Unknown error';
           this.logger.warn(`Failed to update database for device ${deviceId}: ${errorMessage}`);

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,8 +1,126 @@
 # Vizora - Task Tracker
 
-## In Progress: Dashboard Contract Readiness Pass 8 (2026-05-31)
+## In Progress: Performance Readiness Review Pass 9 (2026-05-31)
+
+**Branch:** `feat/performance-readiness-pass-9`
+
+**Why now:** PR #131 merged the bounded dashboard contract fixes. The next
+autonomous slice is a comprehensive repo-side performance/code-review pass over
+customer-critical flows: content upload, pairing, content streaming/playback,
+middleware hot paths, and dashboard workflows. Production deploy remains blocked
+by dirty/diverged prod-local state, so this pass stays inside buildable,
+testable repo work.
+
+**New primitives introduced:** none planned. Prefer existing NestJS modules,
+Prisma models, storage services, realtime gateway, web API client, and dashboard
+patterns.
+
+**Hermes-first analysis:** not applicable unless a selected fix touches
+business agents, MCP tools, Hermes skills, or AI/provider spend paths.
+
+**Plan**
+- [x] Start fresh branch from merged `origin/main`.
+- [x] Re-check production deploy gate after PR #131 merge.
+- [x] Run multi-subagent performance/code-review analysis.
+- [x] Write plan/design for selected buildable fixes.
+- [x] Add focused failing tests/benchmarks where practical.
+- [x] Implement bounded performance/readiness fixes.
+- [x] Run multi-subagent code review before broader tests.
+- [x] Run focused and broader tests/builds/browser checks.
+- [ ] PR, CI, merge.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Deployment gate after PR #131**
+- [x] PR #131 merged at `58df1a276b8252dba7145c75705ae4deabde431f` with CI green.
+- [x] Prod deploy blocked: `/opt/vizora/app` is still `ahead 17, behind 66`, has
+  many modified/untracked prod-local files, and prod `origin/main` is stale while
+  remote `main` is `58df1a276b8252dba7145c75705ae4deabde431f`.
+- [x] Prod core services health check is OK; no deploy/restart performed.
+
+**Analysis feed**
+- [x] Middleware/storage reviewer prioritized streaming-upload memory pressure,
+  unsupported multi-range playback behavior, missing authenticated media validators,
+  unbounded template data-source fetches, and template refresh overlap risk.
+- [x] Pairing/realtime reviewer prioritized false offline status from stale Postgres
+  heartbeat writes, browser-display `clear_cache` deleting credentials, and display
+  clients not recovering from stale-token socket errors.
+- [x] Frontend/dashboard reviewer prioritized content-library all-fetch/render caps,
+  bulk-upload pressure, duplicate dashboard sockets, playlist index eager builder load,
+  dashboard overview list fan-out, and pairing help copy drift.
+
+**Plan/design:** `docs/plans/2026-05-31-performance-readiness-pass-9.md`
+
+**Selected fix bundle**
+- [x] Reject unsupported device-content multi-range requests instead of streaming the
+  full object.
+- [x] Add authenticated `ETag` / `Last-Modified` validators and `304` revalidation
+  path before MinIO stream acquisition.
+- [x] Keep successful protected media cacheable only by revalidation (`private, no-cache`).
+- [x] Refresh display `lastHeartbeat` in Postgres on a throttle and fix stale-status
+  cleanup to use active device IDs.
+- [x] Make browser-display `clear_cache` clear media cache without unpairing.
+- [x] Reset browser/Electron displays on terminal stale-token / missing-device socket errors.
+
+**Focused verification**
+- [x] Red run: middleware device-content, realtime device gateway, web display, and
+  Electron display-client suites failed on the expected missing behaviors.
+- [x] Green run:
+  `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=device-content.controller` -
+  pass, 1 suite / 37 tests after review fixes.
+- [x] Green run:
+  `pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern=device.gateway` -
+  pass, 2 suites / 105 tests after review fixes.
+- [x] Green run:
+  `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="display"` -
+  pass, 6 suites / 20 tests.
+- [x] Green run:
+  `pnpm --filter @vizora/display test -- --runInBand device-client.spec.ts` -
+  pass, 1 suite / 49 tests.
+
+**Broader verification**
+- [x] `pnpm --filter @vizora/realtime test -- --runInBand` - pass, 12 suites / 273 tests.
+- [x] `pnpm --filter @vizora/display test -- --runInBand` - pass, 6 suites / 126 tests.
+- [x] `pnpm --filter @vizora/middleware test -- --runInBand` - pass, 143 suites / 2827 tests.
+- [x] `pnpm --filter @vizora/web test -- --runInBand` - pass, 94 suites / 956 tests with
+  existing React `act(...)` and jsdom navigation warnings only.
+- [x] TypeScript: middleware, realtime, and web `tsc --noEmit --pretty false` pass;
+  display `pnpm --filter @vizora/display run typecheck` passes.
+- [x] Builds:
+  `npx nx build @vizora/middleware` - pass with existing webpack warnings;
+  `npx nx build @vizora/realtime` - pass with existing source-map / optional `ws` warnings;
+  `pnpm --filter @vizora/display run build` - pass;
+  `$env:NODE_OPTIONS='--max-old-space-size=4096'; npx nx build @vizora/web` - pass with
+  existing Next middleware/proxy deprecation and TS project-reference warnings.
+- [x] `git diff --check` - pass with expected LF-to-CRLF warnings only.
+
+**Review gate**
+- [x] Display-client reviewer: CLEAN.
+- [x] Realtime reviewer found stale socket heartbeats could still write Redis/Postgres
+  and cleanup trusted `deviceSockets` entries without checking live Socket.IO state;
+  fixed with an active-socket guard before heartbeat persistence and live-socket pruning.
+- [x] Middleware reviewer found weak ETags on `206`, `304` from cached stale validators,
+  and missing validator cleanup on stream errors; fixed by omitting ETag on partial
+  responses, limiting `304` to fresh-resolved media contexts, and clearing validators
+  on pre-header stream failure.
+- [x] Middleware/realtime re-review after fixes: both CLEAN.
+
+**Deferred follow-ups**
+- [ ] Disk-backed/streaming upload pipeline and per-type frontend upload caps.
+- [ ] Server-backed content-library pagination/search plus thumbnail lazy/virtualized rendering.
+- [ ] Shared dashboard realtime socket provider for status, notifications, and route events.
+- [ ] Playlist index summary payload and removal of dead builder-modal code.
+- [ ] Dashboard overview summary/read-model endpoint.
+- [ ] Pairing help copy update.
+- [ ] Template/widget data-source response caps and template refresh overlap guard.
+- [ ] Single-display queued push response contract.
+- [ ] Electron cache invalidation for replaced media.
+
+---
+
+## Completed: Dashboard Contract Readiness Pass 8 (2026-05-31)
 
 **Branch:** `feat/customer-dashboard-improvements-8`
+**PR / merge commit:** #131 / `58df1a276b8252dba7145c75705ae4deabde431f`
 
 **Why now:** After PR #130 merged, the next highest-value repo-side customer
 readiness work is a bounded set of dashboard contract defects found by the
@@ -28,8 +146,8 @@ behavior, MCP tools, Hermes skills, AI provider calls, or spend paths.
 - [x] Run focused web/middleware tests.
 - [x] Run multi-subagent code review before broader tests.
 - [x] Run broader affected tests/builds/typecheck.
-- [ ] PR, CI, merge.
-- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+- [x] PR, CI, merge.
+- [x] Re-check deployment gate; deploy only if prod checkout is safe.
 
 **Analysis feed**
 - [x] Customer UX review prioritized billing display/trial correctness, pairing guidance,

--- a/web/src/app/display/DisplayClient.tsx
+++ b/web/src/app/display/DisplayClient.tsx
@@ -46,7 +46,7 @@ export function DisplayClient() {
   const impressionRef = useRef<((...args: any[]) => void) | null>(null);
 
   const { isFullscreen, toggleFullscreen } = useFullscreen();
-  const { preloadItems } = useBrowserCache();
+  const { preloadItems, clearCache } = useBrowserCache();
 
   const {
     pairingCode,
@@ -91,8 +91,7 @@ export function DisplayClient() {
         window.location.reload();
         break;
       case 'clear_cache':
-        clearCredentials();
-        window.location.reload();
+        void clearCache().finally(() => window.location.reload());
         break;
       case 'unpair':
         clearCredentials();
@@ -101,7 +100,7 @@ export function DisplayClient() {
       default:
         console.log('[Vizora Display] Unknown command:', command.type);
     }
-  }, []);
+  }, [clearCache]);
 
   const handleConfig = useCallback((_config: DeviceConfig) => {
     // Config received (heartbeat interval, cache settings, etc.)

--- a/web/src/app/display/__tests__/DisplayClient.test.tsx
+++ b/web/src/app/display/__tests__/DisplayClient.test.tsx
@@ -2,12 +2,15 @@ import { render, waitFor } from '@testing-library/react';
 import { DisplayClient } from '../DisplayClient';
 import type { Playlist } from '../lib/types';
 
-const preloadItems = jest.fn();
+var mockPreloadItems = jest.fn();
+var mockClearCache = jest.fn().mockResolvedValue(undefined);
+var mockClearCredentials = jest.fn();
 const updatePlaylist = jest.fn();
 let capturedPlaylistUpdate: ((playlist: Playlist) => void) | undefined;
+let capturedCommand: ((command: { type: string }) => void) | undefined;
 
 jest.mock('../hooks/useBrowserCache', () => ({
-  useBrowserCache: () => ({ preloadItems }),
+  useBrowserCache: () => ({ preloadItems: mockPreloadItems, clearCache: mockClearCache }),
 }));
 
 jest.mock('../hooks/usePairing', () => ({
@@ -25,12 +28,13 @@ jest.mock('../hooks/usePairing', () => ({
     resetPairing: jest.fn(),
     updateDeviceToken: jest.fn(),
   }),
-  clearCredentials: jest.fn(),
+  clearCredentials: () => mockClearCredentials(),
 }));
 
 jest.mock('../hooks/useDeviceConnection', () => ({
   useDeviceConnection: (options: any) => {
     capturedPlaylistUpdate = options.onPlaylistUpdate;
+    capturedCommand = options.onCommand;
     return {
       status: 'connected',
       emitImpression: jest.fn(),
@@ -70,11 +74,19 @@ jest.mock('../components/FullscreenButton', () => ({
 }));
 
 describe('DisplayClient', () => {
+  let reload: jest.Mock;
+
   beforeEach(() => {
     jest.clearAllMocks();
     capturedPlaylistUpdate = undefined;
+    capturedCommand = undefined;
+    reload = jest.fn();
+    const location = new URL('https://display.example.test/display') as URL & {
+      reload: jest.Mock;
+    };
+    location.reload = reload;
     Object.defineProperty(window, 'location', {
-      value: new URL('https://display.example.test/display'),
+      value: location,
       writable: true,
     });
   });
@@ -104,8 +116,20 @@ describe('DisplayClient', () => {
     });
 
     expect(updatePlaylist).toHaveBeenCalled();
-    expect(preloadItems).toHaveBeenCalledWith([
+    expect(mockPreloadItems).toHaveBeenCalledWith([
       '/api/v1/device-content/content-1/file?token=device-token-123',
     ]);
+  });
+
+  it('clears browser media cache without deleting pairing credentials', async () => {
+    render(<DisplayClient />);
+
+    await waitFor(() => expect(capturedCommand).toBeDefined());
+
+    capturedCommand?.({ type: 'clear_cache' });
+
+    await waitFor(() => expect(mockClearCache).toHaveBeenCalledTimes(1));
+    expect(mockClearCredentials).not.toHaveBeenCalled();
+    expect(reload).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/app/display/hooks/__tests__/useDeviceConnection.test.tsx
+++ b/web/src/app/display/hooks/__tests__/useDeviceConnection.test.tsx
@@ -39,6 +39,11 @@ describe('useDeviceConnection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     localStorage.clear();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('acknowledges playlist updates after applying them', () => {
@@ -204,5 +209,38 @@ describe('useDeviceConnection', () => {
     expect(JSON.parse(localStorage.getItem('vizora_display_credentials') || '{}')).toEqual({
       deviceToken: 'new-token',
     });
+  });
+
+  it('resets pairing when connect_error reports a stale device token', () => {
+    const socket = createSocket();
+    (io as jest.Mock).mockReturnValue(socket);
+
+    const handlers = renderConnection();
+    const errorHandler = socket.on.mock.calls.find(
+      (call: any[]) => call[0] === 'connect_error',
+    )?.[1];
+
+    act(() => {
+      errorHandler({ message: 'device_token_stale' });
+    });
+
+    expect(handlers.onUnauthorized).toHaveBeenCalledTimes(1);
+  });
+
+  it('disconnects and resets pairing when socket error reports a missing device', () => {
+    const socket = createSocket();
+    (io as jest.Mock).mockReturnValue(socket);
+
+    const handlers = renderConnection();
+    const errorHandler = socket.on.mock.calls.find(
+      (call: any[]) => call[0] === 'error',
+    )?.[1];
+
+    act(() => {
+      errorHandler({ message: 'device_not_found' });
+    });
+
+    expect(socket.disconnect).toHaveBeenCalledTimes(1);
+    expect(handlers.onUnauthorized).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/app/display/hooks/useDeviceConnection.ts
+++ b/web/src/app/display/hooks/useDeviceConnection.ts
@@ -27,6 +27,21 @@ interface UseDeviceConnectionOptions {
 
 const SOCKET_URL = process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:3002';
 const CREDENTIALS_KEY = 'vizora_display_credentials';
+const TERMINAL_DEVICE_AUTH_ERRORS = [
+  'unauthorized',
+  'invalid token',
+  'device_token_stale',
+  'device_not_found',
+];
+
+function isTerminalDeviceAuthError(message: unknown): boolean {
+  if (typeof message !== 'string') {
+    return false;
+  }
+
+  const normalized = message.toLowerCase();
+  return TERMINAL_DEVICE_AUTH_ERRORS.some((term) => normalized.includes(term));
+}
 
 export function useDeviceConnection({
   credentials,
@@ -141,7 +156,7 @@ export function useDeviceConnection({
       setStatus('error');
       stopHeartbeat();
 
-      if (err.message.includes('unauthorized') || err.message.includes('invalid token')) {
+      if (isTerminalDeviceAuthError(err.message)) {
         onUnauthorized();
       }
     });
@@ -214,6 +229,10 @@ export function useDeviceConnection({
 
     socket.on('error', (err: { message: string }) => {
       console.error('[Vizora Display] Socket error:', err.message);
+      if (isTerminalDeviceAuthError(err.message)) {
+        socket.disconnect();
+        onUnauthorized();
+      }
     });
 
     return () => {


### PR DESCRIPTION
## Summary
- reject unsupported multi-range display media requests and add authenticated ETag/Last-Modified revalidation without opening a MinIO stream
- throttle realtime heartbeat DB refreshes while preserving Redis heartbeat updates and prune stale socket mappings against live Socket.IO state
- keep browser clear_cache from unpairing displays and reset browser/Electron displays on terminal stale-token or missing-device socket errors

## Review gate
- Display-client reviewer: CLEAN
- Middleware reviewer findings fixed: no weak ETag on 206, no 304 from stale cached validators, validator cleanup on stream errors; re-review CLEAN
- Realtime reviewer findings fixed: stale heartbeats no longer persist Redis/DB and cleanup verifies live sockets; re-review CLEAN

## Verification
- pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=device-content.controller
- pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern=device.gateway
- pnpm --filter @vizora/web test -- --runInBand --testPathPattern=display
- pnpm --filter @vizora/display test -- --runInBand device-client.spec.ts
- pnpm --filter @vizora/realtime test -- --runInBand
- pnpm --filter @vizora/display test -- --runInBand
- pnpm --filter @vizora/middleware test -- --runInBand
- pnpm --filter @vizora/web test -- --runInBand
- pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false
- pnpm --filter @vizora/realtime exec tsc --noEmit --pretty false
- pnpm --filter @vizora/web exec tsc --noEmit --pretty false
- pnpm --filter @vizora/display run typecheck
- npx nx build @vizora/middleware
- npx nx build @vizora/realtime
- pnpm --filter @vizora/display run build
- NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000 BACKEND_URL=http://localhost:3000 NODE_OPTIONS=--max-old-space-size=4096 npx nx build @vizora/web
- git diff --check

## Deploy
- Not deployed from this branch. Production deploy is still gated on the `/opt/vizora/app` checkout being safe.