### PR TITLE
feat(content): page and filter dashboard library server-side

### DIFF
--- a/docs/plans/2026-05-31-content-library-server-filter-pagination-pass-14.md
+++ b/docs/plans/2026-05-31-content-library-server-filter-pagination-pass-14.md
@@ -1,0 +1,96 @@
+# Content Library Server Filtering and Pagination - Pass 14
+
+Date: 2026-05-31
+Branch: `feat/customer-performance-pass-14`
+
+## Why Now
+
+The dashboard content library still loads every content row through
+`fetchAllPaginated` and filters in the browser. That is tolerable for demo data,
+but it becomes slow and failure-prone for a customer with hundreds or thousands
+of uploads. The pagination helper already has a 10-page safety cap, so large
+libraries can also fail instead of degrading gracefully.
+
+This pass replaces the all-row dashboard path with server-side search/filter
+queries and bounded page navigation while preserving the existing content
+CRUD/upload/modals.
+
+## New Primitives Introduced
+
+Small extensions to existing primitives only:
+
+- `ContentQueryDto` adds bounded `search`, `dateRange`, and `tagNames` query
+  parameters.
+- Existing content and folder-content list services apply those parameters in
+  tenant-scoped Prisma `where` clauses.
+- The existing dashboard content page tracks one paginated result page at a
+  time.
+- A content folder-list composite index backs `GET /folders/:id/content`.
+
+## Hermes-First Analysis
+
+Not applicable. This pass does not add business agents, MCP tools, Hermes
+skills, AI/provider calls, sidecar runtimes, or spend paths.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Dashboard content listing performance | none applicable | Build in existing dashboard/API substrate. |
+| Content search/filter query handling | none applicable | Build in existing NestJS + Prisma services. |
+
+Awesome-Hermes ecosystem check: not applicable because no agent capability or
+LLM workflow is being introduced.
+
+## Drift Check
+
+Current repo evidence:
+
+- `web/src/app/dashboard/content/page-client.tsx` calls `fetchAllPaginated` for
+  root and folder content, then filters `content.filter(...)` in the client.
+- `middleware/src/modules/content/content.service.ts` already has tenant-scoped
+  paginated queries and type/status/template-orientation filters.
+- `middleware/src/modules/folders/folders.service.ts` has a separate
+  tenant-scoped folder-content query with pagination only.
+- `packages/database/prisma/schema.prisma` already indexes
+  `(organizationId, createdAt)`, `(organizationId, status, createdAt)`, and
+  `(organizationId, type, createdAt)`, so simple server filters are aligned
+  with the schema. Folder-scoped listing still needs a matching composite
+  index for `(organizationId, folderId, createdAt)`.
+
+## Selected Fix Bundle
+
+- Add backend query support for content search, date range, and tag-name filters
+  on both root content and folder content.
+- Update the web API client types for the new list parameters.
+- Change the dashboard content page to fetch one page of results at a time
+  using server-side search/type/status/date/tag parameters.
+- Add page navigation and total-count copy so customers can see bounded result
+  sets instead of waiting for all rows.
+- Add a folder-content composite index to support newest-first folder browsing.
+- Keep existing modal lazy-load behavior for push/add-to-playlist unchanged.
+
+## Acceptance Criteria
+
+- Initial content-library load requests a single bounded page, not every page.
+- Search/type/status/date/tag changes reset to page 1 and send query parameters
+  to the API.
+- Folder content uses the same bounded query behavior.
+- Page navigation requests the next/previous page without losing tenant guards.
+- Backend filters never remove `organizationId` from the Prisma `where` clause.
+- Existing upload, delete, move-to-folder, push, preview, and playlist flows
+  continue to work.
+
+## Verification Plan
+
+- Middleware unit tests for `ContentQueryDto`, `ContentService.findAll`, and
+  `FoldersService.getContents`.
+- Web unit tests for initial bounded fetch, server-filter query params, folder
+  query params, and pagination controls.
+- Type checks for middleware and web.
+- Focused web/middleware Jest suites, then broader affected tests/builds.
+- Multi-subagent code review before running the broader verification suite.
+
+## Deployment
+
+No production deployment from this pass until `/opt/vizora/app` dirty/diverged
+state is classified and preserved. Repo-side merge can proceed after tests, CI,
+and review are green.

--- a/middleware/src/modules/content/content-list-query.ts
+++ b/middleware/src/modules/content/content-list-query.ts
@@ -1,0 +1,131 @@
+import { Prisma } from '@vizora/database';
+
+export const CONTENT_LIST_TYPES = [
+  'image',
+  'video',
+  'url',
+  'html',
+  'pdf',
+  'template',
+  'layout',
+  'widget',
+] as const;
+
+export const CONTENT_LIST_STATUSES = [
+  'active',
+  'archived',
+  'draft',
+  'flagged',
+  'rejected',
+  'pending_approval',
+  'expired',
+  'ready',
+  'processing',
+  'error',
+] as const;
+
+export const CONTENT_TEMPLATE_ORIENTATIONS = ['landscape', 'portrait', 'both'] as const;
+export const CONTENT_DATE_RANGES = ['7days', '30days', '90days'] as const;
+
+export type ContentDateRange = typeof CONTENT_DATE_RANGES[number];
+
+export interface ContentListFilters {
+  type?: string;
+  status?: string;
+  templateOrientation?: string;
+  search?: string;
+  dateRange?: ContentDateRange;
+  tagNames?: string[];
+  folderId?: string;
+}
+
+const DATE_RANGE_DAYS: Record<ContentDateRange, number> = {
+  '7days': 7,
+  '30days': 30,
+  '90days': 90,
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function hasValue<T extends readonly string[]>(values: T, value: string | undefined): value is T[number] {
+  return Boolean(value && values.includes(value as T[number]));
+}
+
+function normalizeTagNames(tagNames: string[] | undefined): string[] {
+  if (!tagNames) return [];
+  return Array.from(new Set(
+    tagNames
+      .map((tagName) => tagName.trim())
+      .filter(Boolean),
+  ));
+}
+
+export function buildContentListWhere(
+  organizationId: string,
+  filters: ContentListFilters = {},
+): Prisma.ContentWhereInput {
+  const where: Prisma.ContentWhereInput = { organizationId };
+  const andFilters: Prisma.ContentWhereInput[] = [];
+
+  if (filters.folderId) {
+    where.folderId = filters.folderId;
+  }
+
+  if (hasValue(CONTENT_LIST_TYPES, filters.type)) {
+    where.type = filters.type;
+  }
+
+  if (hasValue(CONTENT_LIST_STATUSES, filters.status)) {
+    where.status = filters.status;
+  }
+
+  if (hasValue(CONTENT_TEMPLATE_ORIENTATIONS, filters.templateOrientation)) {
+    where.templateOrientation = filters.templateOrientation;
+  }
+
+  const search = filters.search?.trim();
+  if (search) {
+    andFilters.push({
+      OR: [
+        { name: { contains: search, mode: 'insensitive' } },
+        { description: { contains: search, mode: 'insensitive' } },
+      ],
+    });
+  }
+
+  if (filters.dateRange && filters.dateRange in DATE_RANGE_DAYS) {
+    where.createdAt = {
+      gte: new Date(Date.now() - DATE_RANGE_DAYS[filters.dateRange] * DAY_MS),
+    };
+  }
+
+  const tagNames = normalizeTagNames(filters.tagNames);
+  if (tagNames.length > 0) {
+    andFilters.push({
+      OR: tagNames.flatMap((tagName) => [
+        {
+          tags: {
+            some: {
+              tag: {
+                organizationId,
+                name: { equals: tagName, mode: 'insensitive' },
+              },
+            },
+          },
+        },
+        {
+          metadata: {
+            path: ['tags'],
+            array_contains: tagName,
+          },
+        },
+      ]),
+    });
+  }
+
+  if (andFilters.length > 0) {
+    where.AND = andFilters;
+  }
+
+  return where;
+}

--- a/middleware/src/modules/content/content.controller.spec.ts
+++ b/middleware/src/modules/content/content.controller.spec.ts
@@ -457,6 +457,30 @@ describe('ContentController', () => {
         { type: 'image', status: 'active', templateOrientation: undefined },
       );
     });
+
+    it('should pass server-side library filters without mixing them into pagination', async () => {
+      mockContentService.findAll.mockResolvedValue({ data: [], total: 0 } as any);
+
+      await controller.findAll(organizationId, {
+        ...pagination,
+        search: 'menu',
+        dateRange: '7days',
+        tagNames: ['Marketing', 'Seasonal'],
+      } as any);
+
+      expect(mockContentService.findAll).toHaveBeenCalledWith(
+        organizationId,
+        pagination,
+        {
+          type: undefined,
+          status: undefined,
+          templateOrientation: undefined,
+          search: 'menu',
+          dateRange: '7days',
+          tagNames: ['Marketing', 'Seasonal'],
+        },
+      );
+    });
   });
 
   describe('findOne', () => {

--- a/middleware/src/modules/content/content.controller.ts
+++ b/middleware/src/modules/content/content.controller.ts
@@ -369,8 +369,15 @@ export class ContentController {
     @CurrentUser('organizationId') organizationId: string,
     @Query() query: ContentQueryDto,
   ) {
-    const { type, status, templateOrientation, ...pagination } = query;
-    return this.contentService.findAll(organizationId, pagination, { type, status, templateOrientation });
+    const { type, status, templateOrientation, search, dateRange, tagNames, ...pagination } = query;
+    return this.contentService.findAll(organizationId, pagination, {
+      type,
+      status,
+      templateOrientation,
+      search,
+      dateRange,
+      tagNames,
+    });
   }
 
   @Get(':id')

--- a/middleware/src/modules/content/content.service.spec.ts
+++ b/middleware/src/modules/content/content.service.spec.ts
@@ -210,6 +210,73 @@ describe('ContentService', () => {
         }),
       );
     });
+
+    it('should filter by search across name and description while preserving organization scope', async () => {
+      mockDatabaseService.content.findMany.mockResolvedValue([]);
+      mockDatabaseService.content.count.mockResolvedValue(0);
+
+      await service.findAll('org-123', { page: 1, limit: 10 }, { search: 'lunch menu' } as any);
+
+      expect(mockDatabaseService.content.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            organizationId: 'org-123',
+            AND: expect.arrayContaining([
+              {
+                OR: [
+                  { name: { contains: 'lunch menu', mode: 'insensitive' } },
+                  { description: { contains: 'lunch menu', mode: 'insensitive' } },
+                ],
+              },
+            ]),
+          }),
+        }),
+      );
+      expect(mockDatabaseService.content.count).toHaveBeenCalledWith({
+        where: expect.objectContaining({ organizationId: 'org-123' }),
+      });
+    });
+
+    it('should filter by date range and tenant-scoped tags', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-05-31T12:00:00Z'));
+      mockDatabaseService.content.findMany.mockResolvedValue([]);
+      mockDatabaseService.content.count.mockResolvedValue(0);
+
+      try {
+        await service.findAll('org-123', { page: 1, limit: 10 }, {
+          dateRange: '7days',
+          tagNames: ['Marketing'],
+        } as any);
+
+        expect(mockDatabaseService.content.findMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({
+              organizationId: 'org-123',
+              createdAt: { gte: new Date('2026-05-24T12:00:00Z') },
+              AND: expect.arrayContaining([
+                {
+                  OR: expect.arrayContaining([
+                    {
+                      tags: {
+                        some: {
+                          tag: {
+                            organizationId: 'org-123',
+                            name: { equals: 'Marketing', mode: 'insensitive' },
+                          },
+                        },
+                      },
+                    },
+                    { metadata: { path: ['tags'], array_contains: 'Marketing' } },
+                  ]),
+                },
+              ]),
+            }),
+          }),
+        );
+      } finally {
+        jest.useRealTimers();
+      }
+    });
   });
 
   describe('findOne', () => {

--- a/middleware/src/modules/content/content.service.ts
+++ b/middleware/src/modules/content/content.service.ts
@@ -19,6 +19,7 @@ import { DataSourceRegistryService } from './data-source-registry.service';
 import { StorageQuotaService } from '../storage/storage-quota.service';
 import { StorageService } from '../storage/storage.service';
 import type { WidgetDataSource } from './widget-data-sources';
+import { buildContentListWhere, type ContentListFilters } from './content-list-query';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -98,26 +99,12 @@ export class ContentService {
   async findAll(
     organizationId: string,
     pagination: PaginationDto,
-    filters?: { type?: string; status?: string; templateOrientation?: string },
+    filters?: ContentListFilters,
   ) {
     const { page = 1, limit = 10 } = pagination;
     const skip = (page - 1) * limit;
 
-    // Validate filter values - only allow whitelisted values
-    const validTypes = ['image', 'video', 'url', 'html', 'pdf', 'template', 'layout', 'widget'];
-    const validStatuses = ['active', 'archived', 'draft', 'flagged', 'rejected', 'pending_approval'];
-    const validOrientations = ['landscape', 'portrait', 'both'];
-
-    const where: Prisma.ContentWhereInput = { organizationId };
-    if (filters?.type && validTypes.includes(filters.type)) {
-      where.type = filters.type;
-    }
-    if (filters?.status && validStatuses.includes(filters.status)) {
-      where.status = filters.status;
-    }
-    if (filters?.templateOrientation && validOrientations.includes(filters.templateOrientation)) {
-      where.templateOrientation = filters.templateOrientation;
-    }
+    const where = buildContentListWhere(organizationId, filters);
 
     const [data, total] = await Promise.all([
       this.db.content.findMany({

--- a/middleware/src/modules/content/dto/content-query.dto.spec.ts
+++ b/middleware/src/modules/content/dto/content-query.dto.spec.ts
@@ -19,6 +19,10 @@ describe('ContentQueryDto', () => {
     'flagged',
     'rejected',
     'pending_approval',
+    'expired',
+    'ready',
+    'processing',
+    'error',
   ])('accepts status=%s', async (status) => {
     const errors = await validateStatus(status);
     expect(errors).toEqual([]);
@@ -28,5 +32,54 @@ describe('ContentQueryDto', () => {
     const errors = await validateStatus('not-a-real-status');
     expect(errors.length).toBeGreaterThan(0);
     expect(errors[0].constraints).toHaveProperty('isIn');
+  });
+
+  it.each(['image', 'video', 'url', 'html', 'pdf', 'template', 'layout', 'widget'])(
+    'accepts type=%s',
+    async (type) => {
+      const dto = plainToInstance(ContentQueryDto, { type });
+      await expect(validate(dto)).resolves.toEqual([]);
+    },
+  );
+
+  it('accepts bounded server-side search and date range filters', async () => {
+    const dto = plainToInstance(ContentQueryDto, {
+      search: '  lunch menu  ',
+      dateRange: '30days',
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors).toEqual([]);
+    expect(dto.search).toBe('lunch menu');
+  });
+
+  it('rejects oversized search terms', async () => {
+    const dto = plainToInstance(ContentQueryDto, { search: 'a'.repeat(121) });
+
+    const errors = await validate(dto);
+
+    expect(errors.some((error) => error.property === 'search')).toBe(true);
+  });
+
+  it('normalizes comma-separated tag names', async () => {
+    const dto = plainToInstance(ContentQueryDto, {
+      tagNames: 'Marketing, Seasonal, ',
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors).toEqual([]);
+    expect(dto.tagNames).toEqual(['Marketing', 'Seasonal']);
+  });
+
+  it('rejects too many tag names', async () => {
+    const dto = plainToInstance(ContentQueryDto, {
+      tagNames: Array.from({ length: 21 }, (_, index) => `tag-${index}`),
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors.some((error) => error.property === 'tagNames')).toBe(true);
   });
 });

--- a/middleware/src/modules/content/dto/content-query.dto.ts
+++ b/middleware/src/modules/content/dto/content-query.dto.ts
@@ -1,19 +1,61 @@
-import { IsOptional, IsString, IsIn } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { ArrayMaxSize, IsArray, IsIn, IsOptional, IsString, MaxLength } from 'class-validator';
 import { PaginationDto } from '../../common/dto/pagination.dto';
+import {
+  CONTENT_DATE_RANGES,
+  CONTENT_LIST_STATUSES,
+  CONTENT_LIST_TYPES,
+  CONTENT_TEMPLATE_ORIENTATIONS,
+  type ContentDateRange,
+} from '../content-list-query';
+
+const normalizeSearch = ({ value }: { value: unknown }) => {
+  if (typeof value !== 'string') return value;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const normalizeTagNames = ({ value }: { value: unknown }) => {
+  if (value === undefined || value === null) return undefined;
+  const raw = Array.isArray(value) ? value : String(value).split(',');
+  const normalized = raw
+    .map((tagName) => String(tagName).trim())
+    .filter(Boolean);
+  return normalized.length > 0 ? normalized : undefined;
+};
 
 export class ContentQueryDto extends PaginationDto {
   @IsOptional()
   @IsString()
-  @IsIn(['image', 'video', 'url', 'html', 'pdf', 'template'])
+  @IsIn(CONTENT_LIST_TYPES)
   type?: string;
 
   @IsOptional()
   @IsString()
-  @IsIn(['active', 'archived', 'draft', 'flagged', 'rejected', 'pending_approval'])
+  @IsIn(CONTENT_LIST_STATUSES)
   status?: string;
 
   @IsOptional()
   @IsString()
-  @IsIn(['landscape', 'portrait', 'both'])
+  @IsIn(CONTENT_TEMPLATE_ORIENTATIONS)
   templateOrientation?: string;
+
+  @IsOptional()
+  @Transform(normalizeSearch)
+  @IsString()
+  @MaxLength(120)
+  search?: string;
+
+  @IsOptional()
+  @IsString()
+  @IsIn(CONTENT_DATE_RANGES)
+  dateRange?: ContentDateRange;
+
+  @IsOptional()
+  @Transform(normalizeTagNames)
+  @IsArray()
+  @ArrayMaxSize(20)
+  @IsString({ each: true })
+  @MaxLength(64, { each: true })
+  tagNames?: string[];
 }

--- a/middleware/src/modules/folders/folders.controller.spec.ts
+++ b/middleware/src/modules/folders/folders.controller.spec.ts
@@ -217,6 +217,46 @@ describe('FoldersController', () => {
         organizationId,
         'folder-123',
         pagination,
+        {
+          type: undefined,
+          status: undefined,
+          templateOrientation: undefined,
+          search: undefined,
+          dateRange: undefined,
+          tagNames: undefined,
+        },
+      );
+    });
+
+    it('should pass server-side content filters to the folder service', async () => {
+      const query = {
+        page: 1,
+        limit: 10,
+        search: 'menu',
+        type: 'image',
+        status: 'active',
+        dateRange: '30days',
+        tagNames: ['Marketing'],
+      };
+      mockFoldersService.getContents.mockResolvedValue({
+        data: [],
+        meta: { total: 0, page: 1, limit: 10, totalPages: 0 },
+      } as any);
+
+      await controller.getContents(organizationId, 'folder-123', query as any);
+
+      expect(mockFoldersService.getContents).toHaveBeenCalledWith(
+        organizationId,
+        'folder-123',
+        { page: 1, limit: 10 },
+        {
+          search: 'menu',
+          type: 'image',
+          status: 'active',
+          dateRange: '30days',
+          tagNames: ['Marketing'],
+          templateOrientation: undefined,
+        },
       );
     });
 

--- a/middleware/src/modules/folders/folders.controller.ts
+++ b/middleware/src/modules/folders/folders.controller.ts
@@ -18,8 +18,8 @@ import { FoldersService } from './folders.service';
 import { CreateFolderDto } from './dto/create-folder.dto';
 import { UpdateFolderDto } from './dto/update-folder.dto';
 import { MoveContentDto } from './dto/move-content.dto';
-import { PaginationDto } from '../common/dto/pagination.dto';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { ContentQueryDto } from '../content/dto/content-query.dto';
 
 @UseGuards(RolesGuard)
 @Controller('folders')
@@ -88,8 +88,16 @@ export class FoldersController {
   getContents(
     @CurrentUser('organizationId') organizationId: string,
     @Param('id', ParseIdPipe) id: string,
-    @Query() pagination: PaginationDto,
+    @Query() query: ContentQueryDto,
   ) {
-    return this.foldersService.getContents(organizationId, id, pagination);
+    const { type, status, templateOrientation, search, dateRange, tagNames, ...pagination } = query;
+    return this.foldersService.getContents(organizationId, id, pagination, {
+      type,
+      status,
+      templateOrientation,
+      search,
+      dateRange,
+      tagNames,
+    });
   }
 }

--- a/middleware/src/modules/folders/folders.service.spec.ts
+++ b/middleware/src/modules/folders/folders.service.spec.ts
@@ -503,6 +503,61 @@ describe('FoldersService', () => {
       );
     });
 
+    it('should apply server-side filters within the requested folder and organization', async () => {
+      mockDatabaseService.contentFolder.findFirst.mockResolvedValue({
+        ...mockFolder,
+        parent: null,
+        children: [],
+        _count: { content: 0 },
+      });
+      mockDatabaseService.content.findMany.mockResolvedValue([]);
+      mockDatabaseService.content.count.mockResolvedValue(0);
+
+      await service.getContents('org-123', 'folder-123', { page: 1, limit: 10 }, {
+        search: 'menu',
+        type: 'image',
+        tagNames: ['Marketing'],
+      } as any);
+
+      expect(mockDatabaseService.content.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            folderId: 'folder-123',
+            organizationId: 'org-123',
+            type: 'image',
+            AND: expect.arrayContaining([
+              {
+                OR: [
+                  { name: { contains: 'menu', mode: 'insensitive' } },
+                  { description: { contains: 'menu', mode: 'insensitive' } },
+                ],
+              },
+              {
+                OR: expect.arrayContaining([
+                  {
+                    tags: {
+                      some: {
+                        tag: {
+                          organizationId: 'org-123',
+                          name: { equals: 'Marketing', mode: 'insensitive' },
+                        },
+                      },
+                    },
+                  },
+                ]),
+              },
+            ]),
+          }),
+        }),
+      );
+      expect(mockDatabaseService.content.count).toHaveBeenCalledWith({
+        where: expect.objectContaining({
+          folderId: 'folder-123',
+          organizationId: 'org-123',
+        }),
+      });
+    });
+
     it('should map content with title and thumbnailUrl', async () => {
       mockDatabaseService.contentFolder.findFirst.mockResolvedValue({
         ...mockFolder,

--- a/middleware/src/modules/folders/folders.service.ts
+++ b/middleware/src/modules/folders/folders.service.ts
@@ -4,6 +4,7 @@ import { CreateFolderDto } from './dto/create-folder.dto';
 import { UpdateFolderDto } from './dto/update-folder.dto';
 import { MoveContentDto } from './dto/move-content.dto';
 import { PaginationDto, PaginatedResponse } from '../common/dto/pagination.dto';
+import { buildContentListWhere, type ContentListFilters } from '../content/content-list-query';
 
 export interface FolderWithChildren {
   id: string;
@@ -214,16 +215,18 @@ export class FoldersService {
     organizationId: string,
     folderId: string,
     pagination: PaginationDto,
+    filters?: ContentListFilters,
   ) {
     // Verify folder exists
     await this.findOne(organizationId, folderId);
 
     const { page = 1, limit = 10 } = pagination;
     const skip = (page - 1) * limit;
+    const where = buildContentListWhere(organizationId, { ...filters, folderId });
 
     const [data, total] = await Promise.all([
       this.db.content.findMany({
-        where: { folderId, organizationId },
+        where,
         skip,
         take: limit,
         orderBy: { createdAt: 'desc' },
@@ -233,7 +236,7 @@ export class FoldersService {
           },
         },
       }),
-      this.db.content.count({ where: { folderId, organizationId } }),
+      this.db.content.count({ where }),
     ]);
 
     // Map content response for frontend compatibility

--- a/packages/database/prisma/migrations/20260531223800_content_folder_list_index/migration.sql
+++ b/packages/database/prisma/migrations/20260531223800_content_folder_list_index/migration.sql
@@ -1,0 +1,5 @@
+-- Support paged folder content-library queries by organization, folder, and
+-- newest-first ordering. This matches GET /folders/:id/content.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Content_organizationId_folderId_createdAt_idx"
+  ON "Content"("organizationId", "folderId", "createdAt" DESC);

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -247,6 +247,7 @@ model Content {
   @@index([organizationId, status, createdAt(sort: Desc)])
   @@index([organizationId, type, createdAt(sort: Desc)])
   @@index([organizationId, templateOrientation, createdAt(sort: Desc)])
+  @@index([organizationId, folderId, createdAt(sort: Desc)])
   @@index([type])
   @@index([status])
   @@index([expiresAt])

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,104 @@
 # Vizora - Task Tracker
 
-## In Progress: Customer/Performance Readiness Pass 11 (2026-05-31)
+## In Progress: Content Library Performance Pass 14 (2026-05-31)
+
+**Branch:** `feat/customer-performance-pass-14`
+
+**Why now:** PR #136 merged the real dashboard health/storage trust pass and CI
+was green, but production deployment remains blocked by dirty/diverged prod
+state. The next buildable customer-performance gap is the content library:
+it still loads all content rows and filters client-side, which can become slow
+or hit the pagination safety cap for real customer libraries.
+
+**New primitives introduced:** bounded `search`, `dateRange`, and `tagNames`
+content-list query parameters plus paged content-library dashboard state.
+
+**Hermes-first analysis:** not applicable. This pass does not add business
+agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
+
+**Plan**
+- [x] Merge PR #136 after full CI green.
+- [x] Re-check production deploy gate after merge.
+- [x] Start fresh branch from `origin/main`.
+- [x] Write scoped plan/design for content-library server filtering and
+  pagination.
+- [x] Run multi-subagent pre-implementation review/analysis.
+- [x] Add focused failing tests.
+- [x] Implement backend query filters and web paged loading.
+- [x] Run multi-subagent code review before broader tests.
+- [x] Run focused and broader affected verification.
+- [ ] PR, CI, merge.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Current merge/deploy state**
+- [x] PR #136 merged at
+  `35609734a185366f981efc47246e46229836f22d`; CI green for audit, build, e2e,
+  lint, security, and test.
+- [x] No open GitHub PRs after #136 merge.
+- [x] Prod deploy remains blocked: `/opt/vizora/app` is dirty and
+  ahead/behind stale prod `origin/main`, with many local template/web/script
+  changes and untracked operator/docs assets. No production pull, reset, stash,
+  env edit, service restart, DB mutation, or deploy performed.
+
+**Plan/design:**
+`docs/plans/2026-05-31-content-library-server-filter-pagination-pass-14.md`
+
+**Selected fix bundle**
+- [x] Added tenant-scoped server filters for content library lists:
+  `search`, `dateRange`, and `tagNames` now share the middleware DTO and
+  Prisma where-builder for root and folder-scoped content.
+- [x] Added a folder/content list index:
+  `Content(organizationId, folderId, createdAt DESC)`.
+- [x] Updated the dashboard content library to request bounded pages instead
+  of fetching every content row before client-side filtering.
+- [x] Preserved modal-only lazy loading for push/add-to-playlist option data.
+
+**Review**
+- [x] Pre-implementation review:
+  customer/UX and backend/API reviewers confirmed the highest-value small
+  gap was content-library server-side filtering/pagination. The UX reviewer
+  inspected the main checkout instead of this worktree, so its comments were
+  treated as directional and reconciled against local code truth.
+- [x] Backend/API/data code review CLEAN. Residual risk accepted:
+  legacy `metadata.tags` JSON fallback is exact-case while relation-backed
+  tag filtering is case-insensitive.
+- [x] Dashboard UX/performance review found and fixes landed for an unstable
+  toast dependency refetch loop, stale pagination after deleting the only item
+  on a later page, stale page/search fetch sequencing, and mobile paginator
+  wrapping.
+- [x] Targeted re-review CLEAN after the dashboard fixes.
+
+**Verification**
+- [x] Focused middleware tests passed:
+  `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="content-query.dto|content.service|content.controller|folders.service|folders.controller"`
+  (10 suites / 352 tests).
+- [x] Focused web content tests passed after final cleanup:
+  `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="dashboard/content"`
+  (1 suite / 35 tests).
+- [x] Full middleware Jest passed:
+  `pnpm --filter @vizora/middleware test -- --runInBand`
+  (143 suites / 2873 tests).
+- [x] Full web Jest passed:
+  `pnpm --filter @vizora/web test -- --runInBand`
+  (95 suites / 980 tests). Existing unrelated React `act(...)` and jsdom
+  navigation warnings remain in the broader suite.
+- [x] Prisma validate passed for `packages/database/prisma/schema.prisma`.
+- [x] TypeScript checks passed for middleware and web.
+- [x] Production builds passed with required local verification env:
+  `NEXT_PUBLIC_SOCKET_URL=http://localhost:3002`,
+  `NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1`,
+  `BACKEND_URL=http://localhost:3000`.
+- [x] `git diff --check` passed; Windows CRLF conversion warnings only.
+
+**Residual risks / deploy gate**
+- [ ] CI pending until PR is opened.
+- [ ] Production deploy still blocked by the dirty/diverged prod checkout.
+  No production pull, reset, stash, env edit, service restart, DB mutation, or
+  deploy performed.
+
+---
+
+## Completed: Customer/Performance Readiness Pass 11 (2026-05-31)
 
 **Branch:** `feat/performance-readiness-pass-11`
 

--- a/web/src/app/dashboard/content/__tests__/content-page.test.tsx
+++ b/web/src/app/dashboard/content/__tests__/content-page.test.tsx
@@ -31,6 +31,7 @@ jest.mock('@/lib/api', () => ({
 }));
 
 const mockToast = {
+  showToast: jest.fn(),
   success: jest.fn(),
   error: jest.fn(),
   info: jest.fn(),
@@ -39,7 +40,7 @@ const mockToast = {
 };
 
 jest.mock('@/lib/hooks/useToast', () => ({
-  useToast: () => mockToast,
+  useToast: () => ({ ...mockToast }),
 }));
 
 jest.mock('@/lib/hooks/useDebounce', () => ({
@@ -48,13 +49,29 @@ jest.mock('@/lib/hooks/useDebounce', () => ({
 
 jest.mock('@/lib/hooks', () => ({
   useRealtimeEvents: jest.fn(() => ({ isConnected: false, isOffline: true })),
-  useOptimisticState: jest.fn((initialState: any) => ({
+  useOptimisticState: jest.fn((_initialState: any) => ({
     updateOptimistic: jest.fn(),
     commitOptimistic: jest.fn(),
     rollbackOptimistic: jest.fn(),
     getPendingCount: jest.fn(() => 0),
   })),
-  useErrorRecovery: jest.fn(() => ({ retry: jest.fn(), recordError: jest.fn(), isRecovering: false })),
+  useErrorRecovery: jest.fn(() => ({
+    retry: jest.fn(async (
+      _id: string,
+      operation: () => Promise<unknown>,
+      onSuccess?: () => void,
+      onError?: (error: unknown) => void,
+    ) => {
+      try {
+        await operation();
+        onSuccess?.();
+      } catch (error) {
+        onError?.(error);
+      }
+    }),
+    recordError: jest.fn(),
+    isRecovering: false,
+  })),
 }));
 
 jest.mock('@/lib/validation', () => ({
@@ -109,8 +126,8 @@ jest.mock('@/components/ConfirmDialog', () => {
 });
 
 jest.mock('@/components/SearchFilter', () => {
-  return function MockSearch({ onSearch }: any) {
-    return <input data-testid="search-input" placeholder="Search..." onChange={(e) => onSearch?.(e.target.value)} />;
+  return function MockSearch({ value, onChange }: any) {
+    return <input data-testid="search-input" value={value} placeholder="Search..." onChange={(e) => onChange?.(e.target.value)} />;
   };
 });
 
@@ -195,8 +212,8 @@ const sampleContent = [
 describe('ContentClient', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetContent.mockResolvedValue({ data: [], meta: { total: 0 } });
-    mockGetFolderContent.mockResolvedValue({ data: [] });
+    mockGetContent.mockResolvedValue({ data: [], meta: { page: 1, limit: 50, total: 0, totalPages: 0 } });
+    mockGetFolderContent.mockResolvedValue({ data: [], meta: { page: 1, limit: 50, total: 0, totalPages: 0 } });
     mockGetFolders.mockResolvedValue([]);
     mockGetDisplays.mockResolvedValue({ data: [] });
     mockGetPlaylists.mockResolvedValue({ data: [] });
@@ -306,33 +323,151 @@ describe('ContentClient', () => {
     expect(screen.getByText('Menu PDF')).toBeInTheDocument();
   });
 
-  it('renders content from every paginated page', async () => {
+  it('renders one content page at a time and fetches the next page on demand', async () => {
     mockGetContent
       .mockResolvedValueOnce({
         data: [sampleContent[0]],
-        meta: { page: 1, limit: 100, total: 2, totalPages: 2 },
+        meta: { page: 1, limit: 50, total: 2, totalPages: 2 },
       })
       .mockResolvedValueOnce({
         data: [sampleContent[1]],
-        meta: { page: 2, limit: 100, total: 2, totalPages: 2 },
+        meta: { page: 2, limit: 50, total: 2, totalPages: 2 },
       });
 
     render(<ContentClient />);
 
     await waitFor(() => {
       expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
-      expect(screen.getByText('Promo Video')).toBeInTheDocument();
     });
     await waitForAuxiliaryRequestsToSettle();
-    expect(mockGetContent).toHaveBeenNthCalledWith(1, { page: 1, limit: 100 });
-    expect(mockGetContent).toHaveBeenNthCalledWith(2, { page: 2, limit: 100 });
+    expect(screen.queryByText('Promo Video')).not.toBeInTheDocument();
+    expect(screen.getByText('1-1 of 2 items')).toBeInTheDocument();
+    expect(mockGetContent).toHaveBeenNthCalledWith(1, { page: 1, limit: 50 });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next page' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Promo Video')).toBeInTheDocument();
+    });
+    expect(mockGetContent).toHaveBeenNthCalledWith(2, { page: 2, limit: 50 });
+  });
+
+  it('sends search and type filters to the server and resets to the first page', async () => {
+    mockGetContent.mockResolvedValue({
+      data: [sampleContent[0]],
+      meta: { page: 1, limit: 50, total: 1, totalPages: 1 },
+    });
+
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+    mockGetContent.mockClear();
+
+    fireEvent.change(screen.getByTestId('search-input'), { target: { value: 'menu' } });
+
+    await waitFor(() => {
+      expect(mockGetContent).toHaveBeenCalledWith(expect.objectContaining({
+        page: 1,
+        limit: 50,
+        search: 'menu',
+      }));
+    });
+
+    mockGetContent.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: 'Video' }));
+
+    await waitFor(() => {
+      expect(mockGetContent).toHaveBeenCalledWith(expect.objectContaining({
+        page: 1,
+        limit: 50,
+        search: 'menu',
+        type: 'video',
+      }));
+    });
+  });
+
+  it('sends selected tag filters to folder content queries', async () => {
+    mockGetContent.mockResolvedValue({
+      data: sampleContent,
+      meta: { page: 1, limit: 50, total: 3, totalPages: 1 },
+    });
+    mockGetFolderContent.mockResolvedValue({
+      data: [sampleContent[0]],
+      meta: { page: 1, limit: 50, total: 1, totalPages: 1 },
+    });
+
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    fireEvent.click(screen.getByTestId('select-folder'));
+    await waitFor(() => {
+      expect(mockGetFolderContent).toHaveBeenCalledWith('folder-1', expect.objectContaining({
+        page: 1,
+        limit: 50,
+      }));
+    });
+    mockGetFolderContent.mockClear();
+
+    fireEvent.click(screen.getByText(/Tags/));
+    fireEvent.click(screen.getByText('Select Marketing Tag'));
+
+    await waitFor(() => {
+      expect(mockGetFolderContent).toHaveBeenCalledWith('folder-1', expect.objectContaining({
+        page: 1,
+        limit: 50,
+        tagNames: ['Marketing'],
+      }));
+    });
+  });
+
+  it('moves back to a valid page after deleting the only item on a later page', async () => {
+    mockGetContent
+      .mockResolvedValueOnce({
+        data: [sampleContent[0]],
+        meta: { page: 1, limit: 50, total: 2, totalPages: 2 },
+      })
+      .mockResolvedValueOnce({
+        data: [sampleContent[1]],
+        meta: { page: 2, limit: 50, total: 2, totalPages: 2 },
+      })
+      .mockResolvedValueOnce({
+        data: [sampleContent[0]],
+        meta: { page: 1, limit: 50, total: 1, totalPages: 1 },
+      });
+
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next page' }));
+    await waitFor(() => {
+      expect(screen.getByText('Promo Video')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Delete'));
+    fireEvent.click(screen.getByText('Confirm'));
+
+    await waitFor(() => {
+      expect(mockDeleteContent).toHaveBeenCalledWith('c2');
+    });
+    await waitFor(() => {
+      expect(mockGetContent).toHaveBeenLastCalledWith({ page: 1, limit: 50 });
+    });
+    expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    expect(screen.queryByText('Promo Video')).not.toBeInTheDocument();
   });
 
   it('shows error toast on fetch failure', async () => {
     mockGetContent.mockRejectedValue(new Error('Network error'));
     render(<ContentClient />);
     await waitFor(() => {
-      expect(mockToast.error).toHaveBeenCalled();
+      expect(mockToast.showToast).toHaveBeenCalledWith('Network error', 'error');
     });
     await waitForAuxiliaryRequestsToSettle();
   });
@@ -395,18 +530,25 @@ describe('ContentClient', () => {
     await waitForAuxiliaryRequestsToSettle();
 
     fireEvent.click(screen.getByText(/Tags/));
+    mockGetContent.mockClear();
     fireEvent.click(screen.getByText('Select Marketing Tag'));
 
     await waitFor(() => {
-      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
-      expect(screen.queryByText('Promo Video')).not.toBeInTheDocument();
+      expect(mockGetContent).toHaveBeenCalledWith(expect.objectContaining({
+        page: 1,
+        limit: 50,
+        tagNames: ['Marketing'],
+      }));
     });
+    expect(screen.getByTestId('selected-tags')).toHaveTextContent('1');
 
+    mockGetContent.mockClear();
     fireEvent.click(screen.getByText('Clear all'));
 
     await waitFor(() => {
-      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
-      expect(screen.getByText('Promo Video')).toBeInTheDocument();
+      expect(mockGetContent).toHaveBeenCalledWith(expect.not.objectContaining({
+        tagNames: expect.anything(),
+      }));
     });
     expect(screen.getByTestId('selected-tags')).toHaveTextContent('');
   });

--- a/web/src/app/dashboard/content/page-client.tsx
+++ b/web/src/app/dashboard/content/page-client.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useDropzone, type FileRejection } from 'react-dropzone';
 import { apiClient } from '@/lib/api';
+import type { ContentListParams } from '@/lib/api/content';
 import { fetchAllPaginated } from '@/lib/api/pagination';
 import { Content, Display, Playlist, ContentFolder } from '@/lib/types';
 import FolderTree from '@/components/FolderTree';
@@ -47,9 +48,22 @@ type UploadRejectedItem = {
  fileName: string;
  reason: string;
 };
+type ContentPageMeta = {
+ page: number;
+ limit: number;
+ total: number;
+ totalPages: number;
+};
 
 const BULK_UPLOAD_CONCURRENCY = 3;
 const MAX_UPLOAD_QUEUE_ITEMS = 10;
+const CONTENT_PAGE_SIZE = 50;
+const EMPTY_CONTENT_META: ContentPageMeta = {
+ page: 1,
+ limit: CONTENT_PAGE_SIZE,
+ total: 0,
+ totalPages: 0,
+};
 const FILE_UPLOAD_LIMITS: Record<FileUploadType, number> = {
  image: 10 * 1024 * 1024,
  video: 100 * 1024 * 1024,
@@ -79,7 +93,10 @@ const getUploadButtonLabel = (queue: UploadQueueItem[]): string => {
 
 export default function ContentClient() {
  const toast = useToast();
+ const { showToast } = toast;
  const [content, setContent] = useState<Content[]>([]);
+ const [contentMeta, setContentMeta] = useState<ContentPageMeta>(EMPTY_CONTENT_META);
+ const [contentPage, setContentPage] = useState(1);
  const [loading, setLoading] = useState(true);
  const [selectedContent, setSelectedContent] = useState<Content | null>(null);
  const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
@@ -143,12 +160,12 @@ export default function ContentClient() {
 
  // Real-time event handling
  const reconnectTimerRef = useRef<NodeJS.Timeout | null>(null);
- const hasHandledInitialFolderLoadRef = useRef(false);
  const loadContentRequestRef = useRef(0);
  const devicesLoadedRef = useRef(false);
  const playlistsLoadedRef = useRef(false);
  const devicesLoadPromiseRef = useRef<Promise<void> | null>(null);
  const playlistsLoadPromiseRef = useRef<Promise<void> | null>(null);
+ const lastContentFilterKeyRef = useRef('');
  useEffect(() => {
    return () => {
      if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
@@ -198,60 +215,71 @@ export default function ContentClient() {
  },
  });
 
- useEffect(() => {
- loadContent();
- loadFolders();
- }, []);
+ const selectedTagNames = useMemo(() => tags
+ .filter(tag => selectedTags.includes(tag.id))
+ .map(tag => tag.name), [tags, selectedTags]);
 
- // Reload content when folder selection changes
- useEffect(() => {
- if (!hasHandledInitialFolderLoadRef.current) {
- hasHandledInitialFolderLoadRef.current = true;
+ const buildContentListParams = useCallback((): ContentListParams => ({
+ page: contentPage,
+ limit: CONTENT_PAGE_SIZE,
+ ...(filterType !== 'all' ? { type: filterType } : {}),
+ ...(filterStatus !== 'all' ? { status: filterStatus } : {}),
+ ...(filterDateRange !== 'all' ? { dateRange: filterDateRange } : {}),
+ ...(debouncedSearch.trim() ? { search: debouncedSearch.trim() } : {}),
+ ...(selectedTagNames.length > 0 ? { tagNames: selectedTagNames } : {}),
+ }), [contentPage, debouncedSearch, filterDateRange, filterStatus, filterType, selectedTagNames]);
+ const contentFilterKey = `${selectedFolderId ?? 'root'}|${filterType}|${filterStatus}|${filterDateRange}|${debouncedSearch.trim()}|${selectedTagNames.join(',')}`;
+
+ const loadContent = useCallback(async () => {
+ if (lastContentFilterKeyRef.current && lastContentFilterKeyRef.current !== contentFilterKey && contentPage !== 1) {
+ setContentPage(1);
  return;
  }
- loadContent();
- }, [selectedFolderId]);
+ lastContentFilterKeyRef.current = contentFilterKey;
 
- // ESC key handler for preview modal
- useEffect(() => {
- const handleEscape = (e: KeyboardEvent) => {
- if (e.key === 'Escape' && isPreviewModalOpen) {
- setIsPreviewModalOpen(false);
- }
- };
- 
- window.addEventListener('keydown', handleEscape);
- return () => window.removeEventListener('keydown', handleEscape);
- }, [isPreviewModalOpen]);
-
- const loadContent = async () => {
  const requestId = ++loadContentRequestRef.current;
  const folderId = selectedFolderId;
  try {
  setLoading(true);
- let items: Content[];
- if (folderId) {
- items = await fetchAllPaginated((params) => apiClient.getFolderContent(folderId, params));
- } else {
- items = await fetchAllPaginated((params) => apiClient.getContent(params));
- }
+ const params = buildContentListParams();
+ const response = folderId
+ ? await apiClient.getFolderContent(folderId, params)
+ : await apiClient.getContent(params);
+ const items = response.data ?? [];
+ const limit = response.meta?.limit ?? params.limit ?? CONTENT_PAGE_SIZE;
+ const total = response.meta?.total ?? items.length;
+ const meta = {
+ page: response.meta?.page ?? params.page ?? 1,
+ limit,
+ total,
+ totalPages: response.meta?.totalPages ?? (total > 0 ? Math.ceil(total / limit) : 0),
+ };
  if (requestId !== loadContentRequestRef.current) {
  return;
  }
+ if (meta.totalPages > 0 && meta.page > meta.totalPages) {
+ setContentPage(meta.totalPages);
+ return;
+ }
  setContent(items);
+ setContentMeta(meta);
+ setSelectedItems(previous => {
+ const visibleIds = new Set(items.map(item => item.id));
+ return new Set(Array.from(previous).filter(id => visibleIds.has(id)));
+ });
  } catch (error: any) {
  if (requestId !== loadContentRequestRef.current) {
  return;
  }
-  toast.error(error.message || 'Failed to load content');
+  showToast(error.message || 'Failed to load content', 'error');
   } finally {
  if (requestId === loadContentRequestRef.current) {
  setLoading(false);
   }
   }
-  };
+  }, [buildContentListParams, contentFilterKey, contentPage, selectedFolderId, showToast]);
 
- const loadFolders = async () => {
+ const loadFolders = useCallback(async () => {
  try {
  const folderList = await apiClient.getFolders({ format: 'tree' });
  setFolders(folderList || []);
@@ -260,7 +288,7 @@ export default function ContentClient() {
   console.error('[ContentPage] Failed to load folders:', error);
  }
  }
- };
+ }, []);
 
  const handleCreateFolder = async () => {
  if (!newFolderName.trim()) {
@@ -323,6 +351,26 @@ export default function ContentClient() {
  setDevicesLoading(false);
  }
  };
+
+ useEffect(() => {
+ loadFolders();
+ }, [loadFolders]);
+
+ useEffect(() => {
+ loadContent();
+ }, [loadContent]);
+
+ // ESC key handler for preview modal
+ useEffect(() => {
+ const handleEscape = (e: KeyboardEvent) => {
+ if (e.key === 'Escape' && isPreviewModalOpen) {
+ setIsPreviewModalOpen(false);
+ }
+ };
+
+ window.addEventListener('keydown', handleEscape);
+ return () => window.removeEventListener('keydown', handleEscape);
+ }, [isPreviewModalOpen]);
 
  const loadPlaylists = async () => {
  try {
@@ -489,16 +537,15 @@ export default function ContentClient() {
  setActionLoading(true);
  setUploadProgress(0);
 
- let newContent;
  if (uploadForm.file && isFileUploadType(uploadForm.type)) {
  // Use progress-tracking upload for file uploads
- newContent = await apiClient.uploadContentWithProgress(
+ await apiClient.uploadContentWithProgress(
  { title: uploadForm.title, type: uploadForm.type, file: uploadForm.file },
  (percent) => setUploadProgress(percent),
  );
  } else {
  // URL-based content creation
- newContent = await apiClient.createContent({
+ await apiClient.createContent({
  title: uploadForm.title,
  type: uploadForm.type,
  url: uploadForm.url,
@@ -624,7 +671,13 @@ export default function ContentClient() {
  () => {
  // Commit optimistic deletion and update rendered state
  commitOptimistic(deleteId);
+ const wasOnlyVisibleItem = content.length <= 1;
  setContent(prev => prev.filter(item => item.id !== deletedContentId));
+ if (wasOnlyVisibleItem && contentPage > 1) {
+ setContentPage(page => Math.max(1, page - 1));
+ } else {
+ void loadContent();
+ }
  toast.success('Content deleted successfully');
  setIsDeleteModalOpen(false);
  setSelectedContent(null);
@@ -880,42 +933,7 @@ export default function ContentClient() {
  },
  });
 
- // Filter by type and search query
- const filteredContent = content.filter((c) => {
- // Type filter
- const matchesType = filterType === 'all' || c.type === filterType;
-
- // Search filter
- const matchesSearch = !debouncedSearch ||
- c.title.toLowerCase().includes(debouncedSearch.toLowerCase());
-
- // Status filter
- const matchesStatus = filterStatus === 'all' || c.status === filterStatus;
-
- // Date range filter
- let matchesDate = true;
- if (filterDateRange !== 'all' && c.createdAt) {
- const contentDate = new Date(c.createdAt);
- const now = new Date();
- const daysAgo = {
- '7days': 7,
- '30days': 30,
- '90days': 90,
- }[filterDateRange] || 0;
- const cutoffDate = new Date(now.getTime() - daysAgo * 24 * 60 * 60 * 1000);
- matchesDate = contentDate >= cutoffDate;
- }
-
- // Tag filter — matches content whose metadata.tags array includes any selected tag name
- let matchesTags = true;
- if (selectedTags.length > 0) {
- const selectedTagNames = tags.filter(t => selectedTags.includes(t.id)).map(t => t.name.toLowerCase());
- const contentTags: string[] = Array.isArray((c as any).tags) ? (c as any).tags : (c.metadata?.tags || []);
- matchesTags = contentTags.some(ct => selectedTagNames.includes(String(ct).toLowerCase()));
- }
-
- return matchesType && matchesSearch && matchesStatus && matchesDate && matchesTags;
- });
+ const filteredContent = content;
 
  const clearAllFilters = () => {
  setFilterType('all');
@@ -923,6 +941,8 @@ export default function ContentClient() {
  setFilterDateRange('all');
  setSearchQuery('');
  setSelectedTags([]);
+ setSelectedItems(new Set());
+ setContentPage(1);
  };
 
  const hasActiveFilters = filterType !== 'all' || filterStatus !== 'all' || filterDateRange !== 'all' || searchQuery !== '' || selectedTags.length > 0;
@@ -933,6 +953,17 @@ export default function ContentClient() {
  : devicesLoadError
  ? 'Select Devices'
  : `Select Devices (${onlineDeviceCount} online)`;
+ const totalContentItems = contentMeta.total;
+ const currentPageStart = totalContentItems === 0 ? 0 : (contentMeta.page - 1) * contentMeta.limit + 1;
+ const currentPageEnd = totalContentItems === 0 ? 0 : Math.min(currentPageStart + content.length - 1, totalContentItems);
+ const canGoToPreviousPage = contentMeta.page > 1;
+ const canGoToNextPage = contentMeta.page < contentMeta.totalPages;
+ const goToPreviousPage = () => {
+ if (canGoToPreviousPage) setContentPage(page => Math.max(1, page - 1));
+ };
+ const goToNextPage = () => {
+ if (canGoToNextPage) setContentPage(page => page + 1);
+ };
 
  return (
  <div className="flex h-full">
@@ -941,7 +972,11 @@ export default function ContentClient() {
  <FolderTree
  folders={folders}
  selectedFolderId={selectedFolderId}
- onSelectFolder={setSelectedFolderId}
+ onSelectFolder={(folderId) => {
+ setSelectedFolderId(folderId);
+ setSelectedItems(new Set());
+ setContentPage(1);
+ }}
  onCreateFolder={() => setIsCreateFolderModalOpen(true)}
  />
  </div>
@@ -954,7 +989,7 @@ export default function ContentClient() {
  <div>
  <h2 className="eh-dash-title text-2xl">Content Library</h2>
  <p className="mt-1 text-sm text-[var(--foreground-secondary)] flex items-center gap-2">
- {content.length} items
+ {totalContentItems} items
  {realtimeStatus === 'connected' && (
  <span className="inline-flex items-center gap-1" title="Real-time sync enabled">
  <span className="w-2 h-2 bg-green-500 rounded-full animate-pulse"></span>
@@ -992,7 +1027,10 @@ export default function ContentClient() {
  <div className="flex-1 min-w-[200px]">
  <SearchFilter
  value={searchQuery}
- onChange={setSearchQuery}
+ onChange={(value) => {
+ setSearchQuery(value);
+ setSelectedItems(new Set());
+ }}
  placeholder="Search content by title..."
  />
  </div>
@@ -1002,7 +1040,11 @@ export default function ContentClient() {
  {['all', 'image', 'video', 'pdf', 'url'].map((type) => (
  <button
  key={type}
- onClick={() => setFilterType(type)}
+ onClick={() => {
+ setFilterType(type);
+ setSelectedItems(new Set());
+ setContentPage(1);
+ }}
  className={filterType === type ? 'eh-filter-pill eh-filter-pill-active' : 'eh-filter-pill'}
  >
  {type.charAt(0).toUpperCase() + type.slice(1)}
@@ -1046,11 +1088,19 @@ export default function ContentClient() {
  <ContentTagger
  tags={tags}
  selectedTags={selectedTags}
- onChange={setSelectedTags}
+ onChange={(tagIds) => {
+ setSelectedTags(tagIds);
+ setSelectedItems(new Set());
+ setContentPage(1);
+ }}
  />
  {selectedTags.length > 0 && (
  <button
- onClick={() => setSelectedTags([])}
+ onClick={() => {
+ setSelectedTags([]);
+ setSelectedItems(new Set());
+ setContentPage(1);
+ }}
  className="mt-3 text-sm text-[var(--primary)] hover:underline"
  >
  Clear tag filters
@@ -1065,17 +1115,31 @@ export default function ContentClient() {
  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
  <div>
  <label className="block text-sm font-medium text-[var(--foreground-secondary)] mb-2">Status</label>
- <select value={filterStatus} onChange={(e) => setFilterStatus(e.target.value)} className="eh-select">
+ <select value={filterStatus} onChange={(e) => {
+ setFilterStatus(e.target.value);
+ setSelectedItems(new Set());
+ setContentPage(1);
+ }} className="eh-select">
  <option value="all">All Statuses</option>
+ <option value="active">Active</option>
  <option value="ready">Ready</option>
  <option value="processing">Processing</option>
  <option value="error">Error</option>
+ <option value="draft">Draft</option>
  <option value="flagged">Flagged</option>
+ <option value="pending_approval">Pending Approval</option>
+ <option value="rejected">Rejected</option>
+ <option value="archived">Archived</option>
+ <option value="expired">Expired</option>
  </select>
  </div>
  <div>
  <label className="block text-sm font-medium text-[var(--foreground-secondary)] mb-2">Upload Date</label>
- <select value={filterDateRange} onChange={(e) => setFilterDateRange(e.target.value as any)} className="eh-select">
+ <select value={filterDateRange} onChange={(e) => {
+ setFilterDateRange(e.target.value as 'all' | '7days' | '30days' | '90days');
+ setSelectedItems(new Set());
+ setContentPage(1);
+ }} className="eh-select">
  <option value="all">All Time</option>
  <option value="7days">Last 7 days</option>
  <option value="30days">Last 30 days</option>
@@ -1100,7 +1164,7 @@ export default function ContentClient() {
  {/* Search results count */}
  {debouncedSearch && (
  <p className="text-sm text-[var(--foreground-secondary)]">
- {filteredContent.length} {filteredContent.length === 1 ? 'result' : 'results'} found
+ {totalContentItems} {totalContentItems === 1 ? 'result' : 'results'} found
  </p>
  )}
 
@@ -1108,7 +1172,11 @@ export default function ContentClient() {
  <FolderBreadcrumb
  folders={folders}
  currentFolderId={selectedFolderId}
- onNavigate={setSelectedFolderId}
+ onNavigate={(folderId) => {
+ setSelectedFolderId(folderId);
+ setSelectedItems(new Set());
+ setContentPage(1);
+ }}
  />
 
  {/* Bulk Actions Toolbar */}
@@ -1147,6 +1215,37 @@ export default function ContentClient() {
  </div>
  )}
 
+ {!loading && totalContentItems > 0 && (
+ <div className="flex flex-col gap-3 text-sm text-[var(--foreground-secondary)] sm:flex-row sm:items-center sm:justify-between">
+ <span>
+ {currentPageStart}-{currentPageEnd} of {totalContentItems} items
+ </span>
+ <div className="flex flex-wrap items-center gap-2">
+ <button
+ type="button"
+ aria-label="Previous page"
+ onClick={goToPreviousPage}
+ disabled={!canGoToPreviousPage}
+ className="eh-btn-secondary px-3 py-1.5 text-sm disabled:opacity-50"
+ >
+ Previous
+ </button>
+ <span className="text-xs text-[var(--foreground-tertiary)]">
+ Page {contentMeta.page} of {Math.max(contentMeta.totalPages, 1)}
+ </span>
+ <button
+ type="button"
+ aria-label="Next page"
+ onClick={goToNextPage}
+ disabled={!canGoToNextPage}
+ className="eh-btn-secondary px-3 py-1.5 text-sm disabled:opacity-50"
+ >
+ Next
+ </button>
+ </div>
+ </div>
+ )}
+
  {/* Content Grid */}
  {loading ? (
  <div className="eh-dash-card p-12">
@@ -1155,8 +1254,8 @@ export default function ContentClient() {
  ) : filteredContent.length === 0 ? (
  <EmptyState
  icon="folder"
- title="No content yet"
- description="Start by uploading your first media file"
+ title={hasActiveFilters ? 'No matching content' : 'No content yet'}
+ description={hasActiveFilters ? 'Try changing or clearing your filters' : 'Start by uploading your first media file'}
  action={{
  label: 'Upload Content',
  onClick: () => setIsUploadModalOpen(true),

--- a/web/src/lib/api/content.ts
+++ b/web/src/lib/api/content.ts
@@ -4,9 +4,20 @@ import { devLog } from '../logger';
 import type { Content, PaginatedResponse, ContentFolder } from '../types';
 import { ApiClient, getCsrfToken } from './client';
 
+export interface ContentListParams {
+  page?: number;
+  limit?: number;
+  type?: string;
+  status?: string;
+  templateOrientation?: 'landscape' | 'portrait' | 'both';
+  search?: string;
+  dateRange?: '7days' | '30days' | '90days';
+  tagNames?: string[];
+}
+
 declare module './client' {
   interface ApiClient {
-    getContent(params?: { page?: number; limit?: number; type?: string; status?: string; templateOrientation?: 'landscape' | 'portrait' | 'both' }): Promise<PaginatedResponse<Content>>;
+    getContent(params?: ContentListParams): Promise<PaginatedResponse<Content>>;
     getContentItem(id: string): Promise<Content>;
     createContent(data: { title: string; type: string; url?: string; file?: File; metadata?: Record<string, unknown> }): Promise<Content>;
     updateContent(id: string, data: Partial<{ title: string; metadata?: Record<string, unknown> }>): Promise<Content>;
@@ -25,20 +36,30 @@ declare module './client' {
     updateFolder(id: string, data: { name?: string; parentId?: string }): Promise<ContentFolder>;
     deleteFolder(id: string): Promise<void>;
     moveContentToFolder(folderId: string, contentIds: string[]): Promise<{ moved: number }>;
-    getFolderContent(folderId: string, params?: { page?: number; limit?: number }): Promise<PaginatedResponse<Content>>;
+    getFolderContent(folderId: string, params?: ContentListParams): Promise<PaginatedResponse<Content>>;
   }
 }
 
-ApiClient.prototype.getContent = async function (params?: {
-  page?: number;
-  limit?: number;
-  type?: string;
-  status?: string;
-  templateOrientation?: 'landscape' | 'portrait' | 'both';
-}): Promise<PaginatedResponse<Content>> {
-  const query = params ? new URLSearchParams(
-    Object.fromEntries(Object.entries(params).filter(([_, v]) => v !== undefined)) as Record<string, string>
-  ).toString() : '';
+const buildContentListQuery = (params?: ContentListParams): string => {
+  if (!params) return '';
+  const query = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined || value === null) return;
+    if (Array.isArray(value)) {
+      if (value.length > 0) {
+        query.set(key, value.join(','));
+      }
+      return;
+    }
+    query.set(key, String(value));
+  });
+
+  return query.toString();
+};
+
+ApiClient.prototype.getContent = async function (params?: ContentListParams): Promise<PaginatedResponse<Content>> {
+  const query = buildContentListQuery(params);
   return this.request<PaginatedResponse<Content>>(`/content${query ? `?${query}` : ''}`);
 };
 
@@ -285,7 +306,7 @@ ApiClient.prototype.moveContentToFolder = async function (folderId: string, cont
   });
 };
 
-ApiClient.prototype.getFolderContent = async function (folderId: string, params?: { page?: number; limit?: number }): Promise<PaginatedResponse<Content>> {
-  const query = params ? new URLSearchParams(params as Record<string, string>).toString() : '';
+ApiClient.prototype.getFolderContent = async function (folderId: string, params?: ContentListParams): Promise<PaginatedResponse<Content>> {
+  const query = buildContentListQuery(params);
   return this.request<PaginatedResponse<Content>>(`/folders/${folderId}/content${query ? `?${query}` : ''}`);
 };


### PR DESCRIPTION
## Summary
- Adds tenant-scoped server-side content library filters (`search`, `dateRange`, `tagNames`) for root and folder content lists.
- Changes the dashboard content library to fetch bounded pages instead of loading all content rows and filtering client-side.
- Adds a folder/content list index for `organizationId`, `folderId`, and newest-first ordering.

## Review
- Backend/API/data reviewer: CLEAN. Residual risk: legacy `metadata.tags` JSON fallback remains exact-case; relation-backed tag filtering is case-insensitive.
- Dashboard UX/performance reviewer found pagination/refetch issues; fixes landed and targeted re-review was CLEAN.

## Verification
- `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=content-query.dto|content.service|content.controller|folders.service|folders.controller` (10 suites / 352 tests)
- `pnpm --filter @vizora/web test -- --runInBand --testPathPattern=dashboard/content` (1 suite / 35 tests, after final cleanup)
- `pnpm --filter @vizora/middleware test -- --runInBand` (143 suites / 2873 tests)
- `pnpm --filter @vizora/web test -- --runInBand` (95 suites / 980 tests; unrelated existing React act/jsdom warnings)
- `pnpm --filter @vizora/database exec prisma validate --schema prisma/schema.prisma`
- `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
- `pnpm --filter @vizora/web exec tsc --noEmit --pretty false`
- Changed-file ESLint: 0 errors, 25 existing warnings in touched broad files
- `git diff --check` (CRLF warnings only)
- `NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 BACKEND_URL=http://localhost:3000 NODE_OPTIONS=--max-old-space-size=4096 npx nx run-many --target=build --projects=@vizora/middleware,@vizora/web,@vizora/realtime`

## Deployment
- Not deployed. Production checkout remains dirty/diverged and must be preserved/classified before any pull/reload/deploy.