### PR TITLE
fix(playlists): slim list payload content summaries

### DIFF
--- a/docs/plans/2026-06-01-playlist-list-payload-performance-pass-17.md
+++ b/docs/plans/2026-06-01-playlist-list-payload-performance-pass-17.md
@@ -1,0 +1,53 @@
+# Playlist List Payload Performance Pass 17
+
+Date: 2026-06-01
+Branch: `feat/playlist-list-payload-pass-17`
+
+## Drift Check
+
+- `middleware/src/modules/playlists/playlists.service.ts` already has separate `findAll` and `findOne` paths.
+- `findAll` currently loads every playlist item with `content: true`, so the paginated list endpoint returns the full content row for each item.
+- `findOne`, create/update, display-push, and item mutation paths still need richer playlist payloads and are out of scope for this pass.
+- Dashboard list consumers use list item title/thumbnail/type/duration/file-size summary data:
+  - `web/src/app/dashboard/playlists/page-client.tsx` renders thumbnails, first item labels, total duration, and total size.
+  - `web/src/app/dashboard/devices/page-client.tsx` fetches playlists for bulk assignment and mostly needs ids/names.
+
+## New Primitives Introduced
+
+None.
+
+## Hermes-First Analysis
+
+This is not a business-agent, MCP, AI-provider, or Hermes runtime change. It is a local NestJS/Prisma response-shaping improvement on an existing API endpoint.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Playlist list payload shaping | Not applicable | Use existing NestJS service and Prisma query path |
+| Customer dashboard performance | Not applicable | Keep within current `/api/v1/playlists` contract |
+
+Awesome-Hermes-agent ecosystem check: not applicable because no agent skill or provider path is being introduced.
+
+## Design
+
+Use Vizora-native Prisma `select` on the nested `items.content` relation in `PlaylistsService.findAll`.
+
+Keep returned list semantics needed by existing clients:
+- playlist top-level fields remain unchanged
+- `items` remains present and ordered
+- item fields remain present: `id`, `playlistId`, `contentId`, `order`, `duration`
+- `content.title` and `content.thumbnailUrl` are still mapped from `name` and `thumbnail`
+- `totalDuration`, `totalSize`, and `itemCount` remain computed
+
+Only remove heavy content fields from the list query: raw URLs/storage keys, metadata, template/html payloads, processing fields, and other detail-only columns. `findOne` remains the full detail endpoint.
+
+## Test Plan
+
+1. Add a red unit test proving `findAll` uses a nested content projection instead of `content: true`.
+2. Verify the mapped response still contains `title`, `thumbnailUrl`, `type`, duration, file size totals, and item counts.
+3. Run focused playlist service/controller tests.
+4. Run middleware typecheck, changed-file lint, full middleware test suite, build, and diff check.
+5. Dispatch multiple reviewers before broader tests and resolve any high/medium findings.
+
+## Deployment
+
+No direct deployment in this pass unless the production checkout is first reconciled. Current production state remains dirty/diverged and deployment-blocked.

--- a/middleware/src/modules/playlists/playlists.service.spec.ts
+++ b/middleware/src/modules/playlists/playlists.service.spec.ts
@@ -1,5 +1,4 @@
 import { NotFoundException } from '@nestjs/common';
-import { of, throwError } from 'rxjs';
 import { PlaylistsService } from './playlists.service';
 import { DatabaseService } from '../database/database.service';
 
@@ -189,6 +188,59 @@ describe('PlaylistsService', () => {
           where: { organizationId: 'org-123' },
         }),
       );
+    });
+
+    it('should project only summary content fields for list payloads', async () => {
+      mockDatabaseService.playlist.findMany.mockResolvedValue([
+        {
+          ...mockPlaylist,
+          items: [
+            {
+              ...mockPlaylistItem,
+              duration: undefined,
+              content: {
+                id: 'content-123',
+                name: 'Menu Board',
+                type: 'image',
+                thumbnail: '/thumb.png',
+                duration: 12,
+                fileSize: 2048,
+                status: 'active',
+              },
+            },
+          ],
+        },
+      ]);
+      mockDatabaseService.playlist.count.mockResolvedValue(1);
+
+      const result = await service.findAll('org-123', { page: 1, limit: 10 });
+      const query = mockDatabaseService.playlist.findMany.mock.calls[0][0];
+
+      expect(query.include.items.include).toBeUndefined();
+      expect(query.include.items.select.content).toEqual({
+        select: {
+          id: true,
+          name: true,
+          type: true,
+          thumbnail: true,
+          duration: true,
+          fileSize: true,
+          status: true,
+        },
+      });
+      expect(result.data[0].items[0].content).toEqual(
+        expect.objectContaining({
+          id: 'content-123',
+          title: 'Menu Board',
+          thumbnailUrl: '/thumb.png',
+          type: 'image',
+          duration: 12,
+          status: 'active',
+        }),
+      );
+      expect(result.data[0].itemCount).toBe(1);
+      expect(result.data[0].totalDuration).toBe(12);
+      expect(result.data[0].totalSize).toBe(2048);
     });
   });
 

--- a/middleware/src/modules/playlists/playlists.service.ts
+++ b/middleware/src/modules/playlists/playlists.service.ts
@@ -120,8 +120,23 @@ export class PlaylistsService {
         orderBy: { createdAt: 'desc' },
         include: {
           items: {
-            include: {
-              content: true,
+            select: {
+              id: true,
+              playlistId: true,
+              contentId: true,
+              order: true,
+              duration: true,
+              content: {
+                select: {
+                  id: true,
+                  name: true,
+                  type: true,
+                  thumbnail: true,
+                  duration: true,
+                  fileSize: true,
+                  status: true,
+                },
+              },
             },
             orderBy: {
               order: 'asc',

--- a/middleware/test/playlists.e2e-spec.ts
+++ b/middleware/test/playlists.e2e-spec.ts
@@ -13,6 +13,7 @@ describe('Playlists (e2e)', () => {
   let userId: string;
   let organizationId: string;
   let playlistId: string;
+  let listPayloadPlaylistId: string;
   let contentId1: string;
   let contentId2: string;
   let secondUserToken: string;
@@ -95,6 +96,20 @@ describe('Playlists (e2e)', () => {
       });
     contentId2 = content2Res.body.data?.id ?? content2Res.body.id;
 
+    const listPayloadPlaylist = await db.playlist.create({
+      data: {
+        name: 'List Payload Playlist',
+        organizationId,
+        items: {
+          create: [
+            { contentId: contentId1, order: 0, duration: 10 },
+            { contentId: contentId2, order: 1, duration: 30 },
+          ],
+        },
+      },
+    });
+    listPayloadPlaylistId = listPayloadPlaylist.id;
+
     // Create second user for multi-tenant testing
     const timestamp2 = Date.now() + 1;
     const secondUser = {
@@ -119,6 +134,9 @@ describe('Playlists (e2e)', () => {
     // Cleanup
     if (playlistId) {
       await db.playlist.delete({ where: { id: playlistId } }).catch(() => {});
+    }
+    if (listPayloadPlaylistId) {
+      await db.playlist.delete({ where: { id: listPayloadPlaylistId } }).catch(() => {});
     }
     if (contentId1) {
       await db.content.delete({ where: { id: contentId1 } }).catch(() => {});
@@ -231,6 +249,32 @@ describe('Playlists (e2e)', () => {
           
           const found = res.body.data.find((p: any) => p.id === playlistId);
           expect(found).toBeDefined();
+        });
+    });
+
+    it('should return summary content fields for playlist list items', () => {
+      return request(app.getHttpServer())
+        .get('/api/playlists')
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200)
+        .expect((res) => {
+          const found = res.body.data.find((p: any) => p.id === listPayloadPlaylistId);
+          expect(found).toBeDefined();
+          expect(found.items).toHaveLength(2);
+          expect(found.itemCount).toBe(2);
+          expect(found.totalDuration).toBe(40);
+
+          const content = found.items[0].content;
+          expect(content).toEqual(
+            expect.objectContaining({
+              id: contentId1,
+              title: 'Test Content 1',
+              type: 'image',
+              status: 'active',
+            }),
+          );
+          expect(content).not.toHaveProperty('url');
+          expect(content).not.toHaveProperty('metadata');
         });
     });
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1589,7 +1589,7 @@ Plan: `docs/plans/2026-05-31-pairing-active-list-performance-pass-16.md`
 - [x] Run multiple subagent reviews before broader tests.
 - [x] Run focused pairing/display middleware tests.
 - [x] Run broader middleware verification and build.
-- [ ] Open PR, wait for CI, merge if green.
+- [x] Open PR, wait for CI, merge if green. PR #139 merged to `origin/main` at `f9a3df8ad802caaa4a9a7e737e4fd6ff2b4dce60`.
 - [ ] Deploy status: blocked unless production dirty/diverged state is resolved or explicitly approved with a reviewed runbook.
 
 **Pass 16 verification**
@@ -1606,3 +1606,43 @@ Plan: `docs/plans/2026-05-31-pairing-active-list-performance-pass-16.md`
   - `ESLINT_USE_FLAT_CONFIG=false npx eslint middleware/src/modules/displays/pairing.service.ts middleware/src/modules/displays/pairing.service.spec.ts` — 0 errors, 1 pre-existing warning in `pairing.service.spec.ts`.
   - `npx nx build @vizora/middleware` — passed with existing webpack warnings.
   - `git diff --check` — passed with CRLF warnings only.
+- CI verification:
+  - PR #139 passed audit, lint, security, build, test, and e2e before merge.
+
+## Active Workstream: Playlist List Payload Performance Pass 17 (2026-06-01)
+
+Branch: `feat/playlist-list-payload-pass-17`
+Plan: `docs/plans/2026-06-01-playlist-list-payload-performance-pass-17.md`
+
+- [x] Drift-check playlist list/detail split and dashboard consumers.
+- [x] Document pass 17 design and test plan.
+- [x] Add failing unit test for nested content projection on playlist lists.
+- [x] Implement minimal content projection in existing `PlaylistsService.findAll`.
+- [x] Run multiple subagent reviews before broader tests.
+- [x] Run focused playlist middleware tests.
+- [x] Run broader middleware verification and build.
+- [ ] Open PR, wait for CI, merge if green.
+- [ ] Deploy status: blocked unless production dirty/diverged state is resolved or explicitly approved with a reviewed runbook.
+
+**Pass 17 verification**
+- Red/green TDD:
+  - Initial `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=playlists.service` failed on the new projection assertion while `findAll` still used `content: true`.
+  - Post-fix focused run passed: playlist service suite 30 tests.
+- Reviewer gate:
+  - Backend correctness/Prisma/tenant reviewer: CLEAN.
+  - API/frontend contract reviewer first found a medium summary-type contract gap; fixed with `PlaylistSummary` typing and consumer updates.
+  - Follow-up backend reviewer: CLEAN.
+  - Follow-up API/frontend contract reviewer: CLEAN.
+- Local verification:
+  - `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/playlists/playlists.service.spec.ts src/modules/playlists/playlists.controller.spec.ts` — 2 suites / 42 tests passed.
+  - `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="playlists-page|content-page|devices-page|schedules-page|PlaylistPreview|DeviceQuickChange"` — 6 suites / 100 tests passed, with pre-existing React `act()` warnings.
+  - `pnpm --filter @vizora/middleware test -- --runInBand` — 143 suites / 2877 tests passed.
+  - `pnpm --filter @vizora/web test -- --runInBand` — 95 suites / 982 tests passed, with pre-existing React `act()`/jsdom navigation warnings.
+  - `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` — passed.
+  - `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` — passed.
+  - `ESLINT_USE_FLAT_CONFIG=false npx eslint ...changed files...` — 0 errors, existing warnings remain in touched web files.
+  - `npx nx build @vizora/middleware` — passed after killing abandoned local e2e Jest processes that held the generated Prisma directory; existing webpack warnings remain.
+  - `NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 BACKEND_URL=http://localhost:3000 npx nx build @vizora/web` — passed.
+  - `git diff --check` — passed with CRLF warnings only.
+- Local e2e status:
+  - `pnpm --filter @vizora/middleware test:e2e -- --runInBand --testPathPattern=playlists` timed out locally because Docker Desktop is unavailable and test DB/Redis ports `5433`/`6380` are closed. CI e2e must verify the added playlist list contract test.

--- a/web/src/app/dashboard/content/page-client.tsx
+++ b/web/src/app/dashboard/content/page-client.tsx
@@ -5,7 +5,7 @@ import { useDropzone, type FileRejection } from 'react-dropzone';
 import { apiClient } from '@/lib/api';
 import type { ContentListParams } from '@/lib/api/content';
 import { fetchAllPaginated } from '@/lib/api/pagination';
-import { Content, Display, Playlist, ContentFolder } from '@/lib/types';
+import { Content, Display, PlaylistSummary, ContentFolder } from '@/lib/types';
 import FolderTree from '@/components/FolderTree';
 import FolderBreadcrumb from '@/components/FolderBreadcrumb';
 import Modal from '@/components/Modal';
@@ -106,7 +106,7 @@ export default function ContentClient() {
  const [isAddToPlaylistModalOpen, setIsAddToPlaylistModalOpen] = useState(false);
  const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false);
  const [devices, setDevices] = useState<Display[]>([]);
- const [playlists, setPlaylists] = useState<Playlist[]>([]);
+ const [playlists, setPlaylists] = useState<PlaylistSummary[]>([]);
  const [devicesLoading, setDevicesLoading] = useState(false);
  const [playlistsLoading, setPlaylistsLoading] = useState(false);
  const [devicesLoadError, setDevicesLoadError] = useState<string | null>(null);

--- a/web/src/app/dashboard/devices/page-client.tsx
+++ b/web/src/app/dashboard/devices/page-client.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { apiClient } from '@/lib/api';
 import { fetchAllPaginated } from '@/lib/api/pagination';
-import { Display, Playlist, DisplayGroup } from '@/lib/types';
+import { Display, PlaylistSummary, DisplayGroup } from '@/lib/types';
 import Modal from '@/components/Modal';
 import ConfirmDialog from '@/components/ConfirmDialog';
 import LoadingSpinner from '@/components/LoadingSpinner';
@@ -23,7 +23,7 @@ import { useAuth } from '@/lib/hooks/useAuth';
 
 interface DevicesClientProps {
  initialDevices: Display[];
- initialPlaylists: Playlist[];
+ initialPlaylists: PlaylistSummary[];
  initialDevicesComplete?: boolean;
  initialPlaylistsComplete?: boolean;
 }
@@ -39,7 +39,7 @@ export default function DevicesClient({
  const { user } = useAuth();
  const [isOverrideModalOpen, setIsOverrideModalOpen] = useState(false);
  const [devices, setDevices] = useState<Display[]>(initialDevices);
- const [playlists, setPlaylists] = useState<Playlist[]>(initialPlaylists);
+ const [playlists, setPlaylists] = useState<PlaylistSummary[]>(initialPlaylists);
  const [deviceGroups, setDeviceGroups] = useState<any[]>([]);
  const [selectedGroups, setSelectedGroups] = useState<string[]>([]);
  const [loading, setLoading] = useState(!initialDevices.length && initialDevices.length === 0 ? false : false);

--- a/web/src/app/dashboard/devices/page.tsx
+++ b/web/src/app/dashboard/devices/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { serverFetch } from '@/lib/server-api';
 import { unwrapPaginatedData } from '@/lib/api/pagination';
-import type { Display, PaginatedResponse, Playlist } from '@/lib/types';
+import type { Display, PaginatedResponse, PlaylistSummary } from '@/lib/types';
 import DevicesClient from './page-client';
 
 export const metadata: Metadata = {
@@ -10,14 +10,14 @@ export const metadata: Metadata = {
 
 export default async function DevicesPage() {
  let devices: Display[] = [];
- let playlists: Playlist[] = [];
+ let playlists: PlaylistSummary[] = [];
  let devicesComplete = false;
  let playlistsComplete = false;
 
  try {
  const results = await Promise.allSettled([
  serverFetch<PaginatedResponse<Display>>('/displays?limit=100'),
- serverFetch<PaginatedResponse<Playlist>>('/playlists?limit=100'),
+ serverFetch<PaginatedResponse<PlaylistSummary>>('/playlists?limit=100'),
  ]);
 
  if (results[0].status === 'fulfilled') {
@@ -25,7 +25,7 @@ export default async function DevicesPage() {
  devicesComplete = (results[0].value.meta?.totalPages ?? 1) <= 1;
  }
  if (results[1].status === 'fulfilled') {
- playlists = unwrapPaginatedData<Playlist>(results[1].value);
+ playlists = unwrapPaginatedData<PlaylistSummary>(results[1].value);
  playlistsComplete = (results[1].value.meta?.totalPages ?? 1) <= 1;
  }
  } catch {

--- a/web/src/app/dashboard/playlists/page-client.tsx
+++ b/web/src/app/dashboard/playlists/page-client.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { apiClient } from '@/lib/api';
 import { fetchAllPaginated } from '@/lib/api/pagination';
-import { Playlist, Content, Display } from '@/lib/types';
+import { PlaylistSummary, Content, Display } from '@/lib/types';
 import Modal from '@/components/Modal';
 import ConfirmDialog from '@/components/ConfirmDialog';
 import LoadingSpinner from '@/components/LoadingSpinner';
@@ -107,11 +107,11 @@ function SortablePlaylistItem({ item, idx, onRemove, onDurationChange }: {
 export default function PlaylistsClient() {
  const router = useRouter();
  const toast = useToast();
- const [playlists, setPlaylists] = useState<Playlist[]>([]);
+ const [playlists, setPlaylists] = useState<PlaylistSummary[]>([]);
  const [content, setContent] = useState<Content[]>([]);
  const [devices, setDevices] = useState<Display[]>([]);
  const [loading, setLoading] = useState(true);
- const [selectedPlaylist, setSelectedPlaylist] = useState<Playlist | null>(null);
+ const [selectedPlaylist, setSelectedPlaylist] = useState<PlaylistSummary | null>(null);
  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
@@ -122,7 +122,7 @@ export default function PlaylistsClient() {
  const [searchQuery, setSearchQuery] = useState('');
  const debouncedSearch = useDebounce(searchQuery, 300);
  const [realtimeStatus, setRealtimeStatus] = useState<'connected' | 'offline' | 'error'>('offline');
- const [previewPlaylist, setPreviewPlaylist] = useState<Playlist | null>(null);
+ const [previewPlaylist, setPreviewPlaylist] = useState<PlaylistSummary | null>(null);
 
  // Real-time event handling
  const { isConnected, isOffline, emitPlaylistUpdate } = useRealtimeEvents({
@@ -255,11 +255,11 @@ export default function PlaylistsClient() {
  }
  };
 
- const handleEdit = async (playlist: Playlist) => {
+ const handleEdit = async (playlist: PlaylistSummary) => {
  router.push(`/dashboard/playlists/${playlist.id}`);
  };
 
- const handleDelete = (playlist: Playlist) => {
+ const handleDelete = (playlist: PlaylistSummary) => {
  setSelectedPlaylist(playlist);
  setIsDeleteModalOpen(true);
  };
@@ -277,7 +277,14 @@ export default function PlaylistsClient() {
  emitPlaylistUpdate({
  playlistId: deletedPlaylistId,
  action: 'deleted',
- payload: selectedPlaylist,
+ payload: {
+ id: selectedPlaylist.id,
+ name: selectedPlaylist.name,
+ description: selectedPlaylist.description,
+ isActive: selectedPlaylist.isActive,
+ createdAt: selectedPlaylist.createdAt,
+ updatedAt: selectedPlaylist.updatedAt,
+ },
  });
 
  loadPlaylists();
@@ -288,7 +295,7 @@ export default function PlaylistsClient() {
  }
  };
 
- const handlePublish = async (playlist: Playlist) => {
+ const handlePublish = async (playlist: PlaylistSummary) => {
  try {
  await apiClient.updatePlaylist(playlist.id, { name: playlist.name });
  toast.success('Playlist published successfully');
@@ -306,7 +313,7 @@ export default function PlaylistsClient() {
  return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
  };
 
- const getTotalDuration = (playlist: Playlist) => {
+ const getTotalDuration = (playlist: PlaylistSummary) => {
  const total = (playlist as any).totalDuration ||
  (playlist.items?.reduce((sum, item) => sum + (item.duration || 30), 0) || 0);
  if (total === 0) return '0s';

--- a/web/src/app/dashboard/schedules/page-client.tsx
+++ b/web/src/app/dashboard/schedules/page-client.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import { apiClient } from '@/lib/api';
 import { fetchAllPaginated } from '@/lib/api/pagination';
-import { Display, Playlist } from '@/lib/types';
+import { Display, PlaylistSummary } from '@/lib/types';
 import Modal from '@/components/Modal';
 import ConfirmDialog from '@/components/ConfirmDialog';
 import LoadingSpinner from '@/components/LoadingSpinner';
@@ -97,7 +97,7 @@ export default function SchedulesClient() {
  const toast = useToast();
  const [schedules, setSchedules] = useState<Schedule[]>([]);
  const [devices, setDevices] = useState<Display[]>([]);
- const [playlists, setPlaylists] = useState<Playlist[]>([]);
+ const [playlists, setPlaylists] = useState<PlaylistSummary[]>([]);
  const [loading, setLoading] = useState(true);
  const [actionLoading, setActionLoading] = useState(false);
  const [realtimeStatus, setRealtimeStatus] = useState<'connected' | 'offline'>('offline');
@@ -176,7 +176,7 @@ export default function SchedulesClient() {
  }
  if (playlistsRes.status === 'fulfilled') {
  const playlistData = playlistsRes.value || [];
- setPlaylists(playlistData as unknown as Playlist[]);
+ setPlaylists(playlistData as unknown as PlaylistSummary[]);
  }
  if (groupsRes?.status === 'fulfilled') {
  setDisplayGroups(groupsRes.value || []);

--- a/web/src/components/PlaylistPreview.tsx
+++ b/web/src/components/PlaylistPreview.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { PlaylistItem } from '@/lib/types';
+import { PlaylistItemSummary } from '@/lib/types';
 import { Icon } from '@/theme/icons';
 
 interface PlaylistPreviewProps {
-  items: PlaylistItem[];
+  items: PlaylistItemSummary[];
   autoPlay?: boolean;
   onClose?: () => void;
 }

--- a/web/src/components/PlaylistQuickSelect.tsx
+++ b/web/src/components/PlaylistQuickSelect.tsx
@@ -2,12 +2,12 @@
 
 import { useState } from 'react';
 import { apiClient } from '@/lib/api';
-import { Display, Playlist } from '@/lib/types';
+import { Display, PlaylistSummary } from '@/lib/types';
 import LoadingSpinner from './LoadingSpinner';
 
 interface PlaylistQuickSelectProps {
   device: Display;
-  playlists: Playlist[];
+  playlists: PlaylistSummary[];
   onUpdate?: () => void;
   onError?: (error: Error) => void;
   onSuccess?: () => void;

--- a/web/src/lib/api/playlists.ts
+++ b/web/src/lib/api/playlists.ts
@@ -1,11 +1,11 @@
 // Playlist API methods
 
-import type { Playlist, PlaylistItem, PaginatedResponse } from '../types';
+import type { Playlist, PlaylistItem, PlaylistSummary, PaginatedResponse } from '../types';
 import { ApiClient } from './client';
 
 declare module './client' {
   interface ApiClient {
-    getPlaylists(params?: { page?: number; limit?: number }): Promise<PaginatedResponse<Playlist>>;
+    getPlaylists(params?: { page?: number; limit?: number }): Promise<PaginatedResponse<PlaylistSummary>>;
     getPlaylist(id: string): Promise<Playlist>;
     createPlaylist(data: { name: string; description?: string; loop?: boolean; items?: Array<{ contentId: string; duration?: number }> }): Promise<Playlist>;
     updatePlaylist(id: string, data: Partial<{ name: string; description?: string; loop?: boolean }>): Promise<Playlist>;
@@ -18,9 +18,9 @@ declare module './client' {
   }
 }
 
-ApiClient.prototype.getPlaylists = async function (params?: { page?: number; limit?: number }): Promise<PaginatedResponse<Playlist>> {
+ApiClient.prototype.getPlaylists = async function (params?: { page?: number; limit?: number }): Promise<PaginatedResponse<PlaylistSummary>> {
   const query = params ? new URLSearchParams(params as Record<string, string>).toString() : '';
-  return this.request<PaginatedResponse<Playlist>>(`/playlists${query ? `?${query}` : ''}`);
+  return this.request<PaginatedResponse<PlaylistSummary>>(`/playlists${query ? `?${query}` : ''}`);
 };
 
 ApiClient.prototype.getPlaylist = async function (id: string): Promise<Playlist> {

--- a/web/src/lib/hooks/useQueryHooks.ts
+++ b/web/src/lib/hooks/useQueryHooks.ts
@@ -2,7 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { apiClient } from '@/lib/api';
-import type { PaginatedResponse, Content, Display, Playlist, Schedule } from '@/lib/types';
+import type { PaginatedResponse, Content, Display, PlaylistSummary, Schedule } from '@/lib/types';
 
 export function useContent(params?: {
   page?: number;
@@ -24,7 +24,7 @@ export function useDisplays(params?: { page?: number; limit?: number }) {
 }
 
 export function usePlaylists(params?: { page?: number; limit?: number }) {
-  return useQuery<PaginatedResponse<Playlist>>({
+  return useQuery<PaginatedResponse<PlaylistSummary>>({
     queryKey: ['playlists', params],
     queryFn: () => apiClient.getPlaylists(params),
   });

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -24,6 +24,7 @@ export interface Content {
   thumbnailUrl?: string;
   status: 'ready' | 'processing' | 'error' | 'active' | 'archived' | 'flagged' | 'rejected';
   duration?: number;
+  fileSize?: number | null;
   metadata?: Record<string, any>;
   folderId?: string;
   createdAt: Date | string;
@@ -50,6 +51,24 @@ export interface Playlist {
   isActive: boolean;
   createdAt: Date | string;
   updatedAt: Date | string;
+}
+
+export interface PlaylistContentSummary {
+  id: string;
+  title: string;
+  type: Content['type'];
+  thumbnailUrl?: string | null;
+  status: Content['status'];
+  duration?: number;
+  fileSize?: number | null;
+}
+
+export interface PlaylistItemSummary extends Omit<PlaylistItem, 'content'> {
+  content?: PlaylistContentSummary | null;
+}
+
+export interface PlaylistSummary extends Omit<Playlist, 'items'> {
+  items: PlaylistItemSummary[];
 }
 
 export interface Schedule {


### PR DESCRIPTION
## Summary
- Project playlist-list nested content with a summary Prisma select instead of full `content: true`
- Add explicit `PlaylistSummary` web API types and update dashboard/list consumers
- Add unit and e2e contract coverage for playlist list summary fields

## Review
- Backend/Prisma/tenant reviewer: CLEAN
- API/frontend contract reviewer: found medium summary typing gap; fixed with `PlaylistSummary`
- Follow-up backend reviewer: CLEAN
- Follow-up API/frontend reviewer: CLEAN

## Local Verification
- `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/playlists/playlists.service.spec.ts src/modules/playlists/playlists.controller.spec.ts` — pass, 2 suites / 42 tests
- `pnpm --filter @vizora/web test -- --runInBand --testPathPattern=playlists-page|content-page|devices-page|schedules-page|PlaylistPreview|DeviceQuickChange` — pass, 6 suites / 100 tests, existing React act warnings
- `pnpm --filter @vizora/middleware test -- --runInBand` — pass, 143 suites / 2877 tests
- `pnpm --filter @vizora/web test -- --runInBand` — pass, 95 suites / 982 tests, existing React act/jsdom warnings
- `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` — pass
- `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` — pass
- `ESLINT_USE_FLAT_CONFIG=false npx eslint ...changed files...` — 0 errors, existing warnings
- `npx nx build @vizora/middleware` — pass, existing webpack warnings
- `NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 BACKEND_URL=http://localhost:3000 npx nx build @vizora/web` — pass
- `git diff --check` — pass, CRLF warnings only

## Local E2E Status
- `pnpm --filter @vizora/middleware test:e2e -- --runInBand --testPathPattern=playlists` timed out locally because Docker Desktop is unavailable and test DB/Redis ports 5433/6380 are closed. CI e2e must verify the added playlist contract test.

## Deployment
- Do not deploy automatically. Production checkout remains dirty/diverged and must be reconciled first.