### PR TITLE
feat(web): search playlist content library server-side

### DIFF
--- a/docs/plans/2026-06-01-content-library-search-performance-pass-18.md
+++ b/docs/plans/2026-06-01-content-library-search-performance-pass-18.md
@@ -1,0 +1,48 @@
+# Content Library Search Performance Pass 18
+
+Date: 2026-06-01
+Branch: `feat/content-library-search-pass-18`
+
+## Drift Check
+
+- The main content dashboard already uses server-side pagination, type/status/date/tag filters, and `search` via `apiClient.getContent(params)`.
+- The middleware content list API already accepts bounded `search` and applies it with organization scope in `buildContentListWhere`.
+- The playlist-builder `ContentLibraryPanel` still fetches one page and then filters `content` locally, so searching can miss matches on later pages and encourages operators to page through larger content libraries.
+- No new backend primitive is needed.
+
+## New Primitives Introduced
+
+None.
+
+## Hermes-First Analysis
+
+This is not an agent, MCP, AI-provider, or Hermes runtime change. It is a UI consumer improvement using the existing content list API.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Content-library search | Not applicable | Use existing `/api/v1/content?search=` API |
+| Playlist-builder performance | Not applicable | Keep within current React component and API client |
+
+Awesome-Hermes-agent ecosystem check: not applicable because no agent skill or provider path is being introduced.
+
+## Design
+
+Update `ContentLibraryPanel` to:
+- debounce the search input using the existing `useDebounce` hook
+- include non-empty search terms in `apiClient.getContent({ page, limit, type, search })`
+- reset pagination to page 1 when the search or type filter changes
+- render the server response directly instead of filtering only the current page in memory
+
+This preserves the existing API, pagination controls, draggable item behavior, and type filtering.
+
+## Test Plan
+
+1. Add a red component test proving search is sent to `getContent` rather than filtering only the current page.
+2. Add or update coverage proving changing search/type resets to page 1.
+3. Run focused `PlaylistBuilder` tests.
+4. Run web typecheck/build and relevant broader web tests.
+5. Dispatch multiple reviewers before broader tests.
+
+## Deployment
+
+No direct deployment in this pass unless the production checkout is reconciled. Current production remains dirty/diverged and deployment-blocked.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1621,7 +1621,7 @@ Plan: `docs/plans/2026-06-01-playlist-list-payload-performance-pass-17.md`
 - [x] Run multiple subagent reviews before broader tests.
 - [x] Run focused playlist middleware tests.
 - [x] Run broader middleware verification and build.
-- [ ] Open PR, wait for CI, merge if green.
+- [x] Open PR, wait for CI, merge if green. PR #140 merged to `origin/main` at `a3b4380ebbb5a6196ac66db8971060120471b663`.
 - [ ] Deploy status: blocked unless production dirty/diverged state is resolved or explicitly approved with a reviewed runbook.
 
 **Pass 17 verification**
@@ -1646,3 +1646,39 @@ Plan: `docs/plans/2026-06-01-playlist-list-payload-performance-pass-17.md`
   - `git diff --check` — passed with CRLF warnings only.
 - Local e2e status:
   - `pnpm --filter @vizora/middleware test:e2e -- --runInBand --testPathPattern=playlists` timed out locally because Docker Desktop is unavailable and test DB/Redis ports `5433`/`6380` are closed. CI e2e must verify the added playlist list contract test.
+- CI verification:
+  - PR #140 passed audit, lint, security, build, test, and e2e before merge.
+
+## Active Workstream: Content Library Search Performance Pass 18 (2026-06-01)
+
+Branch: `feat/content-library-search-pass-18`
+Plan: `docs/plans/2026-06-01-content-library-search-performance-pass-18.md`
+
+- [x] Drift-check content API search and dashboard content consumers.
+- [x] Document pass 18 design and test plan.
+- [x] Add failing ContentLibraryPanel test for server-side search.
+- [x] Implement debounced server-side search and pagination reset.
+- [x] Run multiple subagent reviews before broader tests.
+- [x] Run focused playlist-builder web tests.
+- [x] Run broader web verification and build.
+- [ ] Open PR, wait for CI, merge if green.
+- [ ] Deploy status: blocked unless production dirty/diverged state is resolved or explicitly approved with a reviewed runbook.
+
+**Pass 18 verification**
+- Red/green TDD:
+  - Initial `pnpm --filter @vizora/web test -- --runInBand --testPathPattern=PlaylistBuilder` failed on the new server-search assertion while `ContentLibraryPanel` only filtered the current page locally.
+  - Reviewer-driven red cases reproduced stale response ordering, debounce-window stale response, whitespace-only page reset/refetch, and stale pagination during pending search before the final fixes.
+  - Post-fix focused run passed: `PlaylistBuilder` suite 29 tests.
+- Reviewer gate:
+  - Initial API/performance reviewer: NOT CLEAN; found stale response race and whitespace-only excess fetch.
+  - Initial React/UX/test reviewer: NOT CLEAN; found stale response race and missing pagination/filter coverage.
+  - Follow-up API reviewer: NOT CLEAN; found whitespace-only edit reset/refetch from page 2.
+  - Follow-up React reviewer: NOT CLEAN; found debounce-window stale response.
+  - Final clean-gate reviewers after request invalidation and pagination guard: CLEAN / CLEAN.
+- Local verification:
+  - `pnpm --filter @vizora/web test -- --runInBand --testPathPattern=PlaylistBuilder` - 1 suite / 29 tests passed, with existing React `act()` warnings.
+  - `pnpm --filter @vizora/web test -- --runInBand` - 95 suites / 987 tests passed, with existing React `act()`/console warnings.
+  - `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` - passed.
+  - `$env:ESLINT_USE_FLAT_CONFIG='false'; npx eslint web/src/components/playlist/ContentLibraryPanel.tsx web/src/components/__tests__/PlaylistBuilder.test.tsx` - 0 errors, 0 warnings in touched files.
+  - `NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 BACKEND_URL=http://localhost:3000 pnpm --filter @vizora/web build` - passed with existing Next middleware/proxy and TS project-reference warnings.
+  - `git diff --check` - passed with CRLF warnings only.

--- a/web/src/components/__tests__/PlaylistBuilder.test.tsx
+++ b/web/src/components/__tests__/PlaylistBuilder.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { useRouter, useParams } from 'next/navigation';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { useParams } from 'next/navigation';
 import PlaylistBuilderPage from '@/app/dashboard/playlists/[id]/page';
 import ContentLibraryPanel from '@/components/playlist/ContentLibraryPanel';
 import PlaylistEditorPanel from '@/components/playlist/PlaylistEditorPanel';
@@ -130,6 +130,22 @@ const mockPlaylist: Playlist = {
   updatedAt: '2024-01-01',
 };
 
+type MockContentResponse = {
+  data: Content[];
+  meta: { total: number; page: number; limit: number; totalPages: number };
+};
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+}
+
 describe('PlaylistBuilder Components', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -181,7 +197,17 @@ describe('PlaylistBuilder Components', () => {
       });
     });
 
-    it('filters content by search query', async () => {
+    it('sends search query to the server instead of filtering only the current page', async () => {
+      (apiClient.getContent as jest.Mock)
+        .mockResolvedValueOnce({
+          data: mockContent,
+          meta: { total: 2, page: 1, limit: 20, totalPages: 1 },
+        })
+        .mockResolvedValueOnce({
+          data: [mockContent[1]],
+          meta: { total: 1, page: 1, limit: 20, totalPages: 1 },
+        });
+
       render(<ContentLibraryPanel organizationId="org-1" />);
 
       await waitFor(() => {
@@ -191,8 +217,17 @@ describe('PlaylistBuilder Components', () => {
       const searchInput = screen.getByPlaceholderText('Search content...');
       fireEvent.change(searchInput, { target: { value: 'Video' } });
 
-      expect(screen.queryByText('Test Image')).not.toBeInTheDocument();
-      expect(screen.getByText('Test Video')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(apiClient.getContent).toHaveBeenLastCalledWith({
+          page: 1,
+          limit: 20,
+          search: 'Video',
+        });
+      });
+      await waitFor(() => {
+        expect(screen.queryByText('Test Image')).not.toBeInTheDocument();
+        expect(screen.getByText('Test Video')).toBeInTheDocument();
+      });
     });
 
     it('filters content by type', async () => {
@@ -209,6 +244,217 @@ describe('PlaylistBuilder Components', () => {
         expect(apiClient.getContent).toHaveBeenCalledWith(
           expect.objectContaining({ type: 'image' })
         );
+      });
+    });
+
+    it('ignores stale content responses after a newer search response wins', async () => {
+      const initialRequest = createDeferred<MockContentResponse>();
+      const searchRequest = createDeferred<MockContentResponse>();
+      (apiClient.getContent as jest.Mock)
+        .mockReturnValueOnce(initialRequest.promise)
+        .mockReturnValueOnce(searchRequest.promise);
+
+      render(<ContentLibraryPanel organizationId="org-1" />);
+
+      await waitFor(() => {
+        expect(apiClient.getContent).toHaveBeenCalledTimes(1);
+      });
+
+      fireEvent.change(screen.getByPlaceholderText('Search content...'), {
+        target: { value: 'Video' },
+      });
+
+      await waitFor(() => {
+        expect(apiClient.getContent).toHaveBeenCalledTimes(2);
+      });
+
+      await act(async () => {
+        searchRequest.resolve({
+          data: [mockContent[1]],
+          meta: { total: 1, page: 1, limit: 20, totalPages: 1 },
+        });
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText('Test Image')).not.toBeInTheDocument();
+        expect(screen.getByText('Test Video')).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        initialRequest.resolve({
+          data: mockContent,
+          meta: { total: 2, page: 1, limit: 20, totalPages: 1 },
+        });
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText('Test Image')).not.toBeInTheDocument();
+        expect(screen.getByText('Test Video')).toBeInTheDocument();
+      });
+    });
+
+    it('ignores stale responses that resolve before the debounced search request starts', async () => {
+      const initialRequest = createDeferred<MockContentResponse>();
+      const searchRequest = createDeferred<MockContentResponse>();
+      (apiClient.getContent as jest.Mock)
+        .mockReturnValueOnce(initialRequest.promise)
+        .mockReturnValueOnce(searchRequest.promise);
+
+      render(<ContentLibraryPanel organizationId="org-1" />);
+
+      await waitFor(() => {
+        expect(apiClient.getContent).toHaveBeenCalledTimes(1);
+      });
+
+      fireEvent.change(screen.getByPlaceholderText('Search content...'), {
+        target: { value: 'Video' },
+      });
+
+      await act(async () => {
+        initialRequest.resolve({
+          data: mockContent,
+          meta: { total: 2, page: 1, limit: 20, totalPages: 1 },
+        });
+      });
+
+      expect(screen.queryByText('Test Image')).not.toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(apiClient.getContent).toHaveBeenCalledTimes(2);
+      });
+
+      await act(async () => {
+        searchRequest.resolve({
+          data: [mockContent[1]],
+          meta: { total: 1, page: 1, limit: 20, totalPages: 1 },
+        });
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText('Test Image')).not.toBeInTheDocument();
+        expect(screen.getByText('Test Video')).toBeInTheDocument();
+      });
+    });
+
+    it('resets to page one and preserves search when type filter changes', async () => {
+      (apiClient.getContent as jest.Mock)
+        .mockResolvedValueOnce({
+          data: mockContent,
+          meta: { total: 40, page: 1, limit: 20, totalPages: 2 },
+        })
+        .mockResolvedValue({
+          data: [mockContent[1]],
+          meta: { total: 1, page: 1, limit: 20, totalPages: 1 },
+        });
+
+      render(<ContentLibraryPanel organizationId="org-1" />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Next'));
+
+      await waitFor(() => {
+        expect(apiClient.getContent).toHaveBeenLastCalledWith({
+          page: 2,
+          limit: 20,
+        });
+      });
+
+      fireEvent.change(screen.getByPlaceholderText('Search content...'), {
+        target: { value: 'Video' },
+      });
+
+      await waitFor(() => {
+        expect(apiClient.getContent).toHaveBeenLastCalledWith({
+          page: 1,
+          limit: 20,
+          search: 'Video',
+        });
+      });
+
+      fireEvent.click(screen.getByText('Video'));
+
+      await waitFor(() => {
+        expect(apiClient.getContent).toHaveBeenLastCalledWith({
+          page: 1,
+          limit: 20,
+          type: 'video',
+          search: 'Video',
+        });
+      });
+    });
+
+    it('does not refetch when only search whitespace changes', async () => {
+      (apiClient.getContent as jest.Mock).mockResolvedValue({
+        data: mockContent,
+        meta: { total: 40, page: 1, limit: 20, totalPages: 2 },
+      });
+
+      render(<ContentLibraryPanel organizationId="org-1" />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByPlaceholderText('Search content...'), {
+        target: { value: 'Video' },
+      });
+
+      await waitFor(() => {
+        expect(apiClient.getContent).toHaveBeenCalledTimes(2);
+      });
+
+      fireEvent.click(screen.getByText('Next'));
+
+      await waitFor(() => {
+        expect(apiClient.getContent).toHaveBeenCalledTimes(3);
+      });
+      await waitFor(() => {
+        expect(apiClient.getContent).toHaveBeenLastCalledWith({
+          page: 2,
+          limit: 20,
+          search: 'Video',
+        });
+      });
+
+      fireEvent.change(screen.getByPlaceholderText('Search content...'), {
+        target: { value: 'Video ' },
+      });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 350));
+      });
+
+      expect(apiClient.getContent).toHaveBeenCalledTimes(3);
+      expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
+    });
+
+    it('does not let stale pagination advance a pending search request', async () => {
+      (apiClient.getContent as jest.Mock).mockResolvedValue({
+        data: mockContent,
+        meta: { total: 40, page: 1, limit: 20, totalPages: 2 },
+      });
+
+      render(<ContentLibraryPanel organizationId="org-1" />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByPlaceholderText('Search content...'), {
+        target: { value: 'Video' },
+      });
+
+      expect(screen.queryByText('Next')).not.toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(apiClient.getContent).toHaveBeenLastCalledWith({
+          page: 1,
+          limit: 20,
+          search: 'Video',
+        });
       });
     });
 

--- a/web/src/components/playlist/ContentLibraryPanel.tsx
+++ b/web/src/components/playlist/ContentLibraryPanel.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { Content } from '@/lib/types';
 import { apiClient } from '@/lib/api';
+import type { ContentListParams } from '@/lib/api/content';
+import { useDebounce } from '@/lib/hooks/useDebounce';
 import { Icon } from '@/theme/icons';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import DraggableContentItem from './DraggableContentItem';
@@ -11,45 +13,77 @@ interface ContentLibraryPanelProps {
   organizationId: string;
 }
 
-export default function ContentLibraryPanel({ organizationId }: ContentLibraryPanelProps) {
+export default function ContentLibraryPanel({ organizationId: _organizationId }: ContentLibraryPanelProps) {
   const [content, setContent] = useState<Content[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
   const [typeFilter, setTypeFilter] = useState<string>('all');
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
+  const debouncedSearch = useDebounce(searchQuery, 300);
+  const normalizedSearchQuery = searchQuery.trim();
+  const normalizedDebouncedSearch = debouncedSearch.trim();
+  const searchSettled = normalizedSearchQuery === normalizedDebouncedSearch;
+  const loadContentRequestRef = useRef(0);
 
-  useEffect(() => {
-    loadContent();
-  }, [page, typeFilter]);
-
-  const loadContent = async () => {
+  const loadContent = useCallback(async () => {
+    const requestId = ++loadContentRequestRef.current;
     try {
       setLoading(true);
-      const params: any = { page, limit: 20 };
+      const params: ContentListParams = { page, limit: 20 };
       if (typeFilter !== 'all') {
         params.type = typeFilter;
       }
+      if (normalizedDebouncedSearch) {
+        params.search = normalizedDebouncedSearch;
+      }
       const response = await apiClient.getContent(params);
+      if (requestId !== loadContentRequestRef.current) {
+        return;
+      }
       setContent(response.data || []);
       if (response.meta) {
         setTotalPages(response.meta.totalPages);
       }
     } catch (error) {
+      if (requestId !== loadContentRequestRef.current) {
+        return;
+      }
       if (process.env.NODE_ENV === 'development') {
         console.error('Failed to load content:', error);
       }
     } finally {
-      setLoading(false);
+      if (requestId === loadContentRequestRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [page, typeFilter, normalizedDebouncedSearch]);
+
+  useEffect(() => {
+    if (!searchSettled) return;
+    void loadContent();
+  }, [loadContent, searchSettled]);
+
+  const invalidatePendingContentLoads = () => {
+    loadContentRequestRef.current += 1;
+    setLoading(true);
+  };
+
+  const handleSearchChange = (value: string) => {
+    const nextNormalizedSearch = value.trim();
+    setSearchQuery(value);
+    if (nextNormalizedSearch !== normalizedSearchQuery) {
+      invalidatePendingContentLoads();
+      setPage(1);
     }
   };
 
-  const filteredContent = content.filter((item) => {
-    if (searchQuery) {
-      return item.title.toLowerCase().includes(searchQuery.toLowerCase());
-    }
-    return true;
-  });
+  const handleTypeFilterChange = (type: string) => {
+    if (type === typeFilter) return;
+    invalidatePendingContentLoads();
+    setTypeFilter(type);
+    setPage(1);
+  };
 
   return (
     <div className="flex flex-col h-full bg-[var(--background)] border-r border-[var(--border)]">
@@ -63,7 +97,7 @@ export default function ContentLibraryPanel({ organizationId }: ContentLibraryPa
           <input
             type="text"
             value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
+            onChange={(e) => handleSearchChange(e.target.value)}
             placeholder="Search content..."
             className="w-full pl-9 pr-3 py-2 text-sm border border-[var(--border)] rounded-lg focus:ring-2 focus:ring-[#00E5A0] focus:border-transparent"
           />
@@ -74,7 +108,7 @@ export default function ContentLibraryPanel({ organizationId }: ContentLibraryPa
           {['all', 'image', 'video', 'url', 'pdf'].map((type) => (
             <button
               key={type}
-              onClick={() => setTypeFilter(type)}
+              onClick={() => handleTypeFilterChange(type)}
               className={`
                 px-3 py-1 text-xs font-medium rounded-full transition
                 ${typeFilter === type
@@ -95,7 +129,7 @@ export default function ContentLibraryPanel({ organizationId }: ContentLibraryPa
           <div className="flex items-center justify-center py-12">
             <LoadingSpinner size="lg" />
           </div>
-        ) : filteredContent.length === 0 ? (
+        ) : content.length === 0 ? (
           <div className="text-center py-12">
             <div className="text-[var(--foreground-tertiary)] mb-2">
               <Icon name="content" size="2xl" className="text-[var(--foreground-tertiary)] mx-auto" />
@@ -105,7 +139,7 @@ export default function ContentLibraryPanel({ organizationId }: ContentLibraryPa
             </p>
             {searchQuery && (
               <button
-                onClick={() => setSearchQuery('')}
+                onClick={() => handleSearchChange('')}
                 className="text-xs text-[#00E5A0] hover:text-[#00CC8E] mt-2"
               >
                 Clear search
@@ -114,7 +148,7 @@ export default function ContentLibraryPanel({ organizationId }: ContentLibraryPa
           </div>
         ) : (
           <>
-            {filteredContent.map((item) => (
+            {content.map((item) => (
               <DraggableContentItem key={item.id} content={item} />
             ))}
           </>
@@ -122,7 +156,7 @@ export default function ContentLibraryPanel({ organizationId }: ContentLibraryPa
       </div>
 
       {/* Pagination */}
-      {totalPages > 1 && (
+      {!loading && searchSettled && totalPages > 1 && (
         <div className="p-4 border-t border-[var(--border)] bg-[var(--surface)]">
           <div className="flex items-center justify-between text-sm">
             <button


### PR DESCRIPTION
## Summary
- Move playlist-builder content library search from current-page local filtering to existing server-side `/content?search=` pagination.
- Add debounced search with latest-request guards, immediate invalidation on semantic search/type changes, and pagination hidden while search results are unsettled.
- Add regression coverage for server search, stale responses, debounce-window races, whitespace-only edits, search/type page reset, and pending-search pagination.

## Reviews
- Multiple subagent review rounds before broader tests.
- Initial/follow-up findings on stale responses, whitespace-only pagination reset, debounce-window stale responses, and stale pagination were fixed.
- Final clean-gate reviewers: CLEAN / CLEAN.

## Verification
- `pnpm --filter @vizora/web test -- --runInBand --testPathPattern=PlaylistBuilder` - 29 tests passed, existing React act warnings.
- `pnpm --filter @vizora/web test -- --runInBand` - 95 suites / 987 tests passed, existing React act/jsdom warnings.
- `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` - passed.
- `$env:ESLINT_USE_FLAT_CONFIG='false'; npx eslint web/src/components/playlist/ContentLibraryPanel.tsx web/src/components/__tests__/PlaylistBuilder.test.tsx` - 0 errors, 0 warnings in touched files.
- `NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 BACKEND_URL=http://localhost:3000 pnpm --filter @vizora/web build` - passed with existing Next middleware/proxy and TS project-reference warnings.
- `git diff --check` - passed with CRLF warnings only.

## Deployment
- Do not deploy from this PR automatically. Production checkout remains known dirty/diverged until rechecked after merge.