### PR TITLE
perf: reduce dashboard and widget fetch pressure

### DIFF
--- a/docs/plans/2026-05-31-performance-readiness-pass-11.md
+++ b/docs/plans/2026-05-31-performance-readiness-pass-11.md
@@ -1,0 +1,89 @@
+# Performance Readiness Pass 11
+
+**Date:** 2026-05-31
+**Branch:** `feat/performance-readiness-pass-11`
+
+## Goal
+
+Reduce customer-visible and middleware performance risk with small repo-side
+changes that are buildable, testable, and safe to merge while production deploy
+remains blocked by dirty/diverged prod-local state.
+
+## New primitives introduced
+
+- `GenericApiDataSource` bounded JSON response reader.
+- Local lazy-load guards for content-page modal-only device/playlist data.
+
+## Hermes-first analysis
+
+Not applicable. This pass does not add business agents, MCP tools, Hermes
+skills, AI/provider calls, or spend paths.
+
+## Reviewer Input
+
+Three read-only reviewers converged on two small, high-value targets:
+
+- Generic API widgets call `res.json()` on arbitrary customer-configured URLs,
+  so a large JSON response can spike middleware memory.
+- Dashboard pages still issue unnecessary first-paint requests: content loads
+  devices/playlists before the related modals open, and devices refetches
+  server-hydrated devices/playlists on mount.
+
+Larger findings are valid but deferred from this slice: shared dashboard
+Socket.IO provider, full server-side content library pagination/search,
+playlist summary payloads, template refresh locking, dashboard real health and
+quota, and API-key surface cleanup.
+
+## Design
+
+### Generic API Widget Body Cap
+
+Add a 1 MiB response cap to `GenericApiDataSource`.
+
+- Reject oversized `Content-Length` before reading the body.
+- Read `Response.body` as a stream and stop once the cap is exceeded.
+- Cancel the body/reader when rejecting an oversized response so the remote
+  transfer is not left running.
+- Parse JSON from the bounded text payload instead of calling `res.json()`.
+- Preserve the existing circuit-breaker fallback behavior.
+- Preserve existing SSRF guard, GET-only restriction, fixed User-Agent/Accept,
+  manual redirect handling, and responseRoot dot-path behavior.
+
+### Dashboard First-Paint Request Reduction
+
+Content dashboard:
+
+- Keep content and folders loading on mount.
+- Lazy-load devices only when the user opens the push-content modal.
+- Lazy-load playlists only when the user opens the add-to-playlist modal.
+- Show a small loading state inside those modals while options are loading.
+- Refresh options on each explicit modal open so long-lived dashboard sessions
+  do not show stale device status or playlist inventory.
+- Show retryable error states inside those modals if option loading fails.
+
+Devices dashboard:
+
+- Keep using server-rendered initial devices and playlists.
+- Skip client refetches only when server pagination metadata proves the initial
+  devices/playlists include the complete first result set.
+- Continue fetching when initial props are empty and after mutating actions.
+
+## Tests
+
+- Middleware unit tests for Generic API oversized `Content-Length`, chunked
+  over-limit body, stream cancellation, valid under-limit JSON, and fallback on
+  body-cap failures.
+- Web content-page tests proving `getDisplays`/`getPlaylists` are not called on
+  mount and are called only when opening the relevant modals.
+- Web content-page tests covering option-load retry recovery and refresh on
+  each modal open.
+- Web devices-page tests proving complete server props do not refetch devices or
+  playlists on mount, while empty/incomplete props still trigger client fetches,
+  including page-2 pagination.
+
+## Non-Goals
+
+- No production deploy or prod-state mutation.
+- No generic data-source POST/OAuth support.
+- No resumable uploads, thumbnail queue, shared realtime socket provider, or
+  full content-library server pagination in this slice.

--- a/middleware/src/modules/content/widget-data-sources/generic-api.data-source.spec.ts
+++ b/middleware/src/modules/content/widget-data-sources/generic-api.data-source.spec.ts
@@ -20,6 +20,15 @@ describe('GenericApiDataSource', () => {
   let circuitBreaker: jest.Mocked<Pick<CircuitBreakerService, 'executeWithFallback'>>;
   const originalFetch = global.fetch;
   const mockLookup = dns.lookup as unknown as jest.Mock;
+  const jsonResponse = (body: unknown, init?: ResponseInit) =>
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+        ...(init?.headers as Record<string, string> | undefined),
+      },
+      ...init,
+    });
 
   beforeEach(() => {
     // Circuit breaker mock: execute the primary callback directly (skip fallback unless asked)
@@ -133,11 +142,7 @@ describe('GenericApiDataSource', () => {
     });
 
     it('allows public hostnames with non-default ports', async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        json: async () => ({ ok: true }),
-      }) as any;
+      global.fetch = jest.fn().mockResolvedValue(jsonResponse({ ok: true })) as any;
       await expect(
         dataSource.fetchData({ url: 'https://api.example.com:8443/path' }),
       ).resolves.toBeDefined();
@@ -158,11 +163,9 @@ describe('GenericApiDataSource', () => {
       });
       // 302 to an internal address would bypass the SSRF guard if we
       // followed redirects. Verify we reject without ever attempting hop 2.
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: false,
-        status: 302,
-        headers: { get: () => 'http://169.254.169.254/' },
-      }) as any;
+      global.fetch = jest.fn().mockResolvedValue(
+        new Response(null, { status: 302, headers: { location: 'http://169.254.169.254/' } }),
+      ) as any;
       const result = await dataSource.fetchData({ url: 'https://api.example.com/x' });
       // Falls back to sample data (circuit breaker behaviour). Just need
       // to assert we never attempted the redirected URL — fetch was called
@@ -179,11 +182,7 @@ describe('GenericApiDataSource', () => {
   // ---------------------------------------------------------------------------
   describe('fetchData (happy path)', () => {
     it('returns { data, fetchedAt } when the endpoint responds with JSON', async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        json: async () => ({ items: ['a', 'b', 'c'] }),
-      }) as any;
+      global.fetch = jest.fn().mockResolvedValue(jsonResponse({ items: ['a', 'b', 'c'] })) as any;
 
       const result = await dataSource.fetchData({ url: 'https://api.example.com/x' });
       expect(result).toHaveProperty('data', { items: ['a', 'b', 'c'] });
@@ -191,11 +190,9 @@ describe('GenericApiDataSource', () => {
     });
 
     it('applies responseRoot dot-path to extract nested data', async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        json: async () => ({ meta: { ts: 1 }, payload: { items: ['x', 'y'] } }),
-      }) as any;
+      global.fetch = jest.fn().mockResolvedValue(
+        jsonResponse({ meta: { ts: 1 }, payload: { items: ['x', 'y'] } }),
+      ) as any;
 
       const result = await dataSource.fetchData({
         url: 'https://api.example.com/x',
@@ -205,11 +202,7 @@ describe('GenericApiDataSource', () => {
     });
 
     it('responseRoot that misses returns data=undefined (no throw)', async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        json: async () => ({ a: 1 }),
-      }) as any;
+      global.fetch = jest.fn().mockResolvedValue(jsonResponse({ a: 1 })) as any;
 
       const result = await dataSource.fetchData({
         url: 'https://api.example.com/x',
@@ -219,11 +212,7 @@ describe('GenericApiDataSource', () => {
     });
 
     it('forwards custom headers to fetch', async () => {
-      const fetchSpy = jest.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        json: async () => ({}),
-      });
+      const fetchSpy = jest.fn().mockResolvedValue(jsonResponse({}));
       global.fetch = fetchSpy as any;
 
       await dataSource.fetchData({
@@ -240,11 +229,7 @@ describe('GenericApiDataSource', () => {
 
     // PR-review fix: customer cannot override User-Agent or Accept via headers
     it('customer headers CANNOT override User-Agent or Accept (defense against WAF/rate-limit bypass)', async () => {
-      const fetchSpy = jest.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        json: async () => ({}),
-      });
+      const fetchSpy = jest.fn().mockResolvedValue(jsonResponse({}));
       global.fetch = fetchSpy as any;
 
       await dataSource.fetchData({
@@ -255,6 +240,52 @@ describe('GenericApiDataSource', () => {
       const fetchOpts = fetchSpy.mock.calls[0][1];
       expect(fetchOpts.headers['User-Agent']).toBe('Vizora-Widget/1.0');
       expect(fetchOpts.headers.Accept).toBe('application/json');
+    });
+  });
+
+  describe('response size limits', () => {
+    it('rejects oversized content-length before reading the body', async () => {
+      const cancel = jest.fn();
+      global.fetch = jest.fn().mockResolvedValue(
+        new Response(
+          new ReadableStream<Uint8Array>({ cancel }),
+          { status: 200, headers: { 'content-length': String(1024 * 1024 + 1) } },
+        ),
+      ) as any;
+
+      await expect(dataSource.fetchData({ url: 'https://api.example.com/x' }))
+        .rejects.toThrow(/response is too large/i);
+      expect(cancel).toHaveBeenCalled();
+    });
+
+    it('rejects chunked responses that exceed the body cap without content-length', async () => {
+      const cancel = jest.fn();
+      const oversizedChunk = new TextEncoder().encode(JSON.stringify({ data: 'x'.repeat(1024 * 1024 + 1) }));
+      global.fetch = jest.fn().mockResolvedValue(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(oversizedChunk);
+            },
+            cancel,
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          },
+        ),
+      ) as any;
+
+      await expect(dataSource.fetchData({ url: 'https://api.example.com/x' }))
+        .rejects.toThrow(/response is too large/i);
+      expect(cancel).toHaveBeenCalled();
+    });
+
+    it('accepts valid under-limit JSON responses', async () => {
+      global.fetch = jest.fn().mockResolvedValue(jsonResponse({ data: ['small'] })) as any;
+
+      await expect(dataSource.fetchData({ url: 'https://api.example.com/x' }))
+        .resolves.toMatchObject({ data: { data: ['small'] } });
     });
   });
 
@@ -275,21 +306,14 @@ describe('GenericApiDataSource', () => {
     });
 
     it('non-200 response → fallback to sample data', async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: false,
-        status: 500,
-      }) as any;
+      global.fetch = jest.fn().mockResolvedValue(new Response('error', { status: 500 })) as any;
 
       const result = await dataSource.fetchData({ url: 'https://api.example.com/x' });
       expect(result.data).toBeInstanceOf(Array); // sample data shape
     });
 
     it('endpoint returns non-JSON (malformed body) → fallback to sample data', async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        json: async () => { throw new SyntaxError('not json'); },
-      }) as any;
+      global.fetch = jest.fn().mockResolvedValue(new Response('not json', { status: 200 })) as any;
 
       const result = await dataSource.fetchData({ url: 'https://api.example.com/x' });
       expect(result.data).toBeInstanceOf(Array);
@@ -301,6 +325,18 @@ describe('GenericApiDataSource', () => {
         err.name = 'AbortError';
         throw err;
       }) as any;
+
+      const result = await dataSource.fetchData({ url: 'https://api.example.com/x' });
+      expect(result.data).toBeInstanceOf(Array);
+    });
+
+    it('oversized body falls back to sample data when circuit breaker handles the failure', async () => {
+      global.fetch = jest.fn().mockResolvedValue(
+        jsonResponse(
+          { ok: true },
+          { headers: { 'content-length': String(1024 * 1024 + 1) } },
+        ),
+      ) as any;
 
       const result = await dataSource.fetchData({ url: 'https://api.example.com/x' });
       expect(result.data).toBeInstanceOf(Array);

--- a/middleware/src/modules/content/widget-data-sources/generic-api.data-source.ts
+++ b/middleware/src/modules/content/widget-data-sources/generic-api.data-source.ts
@@ -20,8 +20,6 @@ import { WidgetDataSource } from './widget-data-source.interface';
  *   - OAuth flows (customer can paste a Bearer token into headers)
  *   - Full JSONPath ($.store.book[?(@.price < 10)]) — simple dot-path
  *     covers the typical case; full JSONPath needs a dependency
- *   - Response size limits — acceptable v1 risk; add a content-length
- *     check if real customers report issues
  */
 @Injectable()
 export class GenericApiDataSource implements WidgetDataSource {
@@ -30,6 +28,7 @@ export class GenericApiDataSource implements WidgetDataSource {
   readonly type = 'generic-api';
 
   private readonly REQUEST_TIMEOUT = 15_000;
+  private readonly MAX_RESPONSE_BYTES = 1024 * 1024;
 
   constructor(private readonly circuitBreaker: CircuitBreakerService) {}
 
@@ -104,7 +103,7 @@ export class GenericApiDataSource implements WidgetDataSource {
 
           let json: unknown;
           try {
-            json = await res.json();
+            json = JSON.parse(await this.readJsonBodyWithLimit(res));
           } catch (err) {
             throw new Error(
               `Endpoint did not return valid JSON: ${err instanceof Error ? err.message : 'unknown'}`,
@@ -123,6 +122,63 @@ export class GenericApiDataSource implements WidgetDataSource {
         return this.getSampleData();
       },
     );
+  }
+
+  private async readJsonBodyWithLimit(res: Response): Promise<string> {
+    const contentLength = res.headers.get('content-length');
+    if (contentLength) {
+      const declaredBytes = Number(contentLength);
+      if (Number.isFinite(declaredBytes) && declaredBytes > this.MAX_RESPONSE_BYTES) {
+        await this.cancelResponseBody(res);
+        throw new Error(`Endpoint response is too large; maximum is ${this.MAX_RESPONSE_BYTES} bytes`);
+      }
+    }
+
+    if (!res.body) {
+      const text = await res.text();
+      if (Buffer.byteLength(text, 'utf8') > this.MAX_RESPONSE_BYTES) {
+        throw new Error(`Endpoint response is too large; maximum is ${this.MAX_RESPONSE_BYTES} bytes`);
+      }
+      return text;
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let receivedBytes = 0;
+    let text = '';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        receivedBytes += value.byteLength;
+        if (receivedBytes > this.MAX_RESPONSE_BYTES) {
+          await this.cancelReader(reader);
+          throw new Error(`Endpoint response is too large; maximum is ${this.MAX_RESPONSE_BYTES} bytes`);
+        }
+        text += decoder.decode(value, { stream: true });
+      }
+      text += decoder.decode();
+      return text;
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  private async cancelResponseBody(res: Response): Promise<void> {
+    try {
+      await res.body?.cancel();
+    } catch {
+      // The size rejection is the important error; body cancellation is cleanup.
+    }
+  }
+
+  private async cancelReader(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<void> {
+    try {
+      await reader.cancel();
+    } catch {
+      // Preserve the response-size error even if stream cancellation fails.
+    }
   }
 
   /**

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,96 @@
 # Vizora - Task Tracker
 
-## In Progress: Upload Pressure Readiness Pass 10 (2026-05-31)
+## In Progress: Customer/Performance Readiness Pass 11 (2026-05-31)
+
+**Branch:** `feat/performance-readiness-pass-11`
+
+**Why now:** PR #133 merged the upload-memory-pressure fix and all checks are
+green, but production deploy is still blocked by dirty/diverged prod-local
+state. The next autonomous slice should use fresh customer-dashboard,
+performance, and production-risk reviews to pick repo-side issues that are
+small enough to build, test, review, merge, and safely defer deploy if the prod
+checkout remains unsafe.
+
+**New primitives introduced:** `GenericApiDataSource` bounded response reader
+and local lazy-load guards for modal-only dashboard option data.
+
+**Hermes-first analysis:** not applicable yet. This pass will avoid business
+agent, MCP, Hermes skill, AI/provider, or spend paths unless a reviewer finds a
+specific existing-agent gap that must use the Hermes/MCP substrate.
+
+**Plan**
+- [x] Merge PR #133 after full CI green.
+- [x] Re-check production deploy gate after merge.
+- [x] Start fresh branch from `origin/main`.
+- [x] Run multi-subagent customer, performance, and production-risk scans before
+  selecting a build target.
+- [x] Reconcile reviewer findings with backlog/repo truth and select the
+  smallest high-value buildable bundle.
+- [x] Write/update a short design plan for selected fixes.
+- [x] Add focused failing tests.
+- [x] Implement scoped fixes.
+- [x] Run focused red/green tests, then multi-subagent code review.
+- [x] Run broader affected tests/builds/typecheck.
+- [ ] PR, CI, merge.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Current merge/deploy state**
+- [x] PR #133 merged at
+  `153091861732b5971e76cbff456763a8e2619ef6`; CI green for audit, build,
+  e2e, lint, security, and test.
+- [x] No open GitHub PRs after #133 merge.
+- [x] Prod deploy remains blocked: `/opt/vizora/app` is `ahead 17, behind 73`
+  from `origin/main=153091861732b5971e76cbff456763a8e2619ef6`, with many dirty
+  template/web/script files and untracked operator-approval/docs assets.
+- [x] Prod runtime probe: middleware/web/realtime PM2 processes are online and
+  middleware health is OK; several ops/Hermes cron processes are stopped. No
+  production pull, reset, stash, env edit, service restart, DB mutation, or
+  deploy performed.
+
+**Plan/design:** `docs/plans/2026-05-31-performance-readiness-pass-11.md`
+
+**Selected fix bundle**
+- [x] Cap Generic API widget response bodies before JSON parsing.
+- [x] Lazy-load content push/add-to-playlist modal options instead of loading
+  devices/playlists on content-page mount.
+- [x] Skip redundant devices-page client refetches only when server pagination
+  metadata proves the server props include the complete devices/playlists list.
+
+**Focused verification and review**
+- [x] Focused tests passed:
+  `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=generic-api.data-source`
+  (35/35) and
+  `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="dashboard/(content|devices)"`
+  (44/44).
+- [x] Middleware reviewer re-review CLEAN after adding stream cancellation on
+  oversized Generic API responses.
+- [x] Dashboard reviewer re-review CLEAN after fixing incomplete first-page
+  devices props, modal lazy-load error states, and playlist option refresh after
+  add-to-playlist.
+- [x] Broader verification passed:
+  middleware full Jest (143 suites / 2846 tests), web full Jest (94 suites /
+  969 tests after review fixes), middleware and web TypeScript checks,
+  `git diff --check`, middleware build, web production build, realtime build,
+  and CI-equivalent middleware/realtime lint. Full ad-hoc web-inclusive ESLint
+  still has a pre-existing repo warning/error backlog outside this branch;
+  changed-file lint exits 0 with warnings only.
+- [x] Final multi-agent review: backend/security/resource review CLEAN; dashboard
+  review low findings fixed and targeted re-review CLEAN.
+
+**Reviewer findings deferred from this slice**
+- [ ] Shared dashboard Socket.IO provider.
+- [ ] Full server-side content-library pagination/search.
+- [ ] Playlist index summary payload.
+- [ ] Template refresh overlap guard and DB-side refresh-enabled scan.
+- [ ] Real dashboard health/quota cards.
+- [ ] API-key customer surface cleanup.
+
+---
+
+## Completed: Upload Pressure Readiness Pass 10 (2026-05-31)
+
+**PR / merge commit:** #133 /
+`153091861732b5971e76cbff456763a8e2619ef6`
 
 **Branch:** `feat/performance-readiness-pass-10`
 
@@ -29,8 +119,8 @@ agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
 - [x] Run focused red/green tests.
 - [x] Run multi-subagent code review before broader tests.
 - [x] Run broader affected tests/builds/typecheck.
-- [ ] PR, CI, merge.
-- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+- [x] PR, CI, merge.
+- [x] Re-check deployment gate; deploy only if prod checkout is safe.
 
 **Deployment gate inherited from pass 9**
 - [x] PR #132 merged at `4383c09b75f3cdbba0d0965ce477fe135d6439d6`; CI green

--- a/web/src/app/dashboard/content/__tests__/content-page.test.tsx
+++ b/web/src/app/dashboard/content/__tests__/content-page.test.tsx
@@ -11,6 +11,7 @@ const mockUploadContent = jest.fn();
 const mockCreateContent = jest.fn();
 const mockUploadContentWithProgress = jest.fn();
 const mockGenerateThumbnail = jest.fn();
+const mockAddPlaylistItem = jest.fn();
 let lastDropzoneOptions: any;
 
 jest.mock('@/lib/api', () => ({
@@ -25,6 +26,7 @@ jest.mock('@/lib/api', () => ({
     createContent: (...args: any[]) => mockCreateContent(...args),
     uploadContentWithProgress: (...args: any[]) => mockUploadContentWithProgress(...args),
     generateThumbnail: (...args: any[]) => mockGenerateThumbnail(...args),
+    addPlaylistItem: (...args: any[]) => mockAddPlaylistItem(...args),
   },
 }));
 
@@ -203,6 +205,7 @@ describe('ContentClient', () => {
     mockCreateContent.mockResolvedValue({ id: 'new-1', title: 'New Content' });
     mockUploadContentWithProgress.mockResolvedValue({ id: 'new-1', title: 'New Content' });
     mockGenerateThumbnail.mockResolvedValue({});
+    mockAddPlaylistItem.mockResolvedValue({});
     lastDropzoneOptions = undefined;
     Object.defineProperty(URL, 'createObjectURL', {
       configurable: true,
@@ -218,8 +221,6 @@ describe('ContentClient', () => {
     await waitFor(() => {
       expect(mockGetContent).toHaveBeenCalled();
       expect(mockGetFolders).toHaveBeenCalled();
-      expect(mockGetDisplays).toHaveBeenCalled();
-      expect(mockGetPlaylists).toHaveBeenCalled();
     });
     await waitFor(() => {
       expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
@@ -232,8 +233,6 @@ describe('ContentClient', () => {
   const waitForAuxiliaryRequestsToSettle = async () => {
     await waitFor(() => {
       expect(mockGetFolders).toHaveBeenCalled();
-      expect(mockGetDisplays).toHaveBeenCalled();
-      expect(mockGetPlaylists).toHaveBeenCalled();
     });
     await act(async () => {
       await Promise.resolve();
@@ -412,9 +411,218 @@ describe('ContentClient', () => {
     expect(screen.getByTestId('selected-tags')).toHaveTextContent('');
   });
 
-  it('also fetches displays and playlists for push/add features', async () => {
+  it('does not fetch modal-only displays and playlists on mount', async () => {
     render(<ContentClient />);
     await waitForInitialRequestsToSettle();
+    expect(mockGetDisplays).not.toHaveBeenCalled();
+    expect(mockGetPlaylists).not.toHaveBeenCalled();
+  });
+
+  it('lazy-loads displays when opening the push modal', async () => {
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+    mockGetDisplays.mockResolvedValue({
+      data: [{ id: 'd1', nickname: 'Lobby Display', status: 'online', location: 'Lobby' }],
+      meta: { total: 1, totalPages: 1 },
+    });
+
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    expect(mockGetDisplays).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getAllByText('Push')[0]);
+
+    await waitFor(() => {
+      expect(mockGetDisplays).toHaveBeenCalledWith({ page: 1, limit: 100 });
+      expect(screen.getByText('Lobby Display')).toBeInTheDocument();
+    });
+    expect(mockGetPlaylists).not.toHaveBeenCalled();
+  });
+
+  it('shows a retryable device-load error in the push modal', async () => {
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+    mockGetDisplays
+      .mockRejectedValueOnce(new Error('Devices unavailable'))
+      .mockResolvedValueOnce({
+        data: [{ id: 'd2', nickname: 'Recovered Display', status: 'online', location: 'Lobby' }],
+        meta: { total: 1, totalPages: 1 },
+      });
+
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByText('Push')[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Devices unavailable')).toBeInTheDocument();
+      expect(screen.getByText('Retry loading devices')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('No devices available')).not.toBeInTheDocument();
+    expect(screen.getByText('Select Devices')).toBeInTheDocument();
+    expect(screen.queryByText('Select Devices (0 online)')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Retry loading devices'));
+
+    await waitFor(() => {
+      expect(mockGetDisplays).toHaveBeenCalledTimes(2);
+      expect(screen.getByText('Recovered Display')).toBeInTheDocument();
+      expect(screen.getByText('Select Devices (1 online)')).toBeInTheDocument();
+    });
+  });
+
+  it('lazy-loads playlists when opening the add-to-playlist modal', async () => {
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+    mockGetPlaylists.mockResolvedValue({
+      data: [{ id: 'p1', name: 'Lunch Menu', items: [] }],
+      meta: { total: 1, totalPages: 1 },
+    });
+
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    expect(mockGetPlaylists).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getAllByText('Playlist')[0]);
+
+    await waitFor(() => {
+      expect(mockGetPlaylists).toHaveBeenCalledWith({ page: 1, limit: 100 });
+      expect(screen.getByText('Lunch Menu (0 items)')).toBeInTheDocument();
+    });
+    expect(mockGetDisplays).not.toHaveBeenCalled();
+  });
+
+  it('shows a retryable playlist-load error in the add-to-playlist modal', async () => {
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+    mockGetPlaylists
+      .mockRejectedValueOnce(new Error('Playlists unavailable'))
+      .mockResolvedValueOnce({
+        data: [{ id: 'p2', name: 'Recovered Playlist', items: [] }],
+        meta: { total: 1, totalPages: 1 },
+      });
+
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByText('Playlist')[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Playlists unavailable')).toBeInTheDocument();
+      expect(screen.getByText('Retry loading playlists')).toBeInTheDocument();
+    });
+    expect(screen.getByDisplayValue('Unable to load playlists')).toBeDisabled();
+
+    fireEvent.click(screen.getByText('Retry loading playlists'));
+
+    await waitFor(() => {
+      expect(mockGetPlaylists).toHaveBeenCalledTimes(2);
+      expect(screen.getByText('Recovered Playlist (0 items)')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('Select a playlist')).not.toBeDisabled();
+    });
+  });
+
+  it('refreshes devices each time the push modal is opened', async () => {
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+    mockGetDisplays
+      .mockResolvedValueOnce({
+        data: [{ id: 'd1', nickname: 'Lobby Display', status: 'online', location: 'Lobby' }],
+        meta: { total: 1, totalPages: 1 },
+      })
+      .mockResolvedValueOnce({
+        data: [{ id: 'd2', nickname: 'Kitchen Display', status: 'offline', location: 'Kitchen' }],
+        meta: { total: 1, totalPages: 1 },
+      });
+
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByText('Push')[0]);
+    await waitFor(() => {
+      expect(screen.getByText('Lobby Display')).toBeInTheDocument();
+      expect(screen.getByText('Select Devices (1 online)')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText('Close modal'));
+    fireEvent.click(screen.getAllByText('Push')[0]);
+
+    await waitFor(() => {
+      expect(mockGetDisplays).toHaveBeenCalledTimes(2);
+      expect(screen.getByText('Kitchen Display')).toBeInTheDocument();
+      expect(screen.getByText('Select Devices (0 online)')).toBeInTheDocument();
+    });
+  });
+
+  it('refreshes playlists each time the add-to-playlist modal is opened', async () => {
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+    mockGetPlaylists
+      .mockResolvedValueOnce({
+        data: [{ id: 'p1', name: 'Lunch Menu', items: [] }],
+        meta: { total: 1, totalPages: 1 },
+      })
+      .mockResolvedValueOnce({
+        data: [{ id: 'p2', name: 'Dinner Menu', items: [{ id: 'item-1' }] }],
+        meta: { total: 1, totalPages: 1 },
+      });
+
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByText('Playlist')[0]);
+    await waitFor(() => {
+      expect(screen.getByText('Lunch Menu (0 items)')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText('Close modal'));
+    fireEvent.click(screen.getAllByText('Playlist')[0]);
+
+    await waitFor(() => {
+      expect(mockGetPlaylists).toHaveBeenCalledTimes(2);
+      expect(screen.getByText('Dinner Menu (1 items)')).toBeInTheDocument();
+    });
+  });
+
+  it('refetches playlist options after adding content to a playlist', async () => {
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+    mockGetPlaylists
+      .mockResolvedValueOnce({
+        data: [{ id: 'p1', name: 'Lunch Menu', items: [] }],
+        meta: { total: 1, totalPages: 1 },
+      })
+      .mockResolvedValueOnce({
+        data: [{ id: 'p1', name: 'Lunch Menu', items: [{ id: 'item-1' }] }],
+        meta: { total: 1, totalPages: 1 },
+      });
+
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByText('Playlist')[0]);
+    await waitFor(() => {
+      expect(screen.getByText('Lunch Menu (0 items)')).toBeInTheDocument();
+    });
+    fireEvent.change(screen.getByDisplayValue('Select a playlist'), { target: { value: 'p1' } });
+    fireEvent.click(screen.getAllByText('Add to Playlist').at(-1)!);
+
+    await waitFor(() => {
+      expect(mockAddPlaylistItem).toHaveBeenCalledWith('p1', 'c1');
+    });
+
+    fireEvent.click(screen.getAllByText('Playlist')[0]);
+    await waitFor(() => {
+      expect(mockGetPlaylists).toHaveBeenCalledTimes(2);
+      expect(screen.getByText('Lunch Menu (1 items)')).toBeInTheDocument();
+    });
   });
 
   it('bulk upload preserves each queued file type after the selector changes', async () => {

--- a/web/src/app/dashboard/content/page-client.tsx
+++ b/web/src/app/dashboard/content/page-client.tsx
@@ -90,6 +90,10 @@ export default function ContentClient() {
  const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false);
  const [devices, setDevices] = useState<Display[]>([]);
  const [playlists, setPlaylists] = useState<Playlist[]>([]);
+ const [devicesLoading, setDevicesLoading] = useState(false);
+ const [playlistsLoading, setPlaylistsLoading] = useState(false);
+ const [devicesLoadError, setDevicesLoadError] = useState<string | null>(null);
+ const [playlistsLoadError, setPlaylistsLoadError] = useState<string | null>(null);
  const [selectedDevices, setSelectedDevices] = useState<string[]>([]);
  const [selectedPlaylist, setSelectedPlaylist] = useState('');
  const [pushDuration, setPushDuration] = useState(5);
@@ -141,6 +145,10 @@ export default function ContentClient() {
  const reconnectTimerRef = useRef<NodeJS.Timeout | null>(null);
  const hasHandledInitialFolderLoadRef = useRef(false);
  const loadContentRequestRef = useRef(0);
+ const devicesLoadedRef = useRef(false);
+ const playlistsLoadedRef = useRef(false);
+ const devicesLoadPromiseRef = useRef<Promise<void> | null>(null);
+ const playlistsLoadPromiseRef = useRef<Promise<void> | null>(null);
  useEffect(() => {
    return () => {
      if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
@@ -192,8 +200,6 @@ export default function ContentClient() {
 
  useEffect(() => {
  loadContent();
- loadDevices();
- loadPlaylists();
  loadFolders();
  }, []);
 
@@ -237,14 +243,13 @@ export default function ContentClient() {
  if (requestId !== loadContentRequestRef.current) {
  return;
  }
- toast.error(error.message || 'Failed to load content');
- } finally {
- if (requestId !== loadContentRequestRef.current) {
- return;
- }
+  toast.error(error.message || 'Failed to load content');
+  } finally {
+ if (requestId === loadContentRequestRef.current) {
  setLoading(false);
- }
- };
+  }
+  }
+  };
 
  const loadFolders = async () => {
  try {
@@ -302,32 +307,60 @@ export default function ContentClient() {
 
  const loadDevices = async () => {
  try {
+ setDevicesLoading(true);
+ setDevicesLoadError(null);
  const devicesList = await fetchAllPaginated((params) => apiClient.getDisplays(params));
  setDevices(devicesList);
+ devicesLoadedRef.current = true;
  } catch (error: any) {
+ const message = error.message || 'Could not load devices list';
+ setDevicesLoadError(message);
  if (process.env.NODE_ENV === 'development') {
   console.error('[ContentPage] Failed to load devices:', error);
  }
- // Non-critical: devices are optional for content listing
- if (process.env.NODE_ENV === 'development') {
- toast.warning('Could not load devices list');
- }
+ toast.error(message);
+ } finally {
+ setDevicesLoading(false);
  }
  };
 
  const loadPlaylists = async () => {
  try {
+ setPlaylistsLoading(true);
+ setPlaylistsLoadError(null);
  const playlistList = await fetchAllPaginated((params) => apiClient.getPlaylists(params));
  setPlaylists(playlistList);
+ playlistsLoadedRef.current = true;
  } catch (error: any) {
+ const message = error.message || 'Could not load playlists list';
+ setPlaylistsLoadError(message);
  if (process.env.NODE_ENV === 'development') {
   console.error('[ContentPage] Failed to load playlists:', error);
  }
- // Non-critical: playlists are optional for content listing
- if (process.env.NODE_ENV === 'development') {
- toast.warning('Could not load playlists list');
+ toast.error(message);
+ } finally {
+ setPlaylistsLoading(false);
  }
+ };
+
+ const ensureDevicesLoaded = async (forceRefresh = false) => {
+ if (!forceRefresh && devicesLoadedRef.current) return;
+ if (!devicesLoadPromiseRef.current) {
+ devicesLoadPromiseRef.current = loadDevices().finally(() => {
+ devicesLoadPromiseRef.current = null;
+ });
  }
+ await devicesLoadPromiseRef.current;
+ };
+
+ const ensurePlaylistsLoaded = async (forceRefresh = false) => {
+ if (!forceRefresh && playlistsLoadedRef.current) return;
+ if (!playlistsLoadPromiseRef.current) {
+ playlistsLoadPromiseRef.current = loadPlaylists().finally(() => {
+ playlistsLoadPromiseRef.current = null;
+ });
+ }
+ await playlistsLoadPromiseRef.current;
  };
 
  const handleBulkUpload = async () => {
@@ -616,6 +649,7 @@ export default function ContentClient() {
  setSelectedDevices([]);
  setPushDuration(5);
  setIsPushModalOpen(true);
+ void ensureDevicesLoaded(true);
  };
 
  const confirmPush = async () => {
@@ -643,6 +677,7 @@ export default function ContentClient() {
  setSelectedContent(item);
  setSelectedPlaylist('');
  setIsAddToPlaylistModalOpen(true);
+ void ensurePlaylistsLoaded(true);
  };
 
  const confirmAddToPlaylist = async () => {
@@ -653,6 +688,7 @@ export default function ContentClient() {
  await apiClient.addPlaylistItem(selectedPlaylist, selectedContent.id);
  toast.success('Content added to playlist');
  setIsAddToPlaylistModalOpen(false);
+ playlistsLoadedRef.current = false;
  } catch (error: any) {
  toast.error(error.message || 'Failed to add to playlist');
  } finally {
@@ -891,6 +927,12 @@ export default function ContentClient() {
 
  const hasActiveFilters = filterType !== 'all' || filterStatus !== 'all' || filterDateRange !== 'all' || searchQuery !== '' || selectedTags.length > 0;
  const retryableUploadCount = uploadQueue.filter(item => item.status !== 'success').length;
+ const onlineDeviceCount = devices.filter(d => d.status === 'online').length;
+ const deviceSelectionLabel = devicesLoading
+ ? 'Select Devices (loading...)'
+ : devicesLoadError
+ ? 'Select Devices'
+ : `Select Devices (${onlineDeviceCount} online)`;
 
  return (
  <div className="flex h-full">
@@ -1766,10 +1808,23 @@ export default function ContentClient() {
  {/* Device Selection */}
  <div>
  <label className="block text-sm font-medium text-[var(--foreground-secondary)] mb-2">
- Select Devices ({devices.filter(d => d.status === 'online').length} online)
+ {deviceSelectionLabel}
  </label>
  <div className="max-h-48 overflow-y-auto space-y-2 border border-[var(--border)] rounded-lg p-2">
- {devices.length === 0 ? (
+ {devicesLoading ? (
+ <div className="py-4 flex justify-center"><LoadingSpinner size="sm" /></div>
+ ) : devicesLoadError ? (
+ <div className="py-4 text-center space-y-3">
+ <p className="text-sm text-error-600 dark:text-error-400">{devicesLoadError}</p>
+ <button
+ type="button"
+ onClick={() => void ensureDevicesLoaded(true)}
+ className="px-3 py-1.5 text-sm font-medium bg-[var(--surface)] border border-[var(--border)] rounded-lg hover:bg-[var(--surface-hover)] transition"
+ >
+ Retry loading devices
+ </button>
+ </div>
+ ) : devices.length === 0 ? (
  <p className="text-sm text-[var(--foreground-tertiary)] text-center py-4">No devices available</p>
  ) : (
  devices.map((device) => (
@@ -1845,15 +1900,34 @@ export default function ContentClient() {
  <select
  value={selectedPlaylist}
  onChange={(e) => setSelectedPlaylist(e.target.value)}
+ disabled={playlistsLoading || !!playlistsLoadError}
  className="w-full px-4 py-2 border border-[var(--border)] rounded-lg focus:ring-2 focus:ring-[#00E5A0] focus:border-transparent"
  >
- <option value="">Select a playlist</option>
+ <option value="">
+ {playlistsLoading
+ ? 'Loading playlists...'
+ : playlistsLoadError
+ ? 'Unable to load playlists'
+ : 'Select a playlist'}
+ </option>
  {playlists.map((playlist) => (
  <option key={playlist.id} value={playlist.id}>
  {playlist.name} ({playlist.items?.length || 0} items)
  </option>
  ))}
  </select>
+ {playlistsLoadError && (
+ <div className="mt-3 text-center space-y-3">
+ <p className="text-sm text-error-600 dark:text-error-400">{playlistsLoadError}</p>
+ <button
+ type="button"
+ onClick={() => void ensurePlaylistsLoaded(true)}
+ className="px-3 py-1.5 text-sm font-medium bg-[var(--surface)] border border-[var(--border)] rounded-lg hover:bg-[var(--surface-hover)] transition"
+ >
+ Retry loading playlists
+ </button>
+ </div>
+ )}
  <div className="flex justify-end gap-3 pt-4">
  <button
  onClick={() => setIsAddToPlaylistModalOpen(false)}

--- a/web/src/app/dashboard/devices/__tests__/devices-page.test.tsx
+++ b/web/src/app/dashboard/devices/__tests__/devices-page.test.tsx
@@ -73,7 +73,21 @@ jest.mock('@/lib/hooks', () => ({
     getPendingCount: jest.fn(() => 0),
     hasPendingUpdates: jest.fn(() => false),
   })),
-  useErrorRecovery: jest.fn(() => ({ retry: jest.fn(), recordError: jest.fn(), clearError: jest.fn(), isRecovering: false })),
+  useErrorRecovery: jest.fn(() => ({
+    retry: jest.fn(async (_id, fn, onSuccess, onError) => {
+      try {
+        const result = await fn();
+        onSuccess?.(result);
+        return result;
+      } catch (error) {
+        onError?.(error);
+        throw error;
+      }
+    }),
+    recordError: jest.fn(),
+    clearError: jest.fn(),
+    isRecovering: false,
+  })),
 }));
 
 jest.mock('@/theme/icons', () => ({
@@ -216,12 +230,73 @@ describe('DevicesClient', () => {
     }, { timeout: 3000 });
   });
 
-  it('calls getDisplays API', async () => {
+  it('does not refetch devices or playlists when server props are already present', async () => {
     mockGetDisplays.mockResolvedValue({ data: sampleDevices, meta: { total: 3 } });
-    render(<DevicesClient initialDevices={sampleDevices as any} initialPlaylists={samplePlaylists as any} />);
+    render(
+      <DevicesClient
+        initialDevices={sampleDevices as any}
+        initialPlaylists={samplePlaylists as any}
+        initialDevicesComplete
+        initialPlaylistsComplete
+      />,
+    );
     await waitFor(() => {
       expect(screen.getByText('Lobby Display')).toBeInTheDocument();
     });
+    expect(mockGetDisplays).not.toHaveBeenCalled();
+    expect(mockGetPlaylists).not.toHaveBeenCalled();
+  });
+
+  it('fetches devices and playlists on mount when server props are empty', async () => {
+    mockGetDisplays.mockResolvedValue({ data: sampleDevices, meta: { total: 3 } });
+    mockGetPlaylists.mockResolvedValue({ data: samplePlaylists, meta: { total: 2 } });
+
+    render(<DevicesClient initialDevices={[]} initialPlaylists={[]} />);
+
+    await waitFor(() => {
+      expect(mockGetDisplays).toHaveBeenCalledWith({ page: 1, limit: 100 });
+      expect(mockGetPlaylists).toHaveBeenCalledWith({ page: 1, limit: 100 });
+      expect(screen.getByText('Lobby Display')).toBeInTheDocument();
+    });
+  });
+
+  it('fetches all devices and playlists when server props are only the first page', async () => {
+    mockGetDisplays
+      .mockResolvedValueOnce({
+        data: [{ ...sampleDevices[0], id: 'd100', nickname: 'Fetched First Page Device' }],
+        meta: { page: 1, limit: 100, total: 101, totalPages: 2 },
+      })
+      .mockResolvedValueOnce({
+        data: [{ ...sampleDevices[2], id: 'd101', nickname: 'Overflow Device' }],
+        meta: { page: 2, limit: 100, total: 101, totalPages: 2 },
+      });
+    mockGetPlaylists
+      .mockResolvedValueOnce({
+        data: [{ id: 'p100', name: 'Fetched First Page Playlist', isActive: true }],
+        meta: { page: 1, limit: 100, total: 101, totalPages: 2 },
+      })
+      .mockResolvedValueOnce({
+        data: [{ id: 'p101', name: 'Overflow Playlist', isActive: true }],
+        meta: { page: 2, limit: 100, total: 101, totalPages: 2 },
+      });
+
+    render(
+      <DevicesClient
+        initialDevices={[sampleDevices[0]] as any}
+        initialPlaylists={[samplePlaylists[0]] as any}
+        initialDevicesComplete={false}
+        initialPlaylistsComplete={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockGetDisplays).toHaveBeenCalledWith({ page: 1, limit: 100 });
+      expect(mockGetPlaylists).toHaveBeenCalledWith({ page: 1, limit: 100 });
+      expect(screen.getByText('Overflow Device')).toBeInTheDocument();
+    });
+    expect(mockGetDisplays).toHaveBeenCalledWith({ page: 2, limit: 100 });
+    expect(mockGetPlaylists).toHaveBeenCalledWith({ page: 2, limit: 100 });
+    expect(screen.getByText('Fetched First Page Device')).toBeInTheDocument();
   });
 
   it('renders devices from initial props', async () => {

--- a/web/src/app/dashboard/devices/page-client.tsx
+++ b/web/src/app/dashboard/devices/page-client.tsx
@@ -24,9 +24,16 @@ import { useAuth } from '@/lib/hooks/useAuth';
 interface DevicesClientProps {
  initialDevices: Display[];
  initialPlaylists: Playlist[];
+ initialDevicesComplete?: boolean;
+ initialPlaylistsComplete?: boolean;
 }
 
-export default function DevicesClient({ initialDevices, initialPlaylists }: DevicesClientProps) {
+export default function DevicesClient({
+ initialDevices,
+ initialPlaylists,
+ initialDevicesComplete,
+ initialPlaylistsComplete,
+}: DevicesClientProps) {
  const router = useRouter();
  const toast = useToast();
  const { user } = useAuth();
@@ -58,6 +65,8 @@ export default function DevicesClient({ initialDevices, initialPlaylists }: Devi
  const [bulkPlaylistId, setBulkPlaylistId] = useState('');
  const [bulkGroupId, setBulkGroupId] = useState('');
  const [realtimeStatus, setRealtimeStatus] = useState<'connected' | 'offline' | 'error'>('offline');
+ const hasCompleteInitialDevices = initialDevicesComplete ?? initialDevices.length > 0;
+ const hasCompleteInitialPlaylists = initialPlaylistsComplete ?? initialPlaylists.length > 0;
 
  // Memoized callback for device status changes
  const handleDeviceStatusChange = useCallback((update: { deviceId: string; status: 'online' | 'offline'; lastSeen?: string; currentPlaylistId?: string }) => {
@@ -116,8 +125,12 @@ export default function DevicesClient({ initialDevices, initialPlaylists }: Devi
  });
 
  useEffect(() => {
- loadDevices(initialDevices.length === 0);
+ if (!hasCompleteInitialDevices) {
+ loadDevices(true);
+ }
+ if (!hasCompleteInitialPlaylists) {
  loadPlaylists();
+ }
  loadGroups();
  }, []);
 

--- a/web/src/app/dashboard/devices/page.tsx
+++ b/web/src/app/dashboard/devices/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { serverFetch } from '@/lib/server-api';
 import { unwrapPaginatedData } from '@/lib/api/pagination';
-import type { Display, Playlist } from '@/lib/types';
+import type { Display, PaginatedResponse, Playlist } from '@/lib/types';
 import DevicesClient from './page-client';
 
 export const metadata: Metadata = {
@@ -11,22 +11,33 @@ export const metadata: Metadata = {
 export default async function DevicesPage() {
  let devices: Display[] = [];
  let playlists: Playlist[] = [];
+ let devicesComplete = false;
+ let playlistsComplete = false;
 
  try {
  const results = await Promise.allSettled([
- serverFetch<any>('/displays?limit=100'),
- serverFetch<any>('/playlists?limit=100'),
+ serverFetch<PaginatedResponse<Display>>('/displays?limit=100'),
+ serverFetch<PaginatedResponse<Playlist>>('/playlists?limit=100'),
  ]);
 
  if (results[0].status === 'fulfilled') {
  devices = unwrapPaginatedData<Display>(results[0].value);
+ devicesComplete = (results[0].value.meta?.totalPages ?? 1) <= 1;
  }
  if (results[1].status === 'fulfilled') {
  playlists = unwrapPaginatedData<Playlist>(results[1].value);
+ playlistsComplete = (results[1].value.meta?.totalPages ?? 1) <= 1;
  }
  } catch {
  // Client handles empty state gracefully
  }
 
- return <DevicesClient initialDevices={devices} initialPlaylists={playlists} />;
+ return (
+ <DevicesClient
+ initialDevices={devices}
+ initialPlaylists={playlists}
+ initialDevicesComplete={devicesComplete}
+ initialPlaylistsComplete={playlistsComplete}
+ />
+ );
 }


### PR DESCRIPTION
﻿## Summary
- cap Generic API widget JSON responses at 1 MiB and cancel oversized response streams
- lazy-load content push/add-to-playlist modal options with retryable in-modal errors and refresh on each explicit open
- skip devices-page client refetches only when server pagination metadata proves initial devices/playlists are complete

## Verification
- `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=generic-api.data-source` (35/35)
- `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="dashboard/(content|devices)"` (46/46)
- `pnpm --filter @vizora/web exec tsc --noEmit --pretty false`
- `git diff --check`
- `pnpm --filter @vizora/web test -- --runInBand` (94 suites / 969 tests)
- `pnpm --filter @vizora/middleware test -- --runInBand` (143 suites / 2846 tests)
- `npx nx build @vizora/middleware` (known webpack warnings)
- `npx nx build @vizora/web` with production env defaults (known Next warnings)
- `npx nx build @vizora/realtime` (known webpack warnings)
- Windows CI-equivalent middleware/realtime ESLint scope exits 0 with warnings only

## Reviews
- Backend/security/resource subagent review: CLEAN
- Dashboard/customer-performance review: low findings fixed; targeted re-review CLEAN

## Deploy
- Not deployed from this PR. Last prod gate was blocked by dirty/diverged `/opt/vizora/app`; re-check after merge before any deploy/restart.
