### PR TITLE
fix(middleware): batch active pairing lookups

### DIFF
--- a/docs/plans/2026-05-31-pairing-active-list-performance-pass-16.md
+++ b/docs/plans/2026-05-31-pairing-active-list-performance-pass-16.md
@@ -1,0 +1,93 @@
+# Pairing Active List Performance Pass 16
+
+Date: 2026-05-31
+Branch: `feat/device-content-streaming-pass-16`
+
+## Context
+
+The next customer-visible performance target is the pairing path. The old
+device-content concern that middleware buffered media into memory is stale on
+current `origin/main`: `DeviceContentController` already opens MinIO streams,
+supports range requests, handles 304 validators before stream acquisition, and
+uses `pipeline(stream, res)`.
+
+The residual repo-side bottleneck is `PairingService.getActivePairings()`. It
+scans Redis pairing keys, then reads each key and, for unclaimed devices, queries
+the display table one request at a time. A busy customer install or shared demo
+environment can turn the dashboard pairing panel into serial Redis and DB work.
+
+Production deployment remains blocked by dirty/diverged prod-local state. This
+pass is repo-side until the deploy gate is made safe.
+
+## New Primitives Introduced
+
+No new service, module, Redis topology, schema, env var, or PM2 process.
+
+Small helper logic inside existing `PairingService` only:
+
+- batch Redis value reads for scanned pairing keys with `MGET`
+- batch display ownership lookup with a single tenant-preserving `findMany`
+
+## Hermes-First Analysis
+
+Not applicable. This pass does not add business agents, MCP tools, Hermes
+skills, AI/provider calls, spend paths, or customer-lifecycle/support automation.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Device pairing dashboard performance | none applicable | Use existing NestJS pairing service and Redis substrate. |
+| Redis read batching | none applicable | Build in the existing middleware service; Hermes is not in request serving. |
+
+Awesome-Hermes ecosystem check: no relevant runtime serving or Redis batching
+primitive applies to this middleware hot path.
+
+## Drift Check
+
+Current repo evidence:
+
+- `middleware/src/modules/content/device-content.controller.ts` parses byte
+  ranges, sets `Accept-Ranges`, and streams via `pipeline(stream, res)`.
+- `middleware/src/modules/content/device-content.controller.spec.ts` covers
+  range responses, 304-before-stream behavior, stale cache recovery, stream
+  acquisition failure handling, and max-size rejection.
+- `middleware/src/modules/displays/pairing.service.ts` still scans pairing keys,
+  then calls `getPairingRequest()` and `display.findUnique()` inside the loop.
+
+## Selected Fix
+
+- Keep the existing pairing-key scan, TTL checks, and response shape.
+- Read all scanned Redis values in one `MGET` call and parse them by key.
+- For unclaimed pairing requests, lookup existing display ownership with one
+  `display.findMany({ deviceIdentifier: { in: [...] } })` query.
+- Preserve existing visibility semantics:
+  - completed pairings show only to their organization
+  - unclaimed pairings show when the device is brand new or already belongs to
+    the current organization
+  - expired or malformed Redis values are skipped
+
+## Acceptance Criteria
+
+- `getActivePairings()` no longer performs one Redis GET per scanned key when a
+  Redis client is available.
+- `getActivePairings()` performs at most one display ownership query for
+  unclaimed active requests.
+- Completed organization-scoped pairings do not trigger a display ownership
+  query.
+- Existing active/expired pairing tests continue to pass.
+- No auth, tenant, pairing-token, or response-envelope behavior changes.
+
+## Verification Plan
+
+- Add failing unit tests for batched active-pairing reads and display ownership
+  lookup.
+- Run focused `pairing.service` tests for red/green.
+- Run a reviewer gate before broader tests.
+- Run the displays middleware test slice, then broader middleware verification
+  and build if the diff review is clean.
+
+## Deploy Gate
+
+Do not deploy from this pass while `/opt/vizora/app` is dirty/diverged with
+unclassified production-local work. No prod pull, reset, stash, service restart,
+env edit, DB mutation, or deploy should happen until that state is preserved or
+explicitly promoted with a reviewed runbook.

--- a/middleware/src/modules/displays/pairing.service.spec.ts
+++ b/middleware/src/modules/displays/pairing.service.spec.ts
@@ -14,6 +14,7 @@ describe('PairingService', () => {
   let mockDatabaseService: jest.Mocked<DatabaseService>;
   let mockJwtService: jest.Mocked<JwtService>;
   let mockRedisService: jest.Mocked<RedisService>;
+  let redisClient: { scan: jest.Mock; mget: jest.Mock };
 
   // In-memory store to simulate Redis behavior
   let redisStore: Map<string, { value: string; ttl: number; expiresAt: number }>;
@@ -27,6 +28,7 @@ describe('PairingService', () => {
     mockDatabaseService = {
       display: {
         findUnique: jest.fn(),
+        findMany: jest.fn(),
         create: jest.fn(),
         update: jest.fn(),
       },
@@ -35,6 +37,36 @@ describe('PairingService', () => {
     mockJwtService = {
       sign: jest.fn().mockReturnValue('mock-jwt-token'),
     } as any;
+
+    redisClient = {
+      scan: jest.fn().mockImplementation(async (cursor: string, _match: string, pattern: string, _count: string, _countVal: number) => {
+        // Return all keys matching the pattern on first call
+        const prefix = pattern.replace('*', '');
+        const matchingKeys: string[] = [];
+        for (const [key, entry] of redisStore.entries()) {
+          if (key.startsWith(prefix)) {
+            // Also check TTL
+            if (entry.expiresAt > 0 && Date.now() >= entry.expiresAt) {
+              redisStore.delete(key);
+              continue;
+            }
+            matchingKeys.push(key);
+          }
+        }
+        return ['0', matchingKeys];
+      }),
+      mget: jest.fn().mockImplementation(async (...keys: string[]) => {
+        return keys.map((key) => {
+          const entry = redisStore.get(key);
+          if (!entry) return null;
+          if (entry.expiresAt > 0 && Date.now() >= entry.expiresAt) {
+            redisStore.delete(key);
+            return null;
+          }
+          return entry.value;
+        });
+      }),
+    };
 
     // Create a mock RedisService that uses an in-memory Map to simulate Redis
     mockRedisService = {
@@ -66,24 +98,7 @@ describe('PairingService', () => {
         }
         return true;
       }),
-      getClient: jest.fn().mockReturnValue({
-        scan: jest.fn().mockImplementation(async (cursor: string, _match: string, pattern: string, _count: string, _countVal: number) => {
-          // Return all keys matching the pattern on first call
-          const prefix = pattern.replace('*', '');
-          const matchingKeys: string[] = [];
-          for (const [key, entry] of redisStore.entries()) {
-            if (key.startsWith(prefix)) {
-              // Also check TTL
-              if (entry.expiresAt > 0 && Date.now() >= entry.expiresAt) {
-                redisStore.delete(key);
-                continue;
-              }
-              matchingKeys.push(key);
-            }
-          }
-          return ['0', matchingKeys];
-        }),
-      }),
+      getClient: jest.fn().mockReturnValue(redisClient),
       isAvailable: jest.fn().mockReturnValue(true),
       ping: jest.fn().mockResolvedValue(true),
       healthCheck: jest.fn().mockResolvedValue({ healthy: true, responseTime: 1 }),
@@ -598,6 +613,7 @@ describe('PairingService', () => {
 
     it('should return active pairings', async () => {
       mockDatabaseService.display.findUnique.mockResolvedValue(null);
+      mockDatabaseService.display.findMany.mockResolvedValue([]);
 
       await service.requestPairingCode({
         deviceIdentifier: 'device-1',
@@ -624,6 +640,7 @@ describe('PairingService', () => {
 
     it('should not return expired pairings', async () => {
       mockDatabaseService.display.findUnique.mockResolvedValue(null);
+      mockDatabaseService.display.findMany.mockResolvedValue([]);
 
       await service.requestPairingCode({
         deviceIdentifier: 'device-expired',
@@ -637,6 +654,100 @@ describe('PairingService', () => {
       const result = await service.getActivePairings('org-123');
 
       expect(result).toHaveLength(0);
+    });
+
+    it('should batch Redis reads and display ownership lookup for active pairings', async () => {
+      const orgId = 'org-123';
+      mockDatabaseService.display.findUnique.mockResolvedValue(null);
+      mockDatabaseService.display.findMany.mockResolvedValue([
+        {
+          deviceIdentifier: 'device-owned',
+          organizationId: orgId,
+        },
+        {
+          deviceIdentifier: 'device-other-org',
+          organizationId: 'org-other',
+        },
+      ] as any);
+
+      await service.requestPairingCode({
+        deviceIdentifier: 'device-owned',
+        nickname: 'Owned Display',
+        metadata: {},
+      });
+      await service.requestPairingCode({
+        deviceIdentifier: 'device-other-org',
+        nickname: 'Other Org Display',
+        metadata: {},
+      });
+      await service.requestPairingCode({
+        deviceIdentifier: 'device-new',
+        nickname: 'Brand New Display',
+        metadata: {},
+      });
+      mockDatabaseService.display.findUnique.mockClear();
+
+      const result = await service.getActivePairings(orgId);
+
+      expect(redisClient.mget).toHaveBeenCalledTimes(1);
+      expect(mockRedisService.get).not.toHaveBeenCalled();
+      expect(mockDatabaseService.display.findMany).toHaveBeenCalledTimes(1);
+      expect(mockDatabaseService.display.findMany).toHaveBeenCalledWith({
+        where: {
+          deviceIdentifier: {
+            in: expect.arrayContaining(['device-owned', 'device-other-org', 'device-new']),
+          },
+        },
+        select: { deviceIdentifier: true, organizationId: true },
+      });
+      expect(mockDatabaseService.display.findUnique).not.toHaveBeenCalled();
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ nickname: 'Owned Display' }),
+          expect.objectContaining({ nickname: 'Brand New Display' }),
+        ]),
+      );
+      expect(result).toHaveLength(2);
+      expect(result).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ nickname: 'Other Org Display' }),
+        ]),
+      );
+    });
+
+    it('should not query display ownership for already completed org pairings', async () => {
+      const orgId = 'org-123';
+      const userId = 'user-123';
+      mockDatabaseService.display.findUnique.mockResolvedValue(null);
+      mockDatabaseService.display.findMany.mockResolvedValue([]);
+
+      const pairingResult = await service.requestPairingCode({
+        deviceIdentifier: 'completed-device',
+        nickname: 'Completed Display',
+        metadata: {},
+      });
+
+      mockDatabaseService.display.create.mockResolvedValue({
+        id: 'new-id',
+        nickname: 'Completed Display',
+        deviceIdentifier: 'completed-device',
+        status: 'pairing',
+      } as any);
+
+      await service.completePairing(orgId, userId, { code: pairingResult.code });
+      mockDatabaseService.display.findUnique.mockClear();
+      mockDatabaseService.display.findMany.mockClear();
+      mockRedisService.get.mockClear();
+      redisClient.mget.mockClear();
+
+      const result = await service.getActivePairings(orgId);
+
+      expect(redisClient.mget).toHaveBeenCalledTimes(1);
+      expect(mockRedisService.get).not.toHaveBeenCalled();
+      expect(mockDatabaseService.display.findMany).not.toHaveBeenCalled();
+      expect(mockDatabaseService.display.findUnique).not.toHaveBeenCalled();
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(expect.objectContaining({ nickname: 'Completed Display' }));
     });
   });
 

--- a/middleware/src/modules/displays/pairing.service.ts
+++ b/middleware/src/modules/displays/pairing.service.ts
@@ -28,12 +28,25 @@ interface PairingRequest {
   plaintextToken?: string;
 }
 
+interface ActivePairingResponse {
+  code: string;
+  nickname: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
+interface PairingRequestRecord {
+  code: string;
+  request: PairingRequest;
+}
+
 @Injectable()
 export class PairingService implements OnModuleDestroy {
   private readonly logger = new Logger(PairingService.name);
   private readonly PAIRING_CODE_LENGTH = 6;
   private readonly PAIRING_EXPIRY_MS = 5 * 60 * 1000; // 5 minutes
   private readonly PAIRING_TTL_SECONDS = 300; // 5 minutes
+  private readonly PAIRING_READ_BATCH_SIZE = 100;
   private readonly REDIS_KEY_PREFIX = 'pairing:';
   private cleanupIntervalId: NodeJS.Timeout | null = null;
 
@@ -66,9 +79,18 @@ export class PairingService implements OnModuleDestroy {
     try {
       const data = await this.redisService.get(this.redisKey(code));
       if (!data) return null;
-      return JSON.parse(data) as PairingRequest;
+      return this.parsePairingRequest(data, code);
     } catch (error) {
       this.logger.error(`Failed to get pairing request for code ${code}: ${error}`);
+      return null;
+    }
+  }
+
+  private parsePairingRequest(data: string, code: string): PairingRequest | null {
+    try {
+      return JSON.parse(data) as PairingRequest;
+    } catch (error) {
+      this.logger.error(`Failed to parse pairing request for code ${code}: ${error}`);
       return null;
     }
   }
@@ -344,23 +366,21 @@ export class PairingService implements OnModuleDestroy {
     };
   }
 
-  async getActivePairings(organizationId: string) {
+  async getActivePairings(organizationId: string): Promise<ActivePairingResponse[]> {
     // Return active pairing requests filtered by organization
     // Only show requests that have been completed for this org,
     // or where the device already belongs to this org
-    const activePairings: PairingRequest[] = [];
+    const activePairings: ActivePairingResponse[] = [];
 
     // Use SCAN to find all pairing keys in Redis
     const keys = await this.scanPairingKeys();
+    const records = await this.getPairingRequestRecords(keys);
+    const now = new Date();
+    const unclaimedRequests: PairingRequest[] = [];
 
-    for (const key of keys) {
-      const code = key.replace(this.REDIS_KEY_PREFIX, '');
-      const request = await this.getPairingRequest(code);
-
-      if (!request) continue;
-
+    for (const { code, request } of records) {
       // Check if expired (safety check)
-      if (new Date() >= new Date(request.expiresAt)) {
+      if (now >= new Date(request.expiresAt)) {
         continue;
       }
 
@@ -375,26 +395,98 @@ export class PairingService implements OnModuleDestroy {
         continue;
       }
 
-      // If not yet paired to any org, check if device exists in this org
       if (!request.organizationId) {
-        const display = await this.db.display.findUnique({
-          where: { deviceIdentifier: request.deviceIdentifier },
-          select: { organizationId: true },
-        });
+        unclaimedRequests.push(request);
+      }
+    }
 
-        // Show if device belongs to this org, or is brand new (no org yet)
-        if (!display || display.organizationId === organizationId) {
-          activePairings.push({
-            code,
-            nickname: request.nickname,
-            createdAt: request.createdAt,
-            expiresAt: request.expiresAt,
-          });
-        }
+    const displayOrganizationsByDevice = await this.getDisplayOrganizationsByDevice(unclaimedRequests);
+
+    for (const request of unclaimedRequests) {
+      const displayOrganizationId = displayOrganizationsByDevice.get(request.deviceIdentifier);
+
+      // Show if device belongs to this org, or is brand new (no org yet)
+      if (!displayOrganizationId || displayOrganizationId === organizationId) {
+        activePairings.push({
+          code: request.code,
+          nickname: request.nickname,
+          createdAt: request.createdAt,
+          expiresAt: request.expiresAt,
+        });
       }
     }
 
     return activePairings;
+  }
+
+  private async getPairingRequestRecords(keys: string[]): Promise<PairingRequestRecord[]> {
+    if (keys.length === 0) return [];
+
+    const client = this.redisService.getClient();
+
+    if (client) {
+      try {
+        const records: PairingRequestRecord[] = [];
+
+        for (let index = 0; index < keys.length; index += this.PAIRING_READ_BATCH_SIZE) {
+          const batchKeys = keys.slice(index, index + this.PAIRING_READ_BATCH_SIZE);
+          const values = await client.mget(...batchKeys);
+
+          values.forEach((data, valueIndex) => {
+            if (!data) return;
+
+            const key = batchKeys[valueIndex];
+            const code = key.replace(this.REDIS_KEY_PREFIX, '');
+            const request = this.parsePairingRequest(data, code);
+
+            if (request) {
+              records.push({ code, request });
+            }
+          });
+        }
+
+        return records;
+      } catch (error) {
+        this.logger.error(`Failed to batch get pairing requests: ${error}`);
+      }
+    }
+
+    const records: PairingRequestRecord[] = [];
+    for (const key of keys) {
+      const code = key.replace(this.REDIS_KEY_PREFIX, '');
+      const request = await this.getPairingRequest(code);
+
+      if (request) {
+        records.push({ code, request });
+      }
+    }
+
+    return records;
+  }
+
+  private async getDisplayOrganizationsByDevice(
+    requests: PairingRequest[],
+  ): Promise<Map<string, string>> {
+    const deviceIdentifiers = Array.from(new Set(
+      requests.map(request => request.deviceIdentifier).filter(Boolean),
+    ));
+
+    if (deviceIdentifiers.length === 0) {
+      return new Map();
+    }
+
+    const displays = await this.db.display.findMany({
+      where: {
+        deviceIdentifier: {
+          in: deviceIdentifiers,
+        },
+      },
+      select: { deviceIdentifier: true, organizationId: true },
+    });
+
+    return new Map(
+      displays.map(display => [display.deviceIdentifier, display.organizationId]),
+    );
   }
 
   /**

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1565,7 +1565,7 @@ Plan: `docs/plans/2026-05-31-customer-dashboard-trust-pass-13.md`
   - `npx nx build @vizora/web` — pass.
   - `pnpm --filter @vizora/web test -- --runInBand` — 95 suites / 977 tests pass; unrelated existing act warnings remain in non-dashboard suites.
   - Playwright browser smoke against `next start` on `localhost:3001`: desktop and mobile dashboard render with no page errors after the layout hydration fix; screenshots in `logs/dashboard-pass13-{desktop,mobile}.png`.
-- [ ] Open PR, wait for CI, merge if green.
+- [x] Open PR, wait for CI, merge if green. PR #139 opened; CI passed audit, lint, security, build, test, and e2e.
 - [ ] Deploy status: blocked unless production dirty/diverged state is resolved or explicitly approved with a reviewed runbook.
 
 ## Next Up (Not Started)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1573,3 +1573,36 @@ Plan: `docs/plans/2026-05-31-customer-dashboard-trust-pass-13.md`
 Continue the ranked customer/performance findings after pass 13: shared dashboard
 Socket.IO provider, server-side content-library search, playlist summary payloads,
 org broadcast scaling, and template refresh scheduling.
+
+---
+
+## Active Workstream: Pairing Active List Performance Pass 16 (2026-05-31)
+
+Branch: `feat/device-content-streaming-pass-16`
+Plan: `docs/plans/2026-05-31-pairing-active-list-performance-pass-16.md`
+
+- [x] Drift-check old device streaming bottleneck against current code.
+- [x] Identify residual pairing-dashboard serial Redis/DB work.
+- [x] Document pass 16 design and test plan.
+- [x] Add failing unit tests for batched active-pairing Redis reads and display ownership lookup.
+- [x] Implement batched Redis `MGET` parsing and one-query display ownership lookup in existing `PairingService`.
+- [x] Run multiple subagent reviews before broader tests.
+- [x] Run focused pairing/display middleware tests.
+- [x] Run broader middleware verification and build.
+- [ ] Open PR, wait for CI, merge if green.
+- [ ] Deploy status: blocked unless production dirty/diverged state is resolved or explicitly approved with a reviewed runbook.
+
+**Pass 16 verification**
+- Red/green TDD:
+  - Initial `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=pairing.service` failed on the new batching assertions before implementation.
+  - Post-fix focused run passed: 1 suite / 32 tests.
+- Reviewer gate:
+  - Security/tenant/architecture reviewer: CLEAN; focused pairing suite passed.
+  - Redis/performance/test-safety reviewer: CLEAN; focused pairing suite, middleware build, and `git diff --check` passed.
+- Local verification:
+  - `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/displays/pairing.service.spec.ts src/modules/displays/pairing.controller.spec.ts src/modules/displays/displays.service.spec.ts src/modules/displays/displays.controller.spec.ts` — 4 suites / 103 tests passed.
+  - `pnpm --filter @vizora/middleware test -- --runInBand` — 143 suites / 2876 tests passed.
+  - `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` — passed.
+  - `ESLINT_USE_FLAT_CONFIG=false npx eslint middleware/src/modules/displays/pairing.service.ts middleware/src/modules/displays/pairing.service.spec.ts` — 0 errors, 1 pre-existing warning in `pairing.service.spec.ts`.
+  - `npx nx build @vizora/middleware` — passed with existing webpack warnings.
+  - `git diff --check` — passed with CRLF warnings only.


### PR DESCRIPTION
﻿## Summary
- batch active-pairing Redis value reads with `MGET` after the existing SCAN
- batch unclaimed-device display ownership checks into one Prisma `findMany`
- document that the old device media buffering concern is stale on current main and record Pass 16 verification evidence

## Verification
- `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=pairing.service` (red before implementation, green after)
- `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/displays/pairing.service.spec.ts src/modules/displays/pairing.controller.spec.ts src/modules/displays/displays.service.spec.ts src/modules/displays/displays.controller.spec.ts` ? 4 suites / 103 tests passed
- `pnpm --filter @vizora/middleware test -- --runInBand` ? 143 suites / 2876 tests passed
- `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
- `ESLINT_USE_FLAT_CONFIG=false npx eslint middleware/src/modules/displays/pairing.service.ts middleware/src/modules/displays/pairing.service.spec.ts` ? 0 errors, 1 pre-existing warning
- `npx nx build @vizora/middleware` ? passed with existing webpack warnings
- `git diff --check` ? passed with CRLF warnings only

## Reviews
- Security/tenant/architecture reviewer: CLEAN
- Redis/performance/test-safety reviewer: CLEAN

## Deploy
- Not deployed. Production checkout remains dirty/diverged and should not be pulled/reset/stashed/restarted until preserved or promoted intentionally.
