### PR TITLE
Slim content list payloads

### DIFF
--- a/docs/plans/2026-06-01-content-list-payload-performance-pass-19.md
+++ b/docs/plans/2026-06-01-content-list-payload-performance-pass-19.md
@@ -1,0 +1,57 @@
+# Content List Payload Performance Pass 19
+
+Date: 2026-06-01
+Branch: `feat/content-list-payload-pass-19`
+
+## Why Now
+
+The content dashboard now uses server-side pagination and filtering, but the
+root and folder list endpoints still fetch and return full `Content` rows. For
+real customer libraries this means every list page can carry modal-only fields
+such as full media URLs and large `metadata` JSON blobs containing template HTML
+or rendered widget payloads.
+
+## New primitives introduced
+
+No new runtime primitives. This pass adds a shared content-list projection and
+uses the existing `GET /content/:id` detail endpoint for modal-only hydration.
+
+## Hermes-first analysis
+
+Not applicable. This pass does not add business agents, MCP tools, Hermes
+skills, AI/provider calls, or spend paths.
+
+## Current Runtime/Code Evidence
+
+- `ContentService.findAll` uses `content.findMany(... include: { tags })` and
+  maps full rows into the list response.
+- `FoldersService.getContents` does the same for folder-scoped content lists.
+- `ContentClient` renders list/grid cards from `title`, `type`, `status`,
+  `thumbnailUrl`, `duration`, and `createdAt`.
+- `PreviewModal`, edit URL fields, and flagged-review reason display need full
+  detail fields and can use the existing `apiClient.getContentItem(id)` path.
+
+## Plan
+
+- Add backend tests proving root and folder content lists use a bounded
+  projection that excludes modal-only `url`, `metadata`, `mimeType`, and
+  playlist relations.
+- Implement a shared list select in the middleware content service and reuse it
+  from folder content lists.
+- Add dashboard tests proving initial list render does not need `url` or
+  `metadata`, and preview/edit/review actions hydrate full content through
+  `getContentItem`.
+- Implement a small detail-loading helper in the content dashboard that preserves
+  the selected summary immediately and opens the modal after detail fetch
+  succeeds.
+- Run focused middleware/web tests, subagent code review, broader affected
+  verification, PR/CI/merge, then re-check the production deploy gate.
+
+## Risks
+
+- Removing fields from list responses can break hidden dashboard assumptions.
+  Mitigation: tests cover summary-only list render and modal hydration paths.
+- Folder content responses should match root list shape. Mitigation: both
+  services use the same select constant.
+- Production deploy remains gated by the dirty/diverged prod checkout; no deploy
+  should occur until that is classified or repaired by an operator-safe process.

--- a/middleware/src/modules/content/content-list-select.ts
+++ b/middleware/src/modules/content/content-list-select.ts
@@ -1,0 +1,44 @@
+import { Prisma } from '@vizora/database';
+
+export const CONTENT_LIST_SELECT = {
+  id: true,
+  organizationId: true,
+  name: true,
+  type: true,
+  thumbnail: true,
+  duration: true,
+  fileSize: true,
+  status: true,
+  folderId: true,
+  createdAt: true,
+  updatedAt: true,
+  tags: {
+    select: {
+      id: true,
+      contentId: true,
+      tagId: true,
+      createdAt: true,
+      tag: {
+        select: {
+          id: true,
+          name: true,
+          color: true,
+          organizationId: true,
+          createdAt: true,
+        },
+      },
+    },
+  },
+} satisfies Prisma.ContentSelect;
+
+export type ContentListRecord = Prisma.ContentGetPayload<{
+  select: typeof CONTENT_LIST_SELECT;
+}>;
+
+export function mapContentListResponse(content: ContentListRecord) {
+  return {
+    ...content,
+    title: content.name,
+    thumbnailUrl: content.thumbnail,
+  };
+}

--- a/middleware/src/modules/content/content.service.spec.ts
+++ b/middleware/src/modules/content/content.service.spec.ts
@@ -185,6 +185,33 @@ describe('ContentService', () => {
       expect(result.meta.total).toBe(1);
     });
 
+    it('should use a bounded list projection without modal-only fields', async () => {
+      mockDatabaseService.content.findMany.mockResolvedValue([mockContent]);
+      mockDatabaseService.content.count.mockResolvedValue(1);
+
+      await service.findAll('org-123', { page: 1, limit: 10 });
+
+      const call = mockDatabaseService.content.findMany.mock.calls[0][0];
+      expect(call).not.toHaveProperty('include');
+      expect(call.select).toEqual(expect.objectContaining({
+        id: true,
+        organizationId: true,
+        name: true,
+        type: true,
+        thumbnail: true,
+        duration: true,
+        fileSize: true,
+        status: true,
+        folderId: true,
+        createdAt: true,
+        updatedAt: true,
+      }));
+      expect(call.select).not.toHaveProperty('url');
+      expect(call.select).not.toHaveProperty('metadata');
+      expect(call.select).not.toHaveProperty('mimeType');
+      expect(call.select).not.toHaveProperty('playlistItems');
+    });
+
     it('should filter by type', async () => {
       mockDatabaseService.content.findMany.mockResolvedValue([mockContent]);
       mockDatabaseService.content.count.mockResolvedValue(1);

--- a/middleware/src/modules/content/content.service.ts
+++ b/middleware/src/modules/content/content.service.ts
@@ -20,6 +20,7 @@ import { StorageQuotaService } from '../storage/storage-quota.service';
 import { StorageService } from '../storage/storage.service';
 import type { WidgetDataSource } from './widget-data-sources';
 import { buildContentListWhere, type ContentListFilters } from './content-list-query';
+import { CONTENT_LIST_SELECT, mapContentListResponse } from './content-list-select';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -112,19 +113,13 @@ export class ContentService {
         skip,
         take: limit,
         orderBy: { createdAt: 'desc' },
-        include: {
-          tags: {
-            include: {
-              tag: true,
-            },
-          },
-        },
+        select: CONTENT_LIST_SELECT,
       }),
       this.db.content.count({ where }),
     ]);
 
     // Map each content item to include thumbnailUrl
-    const mappedData = data.map(item => this.mapContentResponse(item));
+    const mappedData = data.map(mapContentListResponse);
     return new PaginatedResponse(mappedData, total, page, limit);
   }
 

--- a/middleware/src/modules/folders/folders.service.spec.ts
+++ b/middleware/src/modules/folders/folders.service.spec.ts
@@ -459,6 +459,39 @@ describe('FoldersService', () => {
       expect(result.meta.total).toBe(1);
     });
 
+    it('should use a bounded list projection without modal-only fields', async () => {
+      mockDatabaseService.contentFolder.findFirst.mockResolvedValue({
+        ...mockFolder,
+        parent: null,
+        children: [],
+        _count: { content: 1 },
+      });
+      mockDatabaseService.content.findMany.mockResolvedValue([mockContent]);
+      mockDatabaseService.content.count.mockResolvedValue(1);
+
+      await service.getContents('org-123', 'folder-123', { page: 1, limit: 10 });
+
+      const call = mockDatabaseService.content.findMany.mock.calls[0][0];
+      expect(call).not.toHaveProperty('include');
+      expect(call.select).toEqual(expect.objectContaining({
+        id: true,
+        organizationId: true,
+        name: true,
+        type: true,
+        thumbnail: true,
+        duration: true,
+        fileSize: true,
+        status: true,
+        folderId: true,
+        createdAt: true,
+        updatedAt: true,
+      }));
+      expect(call.select).not.toHaveProperty('url');
+      expect(call.select).not.toHaveProperty('metadata');
+      expect(call.select).not.toHaveProperty('mimeType');
+      expect(call.select).not.toHaveProperty('playlistItems');
+    });
+
     it('should throw NotFoundException if folder not found', async () => {
       mockDatabaseService.contentFolder.findFirst.mockResolvedValue(null);
 

--- a/middleware/src/modules/folders/folders.service.ts
+++ b/middleware/src/modules/folders/folders.service.ts
@@ -5,6 +5,7 @@ import { UpdateFolderDto } from './dto/update-folder.dto';
 import { MoveContentDto } from './dto/move-content.dto';
 import { PaginationDto, PaginatedResponse } from '../common/dto/pagination.dto';
 import { buildContentListWhere, type ContentListFilters } from '../content/content-list-query';
+import { CONTENT_LIST_SELECT, mapContentListResponse } from '../content/content-list-select';
 
 export interface FolderWithChildren {
   id: string;
@@ -230,21 +231,13 @@ export class FoldersService {
         skip,
         take: limit,
         orderBy: { createdAt: 'desc' },
-        include: {
-          tags: {
-            include: { tag: true },
-          },
-        },
+        select: CONTENT_LIST_SELECT,
       }),
       this.db.content.count({ where }),
     ]);
 
     // Map content response for frontend compatibility
-    const mappedData = data.map((content) => ({
-      ...content,
-      title: content.name,
-      thumbnailUrl: content.thumbnail,
-    }));
+    const mappedData = data.map(mapContentListResponse);
 
     return new PaginatedResponse(mappedData, total, page, limit);
   }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,91 @@
 # Vizora - Task Tracker
 
+## In Progress: Content List Payload Performance Pass 19 (2026-06-01)
+
+**Branch:** `feat/content-list-payload-pass-19`
+
+**Why now:** PR #141 merged playlist-builder server-side content search and CI
+is green, but production deployment remains blocked by dirty/diverged prod
+state. The next customer-visible performance gap is list payload size: root and
+folder content-list endpoints still fetch full content rows even though the
+dashboard cards need only summary fields.
+
+**New primitives introduced:** no new runtime primitives. This pass adds a
+shared content-list projection and uses the existing `GET /content/:id` detail
+endpoint for modal-only dashboard hydration.
+
+**Hermes-first analysis:** not applicable. This pass does not add business
+agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
+
+**Plan**
+- [x] Merge PR #141 after full CI green.
+- [x] Re-check production deploy gate after merge.
+- [x] Start fresh branch from `origin/main`.
+- [x] Write scoped plan/design for content-list payload slimming.
+- [x] Add focused failing middleware and web tests.
+- [x] Implement backend list projection and frontend detail hydration.
+- [x] Run multi-subagent code review before broader tests.
+- [x] Run focused and broader affected verification.
+- [ ] PR, CI, merge.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Current merge/deploy state**
+- [x] PR #141 merged at
+  `6fcc39deb60634037be37758843aa638dcf1cb3d`; CI green for audit, build, e2e,
+  lint, security, and test.
+- [x] Prod deploy remains blocked: `/opt/vizora/app` is dirty and
+  ahead/behind stale prod `origin/main`; no production pull, reset, stash, env
+  edit, service restart, DB mutation, or deploy performed.
+
+**Plan/design:**
+`docs/plans/2026-06-01-content-list-payload-performance-pass-19.md`
+
+**Review**
+- [x] Backend/API/data-contract reviewer CLEAN: list projection keeps tenant
+  scoping, valid Prisma select shape, envelope-compatible paginated response,
+  and full-detail paths still use `findOne` / device-specific fetches.
+- [x] Frontend reviewer found stale detail races, edit hydration gap, and
+  repeated-detail request fanout. Fixed with request invalidation, pending
+  request dedupe, edit detail hydration, pagination invalidation, and regression
+  tests. Follow-up frontend re-review CLEAN.
+- [x] Test/CI reviewer found the untracked helper risk and stale tracker counts.
+  The helper will be staged with the commit; verification counts below are
+  updated after final focused/broad runs.
+
+**Verification**
+- [x] Focused middleware tests passed:
+  `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="content.service|folders.service"`
+  (2 suites / 140 tests).
+- [x] Focused web content dashboard tests passed:
+  `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/dashboard/content/__tests__/content-page.test.tsx`
+  (1 suite / 42 tests).
+- [x] Full middleware tests passed:
+  `pnpm --filter @vizora/middleware test -- --runInBand`
+  (143 suites / 2879 tests).
+- [x] Full web tests passed:
+  `pnpm --filter @vizora/web test -- --runInBand`
+  (95 suites / 994 tests; existing unrelated React `act(...)` and jsdom
+  navigation warnings remain).
+- [x] TypeScript checks passed:
+  `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` and
+  `pnpm --filter @vizora/web exec tsc --noEmit --pretty false`.
+- [x] Changed-file ESLint passed with warnings only:
+  `npx eslint middleware/src/modules/content/content.service.ts middleware/src/modules/content/content-list-select.ts middleware/src/modules/folders/folders.service.ts web/src/app/dashboard/content/page-client.tsx web/src/app/dashboard/content/__tests__/content-page.test.tsx`
+  (legacy explicit-`any` warnings remain in `page-client.tsx`).
+- [x] Builds passed:
+  `npx nx build @vizora/middleware`,
+  `npx nx build @vizora/realtime`, and
+  `npx nx build @vizora/web` with local public URL env vars.
+- [x] `git diff --check` passed with CRLF warnings only.
+- [x] Targeted Playwright content/folder E2E attempted:
+  `npx playwright test e2e-tests/04-content.spec.ts e2e-tests/20-content-folders.spec.ts --reporter=list`
+  failed 14/14 at auth fixture setup with `ECONNREFUSED ::1:3000`
+  (`POST http://localhost:3000/api/v1/auth/register`). Docker Desktop is not
+  available and no services are listening on ports 3000/3001/3002, so this is
+  an environment failure before the changed content flows are exercised.
+
+---
+
 ## In Progress: Dashboard Summary Performance Pass 15 (2026-05-31)
 
 **Branch:** `feat/customer-dashboard-pass-15`

--- a/web/src/app/dashboard/content/__tests__/content-page.test.tsx
+++ b/web/src/app/dashboard/content/__tests__/content-page.test.tsx
@@ -2,26 +2,31 @@ import { render, screen, waitFor, fireEvent, act } from '@testing-library/react'
 import ContentClient from '../page-client';
 
 const mockGetContent = jest.fn();
+const mockGetContentItem = jest.fn();
 const mockGetFolderContent = jest.fn();
 const mockGetFolders = jest.fn();
 const mockGetDisplays = jest.fn();
 const mockGetPlaylists = jest.fn();
 const mockDeleteContent = jest.fn();
+const mockUpdateContent = jest.fn();
 const mockUploadContent = jest.fn();
 const mockCreateContent = jest.fn();
 const mockUploadContentWithProgress = jest.fn();
 const mockGenerateThumbnail = jest.fn();
 const mockAddPlaylistItem = jest.fn();
+const mockValidateForm = jest.fn<Record<string, string>, [unknown, unknown]>(() => ({}));
 let lastDropzoneOptions: any;
 
 jest.mock('@/lib/api', () => ({
   apiClient: {
     getContent: (...args: any[]) => mockGetContent(...args),
+    getContentItem: (...args: any[]) => mockGetContentItem(...args),
     getFolderContent: (...args: any[]) => mockGetFolderContent(...args),
     getFolders: (...args: any[]) => mockGetFolders(...args),
     getDisplays: (...args: any[]) => mockGetDisplays(...args),
     getPlaylists: (...args: any[]) => mockGetPlaylists(...args),
     deleteContent: (...args: any[]) => mockDeleteContent(...args),
+    updateContent: (...args: any[]) => mockUpdateContent(...args),
     uploadContent: (...args: any[]) => mockUploadContent(...args),
     createContent: (...args: any[]) => mockCreateContent(...args),
     uploadContentWithProgress: (...args: any[]) => mockUploadContentWithProgress(...args),
@@ -76,7 +81,7 @@ jest.mock('@/lib/hooks', () => ({
 
 jest.mock('@/lib/validation', () => ({
   contentUploadSchema: { parse: jest.fn() },
-  validateForm: jest.fn(() => ({})),
+  validateForm: (schema: unknown, values: unknown) => mockValidateForm(schema, values),
 }));
 
 jest.mock('@/theme/icons', () => ({
@@ -111,7 +116,14 @@ jest.mock('@/components/Modal', () => {
 });
 
 jest.mock('@/components/PreviewModal', () => {
-  return function MockPreviewModal() { return null; };
+  return function MockPreviewModal({ isOpen, content }: any) {
+    return isOpen ? (
+      <div data-testid="preview-modal">
+        <span>{content?.title}</span>
+        <span data-testid="preview-url">{content?.url || ''}</span>
+      </div>
+    ) : null;
+  };
 });
 
 jest.mock('@/components/ConfirmDialog', () => {
@@ -209,20 +221,33 @@ const sampleContent = [
   },
 ];
 
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+};
+
 describe('ContentClient', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetContent.mockResolvedValue({ data: [], meta: { page: 1, limit: 50, total: 0, totalPages: 0 } });
+    mockGetContentItem.mockResolvedValue(sampleContent[0]);
     mockGetFolderContent.mockResolvedValue({ data: [], meta: { page: 1, limit: 50, total: 0, totalPages: 0 } });
     mockGetFolders.mockResolvedValue([]);
     mockGetDisplays.mockResolvedValue({ data: [] });
     mockGetPlaylists.mockResolvedValue({ data: [] });
     mockDeleteContent.mockResolvedValue({});
+    mockUpdateContent.mockResolvedValue(sampleContent[0]);
     mockUploadContent.mockResolvedValue({ id: 'new-1', title: 'New Content' });
     mockCreateContent.mockResolvedValue({ id: 'new-1', title: 'New Content' });
     mockUploadContentWithProgress.mockResolvedValue({ id: 'new-1', title: 'New Content' });
     mockGenerateThumbnail.mockResolvedValue({});
     mockAddPlaylistItem.mockResolvedValue({});
+    mockValidateForm.mockReturnValue({});
     lastDropzoneOptions = undefined;
     Object.defineProperty(URL, 'createObjectURL', {
       configurable: true,
@@ -321,6 +346,249 @@ describe('ContentClient', () => {
     await waitForAuxiliaryRequestsToSettle();
     expect(screen.getByText('Promo Video')).toBeInTheDocument();
     expect(screen.getByText('Menu PDF')).toBeInTheDocument();
+  });
+
+  it('renders content list cards from summary payloads without url or metadata', async () => {
+    const summaryContent = { ...sampleContent[0] };
+    delete (summaryContent as any).url;
+    delete (summaryContent as any).metadata;
+    mockGetContent.mockResolvedValue({
+      data: [summaryContent],
+      meta: { page: 1, limit: 50, total: 1, totalPages: 1 },
+    });
+
+    render(<ContentClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+    expect(mockGetContentItem).not.toHaveBeenCalled();
+  });
+
+  it('hydrates full content before opening preview from a summary payload', async () => {
+    const summaryContent = { ...sampleContent[0] };
+    delete (summaryContent as any).url;
+    delete (summaryContent as any).metadata;
+    mockGetContent.mockResolvedValue({
+      data: [summaryContent],
+      meta: { page: 1, limit: 50, total: 1, totalPages: 1 },
+    });
+    mockGetContentItem.mockResolvedValue({
+      ...sampleContent[0],
+      url: '/uploads/banner.png',
+      metadata: { tags: ['Marketing'] },
+    });
+
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    fireEvent.click(screen.getByTitle('Click to preview'));
+
+    await waitFor(() => {
+      expect(mockGetContentItem).toHaveBeenCalledWith('c1');
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('preview-url')).toHaveTextContent('/uploads/banner.png');
+    });
+  });
+
+  it('does not open stale preview detail after the list context changes', async () => {
+    const summaryContent = { ...sampleContent[0] };
+    delete (summaryContent as any).url;
+    delete (summaryContent as any).metadata;
+    const deferredDetail = createDeferred<any>();
+    mockGetContent
+      .mockResolvedValueOnce({
+        data: [summaryContent],
+        meta: { page: 1, limit: 50, total: 1, totalPages: 1 },
+      })
+      .mockResolvedValue({
+        data: [],
+        meta: { page: 1, limit: 50, total: 0, totalPages: 0 },
+      });
+    mockGetContentItem.mockReturnValueOnce(deferredDetail.promise);
+
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    fireEvent.click(screen.getByTitle('Click to preview'));
+    await waitFor(() => {
+      expect(mockGetContentItem).toHaveBeenCalledWith('c1');
+    });
+
+    fireEvent.change(screen.getByTestId('search-input'), { target: { value: 'menu' } });
+    await waitFor(() => {
+      expect(mockGetContent).toHaveBeenLastCalledWith(expect.objectContaining({ search: 'menu' }));
+    });
+
+    await act(async () => {
+      deferredDetail.resolve({
+        ...sampleContent[0],
+        url: '/uploads/banner.png',
+      });
+      await deferredDetail.promise;
+    });
+
+    expect(screen.queryByTestId('preview-modal')).not.toBeInTheDocument();
+  });
+
+  it('dedupes repeated preview detail loads for the same item', async () => {
+    const summaryContent = { ...sampleContent[0] };
+    delete (summaryContent as any).url;
+    delete (summaryContent as any).metadata;
+    const deferredDetail = createDeferred<any>();
+    mockGetContent.mockResolvedValue({
+      data: [summaryContent],
+      meta: { page: 1, limit: 50, total: 1, totalPages: 1 },
+    });
+    mockGetContentItem.mockReturnValueOnce(deferredDetail.promise);
+
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    const previewTarget = screen.getByTitle('Click to preview');
+    fireEvent.click(previewTarget);
+    fireEvent.click(previewTarget);
+
+    expect(mockGetContentItem).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      deferredDetail.resolve({
+        ...sampleContent[0],
+        url: '/uploads/banner.png',
+      });
+      await deferredDetail.promise;
+    });
+
+    expect(screen.getByTestId('preview-url')).toHaveTextContent('/uploads/banner.png');
+  });
+
+  it('does not open a second modal from mixed actions while detail is loading', async () => {
+    const flaggedSummary = {
+      ...sampleContent[0],
+      status: 'flagged',
+    };
+    delete (flaggedSummary as any).url;
+    delete (flaggedSummary as any).metadata;
+    const deferredDetail = createDeferred<any>();
+    mockGetContent.mockResolvedValue({
+      data: [flaggedSummary],
+      meta: { page: 1, limit: 50, total: 1, totalPages: 1 },
+    });
+    mockGetContentItem.mockReturnValueOnce(deferredDetail.promise);
+
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    fireEvent.click(screen.getByTitle('Click to preview'));
+    fireEvent.click(screen.getByRole('button', { name: /review/i }));
+
+    expect(mockGetContentItem).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      deferredDetail.resolve({
+        ...flaggedSummary,
+        url: '/uploads/banner.png',
+        metadata: {
+          moderation: {
+            flagReason: 'Wrong location',
+          },
+        },
+      });
+      await deferredDetail.promise;
+    });
+
+    expect(screen.getByTestId('preview-url')).toHaveTextContent('/uploads/banner.png');
+    expect(screen.queryByText('Review Flagged Content')).not.toBeInTheDocument();
+  });
+
+  it('hydrates detail before edit validation when the list row is only a summary', async () => {
+    const summaryContent = { ...sampleContent[0] };
+    delete (summaryContent as any).url;
+    delete (summaryContent as any).metadata;
+    mockGetContent.mockResolvedValue({
+      data: [summaryContent],
+      meta: { page: 1, limit: 50, total: 1, totalPages: 1 },
+    });
+    mockGetContentItem.mockResolvedValue({
+      ...sampleContent[0],
+      url: '/uploads/banner.png',
+    });
+
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    fireEvent.click(screen.getByText('Edit'));
+
+    await waitFor(() => {
+      expect(mockGetContentItem).toHaveBeenCalledWith('c1');
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Edit Content')).toBeInTheDocument();
+    });
+
+    mockValidateForm.mockClear();
+    fireEvent.click(screen.getByText('Save Changes'));
+
+    await waitFor(() => {
+      expect(mockValidateForm).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ url: '/uploads/banner.png' }),
+      );
+    });
+  });
+
+  it('hydrates flagged content detail before showing moderation metadata', async () => {
+    const flaggedSummary = {
+      ...sampleContent[0],
+      status: 'flagged',
+    };
+    delete (flaggedSummary as any).url;
+    delete (flaggedSummary as any).metadata;
+    mockGetContent.mockResolvedValue({
+      data: [flaggedSummary],
+      meta: { page: 1, limit: 50, total: 1, totalPages: 1 },
+    });
+    mockGetContentItem.mockResolvedValue({
+      ...flaggedSummary,
+      url: '/uploads/banner.png',
+      metadata: {
+        moderation: {
+          flagReason: 'Wrong location',
+        },
+      },
+    });
+
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    fireEvent.click(screen.getByRole('button', { name: /review/i }));
+
+    await waitFor(() => {
+      expect(mockGetContentItem).toHaveBeenCalledWith('c1');
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/Reason: Wrong location/)).toBeInTheDocument();
+    });
   });
 
   it('renders one content page at a time and fetches the next page on demand', async () => {

--- a/web/src/app/dashboard/content/page-client.tsx
+++ b/web/src/app/dashboard/content/page-client.tsx
@@ -99,6 +99,7 @@ export default function ContentClient() {
  const [contentPage, setContentPage] = useState(1);
  const [loading, setLoading] = useState(true);
  const [selectedContent, setSelectedContent] = useState<Content | null>(null);
+ const [contentDetailLoadingId, setContentDetailLoadingId] = useState<string | null>(null);
  const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
@@ -161,6 +162,12 @@ export default function ContentClient() {
  // Real-time event handling
  const reconnectTimerRef = useRef<NodeJS.Timeout | null>(null);
  const loadContentRequestRef = useRef(0);
+ const contentDetailRequestRef = useRef(0);
+ const contentDetailPromiseRef = useRef<{
+ id: string;
+ requestId: number;
+ promise: Promise<Content | null>;
+ } | null>(null);
  const devicesLoadedRef = useRef(false);
  const playlistsLoadedRef = useRef(false);
  const devicesLoadPromiseRef = useRef<Promise<void> | null>(null);
@@ -278,6 +285,57 @@ export default function ContentClient() {
   }
   }
   }, [buildContentListParams, contentFilterKey, contentPage, selectedFolderId, showToast]);
+
+ const invalidateContentDetailRequest = useCallback(() => {
+ contentDetailRequestRef.current += 1;
+ contentDetailPromiseRef.current = null;
+ setContentDetailLoadingId(null);
+ }, []);
+
+  const loadContentDetail = useCallback(async (item: Content) => {
+ const existingRequest = contentDetailPromiseRef.current;
+ if (existingRequest?.id === item.id) {
+ setSelectedContent(item);
+ return existingRequest.promise;
+ }
+ const requestId = ++contentDetailRequestRef.current;
+ setSelectedContent(item);
+ setContentDetailLoadingId(item.id);
+ const promise = (async () => {
+ try {
+ const detail = await apiClient.getContentItem(item.id);
+ if (requestId !== contentDetailRequestRef.current) {
+ return null;
+ }
+ setSelectedContent(detail);
+ return detail;
+ } catch (error) {
+ if (requestId === contentDetailRequestRef.current) {
+ toast.error(error instanceof Error ? error.message : 'Failed to load content details');
+ }
+ return null;
+ } finally {
+ if (contentDetailPromiseRef.current?.requestId === requestId) {
+ contentDetailPromiseRef.current = null;
+ }
+ if (requestId === contentDetailRequestRef.current) {
+ setContentDetailLoadingId(null);
+ }
+  }
+ })();
+ contentDetailPromiseRef.current = {
+ id: item.id,
+ requestId,
+ promise,
+ };
+ return promise;
+ }, [toast]);
+
+ useEffect(() => {
+ invalidateContentDetailRequest();
+ setIsPreviewModalOpen(false);
+ setIsReviewModalOpen(false);
+ }, [contentFilterKey, contentPage, invalidateContentDetailRequest]);
 
  const loadFolders = useCallback(async () => {
  try {
@@ -570,20 +628,38 @@ export default function ContentClient() {
  };
 
  const handlePreview = (item: Content) => {
- setSelectedContent(item);
+ if (hasPendingDetailLoad(item.id)) {
+ return;
+ }
+ setIsPreviewModalOpen(false);
+ void (async () => {
+ const detail = await loadContentDetail(item);
+ if (detail) {
  setIsPreviewModalOpen(true);
+ }
+ })();
  };
 
  const handleEdit = (item: Content) => {
- setSelectedContent(item);
+ if (hasPendingDetailLoad(item.id)) {
+ return;
+ }
+ setIsEditModalOpen(false);
+ void (async () => {
+ const detail = await loadContentDetail(item);
+ if (!detail) {
+ return;
+ }
+ setSelectedContent(detail);
  setUploadForm({
- title: item.title,
- type: item.type as 'image' | 'video' | 'pdf' | 'url',
- url: item.url || '',
+ title: detail.title,
+ type: detail.type as UploadFormType,
+ url: detail.url || '',
  file: null,
  });
  setFormErrors({});
  setIsEditModalOpen(true);
+ })();
  };
 
  const handleSaveEdit = async () => {
@@ -644,6 +720,7 @@ export default function ContentClient() {
  };
 
  const handleDelete = (item: Content) => {
+ invalidateContentDetailRequest();
  setSelectedContent(item);
  setIsDeleteModalOpen(true);
  };
@@ -698,6 +775,7 @@ export default function ContentClient() {
  };
 
  const handlePushToDevice = (item: Content) => {
+ invalidateContentDetailRequest();
  setSelectedContent(item);
  setSelectedDevices([]);
  setPushDuration(5);
@@ -727,6 +805,7 @@ export default function ContentClient() {
  };
 
  const handleAddToPlaylist = (item: Content) => {
+ invalidateContentDetailRequest();
  setSelectedContent(item);
  setSelectedPlaylist('');
  setIsAddToPlaylistModalOpen(true);
@@ -751,6 +830,7 @@ export default function ContentClient() {
 
  // Moderation handlers
  const handleFlag = (item: Content) => {
+ invalidateContentDetailRequest();
  setSelectedContent(item);
  setFlagReason('');
  setIsFlagModalOpen(true);
@@ -774,9 +854,17 @@ export default function ContentClient() {
  };
 
  const handleReview = (item: Content) => {
- setSelectedContent(item);
+ if (hasPendingDetailLoad(item.id)) {
+ return;
+ }
  setReviewReason('');
+ setIsReviewModalOpen(false);
+ void (async () => {
+ const detail = await loadContentDetail(item);
+ if (detail) {
  setIsReviewModalOpen(true);
+ }
+ })();
  };
 
  const confirmReview = async (action: 'approve' | 'reject') => {
@@ -934,8 +1022,18 @@ export default function ContentClient() {
  });
 
  const filteredContent = content;
+ const isContentDetailLoading = (itemId: string) => contentDetailLoadingId === itemId;
+
+ const resetPendingDetailForListChange = () => {
+ invalidateContentDetailRequest();
+ setIsPreviewModalOpen(false);
+ setIsReviewModalOpen(false);
+ };
+
+ const hasPendingDetailLoad = (itemId: string) => contentDetailPromiseRef.current?.id === itemId;
 
  const clearAllFilters = () => {
+ resetPendingDetailForListChange();
  setFilterType('all');
  setFilterStatus('all');
  setFilterDateRange('all');
@@ -959,10 +1057,16 @@ export default function ContentClient() {
  const canGoToPreviousPage = contentMeta.page > 1;
  const canGoToNextPage = contentMeta.page < contentMeta.totalPages;
  const goToPreviousPage = () => {
- if (canGoToPreviousPage) setContentPage(page => Math.max(1, page - 1));
+ if (canGoToPreviousPage) {
+ resetPendingDetailForListChange();
+ setContentPage(page => Math.max(1, page - 1));
+ }
  };
  const goToNextPage = () => {
- if (canGoToNextPage) setContentPage(page => page + 1);
+ if (canGoToNextPage) {
+ resetPendingDetailForListChange();
+ setContentPage(page => page + 1);
+ }
  };
 
  return (
@@ -973,6 +1077,7 @@ export default function ContentClient() {
  folders={folders}
  selectedFolderId={selectedFolderId}
  onSelectFolder={(folderId) => {
+ resetPendingDetailForListChange();
  setSelectedFolderId(folderId);
  setSelectedItems(new Set());
  setContentPage(1);
@@ -1028,6 +1133,7 @@ export default function ContentClient() {
  <SearchFilter
  value={searchQuery}
  onChange={(value) => {
+ resetPendingDetailForListChange();
  setSearchQuery(value);
  setSelectedItems(new Set());
  }}
@@ -1041,6 +1147,7 @@ export default function ContentClient() {
  <button
  key={type}
  onClick={() => {
+ resetPendingDetailForListChange();
  setFilterType(type);
  setSelectedItems(new Set());
  setContentPage(1);
@@ -1089,6 +1196,7 @@ export default function ContentClient() {
  tags={tags}
  selectedTags={selectedTags}
  onChange={(tagIds) => {
+ resetPendingDetailForListChange();
  setSelectedTags(tagIds);
  setSelectedItems(new Set());
  setContentPage(1);
@@ -1097,6 +1205,7 @@ export default function ContentClient() {
  {selectedTags.length > 0 && (
  <button
  onClick={() => {
+ resetPendingDetailForListChange();
  setSelectedTags([]);
  setSelectedItems(new Set());
  setContentPage(1);
@@ -1116,6 +1225,7 @@ export default function ContentClient() {
  <div>
  <label className="block text-sm font-medium text-[var(--foreground-secondary)] mb-2">Status</label>
  <select value={filterStatus} onChange={(e) => {
+ resetPendingDetailForListChange();
  setFilterStatus(e.target.value);
  setSelectedItems(new Set());
  setContentPage(1);
@@ -1136,6 +1246,7 @@ export default function ContentClient() {
  <div>
  <label className="block text-sm font-medium text-[var(--foreground-secondary)] mb-2">Upload Date</label>
  <select value={filterDateRange} onChange={(e) => {
+ resetPendingDetailForListChange();
  setFilterDateRange(e.target.value as 'all' | '7days' | '30days' | '90days');
  setSelectedItems(new Set());
  setContentPage(1);
@@ -1173,6 +1284,7 @@ export default function ContentClient() {
  folders={folders}
  currentFolderId={selectedFolderId}
  onNavigate={(folderId) => {
+ resetPendingDetailForListChange();
  setSelectedFolderId(folderId);
  setSelectedItems(new Set());
  setContentPage(1);
@@ -1301,6 +1413,8 @@ export default function ContentClient() {
  tabIndex={0}
  aria-label={`Preview ${item.title}`}
  className="flex items-center gap-3 cursor-pointer focus:outline-none focus:ring-2 focus:ring-[var(--primary)] rounded"
+ aria-busy={isContentDetailLoading(item.id)}
+ aria-disabled={isContentDetailLoading(item.id)}
  onClick={() => handlePreview(item)}
  onKeyDown={(e) => {
  if (e.key === 'Enter' || e.key === ' ') {
@@ -1344,6 +1458,7 @@ export default function ContentClient() {
  {item.status === 'flagged' ? (
  <button
  onClick={() => handleReview(item)}
+ disabled={isContentDetailLoading(item.id)}
  className="eh-icon-btn text-amber-400"
  title="Review flagged content"
  >
@@ -1374,6 +1489,7 @@ export default function ContentClient() {
  </button>
  <button
  onClick={() => handleEdit(item)}
+ disabled={isContentDetailLoading(item.id)}
  className="eh-icon-btn"
  title="Edit"
  >
@@ -1402,6 +1518,8 @@ export default function ContentClient() {
  >
  <div
  className="aspect-video bg-gradient-to-br from-[#00E5A0] to-[#00B4D8] flex items-center justify-center relative overflow-hidden cursor-pointer"
+ aria-busy={isContentDetailLoading(item.id)}
+ aria-disabled={isContentDetailLoading(item.id)}
  onClick={() => handlePreview(item)}
  title="Click to preview"
  >
@@ -1452,6 +1570,7 @@ export default function ContentClient() {
  {item.status === 'flagged' ? (
  <button
  onClick={() => handleReview(item)}
+ disabled={isContentDetailLoading(item.id)}
  className="eh-icon-btn text-sm py-2 rounded-lg font-medium flex items-center justify-center gap-1 text-amber-400 col-span-2"
  >
  <Icon name="shield" size="sm" />
@@ -1484,6 +1603,7 @@ export default function ContentClient() {
  </button>
  <button
  onClick={() => handleEdit(item)}
+ disabled={isContentDetailLoading(item.id)}
  className="eh-icon-btn text-sm py-2 rounded-lg font-medium flex items-center justify-center gap-1"
  >
  <Icon name="edit" size="sm" />


### PR DESCRIPTION
## Summary
- Use a shared Prisma content-list `select` for root and folder content lists, excluding modal-only fields (`url`, `metadata`, `mimeType`, playlist relations) from list payloads.
- Keep list/card rendering on summary fields and lazy-hydrate full content detail through the existing `GET /content/:id` path for preview, edit, and flagged-review modals.
- Add stale-request invalidation, same-item request dedupe, and regression coverage for list context changes and repeated actions.

## Review
- Backend/API/data-contract reviewer: CLEAN.
- Frontend reviewer: initial findings fixed for stale detail races, edit hydration, and request fanout; re-review CLEAN.
- Test/CI reviewer: untracked helper and stale tracker findings addressed before commit.

## Verification
- `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=content.service|folders.service` (2 suites / 140 tests)
- `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/dashboard/content/__tests__/content-page.test.tsx` (1 suite / 42 tests)
- `pnpm --filter @vizora/middleware test -- --runInBand` (143 suites / 2879 tests)
- `pnpm --filter @vizora/web test -- --runInBand` (95 suites / 994 tests; existing unrelated warnings)
- `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
- `pnpm --filter @vizora/web exec tsc --noEmit --pretty false`
- changed-file ESLint passed with existing explicit-any warnings in `page-client.tsx`
- `npx nx build @vizora/middleware`
- `npx nx build @vizora/realtime`
- `npx nx build @vizora/web` with local public URL env vars
- `git diff --check`

## E2E note
Targeted Playwright content/folder specs were attempted, but the local stack is unavailable in this session: Docker Desktop is not available and no services are listening on 3000/3001/3002. The run failed 14/14 at auth fixture setup with `ECONNREFUSED ::1:3000` before reaching the changed content flows.

## Deploy note
No production deploy in this PR. The prod checkout was previously observed dirty and diverged; deploy remains gated until re-checked safe.