### PR TITLE
perf: reduce display playback and analytics pressure

### DIFF
--- a/docs/plans/2026-05-31-customer-performance-pass-12.md
+++ b/docs/plans/2026-05-31-customer-performance-pass-12.md
@@ -1,0 +1,80 @@
+# Customer Performance Pass 12
+
+**Date:** 2026-05-31
+**Branch:** `feat/customer-performance-pass-12`
+
+## Goal
+
+Reduce customer-visible performance risk in display playback, legacy template
+data fetches, and realtime impression logging with small backend changes that
+do not require schema changes, secrets, production state edits, or deploy-time
+operator action.
+
+## New primitives introduced
+
+- Shared bounded JSON response reader for customer-configured external JSON
+  endpoints.
+
+## Hermes-first analysis
+
+Not applicable. This pass does not add business agents, MCP tools, Hermes
+skills, AI/provider calls, or spend paths.
+
+## Reviewer Input
+
+Two read-only reviewers ranked the following small, high-confidence targets:
+
+- Device media revalidation currently opens MinIO streams on repeat cached
+  requests, which is costly for looping display playback.
+- Legacy template data-source fetches still use `response.json()` and do not
+  share the 1 MiB body cap added to Generic API widgets.
+- Every realtime content impression does a display lookup even though the
+  authenticated socket already carries `organizationId`.
+
+Larger valid findings are deferred into later passes: dashboard real health and
+quota, shared dashboard Socket.IO provider, server-side content-library search,
+playlist summary payloads, org broadcast scaling, and template refresh
+scheduling.
+
+## Design
+
+### Device Media Revalidation
+
+- Keep device JWT, content, and MinIO metadata caches intact.
+- For non-unsatisfiable MinIO responses, honor matching `If-None-Match` /
+  `If-Modified-Since` before opening an object stream.
+- When the validator match came from a cached content/metadata lookup, recheck
+  the content row and object metadata first so stale cached object keys do not
+  produce false 304s.
+- If live metadata has changed, use the live metadata for the response instead
+  of stale cached headers.
+- Preserve stale-object recovery when cached object keys disappear.
+
+### Legacy Template JSON Body Cap
+
+- Move the Generic API bounded response reader into a shared content utility.
+- Use the same 1 MiB cap for legacy template `rest_api` / `json_url` data
+  sources.
+- Preserve existing SSRF guard, redirect revalidation, timeout, safe-header
+  filtering, circuit-breaker fallback, and JSON-path behavior.
+
+### Impression Logging Lookup Elimination
+
+- Add an optional `organizationId` parameter to `HeartbeatService.logImpression`.
+- Pass `client.data.organizationId` from the authenticated gateway handler.
+- When `organizationId` is present, write `content_impressions` directly and
+  skip the display lookup.
+- Preserve the old lookup path for any direct/internal callers that do not have
+  socket context.
+
+## Tests
+
+- Middleware unit tests for cached media validators returning 304 without
+  opening MinIO object streams.
+- Middleware regression tests for stale cached object keys not returning false
+  304s.
+- Template rendering unit tests for oversized `Content-Length`, chunked
+  oversized JSON, under-limit JSON, and fallback behavior through the existing
+  circuit breaker.
+- Realtime service and gateway unit tests proving organization-aware
+  impressions skip the display lookup and gateway passes socket org context.

--- a/middleware/src/modules/content/device-content.controller.spec.ts
+++ b/middleware/src/modules/content/device-content.controller.spec.ts
@@ -995,6 +995,107 @@ describe('DeviceContentController', () => {
       expect(mockStorageService.getObjectRange).not.toHaveBeenCalled();
     });
 
+    it('should return 304 from cached validators without opening a second MinIO stream', async () => {
+      const now = 3_750_000;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+      const lastModified = new Date('2026-05-31T00:00:00.000Z');
+      const etag = `W/"${createHash('sha256')
+        .update(`${objectKey}:12:${lastModified.getTime()}`)
+        .digest('base64url')}"`;
+      const firstReq = createMockRequest('valid-device-token');
+      const firstRes = createMockResponse();
+      const secondReq = createMockRequest('valid-device-token');
+      secondReq.headers['if-none-match'] = etag;
+      const secondRes = createMockResponse();
+
+      mockJwtService.verify.mockReturnValue(validDevicePayload);
+      mockContentService.findByIdForDevice.mockResolvedValue(mockContent as any);
+      mockStorageService.getFileMetadata.mockResolvedValue({
+        size: 12,
+        lastModified,
+        contentType: 'image/jpeg',
+      });
+      mockStorageService.getObject.mockResolvedValue(Readable.from(['first-stream']));
+
+      await controller.serveFile(contentId, firstReq, firstRes);
+      await controller.serveFile(contentId, secondReq, secondRes);
+
+      expect(secondRes.status).toHaveBeenCalledWith(304);
+      expect(mockContentService.findByIdForDevice).toHaveBeenCalledTimes(2);
+      expect(mockStorageService.getFileMetadata).toHaveBeenCalledTimes(2);
+      expect(mockStorageService.getObject).toHaveBeenCalledTimes(1);
+      expect(mockStorageService.getObjectRange).not.toHaveBeenCalled();
+      expect(secondRes.getBody().toString()).toBe('');
+    });
+
+    it('should reject oversized media discovered during cached metadata revalidation', async () => {
+      const now = 3_850_000;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+      const lastModified = new Date('2026-05-31T00:00:00.000Z');
+      const etag = `W/"${createHash('sha256')
+        .update(`${objectKey}:12:${lastModified.getTime()}`)
+        .digest('base64url')}"`;
+      const firstReq = createMockRequest('valid-device-token');
+      const firstRes = createMockResponse();
+      const secondReq = createMockRequest('valid-device-token');
+      secondReq.headers['if-none-match'] = etag;
+      const secondRes = createMockResponse();
+      const thirdReq = createMockRequest('valid-device-token');
+      const thirdRes = createMockResponse();
+      const oversizedMetadata = {
+        size: 100 * 1024 * 1024 + 1,
+        lastModified,
+        contentType: 'image/jpeg',
+      };
+
+      mockJwtService.verify.mockReturnValue(validDevicePayload);
+      mockContentService.findByIdForDevice.mockResolvedValue(mockContent as any);
+      mockStorageService.getFileMetadata
+        .mockResolvedValueOnce({
+          size: 12,
+          lastModified,
+          contentType: 'image/jpeg',
+        })
+        .mockResolvedValue(oversizedMetadata);
+      mockStorageService.getObject.mockResolvedValue(Readable.from(['first-stream']));
+
+      await controller.serveFile(contentId, firstReq, firstRes);
+      await expect(controller.serveFile(contentId, secondReq, secondRes)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(controller.serveFile(contentId, thirdReq, thirdRes)).rejects.toThrow(
+        BadRequestException,
+      );
+
+      expect(mockStorageService.getObject).toHaveBeenCalledTimes(1);
+      expect(secondRes.status).not.toHaveBeenCalledWith(304);
+    });
+
+    it('should return 304 for a satisfiable range request with a matching validator', async () => {
+      const lastModified = new Date('2026-05-31T00:00:00.000Z');
+      const etag = `W/"${createHash('sha256')
+        .update(`${objectKey}:12:${lastModified.getTime()}`)
+        .digest('base64url')}"`;
+      const req = createMockRequest('valid-device-token');
+      req.headers.range = 'bytes=0-3';
+      req.headers['if-none-match'] = etag;
+      const res = createMockResponse();
+
+      mockContentService.findByIdForDevice.mockResolvedValue(mockContent as any);
+      mockJwtService.verify.mockReturnValue(validDevicePayload);
+      mockStorageService.getFileMetadata.mockResolvedValue({
+        size: 12,
+        lastModified,
+        contentType: 'image/jpeg',
+      });
+
+      await controller.serveFile(contentId, req, res);
+
+      expect(res.status).toHaveBeenCalledWith(304);
+      expect(mockStorageService.getObject).not.toHaveBeenCalled();
+      expect(mockStorageService.getObjectRange).not.toHaveBeenCalled();
+    });
+
     it('should refresh stale cached objects instead of returning 304 from cached validators', async () => {
       const now = 4_000_000;
       jest.spyOn(Date, 'now').mockReturnValue(now);
@@ -1030,7 +1131,6 @@ describe('DeviceContentController', () => {
         });
       mockStorageService.getObject
         .mockResolvedValueOnce(Readable.from(['old']))
-        .mockRejectedValueOnce(new Error('Not Found'))
         .mockResolvedValueOnce(Readable.from(['new']));
 
       await controller.serveFile(contentId, firstReq, firstRes);
@@ -1038,8 +1138,8 @@ describe('DeviceContentController', () => {
 
       expect(secondRes.status).not.toHaveBeenCalledWith(304);
       expect(mockContentService.findByIdForDevice).toHaveBeenCalledTimes(2);
-      expect(mockStorageService.getObject).toHaveBeenNthCalledWith(2, objectKey);
-      expect(mockStorageService.getObject).toHaveBeenNthCalledWith(3, replacementObjectKey);
+      expect(mockStorageService.getObject).toHaveBeenNthCalledWith(1, objectKey);
+      expect(mockStorageService.getObject).toHaveBeenNthCalledWith(2, replacementObjectKey);
       expect(secondRes.getBody().toString()).toBe('new');
     });
 

--- a/middleware/src/modules/content/device-content.controller.ts
+++ b/middleware/src/modules/content/device-content.controller.ts
@@ -619,6 +619,106 @@ export class DeviceContentController {
     return Math.floor(validators.lastModifiedTime / 1000) * 1000 <= sinceTime;
   }
 
+  private withRevalidatedMetadata(
+    resolved: ResolvedMinioContent,
+    metadata: ObjectMetadata,
+    req: Request,
+  ): ResolvedMinioContent {
+    const oldMetadataMimeType = resolved.metadata.contentType || 'application/octet-stream';
+    const nextMetadataMimeType = metadata.contentType || 'application/octet-stream';
+
+    return {
+      ...resolved,
+      metadata,
+      metadataCacheHit: false,
+      mimeType: resolved.mimeType === oldMetadataMimeType
+        ? nextMetadataMimeType
+        : resolved.mimeType,
+      range: this.parseRangeHeader(req.headers.range, metadata.size),
+    };
+  }
+
+  private async revalidateCachedMetadata(
+    resolved: ResolvedMinioContent,
+    req: Request,
+  ): Promise<ResolvedMinioContent | null> {
+    const metadata = await this.storageService.getFileMetadata(resolved.objectKey);
+    if (!metadata) {
+      return null;
+    }
+
+    if (metadata.size > MAX_DEVICE_CONTENT_FILE_SIZE) {
+      this.invalidateCachedMediaContext(resolved);
+      throw new BadRequestException('Content file exceeds maximum size limit (100MB)');
+    }
+
+    this.setCacheValue(
+      this.objectMetadataCache,
+      resolved.metadataCacheKey,
+      metadata,
+      Date.now() + DEVICE_OBJECT_METADATA_CACHE_TTL_MS,
+      DEVICE_OBJECT_METADATA_CACHE_MAX_ENTRIES,
+    );
+
+    return this.withRevalidatedMetadata(resolved, metadata, req);
+  }
+
+  private async writeNotModifiedIfClientCacheFresh(
+    id: string,
+    organizationId: string,
+    req: Request,
+    resolved: ResolvedMinioContent,
+    res: Response,
+  ): Promise<{ handled: true } | { handled: false; resolved: ResolvedDeviceContent }> {
+    if (resolved.range.kind === 'unsatisfiable' || !this.isClientCacheFresh(req, resolved)) {
+      return { handled: false, resolved };
+    }
+
+    let current: ResolvedMinioContent = resolved;
+
+    if (current.contentCacheHit) {
+      this.contentCache.delete(current.contentCacheKey);
+      const refreshed = await this.resolveDeviceContent(id, organizationId, req);
+      if (refreshed.kind !== 'minio') {
+        return { handled: false, resolved: refreshed };
+      }
+      current = refreshed;
+      if (current.range.kind === 'unsatisfiable' || !this.isClientCacheFresh(req, current)) {
+        return { handled: false, resolved: current };
+      }
+    }
+
+    if (current.metadataCacheHit) {
+      let revalidated: ResolvedMinioContent | null;
+      try {
+        revalidated = await this.revalidateCachedMetadata(current, req);
+      } catch (error) {
+        if (!this.isLikelyMissingObjectError(error)) {
+          throw error;
+        }
+        revalidated = null;
+      }
+
+      if (!revalidated) {
+        this.invalidateCachedMediaContext(current);
+        return {
+          handled: false,
+          resolved: await this.resolveDeviceContent(id, organizationId, req),
+        };
+      }
+
+      if (!this.isClientCacheFresh(req, revalidated)) {
+        return { handled: false, resolved: revalidated };
+      }
+
+      this.writeNotModified(revalidated, res);
+      return { handled: true };
+    }
+
+    this.writeNotModified(current, res);
+    return { handled: true };
+  }
+
   private writeNotModified(resolved: ResolvedMinioContent, res: Response): void {
     const validators = this.getMediaValidators(resolved);
     res.status(304);
@@ -679,15 +779,18 @@ export class DeviceContentController {
     );
     let stream: NodeJS.ReadableStream | null = null;
 
-    if (
-      resolved.kind === 'minio' &&
-      resolved.range.kind !== 'unsatisfiable' &&
-      !resolved.contentCacheHit &&
-      !resolved.metadataCacheHit &&
-      this.isClientCacheFresh(req, resolved)
-    ) {
-      this.writeNotModified(resolved, res);
-      return;
+    if (resolved.kind === 'minio') {
+      const notModifiedResult = await this.writeNotModifiedIfClientCacheFresh(
+        id,
+        deviceAuth.payload.organizationId,
+        req,
+        resolved,
+        res,
+      );
+      if (notModifiedResult.handled) {
+        return;
+      }
+      resolved = notModifiedResult.resolved;
     }
 
     if (resolved.kind === 'minio' && resolved.range.kind !== 'unsatisfiable') {

--- a/middleware/src/modules/content/template-rendering.service.spec.ts
+++ b/middleware/src/modules/content/template-rendering.service.spec.ts
@@ -541,20 +541,16 @@ describe('TemplateRenderingService', () => {
       });
       const redirectedData = { items: [{ name: 'Redirected Item' }] };
       mockFetch
-        .mockResolvedValueOnce({
-          ok: false,
+        .mockResolvedValueOnce(new Response(null, {
           status: 302,
           statusText: 'Found',
-          headers: { get: jest.fn((name: string) => (name.toLowerCase() === 'location' ? 'https://api2.example.com/final' : null)) },
-          json: jest.fn(),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
+          headers: { Location: 'https://api2.example.com/final' },
+        }))
+        .mockResolvedValueOnce(new Response(JSON.stringify(redirectedData), {
           status: 200,
           statusText: 'OK',
-          headers: { get: jest.fn() },
-          json: jest.fn().mockResolvedValue(redirectedData),
-        });
+          headers: { 'Content-Type': 'application/json' },
+        }));
       const dataSource: DataSourceDto = {
         type: 'rest_api',
         url: 'https://api.example.com/data',
@@ -580,6 +576,82 @@ describe('TemplateRenderingService', () => {
           },
         }),
       );
+    });
+
+    it('should return fallback without reading an oversized declared JSON response', async () => {
+      mockCircuitBreaker.executeWithFallback.mockImplementation(async (_name, fn, fallback) => {
+        try {
+          return await fn();
+        } catch (error) {
+          return fallback(error as Error);
+        }
+      });
+      mockFetch.mockResolvedValueOnce(new Response('{"ok":true}', {
+        status: 200,
+        statusText: 'OK',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': String(1024 * 1024 + 1),
+        },
+      }));
+      const dataSource: DataSourceDto = {
+        type: 'rest_api',
+        url: 'https://api.example.com/data',
+      };
+
+      await expect(service.fetchDataFromSource(dataSource)).resolves.toEqual({});
+    });
+
+    it('should return fallback when a chunked JSON response exceeds the body cap', async () => {
+      mockCircuitBreaker.executeWithFallback.mockImplementation(async (_name, fn, fallback) => {
+        try {
+          return await fn();
+        } catch (error) {
+          return fallback(error as Error);
+        }
+      });
+      const chunk = new Uint8Array(1024 * 1024 + 1);
+      chunk.fill(0x20);
+      mockFetch.mockResolvedValueOnce(new Response(new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"items":['));
+          controller.enqueue(chunk);
+          controller.close();
+        },
+      }), {
+        status: 200,
+        statusText: 'OK',
+        headers: { 'Content-Type': 'application/json' },
+      }));
+      const dataSource: DataSourceDto = {
+        type: 'json_url',
+        url: 'https://api.example.com/large',
+      };
+
+      await expect(service.fetchDataFromSource(dataSource)).resolves.toEqual({});
+    });
+
+    it('should parse under-limit JSON responses with the shared bounded reader', async () => {
+      mockCircuitBreaker.executeWithFallback.mockImplementation(async (_name, fn, fallback) => {
+        try {
+          return await fn();
+        } catch (error) {
+          return fallback(error as Error);
+        }
+      });
+      mockFetch.mockResolvedValueOnce(new Response(JSON.stringify({ items: ['A', 'B'] }), {
+        status: 200,
+        statusText: 'OK',
+        headers: { 'Content-Type': 'application/json' },
+      }));
+      const dataSource: DataSourceDto = {
+        type: 'rest_api',
+        url: 'https://api.example.com/menu',
+      };
+
+      await expect(service.fetchDataFromSource(dataSource)).resolves.toEqual({
+        items: ['A', 'B'],
+      });
     });
 
     it('should reject private redirect targets before fetching them', async () => {

--- a/middleware/src/modules/content/template-rendering.service.ts
+++ b/middleware/src/modules/content/template-rendering.service.ts
@@ -4,6 +4,7 @@ import DOMPurify from 'isomorphic-dompurify';
 import { CircuitBreakerService } from '../common/services/circuit-breaker.service';
 import { DataSourceDto } from './dto/create-template.dto';
 import { assertUrlIsPublic, fetchWithSsrfGuard, SsrfError } from '../common/utils/ssrf-guard';
+import { readJsonResponseBodyWithLimit } from './utils/bounded-json-response';
 
 /**
  * Result of template validation
@@ -288,8 +289,7 @@ export class TemplateRenderingService {
               throw new Error(`HTTP ${response.status}: ${response.statusText}`);
             }
 
-            const json = await response.json();
-            return json;
+            return JSON.parse(await readJsonResponseBodyWithLimit(response));
           } finally {
             clearTimeout(timeoutId);
           }

--- a/middleware/src/modules/content/utils/bounded-json-response.ts
+++ b/middleware/src/modules/content/utils/bounded-json-response.ts
@@ -1,0 +1,61 @@
+export const DEFAULT_MAX_JSON_RESPONSE_BYTES = 1024 * 1024;
+
+export async function readJsonResponseBodyWithLimit(
+  res: Response,
+  maxBytes = DEFAULT_MAX_JSON_RESPONSE_BYTES,
+): Promise<string> {
+  const contentLength = res.headers.get('content-length');
+  if (contentLength) {
+    const declaredBytes = Number(contentLength);
+    if (Number.isFinite(declaredBytes) && declaredBytes > maxBytes) {
+      await cancelResponseBody(res);
+      throw new Error(`Endpoint response is too large; maximum is ${maxBytes} bytes`);
+    }
+  }
+
+  if (!res.body) {
+    const text = await res.text();
+    if (Buffer.byteLength(text, 'utf8') > maxBytes) {
+      throw new Error(`Endpoint response is too large; maximum is ${maxBytes} bytes`);
+    }
+    return text;
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let receivedBytes = 0;
+  let text = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      receivedBytes += value.byteLength;
+      if (receivedBytes > maxBytes) {
+        await cancelReader(reader);
+        throw new Error(`Endpoint response is too large; maximum is ${maxBytes} bytes`);
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+    return text;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+async function cancelResponseBody(res: Response): Promise<void> {
+  try {
+    await res.body?.cancel();
+  } catch {
+    // Preserve the response-size error even if stream cancellation fails.
+  }
+}
+
+async function cancelReader(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<void> {
+  try {
+    await reader.cancel();
+  } catch {
+    // Preserve the response-size error even if stream cancellation fails.
+  }
+}

--- a/middleware/src/modules/content/widget-data-sources/generic-api.data-source.ts
+++ b/middleware/src/modules/content/widget-data-sources/generic-api.data-source.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, BadRequestException } from '@nestjs/common';
 import { CircuitBreakerService } from '../../common/services/circuit-breaker.service';
 import { assertUrlIsPublic, SsrfError } from '../../common/utils/ssrf-guard';
 import { WidgetDataSource } from './widget-data-source.interface';
+import { readJsonResponseBodyWithLimit } from '../utils/bounded-json-response';
 
 /**
  * O8 — Generic HTTP-poll widget data source.
@@ -28,8 +29,6 @@ export class GenericApiDataSource implements WidgetDataSource {
   readonly type = 'generic-api';
 
   private readonly REQUEST_TIMEOUT = 15_000;
-  private readonly MAX_RESPONSE_BYTES = 1024 * 1024;
-
   constructor(private readonly circuitBreaker: CircuitBreakerService) {}
 
   async fetchData(config: Record<string, unknown>): Promise<Record<string, unknown>> {
@@ -103,7 +102,7 @@ export class GenericApiDataSource implements WidgetDataSource {
 
           let json: unknown;
           try {
-            json = JSON.parse(await this.readJsonBodyWithLimit(res));
+            json = JSON.parse(await readJsonResponseBodyWithLimit(res));
           } catch (err) {
             throw new Error(
               `Endpoint did not return valid JSON: ${err instanceof Error ? err.message : 'unknown'}`,
@@ -122,63 +121,6 @@ export class GenericApiDataSource implements WidgetDataSource {
         return this.getSampleData();
       },
     );
-  }
-
-  private async readJsonBodyWithLimit(res: Response): Promise<string> {
-    const contentLength = res.headers.get('content-length');
-    if (contentLength) {
-      const declaredBytes = Number(contentLength);
-      if (Number.isFinite(declaredBytes) && declaredBytes > this.MAX_RESPONSE_BYTES) {
-        await this.cancelResponseBody(res);
-        throw new Error(`Endpoint response is too large; maximum is ${this.MAX_RESPONSE_BYTES} bytes`);
-      }
-    }
-
-    if (!res.body) {
-      const text = await res.text();
-      if (Buffer.byteLength(text, 'utf8') > this.MAX_RESPONSE_BYTES) {
-        throw new Error(`Endpoint response is too large; maximum is ${this.MAX_RESPONSE_BYTES} bytes`);
-      }
-      return text;
-    }
-
-    const reader = res.body.getReader();
-    const decoder = new TextDecoder();
-    let receivedBytes = 0;
-    let text = '';
-
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        receivedBytes += value.byteLength;
-        if (receivedBytes > this.MAX_RESPONSE_BYTES) {
-          await this.cancelReader(reader);
-          throw new Error(`Endpoint response is too large; maximum is ${this.MAX_RESPONSE_BYTES} bytes`);
-        }
-        text += decoder.decode(value, { stream: true });
-      }
-      text += decoder.decode();
-      return text;
-    } finally {
-      reader.releaseLock();
-    }
-  }
-
-  private async cancelResponseBody(res: Response): Promise<void> {
-    try {
-      await res.body?.cancel();
-    } catch {
-      // The size rejection is the important error; body cancellation is cleanup.
-    }
-  }
-
-  private async cancelReader(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<void> {
-    try {
-      await reader.cancel();
-    } catch {
-      // Preserve the response-size error even if stream cancellation fails.
-    }
   }
 
   /**

--- a/realtime/src/gateways/device.gateway.spec.ts
+++ b/realtime/src/gateways/device.gateway.spec.ts
@@ -1033,7 +1033,7 @@ describe('DeviceGateway', () => {
       const result = await gateway.handleContentImpression(client as any, data as any);
 
       expect(result.success).toBe(true);
-      expect(mockHeartbeatService.logImpression).toHaveBeenCalledWith('device-1', data);
+      expect(mockHeartbeatService.logImpression).toHaveBeenCalledWith('device-1', data, 'org-1');
     });
 
     it('should call heartbeat service logImpression with device ID', async () => {
@@ -1042,7 +1042,20 @@ describe('DeviceGateway', () => {
 
       await gateway.handleContentImpression(client as any, data as any);
 
-      expect(mockHeartbeatService.logImpression).toHaveBeenCalledWith('device-99', data);
+      expect(mockHeartbeatService.logImpression).toHaveBeenCalledWith('device-99', data, 'org-1');
+    });
+
+    it('should omit organization context when the socket lacks one', async () => {
+      const client = createMockSocket({ data: { deviceId: 'device-99', organizationId: undefined } });
+      const data = { contentId: 'content-5' };
+
+      await gateway.handleContentImpression(client as any, data as any);
+
+      expect(mockHeartbeatService.logImpression).toHaveBeenCalledWith(
+        'device-99',
+        data,
+        undefined,
+      );
     });
 
     it('should record impression metrics', async () => {

--- a/realtime/src/gateways/device.gateway.ts
+++ b/realtime/src/gateways/device.gateway.ts
@@ -1344,10 +1344,13 @@ export class DeviceGateway
   ) {
     if (!this.checkMessageRateLimit(client)) return createErrorResponse('rate_limited');
     const deviceId = client.data.deviceId;
+    const organizationId = typeof client.data.organizationId === 'string'
+      ? client.data.organizationId
+      : undefined;
 
     try {
       // Log impression for analytics
-      await this.heartbeatService.logImpression(deviceId, data);
+      await this.heartbeatService.logImpression(deviceId, data, organizationId);
 
       // Record metrics
       this.metricsService.recordImpression(deviceId, data.contentId);

--- a/realtime/src/services/heartbeat.service.spec.ts
+++ b/realtime/src/services/heartbeat.service.spec.ts
@@ -122,6 +122,25 @@ describe('HeartbeatService', () => {
       });
     });
 
+    it('should persist impression without display lookup when organization context is provided', async () => {
+      const data = {
+        contentId: 'c-1',
+        playlistId: 'p-1',
+      };
+
+      await service.logImpression('device-1', data as any, 'org-from-socket');
+
+      expect(mockDatabaseService.display.findUnique).not.toHaveBeenCalled();
+      expect(mockDatabaseService.contentImpression.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          organizationId: 'org-from-socket',
+          contentId: 'c-1',
+          displayId: 'device-1',
+          playlistId: 'p-1',
+        }),
+      });
+    });
+
     it('should not persist impression when device not found', async () => {
       mockDatabaseService.display.findUnique.mockResolvedValueOnce(null);
 

--- a/realtime/src/services/heartbeat.service.ts
+++ b/realtime/src/services/heartbeat.service.ts
@@ -83,7 +83,11 @@ export class HeartbeatService {
   /**
    * Log content impression
    */
-  async logImpression(deviceId: string, data: ImpressionPayload): Promise<void> {
+  async logImpression(
+    deviceId: string,
+    data: ImpressionPayload,
+    organizationId?: string,
+  ): Promise<void> {
     try {
       // Store in Redis for quick daily counters
       await this.redisService.increment(
@@ -94,15 +98,20 @@ export class HeartbeatService {
       // Persist to PostgreSQL
       try {
         const now = new Date();
-        const device = await this.db.display.findUnique({
-          where: { id: deviceId },
-          select: { organizationId: true },
-        });
+        let resolvedOrganizationId = organizationId;
 
-        if (device) {
+        if (!resolvedOrganizationId) {
+          const device = await this.db.display.findUnique({
+            where: { id: deviceId },
+            select: { organizationId: true },
+          });
+          resolvedOrganizationId = device?.organizationId;
+        }
+
+        if (resolvedOrganizationId) {
           await this.db.contentImpression.create({
             data: {
-              organizationId: device.organizationId,
+              organizationId: resolvedOrganizationId,
               contentId: data.contentId,
               displayId: deviceId,
               playlistId: data.playlistId || null,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1341,6 +1341,26 @@ Hermes skills, AI provider calls, or spend paths.
 
 ---
 
+## Active Workstream: Customer Performance Pass 12 (2026-05-31)
+
+Branch: `feat/customer-performance-pass-12`
+Plan: `docs/plans/2026-05-31-customer-performance-pass-12.md`
+
+- [x] Collect customer-dashboard and performance read-only reviews.
+- [x] Pick a small backend performance slice that is repo-side and testable.
+- [x] Document pass 12 design and test plan.
+- [x] Share bounded JSON response reader between Generic API widgets and legacy template data sources.
+- [x] Return cached media 304s without opening MinIO object streams while preserving stale-object recovery.
+- [x] Skip realtime impression display lookup when authenticated socket organization context is available.
+- [x] Run multiple subagent diff reviews before tests.
+- [x] Run focused middleware/realtime tests.
+- [x] Run relevant broader builds/tests and changed-file lint.
+- [ ] Open PR, wait for CI, merge if green.
+- [ ] Deploy status: blocked unless production dirty/diverged state is resolved or explicitly approved with a reviewed runbook.
+
 ## Next Up (Not Started)
 
-_No active tasks. Pick from deferred items above or start a new feature/sprint._
+Continue the ranked customer/performance findings after pass 12: dashboard real
+health/quota, shared dashboard Socket.IO provider, server-side content-library
+search, playlist summary payloads, org broadcast scaling, and template refresh
+scheduling.


### PR DESCRIPTION
﻿## Summary
- avoid opening MinIO object streams for conditional device media requests when the client cache is fresh, while revalidating cached content rows and object metadata to prevent stale false 304s
- share a 1 MiB bounded JSON body reader between Generic API widgets and legacy template data sources
- pass authenticated socket organization context into realtime impression logging to skip a duplicate display lookup
- document pass 12 customer/performance scope and update the task checklist

## Reviews
- Middleware media/template resource review: initially found 3 issues; fixed stale content revalidation, metadata size-cap enforcement, and range precondition behavior; targeted re-review CLEAN
- Realtime analytics/auth review: CLEAN; residual risk noted that direct gateway unit tests do not exercise Nest guard invocation

## Tests
- pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="(device-content.controller|template-rendering.service|generic-api.data-source)" (145/145)
- pnpm --filter @vizora/realtime test -- --runInBand --testPathPattern="(heartbeat.service|device.gateway)" (135/135)
- pnpm --filter @vizora/middleware test -- --runInBand (143 suites / 2852 tests)
- pnpm --filter @vizora/realtime test -- --runInBand (12 suites / 275 tests)
- git diff --check
- changed-file ESLint (0 errors, existing warnings only)
- npx nx build @vizora/realtime (pass; existing warnings)
- npx nx build @vizora/middleware (pass on sequential rerun; existing warnings)

## Notes
- The first middleware build attempt failed because middleware and realtime builds were launched in parallel and raced on @vizora/database:build copying generated Prisma files on Windows. Sequential rerun passed.
- No production deploy performed in this PR.
