### PR TITLE
feat: use analytics summary for dashboard overview

### DIFF
--- a/docs/plans/2026-05-31-dashboard-summary-performance-pass-15.md
+++ b/docs/plans/2026-05-31-dashboard-summary-performance-pass-15.md
@@ -1,0 +1,77 @@
+# Dashboard Summary Performance Pass 15
+
+Date: 2026-05-31
+Branch: `feat/customer-dashboard-pass-15`
+
+## Context
+
+PR #137 moved the content library to bounded server-side pagination and
+filtering. The next customer-visible dashboard performance issue is now the
+overview page: it still performs all-page content and playlist refreshes on the
+client when the server-rendered first page is incomplete. For real customer
+libraries, this recreates the same "load every row to show one dashboard" risk
+that Pass 14 removed from the content library.
+
+## New primitives introduced
+
+Extend the existing `GET /api/v1/analytics/summary` response with two aggregate
+dashboard counters:
+
+- `processingContent`
+- `activePlaylists`
+
+No new service, module, worker, PM2 process, env var, or datastore is added.
+
+## Hermes-first analysis
+
+Not applicable. This pass does not add business agents, MCP tools, Hermes
+skills, AI/provider calls, or spend paths.
+
+## Customer Dashboard Improvement List
+
+Ranked repo-side improvements a paying customer would notice:
+
+1. **Overview speed at scale** — the dashboard overview should show totals
+   from aggregate endpoints and load only recent activity samples, not every
+   content/playlist row.
+2. **Recent activity trust** — activity cards should use fresh bounded samples
+   and device realtime state without blocking the page on large libraries.
+3. **Pairing confidence** — pairing pages should keep copy and token lifecycle
+   clear; most recent work already closed the obvious pairing-code drift.
+4. **Content upload confidence** — uploads now use disk-backed temp files and
+   bounded concurrency; future work is resumable/direct upload, which is larger.
+5. **Critical-path smoke confidence** — prod smoke remains operator-gated, but
+   repo-side smoke should stay aligned with upload, pairing, streaming, playlist,
+   and schedule paths.
+
+## Selected Slice
+
+Replace dashboard overview all-page content/playlist refreshes with:
+
+- `GET /analytics/summary` for aggregate totals.
+- `GET /content?page=1&limit=3` for recent content activity.
+- `GET /playlists?page=1&limit=3` for recent playlist activity.
+- Existing storage and readiness probes unchanged.
+
+The analytics summary remains tenant-scoped through the existing
+`CurrentUser('organizationId')` path. Summary read access should include
+`viewer`, matching the read-only nature of dashboard overview counts.
+
+## Implementation Plan
+
+- Add failing backend tests proving summary returns `processingContent` and
+  `activePlaylists` using aggregate/count queries.
+- Add failing dashboard tests proving overview does not fetch beyond the first
+  small sample page and gets totals from `getAnalyticsSummary`.
+- Extend analytics summary DTO/types and controller role access.
+- Update dashboard server component and client component to pass/use
+  `initialStats` and refresh via summary + bounded samples.
+- Run focused middleware/web tests, reviewer checks, broader affected tests,
+  build, CI, merge.
+
+## Deploy Gate
+
+Production deployment remains blocked because `/opt/vizora/app` is dirty and
+diverged with unclassified local work. No prod pull, reset, stash, env edit,
+service restart, DB mutation, or deploy should happen until that state is
+preserved/promoted intentionally.

--- a/middleware/src/modules/analytics/analytics.controller.spec.ts
+++ b/middleware/src/modules/analytics/analytics.controller.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { Reflector } from '@nestjs/core';
 import { AnalyticsController } from './analytics.controller';
 import { AnalyticsService } from './analytics.service';
 
@@ -114,6 +115,12 @@ describe('AnalyticsController', () => {
 
       expect(result).toEqual(mockData);
       expect(mockAnalyticsService.getSummary).toHaveBeenCalledWith(organizationId);
+    });
+
+    it('allows viewers to read summary metadata', () => {
+      const roles = new Reflector().get<string[]>('roles', controller.getSummary);
+
+      expect(roles).toEqual(expect.arrayContaining(['admin', 'manager', 'viewer']));
     });
   });
 

--- a/middleware/src/modules/analytics/analytics.controller.ts
+++ b/middleware/src/modules/analytics/analytics.controller.ts
@@ -67,7 +67,7 @@ export class AnalyticsController {
   }
 
   @Get('summary')
-  @Roles('admin', 'manager')
+  @Roles('admin', 'manager', 'viewer')
   getSummary(
     @CurrentUser('organizationId') organizationId: string,
   ) {

--- a/middleware/src/modules/analytics/analytics.service.spec.ts
+++ b/middleware/src/modules/analytics/analytics.service.spec.ts
@@ -209,6 +209,8 @@ describe('AnalyticsService', () => {
       expect(result.onlineDevices).toBe(0);
       expect(result.totalContent).toBe(0);
       expect(result.totalPlaylists).toBe(0);
+      expect(result.processingContent).toBe(0);
+      expect(result.activePlaylists).toBe(0);
       expect(result.uptimePercent).toBe(0);
       expect(result.totalImpressions).toBe(0);
     });
@@ -217,8 +219,12 @@ describe('AnalyticsService', () => {
       mockDb.display.count
         .mockResolvedValueOnce(10) // total
         .mockResolvedValueOnce(8); // online
-      mockDb.content.count.mockResolvedValue(50);
-      mockDb.playlist.count.mockResolvedValue(5);
+      mockDb.content.count.mockImplementation((args: any) => (
+        args.where?.status === 'processing' ? Promise.resolve(4) : Promise.resolve(50)
+      ));
+      mockDb.playlist.count.mockImplementation((args: any) => (
+        args.where?.OR ? Promise.resolve(3) : Promise.resolve(5)
+      ));
       mockDb.contentImpression.count.mockResolvedValue(1200);
       mockDb.content.aggregate.mockResolvedValue({ _sum: { fileSize: 1024000 } });
 
@@ -227,9 +233,20 @@ describe('AnalyticsService', () => {
       expect(result.onlineDevices).toBe(8);
       expect(result.uptimePercent).toBe(80);
       expect(result.totalContent).toBe(50);
+      expect(result.processingContent).toBe(4);
       expect(result.totalPlaylists).toBe(5);
+      expect(result.activePlaylists).toBe(3);
       expect(result.totalContentSize).toBe(1024000);
       expect(result.totalImpressions).toBe(1200);
+      expect(mockDb.content.count).toHaveBeenCalledWith({
+        where: { organizationId: 'org-123', status: 'processing' },
+      });
+      expect(mockDb.playlist.count).toHaveBeenCalledWith({
+        where: {
+          organizationId: 'org-123',
+          OR: [{ isDefault: true }, { items: { some: {} } }],
+        },
+      });
     });
   });
 

--- a/middleware/src/modules/analytics/analytics.service.ts
+++ b/middleware/src/modules/analytics/analytics.service.ts
@@ -283,20 +283,35 @@ export class AnalyticsService {
     const thirtyDaysAgo = new Date();
     thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
-    const [totalDevices, onlineDevices, totalContent, totalPlaylists, totalImpressions] = await Promise.all([
+    const [
+      totalDevices,
+      onlineDevices,
+      totalContent,
+      processingContent,
+      totalPlaylists,
+      activePlaylists,
+      totalImpressions,
+      contentSize,
+    ] = await Promise.all([
       this.db.display.count({ where: { organizationId } }),
       this.db.display.count({ where: { organizationId, status: 'online' } }),
       this.db.content.count({ where: { organizationId } }),
+      this.db.content.count({ where: { organizationId, status: 'processing' } }),
       this.db.playlist.count({ where: { organizationId } }),
+      this.db.playlist.count({
+        where: {
+          organizationId,
+          OR: [{ isDefault: true }, { items: { some: {} } }],
+        },
+      }),
       this.db.contentImpression.count({
         where: { organizationId, timestamp: { gte: thirtyDaysAgo } },
       }),
+      this.db.content.aggregate({
+        where: { organizationId },
+        _sum: { fileSize: true },
+      }),
     ]);
-
-    const contentSize = await this.db.content.aggregate({
-      where: { organizationId },
-      _sum: { fileSize: true },
-    });
 
     const uptimePercent = totalDevices > 0
       ? ((onlineDevices / totalDevices) * 100).toFixed(1)
@@ -306,7 +321,9 @@ export class AnalyticsService {
       totalDevices,
       onlineDevices,
       totalContent,
+      processingContent,
       totalPlaylists,
+      activePlaylists,
       totalContentSize: contentSize._sum.fileSize || 0,
       uptimePercent: parseFloat(uptimePercent),
       totalImpressions,

--- a/middleware/src/modules/analytics/dto/analytics-response.dto.ts
+++ b/middleware/src/modules/analytics/dto/analytics-response.dto.ts
@@ -46,7 +46,9 @@ export interface AnalyticsSummary {
   totalDevices: number;
   onlineDevices: number;
   totalContent: number;
+  processingContent: number;
   totalPlaylists: number;
+  activePlaylists: number;
   totalContentSize: number;
   uptimePercent: number;
   totalImpressions: number;

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,94 @@
 # Vizora - Task Tracker
 
-## In Progress: Content Library Performance Pass 14 (2026-05-31)
+## In Progress: Dashboard Summary Performance Pass 15 (2026-05-31)
+
+**Branch:** `feat/customer-dashboard-pass-15`
+
+**Why now:** PR #137 merged server-side content-library pagination/filtering,
+but the dashboard overview still risks all-page content/playlist refreshes just
+to compute top-level counts. A customer with a real media library should see the
+overview hydrate from aggregate counters and tiny recent-activity samples.
+
+**New primitives introduced:** two aggregate fields on the existing analytics
+summary response: `processingContent` and `activePlaylists`.
+
+**Hermes-first analysis:** not applicable. This pass does not add business
+agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
+
+**Plan**
+- [x] Merge PR #137 after CI green.
+- [x] Re-check production deploy gate after merge.
+- [x] Start fresh branch from `origin/main`.
+- [x] Write scoped plan/design for dashboard summary performance.
+- [x] Collect multi-subagent customer/performance/security/test review
+  findings before test gate.
+- [x] Add focused failing tests.
+- [x] Implement analytics-summary-backed dashboard overview.
+- [x] Run multi-subagent code review before broader tests.
+- [x] Run focused and broader affected verification.
+- [ ] PR, CI, merge.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Plan/design:**
+`docs/plans/2026-05-31-dashboard-summary-performance-pass-15.md`
+
+**Current merge/deploy state**
+- [x] PR #137 merged at
+  `7d32929678162e60ad7560f7c3cc81db4c9fc019`; CI green for audit, build, e2e,
+  lint, security, and test.
+- [x] Prod deploy remains blocked: `/opt/vizora/app` is on `main` at
+  `bb76aa1838740bff5b58623dfef7a906d44f46a6`, ahead 17 and behind 77 from
+  `origin/main`, with tracked edits across Hermes scripts, seed templates,
+  thumbnails, landing UI, Tailwind config, plus untracked operator approvals,
+  docs, and preview assets. No production pull, reset, stash, env edit,
+  service restart, DB mutation, or deploy performed.
+
+**Review**
+- [x] Pre-implementation customer/performance/security/test review found the
+  next high-value repo-side dashboard/performance slice: replace overview
+  all-page refreshes with analytics aggregates and bounded activity samples.
+- [x] Backend contract/security review CLEAN: `/analytics/summary` remains
+  tenant-scoped, envelope-compatible, and safe for `viewer` read access.
+- [x] Frontend/runtime review found two blockers: missing server activity
+  samples were not retried, and late summary refreshes could overwrite fresher
+  realtime device counts. Both were fixed and regression-tested.
+- [x] Test/CI review found `AnalyticsSummary` should keep backend-required
+  fields required in web types and that viewer role metadata needed a test.
+  Both were fixed.
+- [x] Follow-up review CLEAN after fixes.
+
+**Verification**
+- [x] Focused middleware tests passed:
+  `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="analytics.(service|controller)"`
+  (2 suites, 47 tests).
+- [x] Focused dashboard tests passed:
+  `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/dashboard/__tests__/dashboard-page.test.tsx src/app/dashboard/__tests__/dashboard-server-page.test.tsx`
+  (2 suites, 20 tests).
+- [x] Broader dashboard web tests passed:
+  `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="dashboard"`
+  (22 suites, 303 tests; pre-existing React `act(...)` warnings remain).
+- [x] Full middleware tests passed:
+  `pnpm --filter @vizora/middleware test -- --runInBand`
+  (143 suites, 2874 tests).
+- [x] Full web tests passed:
+  `pnpm --filter @vizora/web test -- --runInBand`
+  (95 suites, 982 tests; pre-existing React `act(...)` and jsdom navigation
+  warnings remain).
+- [x] TypeScript passed:
+  `pnpm --filter @vizora/web exec tsc --noEmit` and
+  `pnpm --filter @vizora/middleware exec tsc --noEmit`.
+- [x] Builds passed:
+  `npx nx build @vizora/middleware`, `npx nx build @vizora/realtime`, and
+  `npx nx build @vizora/web` with the standard local public URL env vars.
+  The first realtime build attempt failed only because it ran concurrently with
+  middleware build and Windows locked `packages/database/dist/generated/prisma`;
+  sequential rerun passed.
+- [x] Changed-file ESLint passed with warnings only; `git diff --check` passed
+  with CRLF warnings only.
+
+---
+
+## Completed: Content Library Performance Pass 14 (2026-05-31)
 
 **Branch:** `feat/customer-performance-pass-14`
 
@@ -27,14 +115,16 @@ agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
 - [x] Implement backend query filters and web paged loading.
 - [x] Run multi-subagent code review before broader tests.
 - [x] Run focused and broader affected verification.
-- [ ] PR, CI, merge.
-- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+- [x] PR, CI, merge.
+- [x] Re-check deployment gate; deploy only if prod checkout is safe.
 
 **Current merge/deploy state**
 - [x] PR #136 merged at
   `35609734a185366f981efc47246e46229836f22d`; CI green for audit, build, e2e,
   lint, security, and test.
-- [x] No open GitHub PRs after #136 merge.
+- [x] PR #137 merged at
+  `7d32929678162e60ad7560f7c3cc81db4c9fc019`; CI green for audit, build, e2e,
+  lint, security, and test.
 - [x] Prod deploy remains blocked: `/opt/vizora/app` is dirty and
   ahead/behind stale prod `origin/main`, with many local template/web/script
   changes and untracked operator/docs assets. No production pull, reset, stash,
@@ -91,8 +181,8 @@ agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
 - [x] `git diff --check` passed; Windows CRLF conversion warnings only.
 
 **Residual risks / deploy gate**
-- [ ] CI pending until PR is opened.
-- [ ] Production deploy still blocked by the dirty/diverged prod checkout.
+- [x] CI green and PR #137 merged.
+- [x] Production deploy still blocked by the dirty/diverged prod checkout.
   No production pull, reset, stash, env edit, service restart, DB mutation, or
   deploy performed.
 

--- a/web/src/app/dashboard/__tests__/dashboard-page.test.tsx
+++ b/web/src/app/dashboard/__tests__/dashboard-page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import type { ComponentProps } from 'react';
 import DashboardClient from '../page-client';
 import { apiClient } from '@/lib/api';
@@ -22,6 +22,17 @@ jest.mock('@/lib/api', () => ({
   apiClient: {
     getContent: jest.fn().mockResolvedValue({ data: [] }),
     getPlaylists: jest.fn().mockResolvedValue({ data: [] }),
+    getAnalyticsSummary: jest.fn().mockResolvedValue({
+      totalDevices: 0,
+      onlineDevices: 0,
+      totalContent: 0,
+      processingContent: 0,
+      totalPlaylists: 0,
+      activePlaylists: 0,
+      totalImpressions: 0,
+      totalContentSize: 0,
+      uptimePercent: 0,
+    }),
     getQuotaUsage: jest.fn().mockResolvedValue({ screensUsed: 0, screenQuota: 5, remaining: 5, percentUsed: 0 }),
     getStorageInfo: jest.fn().mockResolvedValue({ usedBytes: 0, quotaBytes: 1073741824, availableBytes: 1073741824, usagePercent: 0 }),
     get: jest.fn().mockResolvedValue({ status: 'ok' }),
@@ -62,8 +73,9 @@ async function renderDashboardClient(props: Partial<ComponentProps<typeof Dashbo
     <DashboardClient
       initialContent={props.initialContent ?? []}
       initialPlaylists={props.initialPlaylists ?? []}
-      initialContentComplete={props.initialContentComplete}
-      initialPlaylistsComplete={props.initialPlaylistsComplete}
+      initialStats={props.initialStats}
+      initialContentSampleReady={props.initialContentSampleReady}
+      initialPlaylistsSampleReady={props.initialPlaylistsSampleReady}
       initialStorageInfo={props.initialStorageInfo}
       initialSystemHealth={props.initialSystemHealth}
     />,
@@ -79,6 +91,17 @@ describe('DashboardClient', () => {
     jest.clearAllMocks();
     (apiClient.getContent as jest.Mock).mockReset().mockResolvedValue({ data: [] });
     (apiClient.getPlaylists as jest.Mock).mockReset().mockResolvedValue({ data: [] });
+    (apiClient.getAnalyticsSummary as jest.Mock).mockReset().mockResolvedValue({
+      totalDevices: 0,
+      onlineDevices: 0,
+      totalContent: 0,
+      processingContent: 0,
+      totalPlaylists: 0,
+      activePlaylists: 0,
+      totalImpressions: 0,
+      totalContentSize: 0,
+      uptimePercent: 0,
+    });
     (apiClient.getQuotaUsage as jest.Mock)
       .mockReset()
       .mockResolvedValue({ screensUsed: 0, screenQuota: 5, remaining: 5, percentUsed: 0 });
@@ -192,69 +215,201 @@ describe('DashboardClient', () => {
     expect(screen.getByText('Getting Started')).toBeInTheDocument();
   });
 
-  it('does not refetch content and playlists on mount when server pagination is complete', async () => {
+  it('does not refetch content and playlists on mount when server summary is present', async () => {
+    (apiClient.getAnalyticsSummary as jest.Mock).mockResolvedValueOnce({
+      totalDevices: 2,
+      onlineDevices: 1,
+      totalContent: 12,
+      processingContent: 3,
+      totalPlaylists: 4,
+      activePlaylists: 2,
+      totalImpressions: 0,
+      totalContentSize: 0,
+      uptimePercent: 0,
+    });
+
     await renderDashboardClient({
       initialContent: [{ id: 'c1' }],
       initialPlaylists: [{ id: 'p1', items: [{ id: 'item-1' }] }],
-      initialContentComplete: true,
-      initialPlaylistsComplete: true,
+      initialStats: {
+        devices: { total: 2, online: 1 },
+        content: { total: 12, processing: 3 },
+        playlists: { total: 4, active: 2 },
+      },
+      initialContentSampleReady: true,
+      initialPlaylistsSampleReady: true,
     });
 
+    expect(apiClient.getAnalyticsSummary).toHaveBeenCalledTimes(1);
     expect(apiClient.getContent).not.toHaveBeenCalled();
     expect(apiClient.getPlaylists).not.toHaveBeenCalled();
-    expect(screen.getByText('Content Items').parentElement?.parentElement).toHaveTextContent('1');
-    expect(screen.getByText('Playlists').parentElement?.parentElement).toHaveTextContent('1');
+    await waitFor(() => {
+      expect(screen.getByText('Total Devices').parentElement?.parentElement).toHaveTextContent('2');
+      expect(screen.getByText('Content Items').parentElement?.parentElement).toHaveTextContent('12');
+      expect(screen.getByText('Playlists').parentElement?.parentElement).toHaveTextContent('4');
+    });
   });
 
-  it('refreshes overview counts from all paginated pages on mount', async () => {
-    (apiClient.getContent as jest.Mock)
-      .mockResolvedValueOnce({
-        data: [{ id: 'c1' }],
-        meta: { page: 1, limit: 100, total: 2, totalPages: 2 },
-      })
-      .mockResolvedValueOnce({
-        data: [{ id: 'c2', status: 'processing' }],
-        meta: { page: 2, limit: 100, total: 2, totalPages: 2 },
-      });
+  it('refreshes overview totals from analytics summary and only samples recent activity', async () => {
+    (apiClient.getAnalyticsSummary as jest.Mock).mockResolvedValueOnce({
+      totalDevices: 10,
+      onlineDevices: 8,
+      totalContent: 250,
+      processingContent: 7,
+      totalPlaylists: 42,
+      activePlaylists: 31,
+      totalImpressions: 1200,
+      totalContentSize: 1024000,
+      uptimePercent: 80,
+    });
+    (apiClient.getContent as jest.Mock).mockResolvedValueOnce({
+      data: [{ id: 'c1', title: 'Fresh Menu', type: 'image', status: 'ready', createdAt: '2026-05-31T12:00:00.000Z' }],
+      meta: { page: 1, limit: 3, total: 250, totalPages: 84 },
+    });
     (apiClient.getPlaylists as jest.Mock).mockResolvedValue({
-      data: [{ id: 'p1', isActive: true }],
-      meta: { page: 1, limit: 100, total: 1, totalPages: 1 },
+      data: [{ id: 'p1', name: 'Lunch Loop', items: [{ id: 'i1' }] }],
+      meta: { page: 1, limit: 3, total: 42, totalPages: 14 },
     });
 
     render(<DashboardClient initialContent={[]} initialPlaylists={[]} />);
 
     await waitFor(() => {
-      expect(apiClient.getContent).toHaveBeenNthCalledWith(1, { page: 1, limit: 100 });
-      expect(apiClient.getContent).toHaveBeenNthCalledWith(2, { page: 2, limit: 100 });
-      expect(apiClient.getPlaylists).toHaveBeenCalledWith({ page: 1, limit: 100 });
+      expect(apiClient.getAnalyticsSummary).toHaveBeenCalledTimes(1);
+      expect(apiClient.getContent).toHaveBeenCalledWith({ page: 1, limit: 3 });
+      expect(apiClient.getPlaylists).toHaveBeenCalledWith({ page: 1, limit: 3 });
+      expect(screen.getByText('Total Devices').parentElement?.parentElement).toHaveTextContent('10');
+      expect(screen.getByText('Content Items').parentElement?.parentElement).toHaveTextContent('250');
+      expect(screen.getByText('Playlists').parentElement?.parentElement).toHaveTextContent('42');
     });
-    expect(screen.getByText('Content Items').parentElement?.parentElement).toHaveTextContent('2');
-    expect(screen.getByText('Playlists').parentElement?.parentElement).toHaveTextContent('1');
+    expect(apiClient.getContent).toHaveBeenCalledTimes(1);
+    expect(apiClient.getPlaylists).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('7 processing')).toBeInTheDocument();
+    expect(screen.getByText('31 ready')).toBeInTheDocument();
+    expect(screen.getByText('Fresh Menu')).toBeInTheDocument();
+    expect(screen.getByText('Lunch Loop')).toBeInTheDocument();
   });
 
-  it('preserves initial overview counts when all-page refresh partially fails', async () => {
-    (apiClient.getContent as jest.Mock).mockRejectedValueOnce(new Error('content unavailable'));
+  it('preserves initial overview counts when summary refresh fails', async () => {
+    (apiClient.getAnalyticsSummary as jest.Mock).mockRejectedValueOnce(new Error('summary unavailable'));
+    (apiClient.getContent as jest.Mock).mockResolvedValueOnce({ data: [] });
     (apiClient.getPlaylists as jest.Mock).mockResolvedValueOnce({
       data: [{ id: 'p1', isActive: true }],
-      meta: { page: 1, limit: 100, total: 1, totalPages: 1 },
+      meta: { page: 1, limit: 3, total: 1, totalPages: 1 },
     });
 
     render(
       <DashboardClient
         initialContent={[{ id: 'c1' }, { id: 'c2' }]}
         initialPlaylists={[{ id: 'p1', isActive: true }]}
+        initialStats={{
+          devices: { total: 0, online: 0 },
+          content: { total: 2, processing: 0 },
+          playlists: { total: 1, active: 1 },
+        }}
       />,
     );
 
     await waitFor(() => {
-      expect(apiClient.getContent).toHaveBeenCalledWith({ page: 1, limit: 100 });
+      expect(apiClient.getAnalyticsSummary).toHaveBeenCalledTimes(1);
       expect(screen.getByText('Some dashboard data could not refresh')).toBeInTheDocument();
     });
     expect(screen.getByText('Content Items').parentElement?.parentElement).toHaveTextContent('2');
     expect(screen.getByText('Playlists').parentElement?.parentElement).toHaveTextContent('1');
   });
 
+  it('retries missing initial activity samples when summary totals indicate data exists', async () => {
+    (apiClient.getAnalyticsSummary as jest.Mock).mockResolvedValueOnce({
+      totalDevices: 0,
+      onlineDevices: 0,
+      totalContent: 5,
+      processingContent: 1,
+      totalPlaylists: 4,
+      activePlaylists: 3,
+      totalImpressions: 0,
+      totalContentSize: 0,
+      uptimePercent: 0,
+    });
+    (apiClient.getContent as jest.Mock).mockResolvedValueOnce({
+      data: [{ id: 'c1', title: 'Recovered Menu', type: 'image', status: 'ready', createdAt: '2026-05-31T12:00:00.000Z' }],
+      meta: { page: 1, limit: 3, total: 5, totalPages: 2 },
+    });
+    (apiClient.getPlaylists as jest.Mock).mockResolvedValueOnce({
+      data: [{ id: 'p1', name: 'Recovered Loop', items: [{ id: 'i1' }] }],
+      meta: { page: 1, limit: 3, total: 4, totalPages: 2 },
+    });
+
+    render(
+      <DashboardClient
+        initialContent={[]}
+        initialPlaylists={[]}
+        initialStats={{
+          devices: { total: 0, online: 0 },
+          content: { total: 5, processing: 1 },
+          playlists: { total: 4, active: 3 },
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(apiClient.getContent).toHaveBeenCalledWith({ page: 1, limit: 3 });
+      expect(apiClient.getPlaylists).toHaveBeenCalledWith({ page: 1, limit: 3 });
+      expect(screen.getByText('Recovered Menu')).toBeInTheDocument();
+      expect(screen.getByText('Recovered Loop')).toBeInTheDocument();
+    });
+  });
+
+  it('keeps live realtime device counts when a summary refresh arrives later', async () => {
+    let resolveSummary: (value: unknown) => void = () => {};
+    (apiClient.getAnalyticsSummary as jest.Mock).mockImplementationOnce(() => new Promise((resolve) => {
+      resolveSummary = resolve;
+    }));
+    mockDeviceStatusContext = {
+      deviceStatuses: {
+        d1: { id: 'd1', status: 'online', metadata: { nickname: 'Lobby Screen' } },
+        d2: { id: 'd2', status: 'offline', metadata: { nickname: 'Kitchen Screen' } },
+      },
+      isInitialized: true,
+    };
+
+    render(<DashboardClient initialContent={[]} initialPlaylists={[]} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Total Devices').parentElement?.parentElement).toHaveTextContent('2');
+      expect(screen.getByText('1 online')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      resolveSummary({
+        totalDevices: 10,
+        onlineDevices: 0,
+        totalContent: 0,
+        processingContent: 0,
+        totalPlaylists: 0,
+        activePlaylists: 0,
+        totalImpressions: 0,
+        totalContentSize: 0,
+        uptimePercent: 0,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Total Devices').parentElement?.parentElement).toHaveTextContent('10');
+      expect(screen.getByText('1 online')).toBeInTheDocument();
+    });
+  });
+
   it('refreshes recent activity after a partial content refresh succeeds', async () => {
+    (apiClient.getAnalyticsSummary as jest.Mock).mockResolvedValueOnce({
+      totalDevices: 0,
+      onlineDevices: 0,
+      totalContent: 1,
+      processingContent: 0,
+      totalPlaylists: 0,
+      activePlaylists: 0,
+      totalImpressions: 0,
+      totalContentSize: 0,
+      uptimePercent: 0,
+    });
     (apiClient.getContent as jest.Mock).mockResolvedValueOnce({
       data: [{
         id: 'c-new',
@@ -263,7 +418,7 @@ describe('DashboardClient', () => {
         status: 'ready',
         createdAt: '2026-05-31T12:00:00.000Z',
       }],
-      meta: { page: 1, limit: 100, total: 1, totalPages: 1 },
+      meta: { page: 1, limit: 3, total: 1, totalPages: 1 },
     });
     (apiClient.getPlaylists as jest.Mock).mockRejectedValueOnce(new Error('playlists unavailable'));
 

--- a/web/src/app/dashboard/__tests__/dashboard-server-page.test.tsx
+++ b/web/src/app/dashboard/__tests__/dashboard-server-page.test.tsx
@@ -32,18 +32,27 @@ describe('DashboardPage server data', () => {
     mockedDashboardClient.mockClear();
   });
 
-  it('passes complete pagination flags and initial health/storage to the client', async () => {
+  it('passes analytics summary, bounded activity samples, and health/storage to the client', async () => {
     mockedServerFetch.mockImplementation(async (path) => {
       switch (path) {
-        case '/content?limit=100':
+        case '/analytics/summary':
+          return {
+            totalDevices: 10,
+            onlineDevices: 8,
+            totalContent: 250,
+            processingContent: 7,
+            totalPlaylists: 42,
+            activePlaylists: 31,
+          } as never;
+        case '/content?limit=3':
           return {
             data: [{ id: 'content-1' }],
-            meta: { page: 1, limit: 100, total: 1, totalPages: 1 },
+            meta: { page: 1, limit: 3, total: 250, totalPages: 84 },
           } as never;
-        case '/playlists?limit=100':
+        case '/playlists?limit=3':
           return {
             data: [{ id: 'playlist-1' }],
-            meta: { page: 1, limit: 100, total: 1, totalPages: 1 },
+            meta: { page: 1, limit: 3, total: 42, totalPages: 14 },
           } as never;
         case '/organizations/storage':
           return {
@@ -65,8 +74,13 @@ describe('DashboardPage server data', () => {
     expect(mockedDashboardClient.mock.calls[0][0]).toEqual(expect.objectContaining({
       initialContent: [{ id: 'content-1' }],
       initialPlaylists: [{ id: 'playlist-1' }],
-      initialContentComplete: true,
-      initialPlaylistsComplete: true,
+      initialStats: {
+        devices: { total: 10, online: 8 },
+        content: { total: 250, processing: 7 },
+        playlists: { total: 42, active: 31 },
+      },
+      initialContentSampleReady: true,
+      initialPlaylistsSampleReady: true,
       initialStorageInfo: {
         usedBytes: 1024,
         quotaBytes: 2048,
@@ -77,18 +91,27 @@ describe('DashboardPage server data', () => {
     }));
   });
 
-  it('marks paginated server data incomplete when more pages remain', async () => {
+  it('does not mark paginated server data incomplete when only bounded samples are fetched', async () => {
     mockedServerFetch.mockImplementation(async (path) => {
       switch (path) {
-        case '/content?limit=100':
+        case '/analytics/summary':
+          return {
+            totalDevices: 0,
+            onlineDevices: 0,
+            totalContent: 2,
+            processingContent: 0,
+            totalPlaylists: 2,
+            activePlaylists: 1,
+          } as never;
+        case '/content?limit=3':
           return {
             data: [{ id: 'content-1' }],
-            meta: { page: 1, limit: 100, total: 2, totalPages: 2 },
+            meta: { page: 1, limit: 3, total: 2, totalPages: 1 },
           } as never;
-        case '/playlists?limit=100':
+        case '/playlists?limit=3':
           return {
             data: [{ id: 'playlist-1' }],
-            meta: { page: 1, limit: 100, total: 2, totalPages: 2 },
+            meta: { page: 1, limit: 3, total: 2, totalPages: 1 },
           } as never;
         case '/organizations/storage':
           return null as never;
@@ -102,17 +125,24 @@ describe('DashboardPage server data', () => {
     render(await DashboardPage());
 
     expect(mockedDashboardClient.mock.calls[0][0]).toEqual(expect.objectContaining({
-      initialContentComplete: false,
-      initialPlaylistsComplete: false,
+      initialStats: {
+        devices: { total: 0, online: 0 },
+        content: { total: 2, processing: 0 },
+        playlists: { total: 2, active: 1 },
+      },
+      initialContentSampleReady: true,
+      initialPlaylistsSampleReady: true,
     }));
   });
 
   it('preserves unhealthy readiness from a server-side 503 response', async () => {
     mockedServerFetch.mockImplementation(async (path) => {
       switch (path) {
-        case '/content?limit=100':
-        case '/playlists?limit=100':
-          return { data: [], meta: { page: 1, limit: 100, total: 0, totalPages: 1 } } as never;
+        case '/analytics/summary':
+          return null as never;
+        case '/content?limit=3':
+        case '/playlists?limit=3':
+          return { data: [], meta: { page: 1, limit: 3, total: 0, totalPages: 1 } } as never;
         case '/organizations/storage':
           return null as never;
         case '/health/ready':

--- a/web/src/app/dashboard/page-client.tsx
+++ b/web/src/app/dashboard/page-client.tsx
@@ -3,13 +3,13 @@
 import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { apiClient } from '@/lib/api';
-import { fetchAllPaginated } from '@/lib/api/pagination';
 import type { StorageInfo } from '@/lib/api/organizations';
 import { useDeviceStatus } from '@/lib/context/DeviceStatusContext';
 import UpgradeBanner from '@/components/UpgradeBanner';
 import { HelpIcon } from '@/components/Tooltip';
 import { isApiError } from '@/lib/error-handler';
 import { Icon, type IconName, iconMap } from '@/theme/icons';
+import type { AnalyticsSummary } from '@/lib/types';
 
 // Helper to ensure valid icon names
 const getValidIconName = (name: string | undefined): IconName => {
@@ -22,8 +22,9 @@ const getValidIconName = (name: string | undefined): IconName => {
 interface DashboardClientProps {
  initialContent: any[];
  initialPlaylists: any[];
- initialContentComplete?: boolean;
- initialPlaylistsComplete?: boolean;
+ initialStats?: DashboardStats | null;
+ initialContentSampleReady?: boolean;
+ initialPlaylistsSampleReady?: boolean;
  initialStorageInfo?: StorageInfo | null;
  initialSystemHealth?: DashboardSystemHealth | null;
 }
@@ -41,10 +42,24 @@ type DashboardListResult = {
  data: any[];
 };
 
+type DashboardStats = {
+ devices: { total: number; online: number };
+ content: { total: number; processing: number };
+ playlists: { total: number; active: number };
+};
+
 const UNKNOWN_HEALTH: DashboardSystemHealth = {
  status: 'unknown',
  message: 'Readiness unavailable',
 };
+
+const EMPTY_STATS: DashboardStats = {
+ devices: { total: 0, online: 0 },
+ content: { total: 0, processing: 0 },
+ playlists: { total: 0, active: 0 },
+};
+
+const DASHBOARD_ACTIVITY_LIMIT = 3;
 
 const formatBytes = (bytes: number): string => {
  if (!Number.isFinite(bytes) || bytes <= 0) {
@@ -137,21 +152,60 @@ const loadSystemHealth = async (): Promise<DashboardSystemHealth> => {
  }
 };
 
+const statsFromSummary = (summary: AnalyticsSummary): DashboardStats => ({
+ devices: {
+ total: summary.totalDevices ?? 0,
+ online: summary.onlineDevices ?? 0,
+ },
+ content: {
+ total: summary.totalContent ?? 0,
+ processing: summary.processingContent ?? 0,
+ },
+ playlists: {
+ total: summary.totalPlaylists ?? 0,
+ active: summary.activePlaylists ?? 0,
+ },
+});
+
+const statsFromDeviceStatuses = (
+ statuses: Record<string, any>,
+ minimumTotal = 0,
+): DashboardStats['devices'] | null => {
+ const devicesList = Object.values(statuses);
+ if (devicesList.length === 0) {
+ return null;
+ }
+
+ return {
+ total: Math.max(minimumTotal, devicesList.length),
+ online: devicesList.filter((d: any) => d.status === 'online').length,
+ };
+};
+
+const statsFromSamples = (content: any[], playlists: any[]): DashboardStats => ({
+ devices: { ...EMPTY_STATS.devices },
+ content: {
+ total: content.length,
+ processing: content.filter((c: any) => c?.status === 'processing').length,
+ },
+ playlists: {
+ total: playlists.length,
+ active: playlists.filter((p: any) => (p?.items?.length || 0) > 0 || p?.isDefault === true).length,
+ },
+});
+
 export default function DashboardClient({
  initialContent,
  initialPlaylists,
- initialContentComplete = false,
- initialPlaylistsComplete = false,
+ initialStats = null,
+ initialContentSampleReady = false,
+ initialPlaylistsSampleReady = false,
  initialStorageInfo = null,
  initialSystemHealth = null,
 }: DashboardClientProps) {
  const router = useRouter();
  const { deviceStatuses, isInitialized } = useDeviceStatus();
- const [stats, setStats] = useState({
- devices: { total: 0, online: 0 },
- content: { total: 0, processing: 0 },
- playlists: { total: 0, active: 0 },
- });
+ const [stats, setStats] = useState<DashboardStats>(() => initialStats ?? statsFromSamples(initialContent, initialPlaylists));
  const [recentActivity, setRecentActivity] = useState<any[]>([]);
  const [storageInfo, setStorageInfo] = useState<StorageInfo | null>(initialStorageInfo);
  const [systemHealth, setSystemHealth] = useState<DashboardSystemHealth | null>(
@@ -172,20 +226,14 @@ export default function DashboardClient({
  activityContentRef.current = content;
  activityPlaylistsRef.current = playlists;
 
- setStats(prev => ({
+ setStats(prev => initialStats ?? {
  ...prev,
- content: {
- total: content.length,
- processing: content.filter((c: any) => c?.status === 'processing').length,
- },
- playlists: {
- total: playlists.length,
- active: playlists.filter((p: any) => (p?.items?.length || 0) > 0 || p?.isDefault === true).length,
- },
- }));
+ ...statsFromSamples(content, playlists),
+ devices: prev.devices,
+ });
 
  buildRecentActivity(content, playlists, deviceStatusesRef.current);
- }, [initialContent, initialPlaylists]);
+ }, [initialContent, initialPlaylists, initialStats]);
 
  useEffect(() => {
  setStorageInfo(initialStorageInfo);
@@ -203,13 +251,15 @@ export default function DashboardClient({
  useEffect(() => {
  if (!isInitialized) return;
 
- const devicesList = Object.values(deviceStatuses);
+ const deviceStats = statsFromDeviceStatuses(deviceStatuses);
+ if (!deviceStats) {
+ buildRecentActivity(activityContentRef.current, activityPlaylistsRef.current, deviceStatuses);
+ return;
+ }
+
  setStats(prev => ({
  ...prev,
- devices: {
- total: devicesList.length,
- online: devicesList.filter(d => d.status === 'online').length,
- },
+ devices: statsFromDeviceStatuses(deviceStatuses, prev.devices.total) ?? prev.devices,
  }));
  buildRecentActivity(activityContentRef.current, activityPlaylistsRef.current, deviceStatuses);
  }, [deviceStatuses, isInitialized]);
@@ -260,34 +310,37 @@ export default function DashboardClient({
  initialRefreshCompleteRef.current = true;
  }
 
- const contentPromise: Promise<DashboardListResult> = isInitialAutoRefresh && initialContentComplete
+ const summaryPromise = apiClient.getAnalyticsSummary();
+ const contentPromise: Promise<DashboardListResult> = isInitialAutoRefresh && initialContentSampleReady
  ? Promise.resolve({ data: activityContentRef.current })
- : fetchAllPaginated((params) => apiClient.getContent(params))
- .then((data) => ({ data }));
- const playlistsPromise: Promise<DashboardListResult> = isInitialAutoRefresh && initialPlaylistsComplete
+ : apiClient.getContent({ page: 1, limit: DASHBOARD_ACTIVITY_LIMIT })
+ .then((response) => ({ data: response.data ?? [] }));
+ const playlistsPromise: Promise<DashboardListResult> = isInitialAutoRefresh && initialPlaylistsSampleReady
  ? Promise.resolve({ data: activityPlaylistsRef.current })
- : fetchAllPaginated((params) => apiClient.getPlaylists(params))
- .then((data) => ({ data }));
+ : apiClient.getPlaylists({ page: 1, limit: DASHBOARD_ACTIVITY_LIMIT })
+ .then((response) => ({ data: response.data ?? [] }));
 
  const results = await Promise.allSettled([
+ summaryPromise,
  contentPromise,
  playlistsPromise,
  apiClient.getStorageInfo(),
  loadSystemHealth(),
  ]);
 
- const content = results[0].status === 'fulfilled' ? results[0].value.data : null;
- const playlists = results[1].status === 'fulfilled' ? results[1].value.data : null;
+ const summary = results[0].status === 'fulfilled' ? results[0].value : null;
+ const content = results[1].status === 'fulfilled' ? results[1].value.data : null;
+ const playlists = results[2].status === 'fulfilled' ? results[2].value.data : null;
  if (content) activityContentRef.current = content;
  if (playlists) activityPlaylistsRef.current = playlists;
- if (results[2].status === 'fulfilled') {
- setStorageInfo(results[2].value);
- }
  if (results[3].status === 'fulfilled') {
- setSystemHealth(results[3].value);
+ setStorageInfo(results[3].value);
+ }
+ if (results[4].status === 'fulfilled') {
+ setSystemHealth(results[4].value);
  }
 
- results.slice(0, 2).forEach((result, index) => {
+ results.slice(0, 3).forEach((result, index) => {
  if (result.status === 'rejected') {
  if (process.env.NODE_ENV === 'development') {
  console.warn(`API call ${index + 1} failed:`, result.reason);
@@ -295,25 +348,15 @@ export default function DashboardClient({
  }
  });
 
- setStats(prev => ({
- ...prev,
- ...(content
- ? {
- content: {
- total: content.length,
- processing: content.filter((c: any) => c?.status === 'processing').length,
- },
+ if (summary) {
+ setStats(() => {
+ const next = statsFromSummary(summary);
+ return {
+ ...next,
+ devices: statsFromDeviceStatuses(deviceStatusesRef.current, next.devices.total) ?? next.devices,
+ };
+ });
  }
- : {}),
- ...(playlists
- ? {
- playlists: {
- total: playlists.length,
- active: playlists.filter((p: any) => (p?.items?.length || 0) > 0 || p?.isDefault === true).length,
- },
- }
- : {}),
- }));
 
  if (content || playlists) {
  buildRecentActivity(
@@ -323,7 +366,7 @@ export default function DashboardClient({
  );
  }
 
- if (results[0].status === 'fulfilled' && results[1].status === 'fulfilled') {
+ if (results[0].status === 'fulfilled' && results[1].status === 'fulfilled' && results[2].status === 'fulfilled') {
  setError(null);
  } else {
  setError('Some dashboard data could not refresh');

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -2,20 +2,14 @@ import type { Metadata } from 'next';
 import { ServerFetchError, serverFetch } from '@/lib/server-api';
 import { unwrapPaginatedData } from '@/lib/api/pagination';
 import type { StorageInfo } from '@/lib/api/organizations';
+import type { AnalyticsSummary } from '@/lib/types';
 import DashboardClient from './page-client';
 
 export const metadata: Metadata = {
   title: 'Dashboard',
 };
 
-const DASHBOARD_PAGE_LIMIT = 100;
-
-type PaginationMeta = {
-  page?: number;
-  limit?: number;
-  total?: number;
-  totalPages?: number;
-};
+const DASHBOARD_ACTIVITY_LIMIT = 3;
 
 type DashboardHealthStatus = 'ok' | 'degraded' | 'unhealthy' | 'unknown';
 
@@ -24,36 +18,6 @@ interface DashboardSystemHealth {
   timestamp?: string;
   message?: string;
   checks?: Record<string, { status?: string; message?: string }>;
-}
-
-function getPaginationMeta(response: unknown): PaginationMeta | null {
-  if (!response || typeof response !== 'object') {
-    return null;
-  }
-
-  const body = response as { meta?: unknown };
-  if (!body.meta || typeof body.meta !== 'object') {
-    return null;
-  }
-
-  return body.meta as PaginationMeta;
-}
-
-function isPageComplete(items: unknown[], meta: PaginationMeta | null): boolean {
-  if (!meta) {
-    return items.length < DASHBOARD_PAGE_LIMIT;
-  }
-
-  if (typeof meta.page === 'number' && typeof meta.totalPages === 'number') {
-    return meta.page >= meta.totalPages;
-  }
-
-  if (typeof meta.total === 'number') {
-    return items.length >= meta.total;
-  }
-
-  const limit = typeof meta.limit === 'number' ? meta.limit : DASHBOARD_PAGE_LIMIT;
-  return items.length < limit;
 }
 
 function getUnhealthyReadinessFromError(reason: unknown): DashboardSystemHealth | null {
@@ -74,37 +38,61 @@ function getUnhealthyReadinessFromError(reason: unknown): DashboardSystemHealth 
   };
 }
 
+function getDashboardStatsFromSummary(summary: AnalyticsSummary | null) {
+  if (!summary) return null;
+
+  return {
+    devices: {
+      total: summary.totalDevices ?? 0,
+      online: summary.onlineDevices ?? 0,
+    },
+    content: {
+      total: summary.totalContent ?? 0,
+      processing: summary.processingContent ?? 0,
+    },
+    playlists: {
+      total: summary.totalPlaylists ?? 0,
+      active: summary.activePlaylists ?? 0,
+    },
+  };
+}
+
 export default async function DashboardPage() {
   let content: any[] = [];
   let playlists: any[] = [];
-  let initialContentComplete = false;
-  let initialPlaylistsComplete = false;
+  let summary: AnalyticsSummary | null = null;
+  let initialContentSampleReady = false;
+  let initialPlaylistsSampleReady = false;
   let storageInfo: StorageInfo | null = null;
   let systemHealth: DashboardSystemHealth | null = null;
 
   try {
     const results = await Promise.allSettled([
-      serverFetch<any>(`/content?limit=${DASHBOARD_PAGE_LIMIT}`),
-      serverFetch<any>(`/playlists?limit=${DASHBOARD_PAGE_LIMIT}`),
+      serverFetch<AnalyticsSummary>('/analytics/summary'),
+      serverFetch<any>(`/content?limit=${DASHBOARD_ACTIVITY_LIMIT}`),
+      serverFetch<any>(`/playlists?limit=${DASHBOARD_ACTIVITY_LIMIT}`),
       serverFetch<StorageInfo>('/organizations/storage'),
       serverFetch<DashboardSystemHealth>('/health/ready'),
     ]);
 
     if (results[0].status === 'fulfilled') {
-      content = unwrapPaginatedData(results[0].value);
-      initialContentComplete = isPageComplete(content, getPaginationMeta(results[0].value));
+      summary = results[0].value;
     }
     if (results[1].status === 'fulfilled') {
-      playlists = unwrapPaginatedData(results[1].value);
-      initialPlaylistsComplete = isPageComplete(playlists, getPaginationMeta(results[1].value));
+      content = unwrapPaginatedData(results[1].value);
+      initialContentSampleReady = true;
     }
     if (results[2].status === 'fulfilled') {
-      storageInfo = results[2].value;
+      playlists = unwrapPaginatedData(results[2].value);
+      initialPlaylistsSampleReady = true;
     }
     if (results[3].status === 'fulfilled') {
-      systemHealth = results[3].value;
+      storageInfo = results[3].value;
+    }
+    if (results[4].status === 'fulfilled') {
+      systemHealth = results[4].value;
     } else {
-      systemHealth = getUnhealthyReadinessFromError(results[3].reason);
+      systemHealth = getUnhealthyReadinessFromError(results[4].reason);
     }
   } catch {
     // Client handles empty state gracefully
@@ -114,8 +102,9 @@ export default async function DashboardPage() {
     <DashboardClient
       initialContent={content}
       initialPlaylists={playlists}
-      initialContentComplete={initialContentComplete}
-      initialPlaylistsComplete={initialPlaylistsComplete}
+      initialStats={getDashboardStatsFromSummary(summary)}
+      initialContentSampleReady={initialContentSampleReady}
+      initialPlaylistsSampleReady={initialPlaylistsSampleReady}
       initialStorageInfo={storageInfo}
       initialSystemHealth={systemHealth}
     />

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -319,9 +319,13 @@ export interface AnalyticsSummary {
   totalDevices: number;
   onlineDevices: number;
   totalContent: number;
+  processingContent: number;
   totalPlaylists: number;
+  activePlaylists: number;
   totalImpressions: number;
-  avgUptimePercent: number;
+  totalContentSize: number;
+  uptimePercent: number;
+  avgUptimePercent?: number;
 }
 
 export interface DeviceMetric {


### PR DESCRIPTION
## Summary
- adds `processingContent` and `activePlaylists` to the existing analytics summary response
- switches dashboard overview totals to `/analytics/summary` and keeps content/playlist calls to `limit=3` recent-activity samples
- preserves realtime device counts over late summary refreshes and retries missing server activity samples

## Review
- Backend/API review: CLEAN
- Frontend/runtime review: fixed sample-retry and realtime-count merge findings, follow-up CLEAN
- Test/CI review: fixed web `AnalyticsSummary` required fields and added viewer role metadata coverage

## Tests
- `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=analytics.(service|controller)`
- `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/dashboard/__tests__/dashboard-page.test.tsx src/app/dashboard/__tests__/dashboard-server-page.test.tsx`
- `pnpm --filter @vizora/web test -- --runInBand --testPathPattern=dashboard`
- `pnpm --filter @vizora/middleware test -- --runInBand`
- `pnpm --filter @vizora/web test -- --runInBand`
- `pnpm --filter @vizora/web exec tsc --noEmit`
- `pnpm --filter @vizora/middleware exec tsc --noEmit`
- `npx nx build @vizora/middleware`
- `npx nx build @vizora/realtime` (rerun sequentially after a Windows file-lock collision in the first parallel attempt)
- `npx nx build @vizora/web`
- changed-file ESLint: 0 errors, warnings only
- `git diff --check`: CRLF warnings only

## Deploy
- Do not deploy from the current prod checkout without preserving/reconciling its dirty, ahead/behind state.