### PR TITLE
feat(web): surface real dashboard health and storage

### DIFF
--- a/docs/plans/2026-05-31-customer-dashboard-trust-pass-13.md
+++ b/docs/plans/2026-05-31-customer-dashboard-trust-pass-13.md
@@ -1,0 +1,76 @@
+# Customer Dashboard Trust Pass 13
+
+**Date:** 2026-05-31
+**Branch:** `feat/customer-dashboard-trust-pass-13`
+
+## Goal
+
+Make the main dashboard more trustworthy for customer-1 by replacing fake
+health/storage indicators with real repo-native data and reducing unnecessary
+first-paint API pressure.
+
+## New primitives introduced
+
+- Dashboard-only storage info API client method for the existing
+  `/api/v1/organizations/storage` endpoint.
+- Dashboard readiness summary type for the existing `/api/v1/health/ready`
+  endpoint.
+
+## Hermes-first analysis
+
+Not applicable. This pass does not add business agents, MCP tools, Hermes
+skills, AI/provider calls, or spend paths.
+
+## Customer Findings Addressed
+
+- The dashboard says "Healthy / All systems operational" even when no real
+  readiness probe has been loaded.
+- Storage usage is estimated from `content count * 2.5 MB` and a hardcoded
+  5 GB quota even though Vizora already tracks real storage usage and quota.
+- The dashboard server fetches content/playlists for first paint, then the
+  client immediately fetches the same complete paginated data again.
+
+## Design
+
+- Server-render the dashboard with initial content/playlists plus pagination
+  completeness flags.
+- Skip the client all-page content/playlist refresh on mount when the server
+  response proves the first page is complete.
+- Add `apiClient.getStorageInfo()` backed by existing
+  `/organizations/storage`.
+- Load storage info and health readiness on dashboard refresh.
+- Render system status as Healthy, Degraded, Critical, or Unknown from the
+  real readiness response instead of a fixed healthy card.
+- Render exact storage usage/quota from storage quota data; show "Not reported"
+  when unavailable.
+
+## Tests
+
+- Dashboard client tests for real storage usage rendering.
+- Dashboard client tests for degraded/critical health rendering.
+- Dashboard client tests proving content/playlists are not refetched on mount
+  when SSR pagination is complete.
+- Existing dashboard tests for partial refresh behavior remain valid.
+
+## Review Results
+
+- Customer-facing dashboard/UI review: CLEAN after fixing server-side unhealthy
+  readiness handling and zero-quota storage copy.
+- API/data/performance review: CLEAN after restoring the `UpgradeBanner` API
+  mock and adding server-page coverage for pagination completeness.
+- Follow-up UI/runtime review for the dashboard layout hydration fix: CLEAN.
+
+## Verification Results
+
+- `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="dashboard-(page|server-page)"` — 2 suites / 18 tests pass.
+- `pnpm --filter @vizora/web test -- --runInBand --testPathPattern=server-api` — 1 suite / 3 tests pass.
+- `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` — pass.
+- `ESLINT_USE_FLAT_CONFIG=false npx eslint ...changed web files...` — 0 errors,
+  19 existing `any` warnings in touched dashboard/API files.
+- `npx nx build @vizora/web` — pass.
+- `pnpm --filter @vizora/web test -- --runInBand` — 95 suites / 977 tests pass;
+  unrelated existing act warnings remain in non-dashboard suites.
+- Browser smoke against `next start` on `localhost:3001`: desktop and mobile
+  dashboard render with no page errors after the dashboard layout hydration fix.
+  Screenshots: `logs/dashboard-pass13-desktop.png` and
+  `logs/dashboard-pass13-mobile.png`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1355,12 +1355,33 @@ Plan: `docs/plans/2026-05-31-customer-performance-pass-12.md`
 - [x] Run multiple subagent diff reviews before tests.
 - [x] Run focused middleware/realtime tests.
 - [x] Run relevant broader builds/tests and changed-file lint.
+- [x] Open PR, wait for CI, merge if green. PR #135 merged to `origin/main` at `1618f31f9e151ca394f4e0471e457267805415a9`.
+- [ ] Deploy status: blocked unless production dirty/diverged state is resolved or explicitly approved with a reviewed runbook.
+
+## Active Workstream: Customer Dashboard Trust Pass 13 (2026-05-31)
+
+Branch: `feat/customer-dashboard-trust-pass-13`
+Plan: `docs/plans/2026-05-31-customer-dashboard-trust-pass-13.md`
+
+- [x] Document pass 13 design and test plan.
+- [x] Add dashboard storage API client method for the existing organization storage endpoint.
+- [x] Pass server-fetched pagination completeness, storage, and readiness data into the dashboard client.
+- [x] Replace hardcoded dashboard system/storage indicators with real readiness and storage state.
+- [x] Skip redundant mount-time content/playlist fetches when SSR pagination proves the data is complete.
+- [x] Run multiple subagent diff reviews before tests. UI/trust reviewer CLEAN; API/data/performance reviewer CLEAN. Follow-up UI review for the dashboard layout hydration fix CLEAN.
+- [x] Run focused dashboard tests and broader web verification:
+  - `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="dashboard-(page|server-page)"` — 2 suites / 18 tests pass.
+  - `pnpm --filter @vizora/web test -- --runInBand --testPathPattern=server-api` — 1 suite / 3 tests pass.
+  - `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` — pass.
+  - `ESLINT_USE_FLAT_CONFIG=false npx eslint ...changed web files...` — 0 errors, 19 existing `any` warnings.
+  - `npx nx build @vizora/web` — pass.
+  - `pnpm --filter @vizora/web test -- --runInBand` — 95 suites / 977 tests pass; unrelated existing act warnings remain in non-dashboard suites.
+  - Playwright browser smoke against `next start` on `localhost:3001`: desktop and mobile dashboard render with no page errors after the layout hydration fix; screenshots in `logs/dashboard-pass13-{desktop,mobile}.png`.
 - [ ] Open PR, wait for CI, merge if green.
 - [ ] Deploy status: blocked unless production dirty/diverged state is resolved or explicitly approved with a reviewed runbook.
 
 ## Next Up (Not Started)
 
-Continue the ranked customer/performance findings after pass 12: dashboard real
-health/quota, shared dashboard Socket.IO provider, server-side content-library
-search, playlist summary payloads, org broadcast scaling, and template refresh
-scheduling.
+Continue the ranked customer/performance findings after pass 13: shared dashboard
+Socket.IO provider, server-side content-library search, playlist summary payloads,
+org broadcast scaling, and template refresh scheduling.

--- a/web/src/app/dashboard/__tests__/dashboard-page.test.tsx
+++ b/web/src/app/dashboard/__tests__/dashboard-page.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import type { ComponentProps } from 'react';
 import DashboardClient from '../page-client';
 import { apiClient } from '@/lib/api';
+import { ApiError } from '@/lib/error-handler';
 
 const mockPush = jest.fn();
 
@@ -20,7 +22,9 @@ jest.mock('@/lib/api', () => ({
   apiClient: {
     getContent: jest.fn().mockResolvedValue({ data: [] }),
     getPlaylists: jest.fn().mockResolvedValue({ data: [] }),
-    getQuotaUsage: jest.fn().mockResolvedValue({ storageUsedBytes: 0, storageQuotaBytes: 1073741824, screenCount: 0, screenQuota: 5 }),
+    getQuotaUsage: jest.fn().mockResolvedValue({ screensUsed: 0, screenQuota: 5, remaining: 5, percentUsed: 0 }),
+    getStorageInfo: jest.fn().mockResolvedValue({ usedBytes: 0, quotaBytes: 1073741824, availableBytes: 1073741824, usagePercent: 0 }),
+    get: jest.fn().mockResolvedValue({ status: 'ok' }),
     setAuthenticated: jest.fn(),
   },
 }));
@@ -49,46 +53,157 @@ jest.mock('@/components/Tooltip', () => ({
   HelpIcon: () => <span>?</span>,
 }));
 
+jest.mock('@/components/UpgradeBanner', () => {
+  return function MockUpgradeBanner() { return <div data-testid="upgrade-banner" />; };
+});
+
+async function renderDashboardClient(props: Partial<ComponentProps<typeof DashboardClient>> = {}) {
+  const view = render(
+    <DashboardClient
+      initialContent={props.initialContent ?? []}
+      initialPlaylists={props.initialPlaylists ?? []}
+      initialContentComplete={props.initialContentComplete}
+      initialPlaylistsComplete={props.initialPlaylistsComplete}
+      initialStorageInfo={props.initialStorageInfo}
+      initialSystemHealth={props.initialSystemHealth}
+    />,
+  );
+  await waitFor(() => {
+    expect(screen.getByText('Healthy')).toBeInTheDocument();
+  });
+  return view;
+}
+
 describe('DashboardClient', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (apiClient.getContent as jest.Mock).mockReset().mockResolvedValue({ data: [] });
+    (apiClient.getPlaylists as jest.Mock).mockReset().mockResolvedValue({ data: [] });
+    (apiClient.getQuotaUsage as jest.Mock)
+      .mockReset()
+      .mockResolvedValue({ screensUsed: 0, screenQuota: 5, remaining: 5, percentUsed: 0 });
+    (apiClient.getStorageInfo as jest.Mock)
+      .mockReset()
+      .mockResolvedValue({
+        usedBytes: 0,
+        quotaBytes: 1073741824,
+        availableBytes: 1073741824,
+        usagePercent: 0,
+      });
+    (apiClient.get as jest.Mock).mockReset().mockResolvedValue({ status: 'ok' });
     mockDeviceStatusContext = {
       deviceStatuses: {},
       isInitialized: true,
     };
   });
 
-  it('renders dashboard overview heading', () => {
-    render(<DashboardClient initialContent={[]} initialPlaylists={[]} />);
+  it('renders dashboard overview heading', async () => {
+    await renderDashboardClient();
     expect(screen.getByText('Dashboard Overview')).toBeInTheDocument();
   });
 
-  it('renders stats cards', () => {
-    render(<DashboardClient initialContent={[]} initialPlaylists={[]} />);
+  it('renders stats cards', async () => {
+    await renderDashboardClient();
     expect(screen.getByText('Total Devices')).toBeInTheDocument();
     expect(screen.getByText('Content Items')).toBeInTheDocument();
     expect(screen.getByText('Playlists')).toBeInTheDocument();
     expect(screen.getByText('System Status')).toBeInTheDocument();
   });
 
-  it('renders quick actions section', () => {
-    render(<DashboardClient initialContent={[]} initialPlaylists={[]} />);
+  it('renders quick actions section', async () => {
+    await renderDashboardClient();
     expect(screen.getByText('Quick Actions')).toBeInTheDocument();
   });
 
-  it('renders recent activity section', () => {
-    render(<DashboardClient initialContent={[]} initialPlaylists={[]} />);
+  it('renders recent activity section', async () => {
+    await renderDashboardClient();
     expect(screen.getByText('Recent Activity')).toBeInTheDocument();
   });
 
-  it('renders storage usage section', () => {
-    render(<DashboardClient initialContent={[]} initialPlaylists={[]} />);
+  it('renders storage usage section', async () => {
+    await renderDashboardClient();
     expect(screen.getByText('Storage Usage')).toBeInTheDocument();
   });
 
-  it('shows getting started guide when no devices', () => {
+  it('renders real storage usage from the organization storage endpoint', async () => {
+    (apiClient.getStorageInfo as jest.Mock).mockResolvedValueOnce({
+      usedBytes: 536870912,
+      quotaBytes: 1073741824,
+      availableBytes: 536870912,
+      usagePercent: 50,
+    });
+
+    render(<DashboardClient initialContent={[{ id: 'c1' }]} initialPlaylists={[]} />);
+
+    await waitFor(() => {
+      expect(apiClient.getStorageInfo).toHaveBeenCalledTimes(1);
+      expect(screen.getByText('512 MB / 1 GB')).toBeInTheDocument();
+      expect(screen.getByText('50.0% used')).toBeInTheDocument();
+    });
+  });
+
+  it('does not show a normal percentage when storage quota is unavailable', async () => {
+    (apiClient.getStorageInfo as jest.Mock).mockResolvedValueOnce({
+      usedBytes: 1048576,
+      quotaBytes: 0,
+      availableBytes: 0,
+      usagePercent: 0,
+    });
+
+    render(<DashboardClient initialContent={[{ id: 'c1' }]} initialPlaylists={[]} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('1 MB / No quota')).toBeInTheDocument();
+      expect(screen.getByText('Quota unavailable')).toBeInTheDocument();
+      expect(screen.queryByText('0.0% used')).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders degraded system readiness instead of a fixed healthy state', async () => {
+    (apiClient.get as jest.Mock).mockResolvedValueOnce({
+      status: 'degraded',
+      message: 'Some dependencies degraded',
+    });
+
     render(<DashboardClient initialContent={[]} initialPlaylists={[]} />);
+
+    await waitFor(() => {
+      expect(apiClient.get).toHaveBeenCalledWith('/health/ready');
+      expect(screen.getByText('Degraded')).toBeInTheDocument();
+      expect(screen.getByText('Some dependencies degraded')).toBeInTheDocument();
+    });
+  });
+
+  it('renders critical system readiness when the readiness endpoint returns unavailable', async () => {
+    (apiClient.get as jest.Mock).mockRejectedValueOnce(
+      new ApiError(503, 'Service unavailable', 'The service is temporarily unavailable.'),
+    );
+
+    render(<DashboardClient initialContent={[]} initialPlaylists={[]} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Critical')).toBeInTheDocument();
+      expect(screen.getByText('Core service needs attention')).toBeInTheDocument();
+    });
+  });
+
+  it('shows getting started guide when no devices', async () => {
+    await renderDashboardClient();
     expect(screen.getByText('Getting Started')).toBeInTheDocument();
+  });
+
+  it('does not refetch content and playlists on mount when server pagination is complete', async () => {
+    await renderDashboardClient({
+      initialContent: [{ id: 'c1' }],
+      initialPlaylists: [{ id: 'p1', items: [{ id: 'item-1' }] }],
+      initialContentComplete: true,
+      initialPlaylistsComplete: true,
+    });
+
+    expect(apiClient.getContent).not.toHaveBeenCalled();
+    expect(apiClient.getPlaylists).not.toHaveBeenCalled();
+    expect(screen.getByText('Content Items').parentElement?.parentElement).toHaveTextContent('1');
+    expect(screen.getByText('Playlists').parentElement?.parentElement).toHaveTextContent('1');
   });
 
   it('refreshes overview counts from all paginated pages on mount', async () => {
@@ -167,7 +282,7 @@ describe('DashboardClient', () => {
       isInitialized: false,
     };
 
-    const { rerender } = render(<DashboardClient initialContent={[]} initialPlaylists={[]} />);
+    const { rerender } = await renderDashboardClient();
 
     expect(screen.getByText('No recent activity yet')).toBeInTheDocument();
 

--- a/web/src/app/dashboard/__tests__/dashboard-server-page.test.tsx
+++ b/web/src/app/dashboard/__tests__/dashboard-server-page.test.tsx
@@ -1,0 +1,137 @@
+import { render } from '@testing-library/react';
+import DashboardPage from '../page';
+import DashboardClient from '../page-client';
+import { ServerFetchError, serverFetch } from '@/lib/server-api';
+
+jest.mock('@/lib/server-api', () => {
+  class MockServerFetchError extends Error {
+    constructor(
+      public statusCode: number,
+      message: string,
+      public body: unknown,
+    ) {
+      super(message);
+      this.name = 'ServerFetchError';
+    }
+  }
+
+  return {
+    ServerFetchError: MockServerFetchError,
+    serverFetch: jest.fn(),
+  };
+});
+
+jest.mock('../page-client', () => jest.fn(() => <div data-testid="dashboard-client" />));
+
+const mockedServerFetch = serverFetch as jest.MockedFunction<typeof serverFetch>;
+const mockedDashboardClient = DashboardClient as jest.Mock;
+
+describe('DashboardPage server data', () => {
+  beforeEach(() => {
+    mockedServerFetch.mockReset();
+    mockedDashboardClient.mockClear();
+  });
+
+  it('passes complete pagination flags and initial health/storage to the client', async () => {
+    mockedServerFetch.mockImplementation(async (path) => {
+      switch (path) {
+        case '/content?limit=100':
+          return {
+            data: [{ id: 'content-1' }],
+            meta: { page: 1, limit: 100, total: 1, totalPages: 1 },
+          } as never;
+        case '/playlists?limit=100':
+          return {
+            data: [{ id: 'playlist-1' }],
+            meta: { page: 1, limit: 100, total: 1, totalPages: 1 },
+          } as never;
+        case '/organizations/storage':
+          return {
+            usedBytes: 1024,
+            quotaBytes: 2048,
+            availableBytes: 1024,
+            usagePercent: 50,
+          } as never;
+        case '/health/ready':
+          return { status: 'ok', timestamp: '2026-05-31T00:00:00.000Z' } as never;
+        default:
+          throw new Error(`Unexpected serverFetch path: ${path}`);
+      }
+    });
+
+    render(await DashboardPage());
+
+    expect(mockedDashboardClient).toHaveBeenCalledTimes(1);
+    expect(mockedDashboardClient.mock.calls[0][0]).toEqual(expect.objectContaining({
+      initialContent: [{ id: 'content-1' }],
+      initialPlaylists: [{ id: 'playlist-1' }],
+      initialContentComplete: true,
+      initialPlaylistsComplete: true,
+      initialStorageInfo: {
+        usedBytes: 1024,
+        quotaBytes: 2048,
+        availableBytes: 1024,
+        usagePercent: 50,
+      },
+      initialSystemHealth: { status: 'ok', timestamp: '2026-05-31T00:00:00.000Z' },
+    }));
+  });
+
+  it('marks paginated server data incomplete when more pages remain', async () => {
+    mockedServerFetch.mockImplementation(async (path) => {
+      switch (path) {
+        case '/content?limit=100':
+          return {
+            data: [{ id: 'content-1' }],
+            meta: { page: 1, limit: 100, total: 2, totalPages: 2 },
+          } as never;
+        case '/playlists?limit=100':
+          return {
+            data: [{ id: 'playlist-1' }],
+            meta: { page: 1, limit: 100, total: 2, totalPages: 2 },
+          } as never;
+        case '/organizations/storage':
+          return null as never;
+        case '/health/ready':
+          return { status: 'ok' } as never;
+        default:
+          throw new Error(`Unexpected serverFetch path: ${path}`);
+      }
+    });
+
+    render(await DashboardPage());
+
+    expect(mockedDashboardClient.mock.calls[0][0]).toEqual(expect.objectContaining({
+      initialContentComplete: false,
+      initialPlaylistsComplete: false,
+    }));
+  });
+
+  it('preserves unhealthy readiness from a server-side 503 response', async () => {
+    mockedServerFetch.mockImplementation(async (path) => {
+      switch (path) {
+        case '/content?limit=100':
+        case '/playlists?limit=100':
+          return { data: [], meta: { page: 1, limit: 100, total: 0, totalPages: 1 } } as never;
+        case '/organizations/storage':
+          return null as never;
+        case '/health/ready':
+          throw new ServerFetchError(503, 'Service unavailable', {
+            status: 'unhealthy',
+            checks: { database: { status: 'down' } },
+          });
+        default:
+          throw new Error(`Unexpected serverFetch path: ${path}`);
+      }
+    });
+
+    render(await DashboardPage());
+
+    expect(mockedDashboardClient.mock.calls[0][0]).toEqual(expect.objectContaining({
+      initialSystemHealth: {
+        status: 'unhealthy',
+        checks: { database: { status: 'down' } },
+      },
+    }));
+  });
+});

--- a/web/src/app/dashboard/layout.tsx
+++ b/web/src/app/dashboard/layout.tsx
@@ -43,10 +43,7 @@ export default function DashboardLayout({
   const brandName = brandConfig?.name || 'Vizora';
   const brandLogo = brandConfig?.logo;
   const brandInitial = brandName.charAt(0).toUpperCase();
-  const [sidebarOpen, setSidebarOpen] = useState(() => {
-    if (typeof window !== 'undefined') return window.innerWidth >= 1024;
-    return true;
-  });
+  const [sidebarOpen, setSidebarOpen] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
 
   // Sync sidebar with viewport — close below lg, open above lg (debounced)

--- a/web/src/app/dashboard/page-client.tsx
+++ b/web/src/app/dashboard/page-client.tsx
@@ -4,10 +4,11 @@ import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { apiClient } from '@/lib/api';
 import { fetchAllPaginated } from '@/lib/api/pagination';
+import type { StorageInfo } from '@/lib/api/organizations';
 import { useDeviceStatus } from '@/lib/context/DeviceStatusContext';
-import LoadingSpinner from '@/components/LoadingSpinner';
 import UpgradeBanner from '@/components/UpgradeBanner';
 import { HelpIcon } from '@/components/Tooltip';
+import { isApiError } from '@/lib/error-handler';
 import { Icon, type IconName, iconMap } from '@/theme/icons';
 
 // Helper to ensure valid icon names
@@ -21,9 +22,129 @@ const getValidIconName = (name: string | undefined): IconName => {
 interface DashboardClientProps {
  initialContent: any[];
  initialPlaylists: any[];
+ initialContentComplete?: boolean;
+ initialPlaylistsComplete?: boolean;
+ initialStorageInfo?: StorageInfo | null;
+ initialSystemHealth?: DashboardSystemHealth | null;
 }
 
-export default function DashboardClient({ initialContent, initialPlaylists }: DashboardClientProps) {
+type DashboardHealthStatus = 'ok' | 'degraded' | 'unhealthy' | 'unknown';
+
+interface DashboardSystemHealth {
+ status: DashboardHealthStatus;
+ timestamp?: string;
+ message?: string;
+ checks?: Record<string, { status?: string; message?: string }>;
+}
+
+type DashboardListResult = {
+ data: any[];
+};
+
+const UNKNOWN_HEALTH: DashboardSystemHealth = {
+ status: 'unknown',
+ message: 'Readiness unavailable',
+};
+
+const formatBytes = (bytes: number): string => {
+ if (!Number.isFinite(bytes) || bytes <= 0) {
+ return '0 B';
+ }
+
+ const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+ let value = bytes;
+ let unitIndex = 0;
+
+ while (value >= 1024 && unitIndex < units.length - 1) {
+ value /= 1024;
+ unitIndex += 1;
+ }
+
+ const valueText = Number.isInteger(value) || value >= 10
+ ? value.toFixed(0)
+ : value.toFixed(1);
+ return `${valueText} ${units[unitIndex]}`;
+};
+
+const getStorageUsagePercent = (storageInfo: StorageInfo | null): number => {
+ if (!storageInfo || storageInfo.quotaBytes <= 0) {
+ return 0;
+ }
+
+ const reportedPercent = Number.isFinite(storageInfo.usagePercent)
+ ? storageInfo.usagePercent
+ : (storageInfo.usedBytes / storageInfo.quotaBytes) * 100;
+
+ return Math.max(0, Math.min(reportedPercent, 100));
+};
+
+const getHealthSummary = (health: DashboardSystemHealth | null) => {
+ switch (health?.status) {
+ case 'ok':
+ return {
+ label: 'Healthy',
+ detail: 'All systems operational',
+ dotClassName: 'bg-success-300 animate-pulse',
+ cardClassName: 'bg-gradient-to-br from-[#00E5A0] to-[#00B4D8]',
+ textClassName: 'text-primary-100',
+ iconClassName: 'text-primary-200',
+ };
+ case 'degraded':
+ return {
+ label: 'Degraded',
+ detail: health.message || 'Some dependencies degraded',
+ dotClassName: 'bg-amber-200 animate-pulse',
+ cardClassName: 'bg-gradient-to-br from-amber-500 to-orange-500',
+ textClassName: 'text-amber-50',
+ iconClassName: 'text-amber-100',
+ };
+ case 'unhealthy':
+ return {
+ label: 'Critical',
+ detail: health.message || 'Core service needs attention',
+ dotClassName: 'bg-red-200 animate-pulse',
+ cardClassName: 'bg-gradient-to-br from-red-600 to-rose-500',
+ textClassName: 'text-red-50',
+ iconClassName: 'text-red-100',
+ };
+ default:
+ return {
+ label: 'Unknown',
+ detail: 'Status unavailable',
+ dotClassName: 'bg-slate-300',
+ cardClassName: 'bg-gradient-to-br from-slate-600 to-slate-500',
+ textClassName: 'text-slate-100',
+ iconClassName: 'text-slate-200',
+ };
+ }
+};
+
+const loadSystemHealth = async (): Promise<DashboardSystemHealth> => {
+ try {
+ return await apiClient.get<DashboardSystemHealth>('/health/ready');
+ } catch (error) {
+ if (isApiError(error) && error.statusCode === 503) {
+ return {
+ status: 'unhealthy',
+ message: 'Core service needs attention',
+ };
+ }
+
+ if (process.env.NODE_ENV === 'development') {
+ console.warn('System readiness check failed:', error);
+ }
+ return UNKNOWN_HEALTH;
+ }
+};
+
+export default function DashboardClient({
+ initialContent,
+ initialPlaylists,
+ initialContentComplete = false,
+ initialPlaylistsComplete = false,
+ initialStorageInfo = null,
+ initialSystemHealth = null,
+}: DashboardClientProps) {
  const router = useRouter();
  const { deviceStatuses, isInitialized } = useDeviceStatus();
  const [stats, setStats] = useState({
@@ -32,11 +153,16 @@ export default function DashboardClient({ initialContent, initialPlaylists }: Da
  playlists: { total: 0, active: 0 },
  });
  const [recentActivity, setRecentActivity] = useState<any[]>([]);
+ const [storageInfo, setStorageInfo] = useState<StorageInfo | null>(initialStorageInfo);
+ const [systemHealth, setSystemHealth] = useState<DashboardSystemHealth | null>(
+ initialSystemHealth,
+ );
  const [loading, setLoading] = useState(false);
  const [error, setError] = useState<string | null>(null);
  const activityContentRef = useRef(initialContent);
  const activityPlaylistsRef = useRef(initialPlaylists);
  const deviceStatusesRef = useRef(deviceStatuses);
+ const initialRefreshCompleteRef = useRef(false);
  deviceStatusesRef.current = deviceStatuses;
 
  // Initialize stats from server-fetched data
@@ -60,6 +186,14 @@ export default function DashboardClient({ initialContent, initialPlaylists }: Da
 
  buildRecentActivity(content, playlists, deviceStatusesRef.current);
  }, [initialContent, initialPlaylists]);
+
+ useEffect(() => {
+ setStorageInfo(initialStorageInfo);
+ }, [initialStorageInfo]);
+
+ useEffect(() => {
+ setSystemHealth(initialSystemHealth);
+ }, [initialSystemHealth]);
 
  useEffect(() => {
  loadStats(false);
@@ -121,17 +255,39 @@ export default function DashboardClient({ initialContent, initialPlaylists }: Da
  const loadStats = async (showLoading = true) => {
  try {
  if (showLoading) setLoading(true);
+ const isInitialAutoRefresh = !showLoading && !initialRefreshCompleteRef.current;
+ if (isInitialAutoRefresh) {
+ initialRefreshCompleteRef.current = true;
+ }
+
+ const contentPromise: Promise<DashboardListResult> = isInitialAutoRefresh && initialContentComplete
+ ? Promise.resolve({ data: activityContentRef.current })
+ : fetchAllPaginated((params) => apiClient.getContent(params))
+ .then((data) => ({ data }));
+ const playlistsPromise: Promise<DashboardListResult> = isInitialAutoRefresh && initialPlaylistsComplete
+ ? Promise.resolve({ data: activityPlaylistsRef.current })
+ : fetchAllPaginated((params) => apiClient.getPlaylists(params))
+ .then((data) => ({ data }));
+
  const results = await Promise.allSettled([
- fetchAllPaginated((params) => apiClient.getContent(params)),
- fetchAllPaginated((params) => apiClient.getPlaylists(params)),
+ contentPromise,
+ playlistsPromise,
+ apiClient.getStorageInfo(),
+ loadSystemHealth(),
  ]);
 
- const content = results[0].status === 'fulfilled' ? results[0].value : null;
- const playlists = results[1].status === 'fulfilled' ? results[1].value : null;
+ const content = results[0].status === 'fulfilled' ? results[0].value.data : null;
+ const playlists = results[1].status === 'fulfilled' ? results[1].value.data : null;
  if (content) activityContentRef.current = content;
  if (playlists) activityPlaylistsRef.current = playlists;
+ if (results[2].status === 'fulfilled') {
+ setStorageInfo(results[2].value);
+ }
+ if (results[3].status === 'fulfilled') {
+ setSystemHealth(results[3].value);
+ }
 
- results.forEach((result, index) => {
+ results.slice(0, 2).forEach((result, index) => {
  if (result.status === 'rejected') {
  if (process.env.NODE_ENV === 'development') {
  console.warn(`API call ${index + 1} failed:`, result.reason);
@@ -167,7 +323,7 @@ export default function DashboardClient({ initialContent, initialPlaylists }: Da
  );
  }
 
- if (content && playlists) {
+ if (results[0].status === 'fulfilled' && results[1].status === 'fulfilled') {
  setError(null);
  } else {
  setError('Some dashboard data could not refresh');
@@ -212,6 +368,18 @@ export default function DashboardClient({ initialContent, initialPlaylists }: Da
  </div>
  );
  }
+
+ const healthSummary = getHealthSummary(systemHealth);
+ const storageUsagePercent = getStorageUsagePercent(storageInfo);
+ const hasStorageQuota = !!storageInfo && storageInfo.quotaBytes > 0;
+ const storageUsageText = storageInfo
+ ? `${formatBytes(storageInfo.usedBytes)} / ${storageInfo.quotaBytes > 0 ? formatBytes(storageInfo.quotaBytes) : 'No quota'}`
+ : 'Not reported';
+ const storageFooterText = storageInfo
+ ? hasStorageQuota
+ ? `${storageUsagePercent.toFixed(1)}% used`
+ : 'Quota unavailable'
+ : 'Storage data unavailable';
 
  return (
  <div className="space-y-8">
@@ -293,15 +461,15 @@ export default function DashboardClient({ initialContent, initialPlaylists }: Da
  </p>
  </div>
 
- <div className="bg-gradient-to-br from-[#00E5A0] to-[#00B4D8] p-6 rounded-lg border border-[var(--border)] hover:-translate-y-[2px] hover:shadow-md transition-all duration-300 text-white animate-[fadeIn_0.6s_ease-out]">
+ <div className={`${healthSummary.cardClassName} p-6 rounded-lg border border-[var(--border)] hover:-translate-y-[2px] hover:shadow-md transition-all duration-300 text-white animate-[fadeIn_0.6s_ease-out]`}>
  <div className="flex items-center justify-between mb-4">
- <p className="text-sm font-medium text-primary-100">System Status</p>
- <Icon name="power" size="2xl" className="text-primary-200" />
+ <p className={`text-sm font-medium ${healthSummary.textClassName}`}>System Status</p>
+ <Icon name="power" size="2xl" className={healthSummary.iconClassName} />
  </div>
- <p className="text-4xl font-bold mb-2">Healthy</p>
+ <p className="text-4xl font-bold mb-2">{healthSummary.label}</p>
  <div className="flex items-center gap-2">
- <span className="w-2 h-2 bg-success-300 rounded-full animate-pulse"></span>
- <p className="text-sm text-primary-100">All systems operational</p>
+ <span className={`w-2 h-2 rounded-full ${healthSummary.dotClassName}`}></span>
+ <p className={`text-sm ${healthSummary.textClassName}`}>{healthSummary.detail}</p>
  </div>
  </div>
  </div>
@@ -406,24 +574,20 @@ export default function DashboardClient({ initialContent, initialPlaylists }: Da
  <div className="flex justify-between text-sm">
  <span className="text-[var(--foreground-secondary)]">Content Storage</span>
  <span className="font-medium text-[var(--foreground)]">
- {stats.content.total > 0
- ? `~${(stats.content.total * 2.5).toFixed(1)} MB`
- : '0 MB'} / 5 GB
+ {storageUsageText}
  </span>
  </div>
  <div className="eh-progress">
  <div
  className="eh-progress-bar transition-all duration-500"
  style={{
- width: `${Math.min((stats.content.total * 2.5 / 5000) * 100, 100)}%`,
+ width: `${storageUsagePercent}%`,
  }}
  />
  </div>
  <div className="flex justify-between text-xs text-[var(--foreground-tertiary)]">
- <span>{stats.content.total} items stored</span>
- <span>
- {((stats.content.total * 2.5 / 5000) * 100).toFixed(1)}% used
- </span>
+ <span>{stats.content.total} {storageInfo ? 'items stored' : 'items tracked'}</span>
+ <span>{storageFooterText}</span>
  </div>
  </div>
  </div>

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -1,31 +1,123 @@
 import type { Metadata } from 'next';
-import { serverFetch } from '@/lib/server-api';
+import { ServerFetchError, serverFetch } from '@/lib/server-api';
 import { unwrapPaginatedData } from '@/lib/api/pagination';
+import type { StorageInfo } from '@/lib/api/organizations';
 import DashboardClient from './page-client';
 
 export const metadata: Metadata = {
   title: 'Dashboard',
 };
 
+const DASHBOARD_PAGE_LIMIT = 100;
+
+type PaginationMeta = {
+  page?: number;
+  limit?: number;
+  total?: number;
+  totalPages?: number;
+};
+
+type DashboardHealthStatus = 'ok' | 'degraded' | 'unhealthy' | 'unknown';
+
+interface DashboardSystemHealth {
+  status: DashboardHealthStatus;
+  timestamp?: string;
+  message?: string;
+  checks?: Record<string, { status?: string; message?: string }>;
+}
+
+function getPaginationMeta(response: unknown): PaginationMeta | null {
+  if (!response || typeof response !== 'object') {
+    return null;
+  }
+
+  const body = response as { meta?: unknown };
+  if (!body.meta || typeof body.meta !== 'object') {
+    return null;
+  }
+
+  return body.meta as PaginationMeta;
+}
+
+function isPageComplete(items: unknown[], meta: PaginationMeta | null): boolean {
+  if (!meta) {
+    return items.length < DASHBOARD_PAGE_LIMIT;
+  }
+
+  if (typeof meta.page === 'number' && typeof meta.totalPages === 'number') {
+    return meta.page >= meta.totalPages;
+  }
+
+  if (typeof meta.total === 'number') {
+    return items.length >= meta.total;
+  }
+
+  const limit = typeof meta.limit === 'number' ? meta.limit : DASHBOARD_PAGE_LIMIT;
+  return items.length < limit;
+}
+
+function getUnhealthyReadinessFromError(reason: unknown): DashboardSystemHealth | null {
+  if (!(reason instanceof ServerFetchError) || reason.statusCode !== 503) {
+    return null;
+  }
+
+  if (reason.body && typeof reason.body === 'object') {
+    const body = reason.body as { status?: unknown; message?: unknown };
+    if (body.status === 'unhealthy') {
+      return body as DashboardSystemHealth;
+    }
+  }
+
+  return {
+    status: 'unhealthy',
+    message: 'Core service needs attention',
+  };
+}
+
 export default async function DashboardPage() {
- let content: any[] = [];
- let playlists: any[] = [];
+  let content: any[] = [];
+  let playlists: any[] = [];
+  let initialContentComplete = false;
+  let initialPlaylistsComplete = false;
+  let storageInfo: StorageInfo | null = null;
+  let systemHealth: DashboardSystemHealth | null = null;
 
- try {
- const results = await Promise.allSettled([
- serverFetch<any>('/content?limit=100'),
- serverFetch<any>('/playlists?limit=100'),
- ]);
+  try {
+    const results = await Promise.allSettled([
+      serverFetch<any>(`/content?limit=${DASHBOARD_PAGE_LIMIT}`),
+      serverFetch<any>(`/playlists?limit=${DASHBOARD_PAGE_LIMIT}`),
+      serverFetch<StorageInfo>('/organizations/storage'),
+      serverFetch<DashboardSystemHealth>('/health/ready'),
+    ]);
 
- if (results[0].status === 'fulfilled') {
- content = unwrapPaginatedData(results[0].value);
- }
- if (results[1].status === 'fulfilled') {
- playlists = unwrapPaginatedData(results[1].value);
- }
- } catch {
- // Client handles empty state gracefully
- }
+    if (results[0].status === 'fulfilled') {
+      content = unwrapPaginatedData(results[0].value);
+      initialContentComplete = isPageComplete(content, getPaginationMeta(results[0].value));
+    }
+    if (results[1].status === 'fulfilled') {
+      playlists = unwrapPaginatedData(results[1].value);
+      initialPlaylistsComplete = isPageComplete(playlists, getPaginationMeta(results[1].value));
+    }
+    if (results[2].status === 'fulfilled') {
+      storageInfo = results[2].value;
+    }
+    if (results[3].status === 'fulfilled') {
+      systemHealth = results[3].value;
+    } else {
+      systemHealth = getUnhealthyReadinessFromError(results[3].reason);
+    }
+  } catch {
+    // Client handles empty state gracefully
+  }
 
- return <DashboardClient initialContent={content} initialPlaylists={playlists} />;
+  return (
+    <DashboardClient
+      initialContent={content}
+      initialPlaylists={playlists}
+      initialContentComplete={initialContentComplete}
+      initialPlaylistsComplete={initialPlaylistsComplete}
+      initialStorageInfo={storageInfo}
+      initialSystemHealth={systemHealth}
+    />
+  );
 }

--- a/web/src/lib/api/organizations.ts
+++ b/web/src/lib/api/organizations.ts
@@ -16,6 +16,13 @@ export interface BrandingConfig {
 
 export type FeatureFlags = Record<string, boolean>;
 
+export interface StorageInfo {
+  usedBytes: number;
+  quotaBytes: number;
+  availableBytes: number;
+  usagePercent: number;
+}
+
 declare module './client' {
   interface ApiClient {
     getOrganization(): Promise<Organization>;
@@ -25,6 +32,7 @@ declare module './client' {
     uploadBrandingLogo(orgId: string, file: File): Promise<{ logoUrl: string }>;
     getFeatureFlags(): Promise<FeatureFlags>;
     updateFeatureFlags(flags: Partial<FeatureFlags>): Promise<FeatureFlags>;
+    getStorageInfo(): Promise<StorageInfo>;
   }
 }
 
@@ -65,4 +73,8 @@ ApiClient.prototype.updateFeatureFlags = async function (flags: Partial<FeatureF
     method: 'PATCH',
     body: JSON.stringify(flags),
   });
+};
+
+ApiClient.prototype.getStorageInfo = async function (): Promise<StorageInfo> {
+  return this.request<StorageInfo>('/organizations/storage');
 };

--- a/web/src/lib/server-api.ts
+++ b/web/src/lib/server-api.ts
@@ -2,6 +2,17 @@ import { cookies } from 'next/headers';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000/api/v1';
 
+export class ServerFetchError extends Error {
+  constructor(
+    public statusCode: number,
+    message: string,
+    public body: unknown,
+  ) {
+    super(message);
+    this.name = 'ServerFetchError';
+  }
+}
+
 export async function serverFetch<T>(path: string, options?: RequestInit): Promise<T> {
   const cookieStore = await cookies();
   const token = cookieStore.get('vizora_auth_token')?.value;
@@ -24,7 +35,7 @@ export async function serverFetch<T>(path: string, options?: RequestInit): Promi
       body && typeof body === 'object' && 'message' in body
         ? String((body as { message: unknown }).message)
         : `API error: ${res.status} ${res.statusText}`;
-    throw new Error(message);
+    throw new ServerFetchError(res.status, message, body);
   }
 
   if (body && typeof body === 'object' && 'success' in body && 'data' in body) {


### PR DESCRIPTION
## Summary
- replace hardcoded dashboard health/storage indicators with real readiness and organization storage data
- carry SSR pagination completeness into the dashboard client to skip redundant initial content/playlist refetches when data is complete
- preserve unhealthy `/health/ready` 503 bodies server-side and fix dashboard mobile hydration from viewport-dependent sidebar initial state

## Reviews
- Customer-facing dashboard/UI reviewer: CLEAN
- API/data/performance reviewer: CLEAN
- Follow-up UI/runtime review for layout hydration fix: CLEAN

## Verification
- `pnpm --filter @vizora/web test -- --runInBand --testPathPattern=dashboard-(page|server-page)` — 2 suites / 18 tests pass
- `pnpm --filter @vizora/web test -- --runInBand --testPathPattern=server-api` — 1 suite / 3 tests pass
- `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` — pass
- `ESLINT_USE_FLAT_CONFIG=false npx eslint ...changed web files...` — 0 errors, 19 existing any warnings
- `npx nx build @vizora/web` — pass
- `pnpm --filter @vizora/web test -- --runInBand` — 95 suites / 977 tests pass; unrelated existing act warnings remain in non-dashboard suites
- Playwright browser smoke against `next start` on `localhost:3001`: desktop and mobile dashboard render with no page errors; screenshots saved locally in `logs/dashboard-pass13-{desktop,mobile}.png`

## Deployment
- Not deployed. Production repo remains dirty/diverged and needs operator classification/preservation before repo-native deploy.