### PR TITLE
feat(web): share dashboard socket connection

### DIFF
--- a/docs/plans/2026-06-01-dashboard-shared-socket-pass-20.md
+++ b/docs/plans/2026-06-01-dashboard-shared-socket-pass-20.md
@@ -1,0 +1,56 @@
+# Dashboard Shared Socket Performance Pass 20
+
+Date: 2026-06-01
+Branch: `feat/dashboard-customer-improvements-pass-20`
+
+## Why Now
+
+Recent performance passes reduced content, playlist, pairing, and dashboard
+payload pressure. The remaining current-branch dashboard hot path is realtime:
+notification bell, device status context, page-level `useRealtimeEvents`, and
+device preview each call `useSocket` independently. A customer sitting on the
+dashboard can therefore create multiple Socket.IO client connections for one
+org, multiplying reconnect attempts and realtime listener work.
+
+## New primitives introduced
+
+One dashboard-scoped `SocketProvider` in the existing `useSocket` module. It
+does not add a new transport, gateway, event type, process, or backend route.
+
+## Hermes-first analysis
+
+Not applicable. This pass does not add business agents, MCP tools, Hermes
+skills, AI/provider calls, or spend paths.
+
+## Current Code Evidence
+
+- `useSocket` constructs a new Socket.IO client for every hook instance.
+- `NotificationBell` uses `useNotifications`, which calls `useSocket`.
+- `DeviceStatusProvider` calls `useSocket` to listen for device status events.
+- Dashboard pages call `useRealtimeEvents`, which calls `useSocket`.
+- `DevicePreviewModal` calls `useSocket` for screenshot events.
+- `DashboardLayout` already has the authenticated user/org context needed to
+  provide one shared dashboard socket.
+
+## Plan
+
+- Add focused tests proving multiple dashboard consumers under `SocketProvider`
+  share one Socket.IO client and still register independent listeners.
+- Keep standalone `useSocket` behavior for callers outside the provider and for
+  explicit custom options such as `autoConnect: false` or custom URLs.
+- Wrap dashboard chrome and page content in `SocketProvider user={user}` so the
+  notification bell, device status provider, page realtime hooks, and preview
+  modal share the same org-scoped socket.
+- Preserve existing auth, room-join, reconnect cooldown, and callback APIs.
+- Run focused hook/layout tests, then broader web verification and build.
+
+## Risks
+
+- Realtime listeners from independent components must not overwrite each other.
+  Mitigation: provider returns the same `on/off` API and tests register multiple
+  listeners on one client.
+- Explicit standalone socket use must remain possible. Mitigation: `useSocket`
+  falls back to the standalone lifecycle for `autoConnect: false`, custom URLs,
+  and custom reconnection options.
+- The dashboard layout renders before auth resolves. Mitigation: provider uses
+  `autoConnect: !!user` and reconnects only when the user/org becomes available.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,89 @@
 # Vizora - Task Tracker
 
-## In Progress: Content List Payload Performance Pass 19 (2026-06-01)
+## In Progress: Dashboard Customer Improvements Pass 20 (2026-06-01)
+
+**Branch:** `feat/dashboard-customer-improvements-pass-20`
+
+**Why now:** PR #142 merged the content-list payload pass with green PR checks,
+but production deployment remains blocked by a dirty/diverged production
+checkout. The next autonomous step is to review the dashboard as a customer,
+pick the highest-value repo-side improvement that is small enough to build,
+test, review, merge, and keep deployment gated until prod state is safe.
+
+**New primitives introduced:** one dashboard-scoped `SocketProvider` in the
+existing web `useSocket` module. No new transport, gateway, event type,
+process, backend route, agent, or deployment primitive.
+
+**Hermes-first analysis:** not applicable. This pass does not add business
+agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
+
+**Plan**
+- [x] Merge PR #142 after full PR CI green.
+- [x] Re-check production deploy gate after merge.
+- [x] Start fresh branch from `origin/main`.
+- [x] Dispatch read-only customer UX, backend/performance, and test/release
+  readiness reviewers.
+- [x] Reconcile tracker/backlog stale state after recent merges.
+- [x] Select the highest-value buildable repo-side target.
+- [x] Write scoped plan/design before code.
+- [x] Add focused failing shared-socket tests.
+- [x] Implement dashboard shared Socket.IO provider.
+- [x] Run multi-subagent code review before broader tests.
+- [x] Run focused and broader affected verification.
+- [ ] PR, CI, merge.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Current merge/deploy state**
+- [x] PR #142 merged at
+  `80463b2aaad1c041d14e4cfe55ffcdae627b7b09`; PR checks green for audit,
+  build, e2e, lint, security, and test.
+- [x] Post-merge `main` CI for `80463b2aaad1c041d14e4cfe55ffcdae627b7b09`
+  completed successfully.
+- [x] Prod deploy remains blocked: `/opt/vizora/app` is at
+  `bb76aa1838740bff5b58623dfef7a906d44f46a6`, while `origin/main` is
+  `80463b2aaad1c041d14e4cfe55ffcdae627b7b09`; prod is `ahead 17, behind 77`
+  with many tracked edits and untracked files. No production pull, reset,
+  stash, env edit, service restart, DB mutation, or deploy performed.
+
+**Plan/design:**
+`docs/plans/2026-06-01-dashboard-shared-socket-pass-20.md`
+
+**Selected target**
+- [x] Current-branch drift check confirmed several stale UX findings are
+  already fixed on `origin/main` (multi-file upload queue, filtered content
+  empty state, health page mock telemetry, and multi-device schedule creation).
+- [x] Remaining buildable customer/performance target: share one dashboard
+  Socket.IO connection across notification bell, device status context,
+  page-level realtime hooks, and device preview instead of creating one client
+  per hook instance.
+
+**Focused verification**
+- [x] Red/green shared-socket hook test added. Initial focused run failed
+  because `SocketProvider` did not exist.
+- [x] Multi-vector code review CLEAN after two reviewer passes:
+  architecture/tenant/listener-isolation review and UX/release/regression
+  review. Initial findings added missing listener-isolation, layout
+  integration, tenant fallback, and custom-option fallback coverage; all were
+  fixed before broader tests.
+- [x] Focused web tests passed:
+  `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/lib/hooks/__tests__/useSocket.test.ts src/lib/hooks/__tests__/useRealtimeEvents.test.ts src/app/dashboard/__tests__/dashboard-page.test.tsx src/app/dashboard/__tests__/dashboard-layout.test.tsx`
+  (4 suites / 47 tests).
+- [x] Web TypeScript passed:
+  `pnpm --filter @vizora/web exec tsc --noEmit --pretty false`.
+- [x] Changed-file ESLint passed with warnings only:
+  `ESLINT_USE_FLAT_CONFIG=false npx eslint web/src/lib/hooks/useSocket.ts web/src/lib/hooks/__tests__/useSocket.test.ts web/src/app/dashboard/layout.tsx web/src/app/dashboard/__tests__/dashboard-layout.test.tsx`
+  (legacy explicit-`any` / test `require()` warnings only).
+- [x] Full web Jest passed:
+  `pnpm --filter @vizora/web test -- --runInBand`
+  (96 suites / 1001 tests). Existing unrelated React `act(...)` warnings
+  remain in older suites.
+- [x] Web build passed:
+  `$env:NODE_OPTIONS='--max-old-space-size=4096'; $env:NEXT_PUBLIC_SOCKET_URL='http://localhost:3002'; $env:NEXT_PUBLIC_API_URL='http://localhost:3000/api/v1'; $env:BACKEND_URL='http://localhost:3000'; npx nx build @vizora/web`.
+- [x] `git diff --check` passed with CRLF normalization warnings only.
+
+---
+
+## Completed: Content List Payload Performance Pass 19 (2026-06-01)
 
 **Branch:** `feat/content-list-payload-pass-19`
 
@@ -26,13 +109,17 @@ agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
 - [x] Implement backend list projection and frontend detail hydration.
 - [x] Run multi-subagent code review before broader tests.
 - [x] Run focused and broader affected verification.
-- [ ] PR, CI, merge.
-- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+- [x] PR, CI, merge. PR #142 merged at
+  `80463b2aaad1c041d14e4cfe55ffcdae627b7b09`.
+- [x] Re-check deployment gate; deploy only if prod checkout is safe.
 
 **Current merge/deploy state**
 - [x] PR #141 merged at
   `6fcc39deb60634037be37758843aa638dcf1cb3d`; CI green for audit, build, e2e,
   lint, security, and test.
+- [x] PR #142 merged at
+  `80463b2aaad1c041d14e4cfe55ffcdae627b7b09`; PR CI green for audit, build,
+  e2e, lint, security, and test.
 - [x] Prod deploy remains blocked: `/opt/vizora/app` is dirty and
   ahead/behind stale prod `origin/main`; no production pull, reset, stash, env
   edit, service restart, DB mutation, or deploy performed.

--- a/web/src/app/dashboard/__tests__/dashboard-layout.test.tsx
+++ b/web/src/app/dashboard/__tests__/dashboard-layout.test.tsx
@@ -1,0 +1,141 @@
+import { act, render, waitFor } from '@testing-library/react';
+import { useEffect, type ReactNode } from 'react';
+import DashboardLayout from '../layout';
+import { useSocket } from '@/lib/hooks/useSocket';
+
+const mockSocket = {
+  on: jest.fn(),
+  off: jest.fn(),
+  emit: jest.fn(),
+  once: jest.fn(),
+  close: jest.fn(),
+  id: 'layout-socket-id',
+  io: {
+    on: jest.fn(),
+  },
+};
+
+jest.mock('socket.io-client', () => ({
+  __esModule: true,
+  default: jest.fn(() => mockSocket),
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+  usePathname: () => '/dashboard',
+}));
+
+jest.mock('@/lib/hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: {
+      id: 'user-1',
+      email: 'operator@example.com',
+      firstName: 'Operator',
+      lastName: 'One',
+      organizationId: 'org-1',
+      role: 'admin',
+    },
+    loading: false,
+    logout: jest.fn(),
+  }),
+}));
+
+jest.mock('@/components/providers/CustomizationProvider', () => ({
+  useCustomization: () => ({
+    brandConfig: null,
+  }),
+}));
+
+jest.mock('@/lib/api', () => ({
+  apiClient: {
+    getDisplays: jest.fn().mockResolvedValue({ data: [] }),
+    getNotifications: jest.fn().mockResolvedValue({ data: [] }),
+    getUnreadNotificationCount: jest.fn().mockResolvedValue({ count: 0 }),
+    setAuthenticated: jest.fn(),
+  },
+}));
+
+jest.mock('@/lib/providers/QueryProvider', () => {
+  return function MockQueryProvider({ children }: { children: ReactNode }) {
+    return <>{children}</>;
+  };
+});
+
+jest.mock('@/components/support/SupportChatProvider', () => ({
+  SupportChatProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@/components/support/SupportChat', () => ({
+  SupportChat: () => <div data-testid="support-chat" />,
+}));
+
+jest.mock('@/components/TrialBanner', () => {
+  return function MockTrialBanner() {
+    return null;
+  };
+});
+
+jest.mock('@/components/Breadcrumbs', () => {
+  return function MockBreadcrumbs() {
+    return <nav data-testid="breadcrumbs" />;
+  };
+});
+
+jest.mock('@/components/ThemeToggle', () => {
+  return function MockThemeToggle() {
+    return <button type="button">Theme</button>;
+  };
+});
+
+jest.mock('@/theme/icons', () => ({
+  Icon: ({ name }: { name: string }) => <span data-testid={`icon-${name}`}>{name}</span>,
+}));
+
+function RealtimeChild() {
+  const socket = useSocket({ auth: { organizationId: 'org-1' } });
+  useEffect(() => {
+    if (!socket.isConnected) return;
+    return socket.on('child:event', jest.fn());
+  }, [socket]);
+  return <div data-testid="realtime-child" />;
+}
+
+describe('DashboardLayout shared socket integration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSocket.on.mockReset();
+    mockSocket.off.mockReset();
+    mockSocket.emit.mockReset();
+    mockSocket.once.mockReset();
+    mockSocket.close.mockReset();
+    mockSocket.io.on.mockReset();
+  });
+
+  it('shares one org-scoped socket across dashboard chrome, device context, and page children', async () => {
+    const io = require('socket.io-client').default;
+
+    render(
+      <DashboardLayout>
+        <RealtimeChild />
+      </DashboardLayout>,
+    );
+
+    await waitFor(() => {
+      expect(io).toHaveBeenCalledTimes(1);
+    });
+
+    const connectHandler = mockSocket.on.mock.calls.find(([event]) => event === 'connect')?.[1];
+    act(() => {
+      connectHandler?.();
+    });
+
+    expect(mockSocket.emit).toHaveBeenCalledWith('join:organization', { organizationId: 'org-1' });
+    await waitFor(() => {
+      expect(mockSocket.on).toHaveBeenCalledWith('notification:new', expect.any(Function));
+      expect(mockSocket.on).toHaveBeenCalledWith('device:status', expect.any(Function));
+      expect(mockSocket.on).toHaveBeenCalledWith('child:event', expect.any(Function));
+    });
+  });
+});

--- a/web/src/app/dashboard/layout.tsx
+++ b/web/src/app/dashboard/layout.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/lib/hooks/useAuth';
+import { SocketProvider } from '@/lib/hooks/useSocket';
 import Breadcrumbs from '@/components/Breadcrumbs';
 import ThemeToggle from '@/components/ThemeToggle';
 import NotificationBell from '@/components/NotificationBell';
@@ -98,23 +99,26 @@ export default function DashboardLayout({
   if (isEditorRoute) {
     return (
       <SupportChatProvider>
-        <QueryProvider>
-          <DeviceStatusProvider user={user}>
-            {authLoading ? (
-              <div className="flex h-screen items-center justify-center">
-                <LoadingSpinner size="lg" />
-              </div>
-            ) : (
-              children
-            )}
-          </DeviceStatusProvider>
-        </QueryProvider>
+        <SocketProvider user={user}>
+          <QueryProvider>
+            <DeviceStatusProvider user={user}>
+              {authLoading ? (
+                <div className="flex h-screen items-center justify-center">
+                  <LoadingSpinner size="lg" />
+                </div>
+              ) : (
+                children
+              )}
+            </DeviceStatusProvider>
+          </QueryProvider>
+        </SocketProvider>
       </SupportChatProvider>
     );
   }
 
   return (
     <SupportChatProvider>
+    <SocketProvider user={user}>
     <div className="min-h-screen bg-[var(--background)]">
       {/* Header */}
       <header className="bg-[var(--surface)]/80 backdrop-blur-xl border-b border-[var(--border)] fixed top-0 left-0 right-0 z-30 transition-colors duration-200">
@@ -311,6 +315,7 @@ export default function DashboardLayout({
       {/* Support Chat Widget */}
       <SupportChat />
     </div>
+    </SocketProvider>
     </SupportChatProvider>
   );
 }

--- a/web/src/lib/hooks/__tests__/useSocket.test.ts
+++ b/web/src/lib/hooks/__tests__/useSocket.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
-import { useSocket } from '../useSocket';
+import React from 'react';
+import { useSocket, SocketProvider } from '../useSocket';
 
 // Create mock socket instance
 const mockSocket = {
@@ -72,5 +73,117 @@ describe('useSocket', () => {
     const { unmount } = renderHook(() => useSocket({ url: 'http://localhost:3002' }));
     unmount();
     expect(mockSocket.close).toHaveBeenCalled();
+  });
+
+  it('shares one dashboard socket across provider consumers', () => {
+    const io = require('socket.io-client').default;
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      React.createElement(SocketProvider, { user: { organizationId: 'org-1' } }, children)
+    );
+
+    const { result, unmount } = renderHook(
+      () => [
+        useSocket(),
+        useSocket({ auth: { organizationId: 'org-1' } }),
+      ] as const,
+      { wrapper },
+    );
+
+    expect(io).toHaveBeenCalledTimes(1);
+    const connectHandler = mockSocket.on.mock.calls.find(([event]) => event === 'connect')?.[1];
+    act(() => {
+      connectHandler?.();
+    });
+
+    expect(result.current[0].socket).toBe(mockSocket);
+    expect(result.current[1].socket).toBe(mockSocket);
+    expect(mockSocket.emit).toHaveBeenCalledWith('join:organization', { organizationId: 'org-1' });
+
+    const firstListener = jest.fn();
+    const secondListener = jest.fn();
+    const firstUnsubscribe = result.current[0].on('device:status', firstListener);
+    const secondUnsubscribe = result.current[1].on('device:status', secondListener);
+
+    expect(mockSocket.on).toHaveBeenCalledWith('device:status', firstListener);
+    expect(mockSocket.on).toHaveBeenCalledWith('device:status', secondListener);
+
+    firstUnsubscribe();
+    expect(mockSocket.off).toHaveBeenCalledWith('device:status', firstListener);
+    expect(mockSocket.off).not.toHaveBeenCalledWith('device:status', secondListener);
+
+    secondUnsubscribe();
+    expect(mockSocket.off).toHaveBeenCalledWith('device:status', secondListener);
+
+    unmount();
+    expect(mockSocket.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses a standalone socket when the caller opts out of auto connect inside a provider', () => {
+    const io = require('socket.io-client').default;
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      React.createElement(SocketProvider, { user: { organizationId: 'org-1' } }, children)
+    );
+
+    const { result } = renderHook(() => useSocket({ autoConnect: false }), { wrapper });
+
+    expect(io).toHaveBeenCalledTimes(1);
+    expect(result.current.socket).toBeNull();
+  });
+
+  it('does not create a temporary standalone socket while provider auth is still loading', () => {
+    const io = require('socket.io-client').default;
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      React.createElement(SocketProvider, { user: null }, children)
+    );
+
+    const { result } = renderHook(() => useSocket({ auth: { organizationId: 'org-1' } }), { wrapper });
+
+    expect(io).not.toHaveBeenCalled();
+    expect(result.current.socket).toBeNull();
+  });
+
+  it('uses a standalone socket when the caller requests a different organization', () => {
+    const io = require('socket.io-client').default;
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      React.createElement(SocketProvider, { user: { organizationId: 'org-1' } }, children)
+    );
+
+    renderHook(() => useSocket({ auth: { organizationId: 'org-2' } }), { wrapper });
+
+    expect(io).toHaveBeenCalledTimes(2);
+    expect(io).toHaveBeenCalledWith(
+      'http://localhost:3002',
+      expect.objectContaining({ auth: { organizationId: 'org-2' } }),
+    );
+  });
+
+  it('uses a standalone socket when the caller requests a custom URL', () => {
+    const io = require('socket.io-client').default;
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      React.createElement(SocketProvider, { user: { organizationId: 'org-1' } }, children)
+    );
+
+    renderHook(() => useSocket({ url: 'http://localhost:3999' }), { wrapper });
+
+    expect(io).toHaveBeenCalledTimes(2);
+    expect(io).toHaveBeenCalledWith(
+      'http://localhost:3999',
+      expect.objectContaining({ auth: {} }),
+    );
+  });
+
+  it('uses a standalone socket when the caller customizes reconnection options', () => {
+    const io = require('socket.io-client').default;
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      React.createElement(SocketProvider, { user: { organizationId: 'org-1' } }, children)
+    );
+
+    renderHook(() => useSocket({ reconnectionAttempts: 1 }), { wrapper });
+
+    expect(io).toHaveBeenCalledTimes(2);
+    expect(io).toHaveBeenCalledWith(
+      'http://localhost:3002',
+      expect.objectContaining({ reconnectionAttempts: 1 }),
+    );
   });
 });

--- a/web/src/lib/hooks/useSocket.ts
+++ b/web/src/lib/hooks/useSocket.ts
@@ -1,8 +1,8 @@
-import { useEffect, useState, useCallback, useRef } from 'react';
+import { createContext, createElement, useContext, useEffect, useMemo, useState, useCallback, useRef, type ReactNode } from 'react';
 import io, { Socket } from 'socket.io-client';
 import { devLog, devWarn } from '@/lib/logger';
 
-interface UseSocketOptions {
+export interface UseSocketOptions {
   url?: string;
   autoConnect?: boolean;
   reconnection?: boolean;
@@ -34,7 +34,7 @@ function markReconnectExhausted(url: string): void {
   reconnectExhaustedFor.set(url, Date.now());
 }
 
-interface UseSocketReturn {
+export interface UseSocketReturn {
   socket: Socket | null;
   isConnected: boolean;
   connectionError: string | null;
@@ -46,9 +46,75 @@ interface UseSocketReturn {
   leaveRoom: (room: string) => void;
 }
 
-export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
+interface SocketContextValue extends UseSocketReturn {
+  url: string;
+  organizationId?: string;
+}
+
+const SocketContext = createContext<SocketContextValue | null>(null);
+
+function getDefaultSocketUrl(): string {
+  return process.env.NEXT_PUBLIC_SOCKET_URL || (process.env.NODE_ENV === 'production' ? '' : 'http://localhost:3002');
+}
+
+function canUseSharedSocket(options: UseSocketOptions, shared: SocketContextValue | null): shared is SocketContextValue {
+  if (!shared || options.autoConnect === false) return false;
+
+  const requestedUrl = options.url ?? getDefaultSocketUrl();
+  if (requestedUrl !== shared.url) return false;
+
+  const requestedOrgId = options.auth?.organizationId;
+  if (requestedOrgId && shared.organizationId && requestedOrgId !== shared.organizationId) return false;
+
+  return (
+    options.reconnection === undefined &&
+    options.reconnectionDelay === undefined &&
+    options.reconnectionDelayMax === undefined &&
+    options.reconnectionAttempts === undefined
+  );
+}
+
+export function SocketProvider({
+  children,
+  user,
+}: {
+  children: ReactNode;
+  user?: { organizationId?: string | null } | null;
+}) {
+  const organizationId = user?.organizationId || undefined;
+  const url = getDefaultSocketUrl();
+  const socket = useStandaloneSocket({
+    url,
+    autoConnect: !!organizationId,
+    auth: organizationId ? { organizationId } : undefined,
+  });
+  const value = useMemo<SocketContextValue>(
+    () => ({
+      ...socket,
+      url,
+      organizationId,
+    }),
+    [
+      socket.socket,
+      socket.isConnected,
+      socket.connectionError,
+      socket.lastMessage,
+      socket.emit,
+      socket.on,
+      socket.once,
+      socket.joinRoom,
+      socket.leaveRoom,
+      url,
+      organizationId,
+    ],
+  );
+
+  return createElement(SocketContext.Provider, { value }, children);
+}
+
+function useStandaloneSocket(options: UseSocketOptions = {}): UseSocketReturn {
   const {
-    url = process.env.NEXT_PUBLIC_SOCKET_URL || (process.env.NODE_ENV === 'production' ? '' : 'http://localhost:3002'),
+    url = getDefaultSocketUrl(),
     autoConnect = true,
     reconnection = true,
     reconnectionDelay = 1000,
@@ -212,4 +278,12 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     joinRoom,
     leaveRoom,
   };
+}
+
+export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
+  const shared = useContext(SocketContext);
+  const shouldUseShared = canUseSharedSocket(options, shared);
+  const standalone = useStandaloneSocket(shouldUseShared ? { ...options, autoConnect: false } : options);
+
+  return shouldUseShared ? shared : standalone;
 }


### PR DESCRIPTION
﻿## Summary
- Add a dashboard-scoped SocketProvider using the existing useSocket lifecycle so notification bell, device status, page realtime hooks, and preview consumers share one org-scoped Socket.IO client.
- Preserve standalone fallback behavior for custom URLs, autoConnect:false, custom reconnect options, and mismatched org consumers.
- Add hook and dashboard layout coverage for shared connection behavior, listener isolation, org room join, and fallback paths.

## Review evidence
- Multi-vector reviewer pass: initial findings covered listener isolation, layout integration, tenant fallback, and custom option fallback coverage.
- Re-review result: CLEAN from architecture/tenant/listener reviewer and UX/release/regression reviewer.

## Verification
- Focused red/green: initial focused run failed before SocketProvider implementation.
- `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/lib/hooks/__tests__/useSocket.test.ts src/lib/hooks/__tests__/useRealtimeEvents.test.ts src/app/dashboard/__tests__/dashboard-page.test.tsx src/app/dashboard/__tests__/dashboard-layout.test.tsx` (4 suites / 47 tests)
- `pnpm --filter @vizora/web exec tsc --noEmit --pretty false`
- `ESLINT_USE_FLAT_CONFIG=false npx eslint web/src/lib/hooks/useSocket.ts web/src/lib/hooks/__tests__/useSocket.test.ts web/src/app/dashboard/layout.tsx web/src/app/dashboard/__tests__/dashboard-layout.test.tsx` (warnings only: legacy explicit-any / test require())
- `pnpm --filter @vizora/web test -- --runInBand` (96 suites / 1001 tests; existing unrelated React act warnings remain)
- `$env:NODE_OPTIONS='--max-old-space-size=4096'; $env:NEXT_PUBLIC_SOCKET_URL='http://localhost:3002'; $env:NEXT_PUBLIC_API_URL='http://localhost:3000/api/v1'; $env:BACKEND_URL='http://localhost:3000'; npx nx build @vizora/web`
- `git diff --check` (CRLF normalization warnings only)

## Deploy note
Production deploy remains gated until `/opt/vizora/app` dirty/diverged checkout is classified; no prod reset/pull/stash/restart/env/DB action in this PR.
