### PR TITLE
perf: reduce upload memory pressure

### DIFF
--- a/docs/plans/2026-05-31-upload-pressure-readiness-pass-10.md
+++ b/docs/plans/2026-05-31-upload-pressure-readiness-pass-10.md
@@ -1,0 +1,70 @@
+# Upload Pressure Readiness Pass 10 Plan
+
+**Goal:** Reduce customer-visible upload pressure by removing 100MB media buffers from the middleware hot path where practical and by preventing dashboard bulk uploads from driving avoidable concurrent large-file pressure.
+
+**Architecture:** Keep the work inside the existing content upload surfaces: NestJS `ContentController`, `FileValidationService`, `StorageService`, and the dashboard content page. Use Multer disk-backed temporary files for HTTP uploads, stream validation/hash/upload from disk, and preserve the current quota, MinIO, local-dev fallback, thumbnail, and response-envelope behavior.
+
+**Tech Stack:** NestJS, Multer, Node streams, MinIO SDK, Next.js/React content dashboard, Jest.
+
+---
+
+## Scope
+
+**New primitives introduced:** small helper methods only:
+
+- `FileValidationService.validateFileAtPath(...)`
+- `StorageService.uploadFileFromPath(...)`
+- `ContentController` private helpers for uploaded-file validation, storage upload, local fallback, thumbnail scheduling, and temp cleanup.
+
+**Hermes-first analysis:** not applicable to the selected implementation because this pass does not add business agents, MCP tools, Hermes skills, AI provider calls, or spend paths.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| HTTP upload buffering | none applicable | Build in existing middleware controller/storage path |
+| File validation/hash streaming | none applicable | Build in existing validation service |
+| Dashboard upload backpressure | none applicable | Build in existing content dashboard controls |
+
+Awesome-Hermes ecosystem verdict: not applicable; these are first-party upload/runtime paths, not agent skills.
+
+## Current Evidence
+
+- `ContentController` uses `FileInterceptor('file', { limits: { fileSize: 100 * 1024 * 1024 } })`, which defaults to memory-backed Multer storage and leaves uploaded bytes in `file.buffer`.
+- `uploadFile` and `replaceFile` validate `file.buffer`, upload `file.buffer` to MinIO, write local fallback from `file.buffer`, and schedule image thumbnails from `file.buffer`.
+- `StorageService.uploadFile` calls MinIO `putObject` with a `Buffer`.
+- `FileValidationService.validateFile` computes magic-number checks, suspicious-content checks, and hash from a whole buffer.
+- The dashboard content page currently permits several queued files and uses a fixed concurrency of 3.
+
+## Selected Fix Bundle
+
+1. Switch content upload and replace-file interceptors to disk-backed temporary storage while preserving the 100MB HTTP limit.
+2. Add file-path validation that checks allowed MIME/extension/size, reads the magic/signature window for all files, scans full PDFs for active-content markers, scans the first suspicious-content window for other media, and hashes via a stream.
+3. Add MinIO upload-from-path using a read stream and known size, preserving the existing circuit breaker and metadata behavior.
+4. Keep unit-test direct controller calls working for buffer-backed mock files.
+5. Clean temporary upload files on success and failure, including image thumbnail background work.
+6. Add dashboard upload pressure guards: per-type max-size copy enforced by dropzone, a bounded queue, and dynamic concurrency that uploads videos/PDFs one at a time.
+
+## Deferred Follow-Ups
+
+- True multipart/chunked resumable uploads with server-side session state.
+- Background thumbnail queue instead of in-process fire-and-forget work.
+- Server-backed content-library pagination/search and thumbnail virtualization.
+- Shared dashboard realtime socket provider.
+
+## Verification Plan
+
+Focused red/green tests:
+
+- `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="file-validation.service|storage.service|content.controller"`
+- `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="dashboard/content"`
+
+Broader checks after subagent review:
+
+- `pnpm --filter @vizora/middleware test -- --runInBand`
+- `pnpm --filter @vizora/web test -- --runInBand`
+- `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
+- `pnpm --filter @vizora/web exec tsc --noEmit --pretty false`
+- `npx nx build @vizora/middleware`
+- `$env:NEXT_PUBLIC_SOCKET_URL='http://localhost:3002'; $env:NEXT_PUBLIC_API_URL='http://localhost:3000'; $env:BACKEND_URL='http://localhost:3000'; $env:NODE_OPTIONS='--max-old-space-size=4096'; npx nx build @vizora/web`
+- `git diff --check`
+
+Deployment remains blocked unless the production checkout is reconciled and safe after merge.

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -128,6 +128,7 @@
     "isomorphic-dompurify": "^3.0.0",
     "minio": "^8.0.7",
     "mongoose": "^9.1.5",
+    "multer": "2.1.1",
     "nodemailer": "^8.0.1",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",

--- a/middleware/src/modules/content/content.controller.spec.ts
+++ b/middleware/src/modules/content/content.controller.spec.ts
@@ -16,6 +16,9 @@ import { StorageService } from '../storage/storage.service';
 import { StorageQuotaService } from '../storage/storage-quota.service';
 import { SubscriptionActiveGuard } from '../billing/guards/subscription-active.guard';
 import { DatabaseService } from '../database/database.service';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 
 describe('ContentController', () => {
   let controller: ContentController;
@@ -60,18 +63,21 @@ describe('ContentController', () => {
 
     mockThumbnailService = {
       generateThumbnail: jest.fn().mockResolvedValue('/static/thumbnails/thumb-123.jpg'),
+      generateThumbnailFromPath: jest.fn().mockResolvedValue('/static/thumbnails/thumb-123.jpg'),
       generateThumbnailFromUrl: jest.fn().mockResolvedValue('/static/thumbnails/thumb-url-123.jpg'),
     } as any;
 
     mockFileValidationService = {
       validateUrl: jest.fn(),
       validateFile: jest.fn(),
+      validateFileAtPath: jest.fn(),
       sanitizeFilename: jest.fn(),
     } as any;
 
     mockStorageService = {
       isMinioAvailable: jest.fn().mockReturnValue(false),
       uploadFile: jest.fn(),
+      uploadFileFromPath: jest.fn(),
       getPresignedUrl: jest.fn(),
       deleteFile: jest.fn(),
       generateObjectKey: jest.fn(),
@@ -170,6 +176,10 @@ describe('ContentController', () => {
         hash: 'abc123hash',
         mimeType: 'image/jpeg',
       });
+      (mockFileValidationService as any).validateFileAtPath.mockResolvedValue({
+        hash: 'abc123hash',
+        mimeType: 'image/jpeg',
+      });
       mockFileValidationService.sanitizeFilename.mockReturnValue('test-image.jpg');
       mockContentService.create.mockResolvedValue({
         id: 'content-123',
@@ -252,6 +262,57 @@ describe('ContentController', () => {
       );
     });
 
+    it('should validate and upload disk-backed files without using file.buffer', async () => {
+      const diskFile = {
+        path: path.join(os.tmpdir(), 'vizora-content-uploads', 'upload-disk.jpg'),
+        originalname: 'disk-image.jpg',
+        mimetype: 'image/jpeg',
+        size: 4096,
+      } as Express.Multer.File;
+      mockStorageService.isMinioAvailable.mockReturnValueOnce(true);
+      mockStorageService.generateObjectKey.mockReturnValueOnce('org-123/uploads/disk-image.jpg');
+      const unlinkSpy = jest.spyOn(fs.promises, 'unlink').mockResolvedValue(undefined);
+
+      await controller.uploadFile(organizationId, diskFile);
+
+      expect((mockFileValidationService as any).validateFileAtPath).toHaveBeenCalledWith(
+        diskFile.path,
+        diskFile.originalname,
+        diskFile.mimetype,
+        diskFile.size,
+      );
+      expect(mockFileValidationService.validateFile).not.toHaveBeenCalled();
+      expect((mockStorageService as any).uploadFileFromPath).toHaveBeenCalledWith(
+        diskFile.path,
+        'org-123/uploads/disk-image.jpg',
+        diskFile.mimetype,
+        diskFile.size,
+      );
+      expect(mockStorageService.uploadFile).not.toHaveBeenCalled();
+      await new Promise(resolve => setImmediate(resolve));
+      expect(unlinkSpy).toHaveBeenCalledWith(diskFile.path);
+      unlinkSpy.mockRestore();
+    });
+
+    it('should clean disk-backed upload temp files when validation fails before quota reservation', async () => {
+      const diskFile = {
+        path: path.join(os.tmpdir(), 'vizora-content-uploads', 'invalid-disk.jpg'),
+        originalname: 'invalid-disk.jpg',
+        mimetype: 'image/jpeg',
+        size: 4096,
+      } as Express.Multer.File;
+      (mockFileValidationService as any).validateFileAtPath.mockRejectedValueOnce(
+        new BadRequestException('Invalid file'),
+      );
+      const unlinkSpy = jest.spyOn(fs.promises, 'unlink').mockResolvedValue(undefined);
+
+      await expect(controller.uploadFile(organizationId, diskFile)).rejects.toThrow('Invalid file');
+
+      expect(mockStorageQuotaService.reserveQuota).not.toHaveBeenCalled();
+      expect(unlinkSpy).toHaveBeenCalledWith(diskFile.path);
+      unlinkSpy.mockRestore();
+    });
+
     it('should sanitize filename', async () => {
       await controller.uploadFile(organizationId, mockFile);
 
@@ -327,6 +388,44 @@ describe('ContentController', () => {
           thumbnail: expect.any(String),
         }),
       );
+    });
+
+    it('should keep disk-backed image temp files until thumbnail generation settles', async () => {
+      const diskFile = {
+        path: path.join(os.tmpdir(), 'vizora-content-uploads', 'thumbnail-owned.jpg'),
+        originalname: 'thumbnail-owned.jpg',
+        mimetype: 'image/jpeg',
+        size: 4096,
+      } as Express.Multer.File;
+      mockStorageService.isMinioAvailable.mockReturnValueOnce(true);
+      mockStorageService.generateObjectKey.mockReturnValueOnce('org-123/uploads/thumbnail-owned.jpg');
+      let resolveThumbnail: (thumbnail: string) => void = () => {};
+      (mockThumbnailService as any).generateThumbnailFromPath.mockReturnValueOnce(
+        new Promise<string>((resolve) => {
+          resolveThumbnail = resolve;
+        }),
+      );
+      const unlinkSpy = jest.spyOn(fs.promises, 'unlink').mockResolvedValue(undefined);
+
+      await controller.uploadFile(organizationId, diskFile);
+
+      expect((mockThumbnailService as any).generateThumbnailFromPath).toHaveBeenCalledWith(
+        'content-123',
+        diskFile.path,
+        diskFile.mimetype,
+      );
+      expect(unlinkSpy).not.toHaveBeenCalled();
+
+      resolveThumbnail('/static/thumbnails/thumb-path.jpg');
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(mockContentService.update).toHaveBeenCalledWith(
+        organizationId,
+        'content-123',
+        expect.objectContaining({ thumbnail: '/static/thumbnails/thumb-path.jpg' }),
+      );
+      expect(unlinkSpy).toHaveBeenCalledWith(diskFile.path);
+      unlinkSpy.mockRestore();
     });
   });
 
@@ -458,6 +557,10 @@ describe('ContentController', () => {
         hash: 'newHash123',
         mimeType: 'image/jpeg',
       });
+      (mockFileValidationService as any).validateFileAtPath.mockResolvedValue({
+        hash: 'newHash123',
+        mimeType: 'image/jpeg',
+      });
       mockFileValidationService.sanitizeFilename.mockReturnValue('new-image.jpg');
       mockContentService.findOne.mockResolvedValue({
         id: 'content-123',
@@ -506,6 +609,58 @@ describe('ContentController', () => {
         mockFile.originalname,
         mockFile.mimetype,
       );
+    });
+
+    it('should validate and upload disk-backed replacement files without using file.buffer', async () => {
+      const diskFile = {
+        path: path.join(os.tmpdir(), 'vizora-content-uploads', 'replacement-disk.jpg'),
+        originalname: 'replacement-disk.jpg',
+        mimetype: 'image/jpeg',
+        size: 2048,
+      } as Express.Multer.File;
+      mockStorageService.isMinioAvailable.mockReturnValueOnce(true);
+      mockStorageService.generateObjectKey.mockReturnValueOnce('org-123/uploads/replacement-disk.jpg');
+      const unlinkSpy = jest.spyOn(fs.promises, 'unlink').mockResolvedValue(undefined);
+
+      await controller.replaceFile(organizationId, 'content-123', diskFile, {});
+
+      expect((mockFileValidationService as any).validateFileAtPath).toHaveBeenCalledWith(
+        diskFile.path,
+        diskFile.originalname,
+        diskFile.mimetype,
+        diskFile.size,
+      );
+      expect(mockFileValidationService.validateFile).not.toHaveBeenCalled();
+      expect((mockStorageService as any).uploadFileFromPath).toHaveBeenCalledWith(
+        diskFile.path,
+        'org-123/uploads/replacement-disk.jpg',
+        diskFile.mimetype,
+        diskFile.size,
+      );
+      expect(mockStorageService.uploadFile).not.toHaveBeenCalled();
+      await new Promise(resolve => setImmediate(resolve));
+      expect(unlinkSpy).toHaveBeenCalledWith(diskFile.path);
+      unlinkSpy.mockRestore();
+    });
+
+    it('should clean disk-backed replacement temp files when validation fails before quota reservation', async () => {
+      const diskFile = {
+        path: path.join(os.tmpdir(), 'vizora-content-uploads', 'invalid-replacement.jpg'),
+        originalname: 'invalid-replacement.jpg',
+        mimetype: 'image/jpeg',
+        size: 2048,
+      } as Express.Multer.File;
+      (mockFileValidationService as any).validateFileAtPath.mockRejectedValueOnce(
+        new BadRequestException('Invalid file'),
+      );
+      const unlinkSpy = jest.spyOn(fs.promises, 'unlink').mockResolvedValue(undefined);
+
+      await expect(controller.replaceFile(organizationId, 'content-123', diskFile, {}))
+        .rejects.toThrow('Invalid file');
+
+      expect(mockStorageQuotaService.reserveQuota).not.toHaveBeenCalled();
+      expect(unlinkSpy).toHaveBeenCalledWith(diskFile.path);
+      unlinkSpy.mockRestore();
     });
 
     it('should not reserve additional quota when replacement validation fails', async () => {

--- a/middleware/src/modules/content/content.controller.ts
+++ b/middleware/src/modules/content/content.controller.ts
@@ -19,6 +19,7 @@ import {
 } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { diskStorage } from 'multer';
 import { ParseIdPipe } from '../common/pipes/parse-id.pipe';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
@@ -43,9 +44,32 @@ import { ReviewContentDto } from './dto/review-content.dto';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as os from 'os';
+import { randomUUID } from 'crypto';
 
 // Prefix used to identify MinIO-stored content
 const MINIO_URL_PREFIX = 'minio://';
+const MAX_CONTENT_UPLOAD_SIZE = 100 * 1024 * 1024;
+const CONTENT_UPLOAD_TMP_ROOT = path.join(os.tmpdir(), 'vizora-content-uploads');
+
+const contentUploadStorage = diskStorage({
+  destination: (_req, _file, callback) => {
+    fs.mkdir(CONTENT_UPLOAD_TMP_ROOT, { recursive: true }, (error) => {
+      callback(error, CONTENT_UPLOAD_TMP_ROOT);
+    });
+  },
+  filename: (_req, file, callback) => {
+    const extension = path.extname(file.originalname)
+      .toLowerCase()
+      .replace(/[^.\w-]/g, '');
+    callback(null, `${Date.now()}-${randomUUID()}${extension}`);
+  },
+});
+
+const CONTENT_UPLOAD_INTERCEPTOR_OPTIONS = {
+  storage: contentUploadStorage,
+  limits: { fileSize: MAX_CONTENT_UPLOAD_SIZE },
+};
 
 @UseGuards(RolesGuard)
 @RequiresSubscription()
@@ -79,7 +103,7 @@ export class ContentController {
   @Post('upload')
   @Roles('admin', 'manager')
   @HttpCode(HttpStatus.CREATED)
-  @UseInterceptors(FileInterceptor('file', { limits: { fileSize: 100 * 1024 * 1024 } }))
+  @UseInterceptors(FileInterceptor('file', CONTENT_UPLOAD_INTERCEPTOR_OPTIONS))
   async uploadFile(
     @CurrentUser('organizationId') organizationId: string,
     @UploadedFile() file: Express.Multer.File,
@@ -90,24 +114,22 @@ export class ContentController {
       throw new BadRequestException('No file provided');
     }
 
-    // Validate file using magic numbers, size, etc.
-    const validation = await this.fileValidationService.validateFile(
-      file.buffer,
-      file.originalname,
-      file.mimetype,
-    );
-
-    // Sanitize filename
-    const safeFilename = this.fileValidationService.sanitizeFilename(
-      file.originalname,
-    );
-
-    let fileUrl: string;
-    const filename = `${validation.hash}-${safeFilename}`;
+    const tempPath = this.getUploadedTempPath(file);
+    let tempPathOwnedByThumbnail = false;
     let uploadedObjectKey: string | null = null;
+    let quotaReserved = false;
 
-    await this.storageQuotaService.reserveQuota(organizationId, file.size);
     try {
+      const validation = await this.validateUploadedFile(file, tempPath);
+      const safeFilename = this.fileValidationService.sanitizeFilename(
+        file.originalname,
+      );
+      const filename = `${validation.hash}-${safeFilename}`;
+      let fileUrl: string;
+
+      await this.storageQuotaService.reserveQuota(organizationId, file.size);
+      quotaReserved = true;
+
       // Try MinIO first. In production, fail closed instead of creating
       // unreachable /uploads content when object storage is unhealthy.
       if (this.storageService.isMinioAvailable()) {
@@ -116,7 +138,7 @@ export class ContentController {
           validation.hash,
           safeFilename,
         );
-        await this.storageService.uploadFile(file.buffer, objectKey, file.mimetype);
+        await this.uploadToMinio(file, tempPath, objectKey);
         uploadedObjectKey = objectKey;
         // Store with minio:// prefix to identify MinIO-stored content
         fileUrl = `${MINIO_URL_PREFIX}${objectKey}`;
@@ -126,7 +148,7 @@ export class ContentController {
       } else {
         // Development fallback only; production middleware no longer serves
         // /uploads, so accepting this path there would create dead content.
-        fileUrl = await this.saveFileLocally(organizationId, filename, file.buffer);
+        fileUrl = await this.saveFileLocallyFromUpload(organizationId, filename, file, tempPath);
       }
 
       // Determine the content type from the file mimetype
@@ -146,16 +168,14 @@ export class ContentController {
 
       // Generate thumbnail in background (fire-and-forget to avoid blocking upload response)
       if (contentType === 'image') {
-        this.thumbnailService.generateThumbnail(
+        tempPathOwnedByThumbnail = this.scheduleThumbnailGeneration(
+          organizationId,
           content.id,
-          file.buffer,
-          file.mimetype,
-        ).then(async (thumbnailUrl) => {
-          await this.contentService.update(organizationId, content.id, { thumbnail: thumbnailUrl });
-          this.logger.debug(`Thumbnail generated in background: ${thumbnailUrl}`);
-        }).catch((error) => {
-          this.logger.warn(`Background thumbnail generation failed: ${error}`);
-        });
+          file,
+          tempPath,
+          'Background thumbnail generation failed',
+          'Thumbnail generated in background',
+        );
       }
 
       return {
@@ -172,10 +192,14 @@ export class ContentController {
           this.logger.warn(`Failed to clean up uploaded object after upload failure: ${deleteError}`);
         }
       }
-      if (canReleaseQuota) {
+      if (canReleaseQuota && quotaReserved) {
         await this.releaseQuotaReservation(organizationId, file.size);
       }
       throw error;
+    } finally {
+      if (tempPath && !tempPathOwnedByThumbnail) {
+        await this.cleanupTempUpload(tempPath);
+      }
     }
   }
 
@@ -196,6 +220,148 @@ export class ContentController {
     const baseUrl = process.env.API_BASE_URL
       || (process.env.NODE_ENV === 'production' ? (() => { throw new Error('API_BASE_URL must be set in production'); })() : 'http://localhost:3000');
     return `${baseUrl}/uploads/${organizationId}/${filename}`;
+  }
+
+  private async saveFileLocallyFromPath(
+    organizationId: string,
+    filename: string,
+    filePath: string,
+  ): Promise<string> {
+    const uploadsDir = path.join(process.cwd(), 'uploads', organizationId);
+    await fs.promises.mkdir(uploadsDir, { recursive: true });
+
+    const destination = path.join(uploadsDir, filename);
+    await fs.promises.copyFile(filePath, destination);
+
+    const baseUrl = process.env.API_BASE_URL
+      || (process.env.NODE_ENV === 'production' ? (() => { throw new Error('API_BASE_URL must be set in production'); })() : 'http://localhost:3000');
+    return `${baseUrl}/uploads/${organizationId}/${filename}`;
+  }
+
+  private async saveFileLocallyFromUpload(
+    organizationId: string,
+    filename: string,
+    file: Express.Multer.File,
+    tempPath?: string,
+  ): Promise<string> {
+    if (tempPath) {
+      return this.saveFileLocallyFromPath(organizationId, filename, tempPath);
+    }
+
+    if (!file.buffer) {
+      throw new BadRequestException('Uploaded file is missing content');
+    }
+
+    return this.saveFileLocally(organizationId, filename, file.buffer);
+  }
+
+  private getUploadedTempPath(file: Express.Multer.File): string | undefined {
+    const uploadPath = (file as Express.Multer.File & { path?: string }).path;
+    if (!uploadPath) {
+      return undefined;
+    }
+
+    const resolvedPath = path.resolve(uploadPath);
+    if (!this.isPathInsideUploadTempRoot(resolvedPath)) {
+      throw new BadRequestException('Invalid upload temp file');
+    }
+
+    return resolvedPath;
+  }
+
+  private isPathInsideUploadTempRoot(filePath: string): boolean {
+    const root = path.resolve(CONTENT_UPLOAD_TMP_ROOT);
+    const resolvedPath = path.resolve(filePath);
+    return resolvedPath === root || resolvedPath.startsWith(`${root}${path.sep}`);
+  }
+
+  private async validateUploadedFile(
+    file: Express.Multer.File,
+    tempPath?: string,
+  ): Promise<{ valid: boolean; actualType?: string; hash: string }> {
+    if (tempPath) {
+      return this.fileValidationService.validateFileAtPath(
+        tempPath,
+        file.originalname,
+        file.mimetype,
+        file.size,
+      );
+    }
+
+    if (!file.buffer) {
+      throw new BadRequestException('Uploaded file is missing content');
+    }
+
+    return this.fileValidationService.validateFile(
+      file.buffer,
+      file.originalname,
+      file.mimetype,
+    );
+  }
+
+  private async uploadToMinio(
+    file: Express.Multer.File,
+    tempPath: string | undefined,
+    objectKey: string,
+  ): Promise<string> {
+    if (tempPath) {
+      return this.storageService.uploadFileFromPath(
+        tempPath,
+        objectKey,
+        file.mimetype,
+        file.size,
+      );
+    }
+
+    if (!file.buffer) {
+      throw new BadRequestException('Uploaded file is missing content');
+    }
+
+    return this.storageService.uploadFile(file.buffer, objectKey, file.mimetype);
+  }
+
+  private scheduleThumbnailGeneration(
+    organizationId: string,
+    contentId: string,
+    file: Express.Multer.File,
+    tempPath: string | undefined,
+    failureMessage: string,
+    successMessage: string,
+  ): boolean {
+    const thumbnailPromise = tempPath
+      ? this.thumbnailService.generateThumbnailFromPath(contentId, tempPath, file.mimetype)
+      : this.thumbnailService.generateThumbnail(contentId, file.buffer, file.mimetype);
+
+    thumbnailPromise
+      .then(async (thumbnailUrl) => {
+        await this.contentService.update(organizationId, contentId, { thumbnail: thumbnailUrl });
+        this.logger.debug(`${successMessage}: ${thumbnailUrl}`);
+      })
+      .catch((error) => {
+        this.logger.warn(`${failureMessage}: ${error}`);
+      })
+      .finally(() => {
+        if (tempPath) {
+          void this.cleanupTempUpload(tempPath);
+        }
+      });
+
+    return Boolean(tempPath);
+  }
+
+  private async cleanupTempUpload(tempPath: string): Promise<void> {
+    if (!this.isPathInsideUploadTempRoot(tempPath)) {
+      this.logger.warn(`Refusing to clean upload temp file outside temp root: ${tempPath}`);
+      return;
+    }
+
+    try {
+      await fs.promises.unlink(tempPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        this.logger.warn(`Failed to clean upload temp file ${tempPath}: ${error}`);
+      }
+    }
   }
 
   @Get()
@@ -429,7 +595,7 @@ export class ContentController {
   @Post(':id/replace')
   @Roles('admin', 'manager')
   @HttpCode(HttpStatus.OK)
-  @UseInterceptors(FileInterceptor('file', { limits: { fileSize: 100 * 1024 * 1024 } }))
+  @UseInterceptors(FileInterceptor('file', CONTENT_UPLOAD_INTERCEPTOR_OPTIONS))
   async replaceFile(
     @CurrentUser('organizationId') organizationId: string,
     @Param('id', ParseIdPipe) id: string,
@@ -440,37 +606,35 @@ export class ContentController {
       throw new BadRequestException('No file provided');
     }
 
-    // Get existing content to determine net storage change
-    const existingContent = await this.contentService.findOne(organizationId, id);
-    const oldFileSize = existingContent.fileSize || 0;
-    const netIncrease = file.size - oldFileSize;
-    const keepBackup = replaceFileDto.keepBackup === true;
-
-    // Validate file
-    const validation = await this.fileValidationService.validateFile(
-      file.buffer,
-      file.originalname,
-      file.mimetype,
-    );
-
-    // Sanitize filename
-    const safeFilename = this.fileValidationService.sanitizeFilename(
-      file.originalname,
-    );
-
-    let fileUrl: string;
-    const filename = `${validation.hash}-${safeFilename}`;
+    const tempPath = this.getUploadedTempPath(file);
+    let tempPathOwnedByThumbnail = false;
     let uploadedObjectKey: string | null = null;
-
-    // Reserve quota only after validation succeeds so rejected files cannot
-    // leave behind accounting reservations. Backup replacements retain the
-    // previous file, so the quota increase is the full new file size.
-    const quotaReservation = keepBackup ? file.size : Math.max(0, netIncrease);
-    if (quotaReservation > 0) {
-      await this.storageQuotaService.reserveQuota(organizationId, quotaReservation);
-    }
+    let quotaReservation = 0;
+    let quotaReserved = false;
 
     try {
+      // Get existing content to determine net storage change
+      const existingContent = await this.contentService.findOne(organizationId, id);
+      const oldFileSize = existingContent.fileSize || 0;
+      const netIncrease = file.size - oldFileSize;
+      const keepBackup = replaceFileDto.keepBackup === true;
+
+      const validation = await this.validateUploadedFile(file, tempPath);
+      const safeFilename = this.fileValidationService.sanitizeFilename(
+        file.originalname,
+      );
+      const filename = `${validation.hash}-${safeFilename}`;
+      let fileUrl: string;
+
+      // Reserve quota only after validation succeeds so rejected files cannot
+      // leave behind accounting reservations. Backup replacements retain the
+      // previous file, so the quota increase is the full new file size.
+      quotaReservation = keepBackup ? file.size : Math.max(0, netIncrease);
+      if (quotaReservation > 0) {
+        await this.storageQuotaService.reserveQuota(organizationId, quotaReservation);
+        quotaReserved = true;
+      }
+
       // Try MinIO first. In production, fail closed instead of creating
       // unreachable /uploads content when object storage is unhealthy.
       if (this.storageService.isMinioAvailable()) {
@@ -479,14 +643,14 @@ export class ContentController {
           validation.hash,
           safeFilename,
         );
-        await this.storageService.uploadFile(file.buffer, objectKey, file.mimetype);
+        await this.uploadToMinio(file, tempPath, objectKey);
         uploadedObjectKey = objectKey;
         fileUrl = `${MINIO_URL_PREFIX}${objectKey}`;
         this.logger.debug(`Replacement file uploaded to MinIO: ${objectKey}`);
       } else if (process.env.NODE_ENV === 'production') {
         throw new ServiceUnavailableException('Storage service is currently unavailable');
       } else {
-        fileUrl = await this.saveFileLocally(organizationId, filename, file.buffer);
+        fileUrl = await this.saveFileLocallyFromUpload(organizationId, filename, file, tempPath);
       }
 
       // Determine thumbnail for images
@@ -513,16 +677,14 @@ export class ContentController {
 
       // Generate thumbnail in background (fire-and-forget)
       if (contentType === 'image') {
-        this.thumbnailService.generateThumbnail(
+        tempPathOwnedByThumbnail = this.scheduleThumbnailGeneration(
+          organizationId,
           id,
-          file.buffer,
-          file.mimetype,
-        ).then(async (thumbnailUrl) => {
-          await this.contentService.update(organizationId, id, { thumbnail: thumbnailUrl });
-          this.logger.debug(`Replacement thumbnail generated in background: ${thumbnailUrl}`);
-        }).catch((error) => {
-          this.logger.warn(`Background thumbnail generation failed during replace: ${error}`);
-        });
+          file,
+          tempPath,
+          'Background thumbnail generation failed during replace',
+          'Replacement thumbnail generated in background',
+        );
       }
 
       return {
@@ -539,10 +701,14 @@ export class ContentController {
           this.logger.warn(`Failed to clean up replacement object after failure: ${deleteError}`);
         }
       }
-      if (canReleaseQuota && quotaReservation > 0) {
+      if (canReleaseQuota && quotaReserved && quotaReservation > 0) {
         await this.releaseQuotaReservation(organizationId, quotaReservation);
       }
       throw error;
+    } finally {
+      if (tempPath && !tempPathOwnedByThumbnail) {
+        await this.cleanupTempUpload(tempPath);
+      }
     }
   }
 

--- a/middleware/src/modules/content/file-validation.service.spec.ts
+++ b/middleware/src/modules/content/file-validation.service.spec.ts
@@ -1,5 +1,8 @@
 import { BadRequestException } from '@nestjs/common';
 import { FileValidationService } from './file-validation.service';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
 
 // Mock dns/promises to avoid real DNS lookups in tests
 jest.mock('dns/promises', () => ({
@@ -25,10 +28,30 @@ jest.mock('dns/promises', () => ({
 
 describe('FileValidationService', () => {
   let service: FileValidationService;
+  let tempFiles: string[] = [];
 
   beforeEach(() => {
     service = new FileValidationService();
+    tempFiles = [];
   });
+
+  afterEach(async () => {
+    await Promise.all(
+      tempFiles.map((filePath) =>
+        fs.unlink(filePath).catch((error: NodeJS.ErrnoException) => {
+          if (error.code !== 'ENOENT') throw error;
+        }),
+      ),
+    );
+  });
+
+  const writeTempUpload = async (filename: string, data: Buffer): Promise<string> => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vizora-validation-test-'));
+    const filePath = path.join(tempDir, filename);
+    await fs.writeFile(filePath, data);
+    tempFiles.push(filePath);
+    return filePath;
+  };
 
   it('should be defined', () => {
     expect(service).toBeDefined();
@@ -191,6 +214,32 @@ describe('FileValidationService', () => {
 
         expect(result.valid).toBe(true);
       });
+
+      it('should reject spoofed WebP files that only contain a RIFF header', async () => {
+        const spoofedWebp = Buffer.concat([
+          Buffer.from('RIFF'),
+          Buffer.alloc(4),
+          Buffer.from('WAVE'),
+          Buffer.alloc(100),
+        ]);
+
+        await expect(
+          service.validateFile(spoofedWebp, 'fake.webp', 'image/webp'),
+        ).rejects.toThrow('File content does not match declared type');
+      });
+
+      it('should reject spoofed AVI files that only contain a RIFF header', async () => {
+        const spoofedAvi = Buffer.concat([
+          Buffer.from('RIFF'),
+          Buffer.alloc(4),
+          Buffer.from('WAVE'),
+          Buffer.alloc(100),
+        ]);
+
+        await expect(
+          service.validateFile(spoofedAvi, 'fake.avi', 'video/x-msvideo'),
+        ).rejects.toThrow('File content does not match declared type');
+      });
     });
 
     describe('Suspicious Content Detection', () => {
@@ -264,6 +313,18 @@ describe('FileValidationService', () => {
           service.validateFile(maliciousPdf, 'evil.pdf', 'application/pdf'),
         ).rejects.toThrow('suspicious content');
       });
+
+      it('should reject PDFs with JavaScript markers after the first 10KB', async () => {
+        const maliciousPdf = Buffer.concat([
+          Buffer.from([0x25, 0x50, 0x44, 0x46]),
+          Buffer.alloc(12 * 1024, 0x20),
+          Buffer.from('/JS (alert)'),
+        ]);
+
+        await expect(
+          service.validateFile(maliciousPdf, 'late-js.pdf', 'application/pdf'),
+        ).rejects.toThrow('suspicious content');
+      });
     });
 
     describe('Hash Generation', () => {
@@ -305,6 +366,100 @@ describe('FileValidationService', () => {
         );
 
         expect(result1.hash).toBe(result2.hash);
+      });
+
+      it('should validate file paths with the same hash as buffer validation', async () => {
+        const file = Buffer.concat([
+          Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+          Buffer.from('same content'),
+        ]);
+        const filePath = await writeTempUpload('same.png', file);
+
+        const bufferResult = await service.validateFile(file, 'same.png', 'image/png');
+        const pathResult = await (service as any).validateFileAtPath(
+          filePath,
+          'same.png',
+          'image/png',
+        );
+
+        expect(pathResult.valid).toBe(true);
+        expect(pathResult.actualType).toBe('image/png');
+        expect(pathResult.hash).toBe(bufferResult.hash);
+      });
+
+      it('should reject path validation when the expected upload size changed', async () => {
+        const file = Buffer.concat([
+          Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+          Buffer.from('same content'),
+        ]);
+        const filePath = await writeTempUpload('size-changed.png', file);
+
+        await expect(
+          (service as any).validateFileAtPath(
+            filePath,
+            'size-changed.png',
+            'image/png',
+            file.length + 1,
+          ),
+        ).rejects.toThrow('Uploaded file size changed during validation');
+      });
+
+      it('should reject spoofed WebP paths that only contain a RIFF header', async () => {
+        const spoofedWebp = Buffer.concat([
+          Buffer.from('RIFF'),
+          Buffer.alloc(4),
+          Buffer.from('WAVE'),
+          Buffer.alloc(100),
+        ]);
+        const filePath = await writeTempUpload('fake.webp', spoofedWebp);
+
+        await expect(
+          (service as any).validateFileAtPath(filePath, 'fake.webp', 'image/webp'),
+        ).rejects.toThrow('File content does not match declared type');
+      });
+
+      it('should reject spoofed AVI paths that only contain a RIFF header', async () => {
+        const spoofedAvi = Buffer.concat([
+          Buffer.from('RIFF'),
+          Buffer.alloc(4),
+          Buffer.from('WAVE'),
+          Buffer.alloc(100),
+        ]);
+        const filePath = await writeTempUpload('fake.avi', spoofedAvi);
+
+        await expect(
+          (service as any).validateFileAtPath(filePath, 'fake.avi', 'video/x-msvideo'),
+        ).rejects.toThrow('File content does not match declared type');
+      });
+
+      it('should stream-scan PDF paths for JavaScript markers beyond the first 10KB', async () => {
+        const maliciousPdf = Buffer.concat([
+          Buffer.from([0x25, 0x50, 0x44, 0x46]),
+          Buffer.alloc(12 * 1024, 0x20),
+          Buffer.from('/EmbeddedFile'),
+        ]);
+        const filePath = await writeTempUpload('late-embedded.pdf', maliciousPdf);
+
+        await expect(
+          (service as any).validateFileAtPath(filePath, 'late-embedded.pdf', 'application/pdf'),
+        ).rejects.toThrow('suspicious content');
+      });
+
+      it('should detect PDF JavaScript markers split across stream chunks', async () => {
+        const chunkBoundaryPrefix = Buffer.concat([
+          Buffer.from([0x25, 0x50, 0x44, 0x46]),
+          Buffer.alloc(64 * 1024 - 4 - 3, 0x20),
+          Buffer.from('/Ja'),
+        ]);
+        const maliciousPdf = Buffer.concat([
+          chunkBoundaryPrefix,
+          Buffer.from('vaScript (alert)'),
+        ]);
+        const filePath = await writeTempUpload('split-js.pdf', maliciousPdf);
+
+        await expect(
+          (service as any).validateFileAtPath(filePath, 'split-js.pdf', 'application/pdf'),
+        ).rejects.toThrow('suspicious content');
       });
     });
   });

--- a/middleware/src/modules/content/file-validation.service.ts
+++ b/middleware/src/modules/content/file-validation.service.ts
@@ -1,11 +1,22 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
 import * as crypto from 'crypto';
+import * as fs from 'fs';
 import { lookup } from 'dns/promises';
+
+type MagicNumberSignature = Buffer | Array<{ offset: number; bytes: Buffer }>;
+
+interface AllowedFileType {
+  extensions: string[];
+  maxSize: number;
+  magicNumbers: MagicNumberSignature[];
+}
 
 @Injectable()
 export class FileValidationService {
+  private readonly SUSPICIOUS_SCAN_BYTES = 10_000;
+
   // Allowed MIME types with their magic number signatures
-  private readonly allowedTypes = {
+  private readonly allowedTypes: Record<string, AllowedFileType> = {
     // Images
     'image/jpeg': {
       extensions: ['.jpg', '.jpeg'],
@@ -33,7 +44,10 @@ export class FileValidationService {
       extensions: ['.webp'],
       maxSize: 10 * 1024 * 1024,
       magicNumbers: [
-        Buffer.from([0x52, 0x49, 0x46, 0x46]), // RIFF (WebP container)
+        [
+          { offset: 0, bytes: Buffer.from([0x52, 0x49, 0x46, 0x46]) }, // RIFF
+          { offset: 8, bytes: Buffer.from([0x57, 0x45, 0x42, 0x50]) }, // WEBP
+        ],
       ],
     },
     // Videos
@@ -61,7 +75,10 @@ export class FileValidationService {
       extensions: ['.avi'],
       maxSize: 100 * 1024 * 1024, // 100MB
       magicNumbers: [
-        Buffer.from([0x52, 0x49, 0x46, 0x46]), // RIFF
+        [
+          { offset: 0, bytes: Buffer.from([0x52, 0x49, 0x46, 0x46]) }, // RIFF
+          { offset: 8, bytes: Buffer.from([0x41, 0x56, 0x49, 0x20]) }, // AVI
+        ],
       ],
     },
     'video/webm': {
@@ -118,9 +135,7 @@ export class FileValidationService {
     }
 
     // 4. Verify magic numbers (prevent MIME type spoofing)
-    const validMagicNumber = typeConfig.magicNumbers.some((magic) => {
-      return file.slice(0, magic.length).equals(magic);
-    });
+    const validMagicNumber = this.hasValidMagicNumber(file, typeConfig);
 
     if (!validMagicNumber) {
       throw new BadRequestException(
@@ -129,7 +144,7 @@ export class FileValidationService {
     }
 
     // 5. Scan for suspicious content (basic checks)
-    const suspicious = this.detectSuspiciousContent(file);
+    const suspicious = this.detectSuspiciousContent(file, mimeType);
     if (suspicious) {
       throw new BadRequestException(
         'File contains suspicious content and has been rejected',
@@ -146,13 +161,145 @@ export class FileValidationService {
     };
   }
 
+  async validateFileAtPath(
+    filePath: string,
+    filename: string,
+    mimeType: string,
+    expectedSize?: number,
+  ): Promise<{ valid: boolean; actualType?: string; hash: string }> {
+    if (!this.allowedTypes[mimeType]) {
+      throw new BadRequestException(
+        `File type not allowed. Allowed: ${Object.keys(this.allowedTypes).join(', ')}`,
+      );
+    }
+
+    const typeConfig = this.allowedTypes[mimeType];
+    const extension = filename.toLowerCase().substring(filename.lastIndexOf('.'));
+    if (!typeConfig.extensions.includes(extension)) {
+      throw new BadRequestException(
+        `Invalid file extension. Expected: ${typeConfig.extensions.join(', ')}`,
+      );
+    }
+
+    const stat = await fs.promises.stat(filePath);
+    if (expectedSize !== undefined && stat.size !== expectedSize) {
+      throw new BadRequestException('Uploaded file size changed during validation');
+    }
+
+    if (stat.size > typeConfig.maxSize) {
+      throw new BadRequestException(
+        `File too large. Max size: ${typeConfig.maxSize / (1024 * 1024)}MB`,
+      );
+    }
+
+    const head = await this.readFileHead(filePath, this.getHeadReadSize(typeConfig));
+    if (!this.hasValidMagicNumber(head, typeConfig)) {
+      throw new BadRequestException(
+        'File content does not match declared type (possible spoofing attempt)',
+      );
+    }
+
+    const { hash, suspicious } = await this.hashFileAndDetectSuspicious(filePath, mimeType);
+    if (suspicious) {
+      throw new BadRequestException(
+        'File contains suspicious content and has been rejected',
+      );
+    }
+
+    return {
+      valid: true,
+      actualType: mimeType,
+      hash,
+    };
+  }
+
+  private hasValidMagicNumber(file: Buffer, typeConfig: AllowedFileType): boolean {
+    return typeConfig.magicNumbers.some((signature) => {
+      if (Array.isArray(signature)) {
+        return signature.every(({ offset, bytes }) =>
+          file.length >= offset + bytes.length &&
+          file.subarray(offset, offset + bytes.length).equals(bytes),
+        );
+      }
+
+      return file.subarray(0, signature.length).equals(signature);
+    });
+  }
+
+  private getHeadReadSize(typeConfig: AllowedFileType): number {
+    const magicBytes = typeConfig.magicNumbers.reduce((max, signature) => {
+      if (Array.isArray(signature)) {
+        return Math.max(
+          max,
+          ...signature.map(({ offset, bytes }) => offset + bytes.length),
+        );
+      }
+
+      return Math.max(max, signature.length);
+    }, 0);
+
+    return Math.max(magicBytes, this.SUSPICIOUS_SCAN_BYTES);
+  }
+
+  private async readFileHead(filePath: string, bytesToRead: number): Promise<Buffer> {
+    const handle = await fs.promises.open(filePath, 'r');
+    try {
+      const buffer = Buffer.alloc(bytesToRead);
+      const { bytesRead } = await handle.read(buffer, 0, bytesToRead, 0);
+      return buffer.subarray(0, bytesRead);
+    } finally {
+      await handle.close();
+    }
+  }
+
+  private async hashFileAndDetectSuspicious(
+    filePath: string,
+    mimeType: string,
+  ): Promise<{ hash: string; suspicious: boolean }> {
+    const hash = crypto.createHash('sha256');
+    const stream = fs.createReadStream(filePath);
+    const scanFullFile = mimeType === 'application/pdf';
+    let suspicious = false;
+    let scannedBytes = 0;
+    let rollingText = '';
+
+    for await (const chunk of stream) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      hash.update(buffer);
+
+      if (!suspicious && scanFullFile) {
+        rollingText = `${rollingText}${buffer.toString('utf-8')}`;
+        suspicious = this.detectSuspiciousText(rollingText, mimeType);
+        rollingText = rollingText.slice(-256);
+      } else if (!suspicious && scannedBytes < this.SUSPICIOUS_SCAN_BYTES) {
+        const remaining = this.SUSPICIOUS_SCAN_BYTES - scannedBytes;
+        const scanBuffer = buffer.subarray(0, remaining);
+        scannedBytes += scanBuffer.length;
+        rollingText = `${rollingText}${scanBuffer.toString('utf-8')}`;
+        suspicious = this.detectSuspiciousText(rollingText, mimeType);
+      }
+    }
+
+    return {
+      hash: hash.digest('hex'),
+      suspicious,
+    };
+  }
+
   /**
    * Basic malware/script detection
    * Checks for embedded scripts, suspicious strings
    */
-  private detectSuspiciousContent(file: Buffer): boolean {
-    const content = file.toString('utf-8', 0, Math.min(file.length, 10000)); // Check first 10KB
+  private detectSuspiciousContent(file: Buffer, mimeType: string): boolean {
+    const bytesToScan = mimeType === 'application/pdf'
+      ? file.length
+      : Math.min(file.length, this.SUSPICIOUS_SCAN_BYTES);
+    const content = file.toString('utf-8', 0, bytesToScan);
 
+    return this.detectSuspiciousText(content, mimeType);
+  }
+
+  private detectSuspiciousText(content: string, mimeType: string): boolean {
     // Suspicious patterns that shouldn't be in media files
     const suspiciousPatterns = [
       /<script/i,
@@ -165,6 +312,10 @@ export class FileValidationService {
       /\/EmbeddedFile/i, // PDF with embedded files
     ];
 
+    if (mimeType === 'application/pdf') {
+      suspiciousPatterns.push(/\/JS\b/i, /\/JavaScript\b/i);
+    }
+
     return suspiciousPatterns.some((pattern) => pattern.test(content));
   }
 
@@ -174,7 +325,7 @@ export class FileValidationService {
   sanitizeFilename(filename: string): string {
     // Remove path separators and dangerous characters
     return filename
-      .replace(/[\/\\]/g, '')
+      .replace(/[/\\]/g, '')
       .replace(/[^\w.-]/g, '_')
       .substring(0, 255); // Max filename length
   }

--- a/middleware/src/modules/content/thumbnail.service.ts
+++ b/middleware/src/modules/content/thumbnail.service.ts
@@ -72,6 +72,41 @@ export class ThumbnailService {
     }
   }
 
+  async generateThumbnailFromPath(
+    contentId: string,
+    imagePath: string,
+    mimeType: string,
+  ): Promise<string> {
+    try {
+      const stat = await fs.stat(imagePath);
+      if (stat.size > this.MAX_FILE_SIZE) {
+        this.logger.warn(`Image too large for thumbnail: ${contentId} (${stat.size} bytes)`);
+        throw new Error(`Image exceeds maximum size for thumbnail generation (${this.MAX_FILE_SIZE / 1024 / 1024}MB)`);
+      }
+
+      const ext = this.getExtensionFromMime(mimeType);
+      const safeId = contentId.replace(/[^a-zA-Z0-9_-]/g, '');
+      if (!safeId) throw new Error('Invalid content ID');
+      const filename = `${safeId}.${ext}`;
+      const filepath = join(this.THUMBNAIL_DIR, filename);
+
+      await sharp(imagePath)
+        .resize(this.MAX_SIZE, this.MAX_SIZE, {
+          fit: 'inside',
+          withoutEnlargement: true,
+        })
+        .toFile(filepath);
+
+      return `/static/thumbnails/${filename}`;
+    } catch (error) {
+      this.logger.error(
+        `Failed to generate thumbnail for ${contentId}`,
+        error
+      );
+      throw error;
+    }
+  }
+
   /**
    * Generate thumbnail from URL (for already uploaded content).
    * Validates the URL against SSRF before fetching.

--- a/middleware/src/modules/storage/storage.service.spec.ts
+++ b/middleware/src/modules/storage/storage.service.spec.ts
@@ -1,6 +1,9 @@
 import { ConfigService } from '@nestjs/config';
 import { CircuitBreakerService } from '../common/services/circuit-breaker.service';
 import { StorageService } from './storage.service';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
 
 // Mock the minio module
 jest.mock('minio', () => {
@@ -26,6 +29,7 @@ describe('StorageService', () => {
   let mockConfigService: jest.Mocked<ConfigService>;
   let mockCircuitBreaker: jest.Mocked<CircuitBreakerService>;
   let mockMinioClient: any;
+  let tempFiles: string[] = [];
 
   const defaultConfig = {
     MINIO_ENDPOINT: 'localhost',
@@ -38,6 +42,7 @@ describe('StorageService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    tempFiles = [];
 
     mockConfigService = {
       get: jest.fn((key: string) => defaultConfig[key]),
@@ -74,6 +79,24 @@ describe('StorageService', () => {
 
     service = new StorageService(mockConfigService, mockCircuitBreaker);
   });
+
+  afterEach(async () => {
+    await Promise.all(
+      tempFiles.map((filePath) =>
+        fs.unlink(filePath).catch((error: NodeJS.ErrnoException) => {
+          if (error.code !== 'ENOENT') throw error;
+        }),
+      ),
+    );
+  });
+
+  const writeTempFile = async (filename: string, data: Buffer): Promise<string> => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vizora-storage-test-'));
+    const filePath = path.join(tempDir, filename);
+    await fs.writeFile(filePath, data);
+    tempFiles.push(filePath);
+    return filePath;
+  };
 
   describe('initialization', () => {
     it('should be defined', () => {
@@ -348,6 +371,36 @@ describe('StorageService', () => {
         10 * 1024 * 1024,
         expect.anything(),
       );
+    });
+
+    it('should upload a file from disk using a stream and known size', async () => {
+      const buffer = Buffer.from('disk upload content');
+      const filePath = await writeTempFile('upload.jpg', buffer);
+      const objectKey = 'org-123/disk-upload.jpg';
+      mockMinioClient.putObject.mockImplementationOnce(
+        (_bucket, _objectKey, stream) =>
+          new Promise((resolve, reject) => {
+            stream.on('error', reject);
+            stream.on('end', () => resolve({ etag: 'test-etag' }));
+            stream.resume();
+          }),
+      );
+
+      const result = await (service as any).uploadFileFromPath(
+        filePath,
+        objectKey,
+        'image/jpeg',
+        buffer.length,
+      );
+      const putObjectCall = mockMinioClient.putObject.mock.calls[0];
+
+      expect(result).toBe(objectKey);
+      expect(putObjectCall[0]).toBe('vizora-content');
+      expect(putObjectCall[1]).toBe(objectKey);
+      expect(putObjectCall[2]).toEqual(expect.objectContaining({ path: filePath }));
+      expect(typeof putObjectCall[2].pipe).toBe('function');
+      expect(putObjectCall[3]).toBe(buffer.length);
+      expect(putObjectCall[4]).toEqual({ 'Content-Type': 'image/jpeg' });
     });
   });
 

--- a/middleware/src/modules/storage/storage.service.ts
+++ b/middleware/src/modules/storage/storage.service.ts
@@ -2,6 +2,7 @@ import { Injectable, OnModuleInit, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { CircuitBreakerService } from '../common/services/circuit-breaker.service';
 import * as Minio from 'minio';
+import * as fs from 'fs';
 
 const MINIO_CIRCUIT_CONFIG = {
   failureThreshold: 3,
@@ -122,6 +123,42 @@ export class StorageService implements OnModuleInit {
             'Content-Type': mimeType,
           },
         );
+
+        this.logger.debug(`File uploaded to MinIO: ${objectKey}`);
+        return objectKey;
+      },
+      MINIO_CIRCUIT_CONFIG,
+    );
+  }
+
+  async uploadFileFromPath(
+    filePath: string,
+    objectKey: string,
+    mimeType: string,
+    size: number,
+  ): Promise<string> {
+    if (!this.client || !this.available) {
+      throw new Error('MinIO is not available');
+    }
+
+    return this.circuitBreaker.execute(
+      'minio-upload',
+      async () => {
+        const stream = fs.createReadStream(filePath);
+        try {
+          await this.client!.putObject(
+            this.bucket,
+            objectKey,
+            stream,
+            size,
+            {
+              'Content-Type': mimeType,
+            },
+          );
+        } catch (error) {
+          stream.destroy();
+          throw error;
+        }
 
         this.logger.debug(`File uploaded to MinIO: ${objectKey}`);
         return objectKey;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -332,6 +332,9 @@ importers:
       mongoose:
         specifier: ^9.1.5
         version: 9.1.5(socks@2.8.7)
+      multer:
+        specifier: 2.1.1
+        version: 2.1.1
       nodemailer:
         specifier: ^8.0.1
         version: 8.0.1

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -108,6 +108,13 @@ agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
 - [x] `NODE_OPTIONS=--use-system-ca pnpm audit --audit-level=high` - fails with
   150 dependency advisories (1 critical, 56 high). CI marks audit
   continue-on-error; dependency upgrades are deferred to a dedicated security pass.
+- [x] PR #133 opened. Initial CI build failed on Linux because `multer` was
+  only available transitively in local installs; fixed by declaring
+  `multer@2.1.1` in `@vizora/middleware` and updating the lockfile importer.
+- [x] Post-CI-fix verification: `pnpm install --frozen-lockfile --offline
+  --ignore-scripts`, `npx nx build @vizora/middleware`, `pnpm --filter
+  @vizora/middleware exec tsc --noEmit --pretty false`, and `git diff --check`
+  pass locally.
 
 **Deferred follow-ups**
 - [ ] True multipart/chunked resumable uploads with server-side session state.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,8 +1,126 @@
 # Vizora - Task Tracker
 
-## In Progress: Performance Readiness Review Pass 9 (2026-05-31)
+## In Progress: Upload Pressure Readiness Pass 10 (2026-05-31)
+
+**Branch:** `feat/performance-readiness-pass-10`
+
+**Why now:** Pass 9 hardened content streaming and display recovery, but the
+largest remaining customer-critical upload bottleneck is still the middleware
+and dashboard accepting large files in ways that can drive avoidable memory and
+concurrency pressure. This pass stays repo-side and does not require secrets,
+live hardware, production env edits, or production state mutation.
+
+**New primitives introduced:** small helpers in existing modules only:
+`FileValidationService.validateFileAtPath`, `StorageService.uploadFileFromPath`,
+and private `ContentController` upload-temp cleanup helpers.
+
+**Hermes-first analysis:** not applicable. This pass does not add business
+agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
+
+**Plan**
+- [x] Start fresh branch from merged `origin/main`.
+- [x] Re-check pass-9 deploy gate and keep production deployment blocked until
+  `/opt/vizora/app` is reconciled.
+- [x] Write plan/design for disk-backed upload and dashboard backpressure fixes.
+- [x] Run multi-subagent design review before tests.
+- [x] Add focused failing tests for file-path validation, upload-from-path, temp
+  cleanup, and dashboard upload backpressure.
+- [x] Implement bounded middleware/dashboard upload-pressure fixes.
+- [x] Run focused red/green tests.
+- [x] Run multi-subagent code review before broader tests.
+- [x] Run broader affected tests/builds/typecheck.
+- [ ] PR, CI, merge.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Deployment gate inherited from pass 9**
+- [x] PR #132 merged at `4383c09b75f3cdbba0d0965ce477fe135d6439d6`; CI green
+  for audit, lint, security, build, test, and e2e.
+- [x] Prod deploy blocked after merge: `/opt/vizora/app` is still dirty and now
+  `ahead 17, behind 70` from `origin/main=4383c09b75f3cdbba0d0965ce477fe135d6439d6`.
+- [x] Prod core services health check is OK; no deploy, pull, reset, stash, or
+  service restart performed.
+
+**Plan/design:** `docs/plans/2026-05-31-upload-pressure-readiness-pass-10.md`
+
+**Selected fix bundle**
+- [x] Switch content upload and replace-file interceptors to disk-backed temp
+  storage while preserving the 100MB HTTP limit.
+- [x] Add file-path validation that hashes by stream, checks offset-aware RIFF
+  signatures, scans full PDFs for active-content markers, and scans the first
+  suspicious-content window for other media.
+- [x] Add MinIO upload-from-path using a read stream and known size.
+- [x] Preserve buffer-backed direct controller tests and local-dev fallback behavior.
+- [x] Clean temp files on upload success/failure and after image thumbnail
+  background generation.
+- [x] Add dashboard upload guards: per-type max-size enforcement, bounded queue,
+  and single-concurrency large uploads.
+
+**Focused verification**
+- [x] Red run:
+  `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="file-validation.service|storage.service|content.controller"` -
+  failed on missing `validateFileAtPath`, `uploadFileFromPath`, path-based
+  thumbnailing, RIFF subtype checks, and late-PDF scanning.
+- [x] Red run:
+  `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="dashboard/content"` -
+  failed on video concurrency, cumulative queue cap, rejected-file reporting,
+  and partial-failure retry labels.
+- [x] Green run:
+  `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="file-validation.service|storage.service|content.controller"` -
+  pass, 8 suites / 293 tests.
+- [x] Green run:
+  `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="dashboard/content"` -
+  pass, 1 suite / 25 tests.
+
+**Review gate**
+- [x] Design review found thumbnail temp-file ownership, local fallback, temp
+  root/cleanup, RIFF subtype, PDF full-scan, and dashboard backpressure gaps;
+  all selected implementation gaps fixed except durable orphan-cleanup retry,
+  which remains deferred.
+- [x] Code review found web typecheck failure from `onDropRejected` typing;
+  fixed by using `FileRejection`.
+- [x] Code review found `react-dropzone` `maxFiles` rejected over-limit drops
+  before manual queue truncation; fixed by removing `maxFiles` and asserting
+  the manual queue cap owns truncation.
+- [x] Final delta review after all fixes: middleware/upload and dashboard/upload
+  reviewers both CLEAN.
+
+**Broader verification**
+- [x] `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` - pass.
+- [x] `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` - pass.
+- [x] `git diff --check` - pass with expected LF-to-CRLF warnings only.
+- [x] `pnpm --filter @vizora/middleware test -- --runInBand` - pass, 143 suites / 2842 tests.
+- [x] `pnpm --filter @vizora/web test -- --runInBand` - pass, 94 suites / 960 tests
+  with pre-existing React `act(...)` and jsdom navigation warnings only.
+- [x] `npx nx build @vizora/middleware` - pass with existing webpack warnings.
+- [x] `npx nx build @vizora/web` with local API/socket env and 4096MB heap - pass
+  with existing Next middleware/proxy and TS project-reference warnings.
+- [x] `pnpm --filter @vizora/realtime test -- --runInBand` - pass, 12 suites / 273 tests.
+- [x] `npx nx build @vizora/realtime` - pass when run serially; earlier parallel
+  run failed on a Windows file lock in `@vizora/database:build`.
+- [x] `pnpm test:ops` - pass, 5 tests.
+- [x] Lint equivalent on Windows:
+  `$env:ESLINT_USE_FLAT_CONFIG='false'; pnpm exec eslint --no-error-on-unmatched-pattern --ext .ts,.tsx "middleware/src/**/*.ts" "middleware/src/**/*.tsx" "realtime/src/**/*.ts" "realtime/src/**/*.tsx"` -
+  pass with warnings only. The literal `pnpm lint` script is POSIX-env syntax
+  and fails under PowerShell before ESLint starts.
+- [x] `pnpm --dir display test:ci` - pass, 6 suites / 126 tests.
+- [x] `pnpm --dir display typecheck` - pass.
+- [x] `pnpm --dir display build` - pass.
+- [x] `NODE_OPTIONS=--use-system-ca pnpm audit --audit-level=high` - fails with
+  150 dependency advisories (1 critical, 56 high). CI marks audit
+  continue-on-error; dependency upgrades are deferred to a dedicated security pass.
+
+**Deferred follow-ups**
+- [ ] True multipart/chunked resumable uploads with server-side session state.
+- [ ] Background thumbnail queue instead of in-process fire-and-forget work.
+- [ ] Server-backed content-library pagination/search plus thumbnail lazy/virtualized rendering.
+- [ ] Shared dashboard realtime socket provider for status, notifications, and route events.
+
+---
+
+## Completed: Performance Readiness Review Pass 9 (2026-05-31)
 
 **Branch:** `feat/performance-readiness-pass-9`
+**PR / merge commit:** #132 / `4383c09b75f3cdbba0d0965ce477fe135d6439d6`
 
 **Why now:** PR #131 merged the bounded dashboard contract fixes. The next
 autonomous slice is a comprehensive repo-side performance/code-review pass over
@@ -27,8 +145,8 @@ business agents, MCP tools, Hermes skills, or AI/provider spend paths.
 - [x] Implement bounded performance/readiness fixes.
 - [x] Run multi-subagent code review before broader tests.
 - [x] Run focused and broader tests/builds/browser checks.
-- [ ] PR, CI, merge.
-- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+- [x] PR, CI, merge.
+- [x] Re-check deployment gate; deploy only if prod checkout is safe.
 
 **Deployment gate after PR #131**
 - [x] PR #131 merged at `58df1a276b8252dba7145c75705ae4deabde431f` with CI green.
@@ -36,6 +154,14 @@ business agents, MCP tools, Hermes skills, or AI/provider spend paths.
   many modified/untracked prod-local files, and prod `origin/main` is stale while
   remote `main` is `58df1a276b8252dba7145c75705ae4deabde431f`.
 - [x] Prod core services health check is OK; no deploy/restart performed.
+
+**PR / CI / deployment**
+- [x] PR #132 opened from `105f081ba8acb0b1f298d93dd53bdf9d68df74f3`.
+- [x] GitHub CI green: audit, lint, security, build, test, and e2e.
+- [x] PR #132 merged at `4383c09b75f3cdbba0d0965ce477fe135d6439d6`.
+- [x] Deployment gate checked after merge: production health OK, core PM2
+  services online, but `/opt/vizora/app` is dirty/diverged (`ahead 17, behind 70`),
+  so deploy was not attempted.
 
 **Analysis feed**
 - [x] Middleware/storage reviewer prioritized streaming-upload memory pressure,
@@ -105,7 +231,8 @@ business agents, MCP tools, Hermes skills, or AI/provider spend paths.
 - [x] Middleware/realtime re-review after fixes: both CLEAN.
 
 **Deferred follow-ups**
-- [ ] Disk-backed/streaming upload pipeline and per-type frontend upload caps.
+- [ ] Disk-backed/streaming upload pipeline and per-type frontend upload caps
+  (selected for pass 10).
 - [ ] Server-backed content-library pagination/search plus thumbnail lazy/virtualized rendering.
 - [ ] Shared dashboard realtime socket provider for status, notifications, and route events.
 - [ ] Playlist index summary payload and removal of dead builder-modal code.

--- a/web/src/app/dashboard/content/__tests__/content-page.test.tsx
+++ b/web/src/app/dashboard/content/__tests__/content-page.test.tsx
@@ -640,4 +640,145 @@ describe('ContentClient', () => {
       await Promise.all(deferredUploads.slice(1).map((deferred) => deferred.promise));
     });
   });
+
+  it('limits queued video uploads to one concurrent file', async () => {
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+    const deferredUploads: Array<{ resolve: (content: any) => void; promise: Promise<any> }> = [];
+    mockUploadContentWithProgress.mockImplementation((_data, onProgress) => {
+      onProgress?.(10);
+      let resolveUpload: (content: any) => void = () => {};
+      const promise = new Promise((resolve) => {
+        resolveUpload = resolve;
+      });
+      deferredUploads.push({ resolve: resolveUpload, promise });
+      return promise;
+    });
+
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    fireEvent.click(screen.getAllByText('Upload Content')[0]);
+    fireEvent.change(screen.getByDisplayValue('Image'), { target: { value: 'video' } });
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Video')).toBeInTheDocument();
+    });
+
+    const files = [
+      new File(['1'], 'video-1.mp4', { type: 'video/mp4' }),
+      new File(['2'], 'video-2.mp4', { type: 'video/mp4' }),
+    ];
+
+    await act(async () => {
+      lastDropzoneOptions.onDrop(files);
+    });
+
+    fireEvent.click(screen.getByText('Upload 2 Files'));
+
+    await waitFor(() => {
+      expect(mockUploadContentWithProgress).toHaveBeenCalledTimes(1);
+    });
+    expect(mockUploadContentWithProgress.mock.calls[0][0].title).toBe('video-1');
+
+    await act(async () => {
+      deferredUploads[0].resolve({ id: 'video-1', title: 'Video 1' });
+      await deferredUploads[0].promise;
+    });
+
+    await waitFor(() => {
+      expect(mockUploadContentWithProgress).toHaveBeenCalledTimes(2);
+    });
+    expect(mockUploadContentWithProgress.mock.calls[1][0].title).toBe('video-2');
+  });
+
+  it('enforces the upload queue cap across repeated drops', async () => {
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    fireEvent.click(screen.getAllByText('Upload Content')[0]);
+    expect(lastDropzoneOptions.maxFiles).toBeUndefined();
+
+    await act(async () => {
+      lastDropzoneOptions.onDrop(
+        Array.from({ length: 8 }, (_, index) =>
+          new File([String(index)], `queue-${index + 1}.png`, { type: 'image/png' }),
+        ),
+      );
+    });
+    await act(async () => {
+      lastDropzoneOptions.onDrop(
+        Array.from({ length: 5 }, (_, index) =>
+          new File([String(index)], `queue-${index + 9}.png`, { type: 'image/png' }),
+        ),
+      );
+    });
+
+    expect(screen.getByText('Upload Queue (10 files)')).toBeInTheDocument();
+    expect(screen.getByText('queue-10.png')).toBeInTheDocument();
+    expect(screen.queryByText('queue-11.png')).not.toBeInTheDocument();
+    expect(screen.queryByText('queue-13.png')).not.toBeInTheDocument();
+    expect(mockToast.warning).toHaveBeenCalledWith(expect.stringContaining('upload queue'));
+  });
+
+  it('shows rejected upload files inline with the rejection reason', async () => {
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    fireEvent.click(screen.getAllByText('Upload Content')[0]);
+    expect(lastDropzoneOptions.onDropRejected).toEqual(expect.any(Function));
+
+    await act(async () => {
+      lastDropzoneOptions.onDropRejected([
+        {
+          file: new File(['too-large'], 'huge.mp4', { type: 'video/mp4' }),
+          errors: [{ code: 'file-too-large', message: 'File is larger than 100MB' }],
+        },
+      ]);
+    });
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('huge.mp4');
+    expect(alert).toHaveTextContent('File is larger than 100MB');
+  });
+
+  it('labels partial-failure retries with the remaining retryable count and visible row error', async () => {
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+    mockUploadContentWithProgress
+      .mockResolvedValueOnce({ id: 'ok', title: 'OK' })
+      .mockRejectedValueOnce(new Error('Network timeout'));
+
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    fireEvent.click(screen.getAllByText('Upload Content')[0]);
+    const files = [
+      new File(['1'], 'ok.png', { type: 'image/png' }),
+      new File(['2'], 'failed.png', { type: 'image/png' }),
+    ];
+
+    await act(async () => {
+      lastDropzoneOptions.onDrop(files);
+    });
+
+    fireEvent.click(screen.getByText('Upload 2 Files'));
+
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith('1 file(s) uploaded, 1 failed');
+    });
+    expect(screen.getByText('Retry 1 Failed')).toBeInTheDocument();
+    expect(screen.getByText('Network timeout')).toBeInTheDocument();
+  });
 });

--- a/web/src/app/dashboard/content/page-client.tsx
+++ b/web/src/app/dashboard/content/page-client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { useDropzone } from 'react-dropzone';
+import { useDropzone, type FileRejection } from 'react-dropzone';
 import { apiClient } from '@/lib/api';
 import { fetchAllPaginated } from '@/lib/api/pagination';
 import { Content, Display, Playlist, ContentFolder } from '@/lib/types';
@@ -43,8 +43,18 @@ type UploadQueueItem = {
  progress: number;
  error?: string;
 };
+type UploadRejectedItem = {
+ fileName: string;
+ reason: string;
+};
 
 const BULK_UPLOAD_CONCURRENCY = 3;
+const MAX_UPLOAD_QUEUE_ITEMS = 10;
+const FILE_UPLOAD_LIMITS: Record<FileUploadType, number> = {
+ image: 10 * 1024 * 1024,
+ video: 100 * 1024 * 1024,
+ pdf: 50 * 1024 * 1024,
+};
 const FILE_UPLOAD_TYPES = new Set<UploadFormType>(['image', 'video', 'pdf']);
 
 const isFileUploadType = (type: UploadFormType): type is FileUploadType => FILE_UPLOAD_TYPES.has(type);
@@ -52,6 +62,19 @@ const isFileUploadType = (type: UploadFormType): type is FileUploadType => FILE_
 const formatUploadType = (type: FileUploadType): string => {
  if (type === 'pdf') return 'PDF';
  return type.charAt(0).toUpperCase() + type.slice(1);
+};
+
+const getBulkUploadConcurrency = (items: UploadQueueItem[]): number => (
+ items.some(item => item.type === 'video' || item.type === 'pdf') ? 1 : BULK_UPLOAD_CONCURRENCY
+);
+
+const getUploadButtonLabel = (queue: UploadQueueItem[]): string => {
+ const retryableCount = queue.filter(item => item.status !== 'success').length;
+ const failedCount = queue.filter(item => item.status === 'error').length;
+ if (failedCount > 0 && retryableCount === failedCount) {
+ return `Retry ${failedCount} Failed`;
+ }
+ return `Upload ${retryableCount} File${retryableCount === 1 ? '' : 's'}`;
 };
 
 export default function ContentClient() {
@@ -88,6 +111,7 @@ export default function ContentClient() {
  const [formErrors, setFormErrors] = useState<Record<string, string>>({});
  const [uploadProgress, setUploadProgress] = useState<number>(0);
  const [uploadQueue, setUploadQueue] = useState<UploadQueueItem[]>([]);
+ const [uploadRejections, setUploadRejections] = useState<UploadRejectedItem[]>([]);
  const [tags] = useState<ContentTag[]>([
  { id: '1', name: 'Marketing', color: 'blue' },
  { id: '2', name: 'Seasonal', color: 'green' },
@@ -357,7 +381,10 @@ export default function ContentClient() {
  };
 
  try {
- const workerCount = Math.min(BULK_UPLOAD_CONCURRENCY, uploadTargets.length);
+ const workerCount = Math.min(
+ getBulkUploadConcurrency(uploadTargets.map(({ item }) => item)),
+ uploadTargets.length,
+ );
  await Promise.all(Array.from({ length: workerCount }, () => worker()));
  } finally {
  setActionLoading(false);
@@ -398,6 +425,7 @@ export default function ContentClient() {
 
  const clearUploadQueue = () => {
  setUploadQueue([]);
+ setUploadRejections([]);
  clearSelectedUploadFile();
  };
 
@@ -765,13 +793,22 @@ export default function ContentClient() {
  const { getRootProps, getInputProps, isDragActive } = useDropzone({
  accept: getAcceptedFileTypes() as any,
  multiple: true, // Enable multiple file selection
+ maxSize: isFileUploadType(uploadForm.type) ? FILE_UPLOAD_LIMITS[uploadForm.type] : undefined,
  disabled: actionLoading || !isFileUploadType(uploadForm.type),
  useFsAccessApi: false,
  onDrop: (acceptedFiles) => {
  if (!isFileUploadType(uploadForm.type)) return;
  const queuedType = uploadForm.type;
+ const remainingSlots = Math.max(0, MAX_UPLOAD_QUEUE_ITEMS - uploadQueue.length);
+ const filesToQueue = acceptedFiles.slice(0, remainingSlots);
+ const overflowCount = acceptedFiles.length - filesToQueue.length;
+ if (overflowCount > 0) {
+ toast.warning(`Upload queue limit is ${MAX_UPLOAD_QUEUE_ITEMS} files. ${overflowCount} file(s) were not added to the upload queue.`);
+ }
+ if (filesToQueue.length === 0) return;
+ setUploadRejections([]);
  // Add files to upload queue
- const newQueueItems = acceptedFiles.map(file => ({
+ const newQueueItems = filesToQueue.map(file => ({
  file,
  type: queuedType,
  status: 'pending' as const,
@@ -780,8 +817,8 @@ export default function ContentClient() {
  setUploadQueue(prev => [...prev, ...newQueueItems]);
  
  // For backward compatibility, set first file to uploadForm
- if (acceptedFiles.length > 0 && !uploadForm.file) {
- const file = acceptedFiles[0];
+ if (filesToQueue.length > 0 && !uploadForm.file) {
+ const file = filesToQueue[0];
  if (uploadForm.url && uploadForm.url.startsWith('blob:')) {
  URL.revokeObjectURL(uploadForm.url);
  }
@@ -797,6 +834,13 @@ export default function ContentClient() {
  }));
  }
  }
+ },
+ onDropRejected: (fileRejections: FileRejection[]) => {
+ const rejected = fileRejections.map(({ file, errors }) => ({
+ fileName: file.name,
+ reason: errors[0]?.message || 'File rejected',
+ }));
+ setUploadRejections(rejected);
  },
  });
 
@@ -846,6 +890,7 @@ export default function ContentClient() {
  };
 
  const hasActiveFilters = filterType !== 'all' || filterStatus !== 'all' || filterDateRange !== 'all' || searchQuery !== '' || selectedTags.length > 0;
+ const retryableUploadCount = uploadQueue.filter(item => item.status !== 'success').length;
 
  return (
  <div className="flex h-full">
@@ -1433,6 +1478,21 @@ export default function ContentClient() {
  )}
  </div>
  
+ {uploadRejections.length > 0 && (
+ <div className="mt-4 space-y-2" aria-live="polite">
+ {uploadRejections.map((rejection) => (
+ <div
+ key={`${rejection.fileName}-${rejection.reason}`}
+ role="alert"
+ className="rounded border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-600 dark:text-red-300"
+ >
+ <p className="font-medium">{rejection.fileName}</p>
+ <p className="text-xs">{rejection.reason}</p>
+ </div>
+ ))}
+ </div>
+ )}
+
  {/* Upload Queue */}
  {uploadQueue.length > 0 && (
  <div className="mt-4 space-y-2">
@@ -1468,6 +1528,9 @@ export default function ContentClient() {
  style={{ width: `${item.progress}%` }}
  />
  </div>
+ )}
+ {item.status === 'error' && item.error && (
+ <p className="mt-1 text-xs text-red-600 dark:text-red-400">{item.error}</p>
  )}
  </div>
  <div className="ml-4 flex items-center gap-2">
@@ -1571,11 +1634,11 @@ export default function ContentClient() {
  <button
  onClick={handleUpload}
  className="px-4 py-2 text-sm font-medium bg-[#00E5A0] text-[#061A21] rounded-lg hover:bg-[#00CC8E] transition disabled:opacity-50 flex items-center gap-2"
- disabled={actionLoading || (uploadQueue.length === 0 && (!uploadForm.title || !uploadForm.url))}
+ disabled={actionLoading || (uploadQueue.length > 0 ? retryableUploadCount === 0 : (!uploadForm.title || !uploadForm.url))}
  >
  {actionLoading && <LoadingSpinner size="sm" />}
  {uploadQueue.length > 0
- ? `Upload ${uploadQueue.length} File${uploadQueue.length > 1 ? 's' : ''}`
+ ? getUploadButtonLabel(uploadQueue)
  : 'Upload Content'
  }
  </button>


### PR DESCRIPTION
## Summary
- switch content upload/replace to disk-backed temp files with stream validation/hash/upload paths
- add path-based thumbnail generation and guarded temp cleanup after background image work
- add dashboard upload backpressure: per-type max size, bounded queue, single-concurrency large uploads, visible rejection/retry feedback

## Review
- design review: middleware/storage/frontend reviewers found temp ownership, path validation, RIFF/PDF scanning, queue cap, rejection, and retry UX gaps; selected gaps fixed
- code review: fixed FileRejection typecheck issue and react-dropzone maxFiles truncation bug
- final delta review: middleware and dashboard reviewers CLEAN

## Verification
- pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=file-validation.service|storage.service|content.controller (8 suites / 293 tests)
- pnpm --filter @vizora/web test -- --runInBand --testPathPattern=dashboard/content (1 suite / 25 tests)
- pnpm --filter @vizora/middleware test -- --runInBand (143 suites / 2842 tests)
- pnpm --filter @vizora/web test -- --runInBand (94 suites / 960 tests; existing act/jsdom warnings)
- pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false
- pnpm --filter @vizora/web exec tsc --noEmit --pretty false
- npx nx build @vizora/middleware (existing webpack warnings)
- npx nx build @vizora/web (existing Next proxy/project-reference warnings)
- pnpm --filter @vizora/realtime test -- --runInBand (12 suites / 273 tests)
- npx nx build @vizora/realtime (serial run; existing webpack warnings)
- pnpm test:ops (5 tests)
- pnpm --dir display test:ci (6 suites / 126 tests)
- pnpm --dir display typecheck
- pnpm --dir display build
- git diff --check (line-ending warnings only)

## Known residuals
- pnpm audit with system CA reports existing dependency advisories (1 critical, 56 high); CI audit is non-blocking and dependency upgrades need a dedicated security pass.
- production deploy remains gated until `/opt/vizora/app` dirty/diverged state is reconciled.