### PR TITLE
fix(middleware): project safe display responses

### DIFF
--- a/docs/plans/2026-06-01-display-response-projection-pass-21.md
+++ b/docs/plans/2026-06-01-display-response-projection-pass-21.md
@@ -1,0 +1,59 @@
+# Display Response Projection Pass 21
+
+Date: 2026-06-01
+Branch: `feat/customer-dashboard-improvements-pass-21`
+
+## Why Now
+
+Recent customer-readiness passes reduced dashboard content, playlist, pairing,
+and socket pressure. A fresh drift check found that authenticated display
+list/detail/update endpoints still return full Prisma `Display` rows. That can
+include the hashed device JWT, pairing-code fields, and transient socket IDs,
+even though dashboard customers only need safe display fields.
+
+## New primitives introduced
+
+One shared Prisma `select` module for display list/detail responses. No new
+runtime service, route, database model, migration, agent, or infrastructure
+primitive.
+
+## Hermes-first analysis
+
+Not applicable. This pass does not add business agents, MCP tools, Hermes
+skills, AI/provider calls, or spend paths.
+
+## Current Code Evidence
+
+- `DisplaysService.findAll()` uses `include` without `select`, so Prisma returns
+  all scalar display fields plus tags.
+- `DisplaysService.findOne()` returns all scalar display fields plus related
+  tags, groups, and active schedules.
+- `DisplaysService.update()`, `updateQrOverlay()`, and `removeQrOverlay()`
+  re-read the updated display via `findUnique()` without `select`.
+- The dashboard list and detail pages use display identity, status, assignment,
+  location, metadata, screenshot, and presentation fields, but do not need
+  stored token hashes, pairing codes, or live socket IDs.
+
+## Plan
+
+- Add failing middleware tests proving display response queries use explicit
+  safe projections and omit `jwtToken`, `pairingCode`, `pairingCodeExpiresAt`,
+  and `socketId`.
+- Add a shared `display-response.select.ts` with list/detail projections that
+  preserve current dashboard and service behavior.
+- Replace display list/detail/update/QR re-read queries with the shared
+  projections.
+- Run focused display service/controller tests, middleware type/build checks,
+  reviewer passes, then broader middleware verification.
+
+## Risks
+
+- Internal service methods call `findOne()` for operational flows, so the detail
+  projection must include fields those flows need: `deviceIdentifier`,
+  `organizationId`, `status`, `metadata`, `lastScreenshot`, and
+  `lastScreenshotAt`.
+- Dashboard/detail consumers may depend on relation shape. The select keeps
+  tags, groups, active schedules, and playlist scalar summaries with the same
+  relation names.
+- `generatePairingToken()` is the intentional one-time plaintext token path and
+  must remain unchanged.

--- a/middleware/src/modules/display-groups/display-groups.service.spec.ts
+++ b/middleware/src/modules/display-groups/display-groups.service.spec.ts
@@ -16,12 +16,26 @@ describe('DisplayGroupsService', () => {
     displays: [],
   };
 
-  const mockDisplayGroupMember = {
-    id: 'member-123',
-    displayGroupId: 'group-123',
-    displayId: 'display-123',
-    createdAt: new Date(),
-  };
+  const secretDisplayFields = [
+    'jwtToken',
+    'pairingCode',
+    'pairingCodeExpiresAt',
+    'socketId',
+  ];
+
+  function expectNestedDisplaySelectOmitsSecrets(query: any) {
+    const displaySelect = query.include.displays.select.display.select;
+    expect(displaySelect).toEqual(expect.objectContaining({
+      id: true,
+      organizationId: true,
+      deviceIdentifier: true,
+      nickname: true,
+      status: true,
+    }));
+    for (const field of secretDisplayFields) {
+      expect(displaySelect).not.toHaveProperty(field);
+    }
+  }
 
   beforeEach(() => {
     mockDatabaseService = {
@@ -75,11 +89,14 @@ describe('DisplayGroupsService', () => {
           }),
           include: expect.objectContaining({
             displays: expect.objectContaining({
-              include: { display: true },
+              select: expect.objectContaining({
+                display: { select: expect.any(Object) },
+              }),
             }),
           }),
         }),
       );
+      expectNestedDisplaySelectOmitsSecrets(mockDatabaseService.displayGroup.create.mock.calls[0][0]);
     });
 
     it('should create a display group without description', async () => {
@@ -202,7 +219,13 @@ describe('DisplayGroupsService', () => {
           {
             id: 'member-1',
             displayId: 'display-1',
-            display: { id: 'display-1', name: 'Lobby Screen' },
+            display: {
+              id: 'display-1',
+              nickname: 'Lobby Screen',
+              location: 'Lobby',
+              status: 'online',
+              currentPlaylistId: 'playlist-1',
+            },
           },
         ],
       };
@@ -211,7 +234,13 @@ describe('DisplayGroupsService', () => {
       const result = await service.findOne('org-123', 'group-123');
 
       expect(result.displays).toHaveLength(1);
-      expect(result.displays[0].display.name).toBe('Lobby Screen');
+      expect(result.displays[0].display).toEqual(expect.objectContaining({
+        nickname: 'Lobby Screen',
+        location: 'Lobby',
+        status: 'online',
+        currentPlaylistId: 'playlist-1',
+      }));
+      expectNestedDisplaySelectOmitsSecrets(mockDatabaseService.displayGroup.findFirst.mock.calls[0][0]);
     });
 
     it('should enforce organization isolation in findOne', async () => {

--- a/middleware/src/modules/display-groups/display-groups.service.ts
+++ b/middleware/src/modules/display-groups/display-groups.service.ts
@@ -4,6 +4,7 @@ import { CreateDisplayGroupDto } from './dto/create-display-group.dto';
 import { UpdateDisplayGroupDto } from './dto/update-display-group.dto';
 import { ManageDisplaysDto } from './dto/manage-displays.dto';
 import { PaginationDto, PaginatedResponse } from '../common/dto/pagination.dto';
+import { DISPLAY_GROUP_MEMBER_WITH_DISPLAY_SELECT } from '../displays/display-response.select';
 
 @Injectable()
 export class DisplayGroupsService {
@@ -17,9 +18,7 @@ export class DisplayGroupsService {
       },
       include: {
         displays: {
-          include: {
-            display: true,
-          },
+          select: DISPLAY_GROUP_MEMBER_WITH_DISPLAY_SELECT,
         },
       },
     });
@@ -59,9 +58,7 @@ export class DisplayGroupsService {
       where: { id, organizationId },
       include: {
         displays: {
-          include: {
-            display: true,
-          },
+          select: DISPLAY_GROUP_MEMBER_WITH_DISPLAY_SELECT,
         },
       },
     });

--- a/middleware/src/modules/displays/display-response.select.ts
+++ b/middleware/src/modules/displays/display-response.select.ts
@@ -1,0 +1,122 @@
+import type { Prisma } from '@vizora/database';
+
+const TAG_SELECT = {
+  id: true,
+  name: true,
+  color: true,
+  organizationId: true,
+  createdAt: true,
+} satisfies Prisma.TagSelect;
+
+const DISPLAY_TAG_SELECT = {
+  id: true,
+  displayId: true,
+  tagId: true,
+  createdAt: true,
+  tag: {
+    select: TAG_SELECT,
+  },
+} satisfies Prisma.DisplayTagSelect;
+
+const DISPLAY_GROUP_SELECT = {
+  id: true,
+  name: true,
+  description: true,
+  organizationId: true,
+  createdAt: true,
+  updatedAt: true,
+} satisfies Prisma.DisplayGroupSelect;
+
+const DISPLAY_GROUP_MEMBER_SELECT = {
+  id: true,
+  displayId: true,
+  displayGroupId: true,
+  createdAt: true,
+  displayGroup: {
+    select: DISPLAY_GROUP_SELECT,
+  },
+} satisfies Prisma.DisplayGroupMemberSelect;
+
+const PLAYLIST_SUMMARY_SELECT = {
+  id: true,
+  name: true,
+  description: true,
+  loop: true,
+  isDefault: true,
+  organizationId: true,
+  createdAt: true,
+  updatedAt: true,
+} satisfies Prisma.PlaylistSelect;
+
+const ACTIVE_SCHEDULE_SELECT = {
+  id: true,
+  name: true,
+  description: true,
+  startDate: true,
+  endDate: true,
+  startTime: true,
+  endTime: true,
+  daysOfWeek: true,
+  priority: true,
+  isActive: true,
+  organizationId: true,
+  playlistId: true,
+  displayId: true,
+  displayGroupId: true,
+  createdAt: true,
+  updatedAt: true,
+  playlist: {
+    select: PLAYLIST_SUMMARY_SELECT,
+  },
+} satisfies Prisma.ScheduleSelect;
+
+export const DISPLAY_EMBEDDED_SELECT = {
+  id: true,
+  organizationId: true,
+  deviceIdentifier: true,
+  nickname: true,
+  description: true,
+  location: true,
+  status: true,
+  orientation: true,
+  resolution: true,
+  timezone: true,
+  lastHeartbeat: true,
+  isDisabled: true,
+  currentPlaylistId: true,
+  createdAt: true,
+  updatedAt: true,
+  pairedAt: true,
+  unpairedAt: true,
+} satisfies Prisma.DisplaySelect;
+
+export const DISPLAY_LIST_SELECT = {
+  ...DISPLAY_EMBEDDED_SELECT,
+  tags: {
+    select: DISPLAY_TAG_SELECT,
+  },
+} satisfies Prisma.DisplaySelect;
+
+export const DISPLAY_DETAIL_SELECT = {
+  ...DISPLAY_LIST_SELECT,
+  metadata: true,
+  lastScreenshot: true,
+  lastScreenshotAt: true,
+  groups: {
+    select: DISPLAY_GROUP_MEMBER_SELECT,
+  },
+  schedules: {
+    where: { isActive: true },
+    select: ACTIVE_SCHEDULE_SELECT,
+  },
+} satisfies Prisma.DisplaySelect;
+
+export const DISPLAY_GROUP_MEMBER_WITH_DISPLAY_SELECT = {
+  id: true,
+  displayId: true,
+  displayGroupId: true,
+  createdAt: true,
+  display: {
+    select: DISPLAY_EMBEDDED_SELECT,
+  },
+} satisfies Prisma.DisplayGroupMemberSelect;

--- a/middleware/src/modules/displays/displays.controller.spec.ts
+++ b/middleware/src/modules/displays/displays.controller.spec.ts
@@ -34,6 +34,8 @@ describe('DisplaysController', () => {
       getLastScreenshot: jest.fn(),
       disableDevice: jest.fn(),
       enableDevice: jest.fn(),
+      updateQrOverlay: jest.fn(),
+      removeQrOverlay: jest.fn(),
     } as any;
 
     // Mock DatabaseService for QuotaGuard
@@ -372,6 +374,46 @@ describe('DisplaysController', () => {
       await expect(
         controller.getScreenshot('display-123', organizationId)
       ).rejects.toThrow('Display not found');
+    });
+  });
+
+  describe('QR overlay', () => {
+    it('should return the saved QR overlay config', async () => {
+      const config = {
+        enabled: true,
+        url: 'https://example.com/menu',
+        position: 'bottom-right' as const,
+        size: 120,
+        opacity: 1,
+        margin: 16,
+        backgroundColor: '#ffffff',
+      };
+      mockDisplaysService.updateQrOverlay.mockResolvedValue(config as any);
+
+      const result = await controller.updateQrOverlay(
+        organizationId,
+        'display-123',
+        config as any,
+      );
+
+      expect(result).toEqual(config);
+      expect(mockDisplaysService.updateQrOverlay).toHaveBeenCalledWith(
+        organizationId,
+        'display-123',
+        config,
+      );
+    });
+
+    it('should remove QR overlay without returning a display row', async () => {
+      mockDisplaysService.removeQrOverlay.mockResolvedValue(undefined as any);
+
+      await expect(
+        controller.removeQrOverlay(organizationId, 'display-123'),
+      ).resolves.toBeUndefined();
+      expect(mockDisplaysService.removeQrOverlay).toHaveBeenCalledWith(
+        organizationId,
+        'display-123',
+      );
     });
   });
 });

--- a/middleware/src/modules/displays/displays.service.spec.ts
+++ b/middleware/src/modules/displays/displays.service.spec.ts
@@ -39,6 +39,28 @@ describe('DisplaysService', () => {
     updatedAt: new Date('2026-01-27T12:00:00Z'),
   };
 
+  const secretDisplayFields = [
+    'jwtToken',
+    'pairingCode',
+    'pairingCodeExpiresAt',
+    'socketId',
+  ];
+
+  function expectSafeDisplaySelect(select: Record<string, unknown> | undefined) {
+    expect(select).toBeDefined();
+    expect(select).toEqual(expect.objectContaining({
+      id: true,
+      organizationId: true,
+      deviceIdentifier: true,
+      nickname: true,
+      status: true,
+      currentPlaylistId: true,
+    }));
+    for (const field of secretDisplayFields) {
+      expect(select).not.toHaveProperty(field);
+    }
+  }
+
   beforeEach(async () => {
     process.env.INTERNAL_API_SECRET = 'test-internal-secret';
 
@@ -143,7 +165,10 @@ describe('DisplaysService', () => {
           timezone: 'America/New_York',
           organizationId: mockOrganizationId,
         },
+        select: expect.any(Object),
       });
+      const query = databaseService.display.create.mock.calls[0][0] as any;
+      expectSafeDisplaySelect(query.select);
       expect(result).toEqual(mockDisplay);
     });
 
@@ -175,14 +200,11 @@ describe('DisplaysService', () => {
         skip: 0,
         take: 10,
         orderBy: { createdAt: 'desc' },
-        include: {
-          tags: {
-            include: {
-              tag: true,
-            },
-          },
-        },
+        select: expect.any(Object),
       });
+      const query = databaseService.display.findMany.mock.calls[0][0] as any;
+      expect(query).not.toHaveProperty('include');
+      expectSafeDisplaySelect(query.select);
       expect(databaseService.display.count).toHaveBeenCalledWith({
         where: { organizationId: mockOrganizationId },
       });
@@ -204,13 +226,7 @@ describe('DisplaysService', () => {
         skip: 10,
         take: 10,
         orderBy: { createdAt: 'desc' },
-        include: {
-          tags: {
-            include: {
-              tag: true,
-            },
-          },
-        },
+        select: expect.any(Object),
       });
       expect(result.meta.page).toBe(2);
       expect(result.meta.totalPages).toBe(2);
@@ -242,25 +258,19 @@ describe('DisplaysService', () => {
 
       expect(databaseService.display.findFirst).toHaveBeenCalledWith({
         where: { id: mockDisplayId, organizationId: mockOrganizationId },
-        include: {
-          tags: {
-            include: {
-              tag: true,
-            },
-          },
-          groups: {
-            include: {
-              displayGroup: true,
-            },
-          },
-          schedules: {
-            where: { isActive: true },
-            include: {
-              playlist: true,
-            },
-          },
-        },
+        select: expect.any(Object),
       });
+      const query = databaseService.display.findFirst.mock.calls[0][0] as any;
+      expect(query).not.toHaveProperty('include');
+      expectSafeDisplaySelect(query.select);
+      expect(query.select).toEqual(expect.objectContaining({
+        metadata: true,
+        lastScreenshot: true,
+        lastScreenshotAt: true,
+        tags: expect.any(Object),
+        groups: expect.any(Object),
+        schedules: expect.any(Object),
+      }));
       expect(result).toEqual(mockDisplayWithRelations);
     });
 
@@ -315,6 +325,12 @@ describe('DisplaysService', () => {
           nickname: 'Updated Display',
         },
       });
+      const findUniqueQuery = databaseService.display.findUnique.mock.calls[0][0] as any;
+      expect(findUniqueQuery).toEqual({
+        where: { id: mockDisplayId },
+        select: expect.any(Object),
+      });
+      expectSafeDisplaySelect(findUniqueQuery.select);
       expect(result.nickname).toBe('Updated Display');
     });
 
@@ -716,6 +732,73 @@ describe('DisplaysService', () => {
           lastScreenshotAt: expect.any(Date),
         },
       });
+    });
+  });
+
+  describe('QR overlay', () => {
+    const mockDisplayWithMetadata = {
+      ...mockDisplay,
+      tags: [],
+      groups: [],
+      schedules: [],
+      metadata: {
+        brightness: 80,
+        qrOverlay: {
+          enabled: true,
+          url: 'https://old.example.com',
+          position: 'top-left',
+        },
+      },
+    };
+
+    it('updates QR overlay metadata and returns the saved overlay config', async () => {
+      databaseService.display.findFirst.mockResolvedValue(mockDisplayWithMetadata as any);
+      databaseService.display.updateMany.mockResolvedValue({ count: 1 });
+
+      const result = await service.updateQrOverlay(mockOrganizationId, mockDisplayId, {
+        enabled: true,
+        url: 'https://example.com/menu',
+        position: 'bottom-right',
+      });
+
+      expect(result).toEqual({
+        enabled: true,
+        url: 'https://example.com/menu',
+        position: 'bottom-right',
+        size: 120,
+        opacity: 1,
+        margin: 16,
+        backgroundColor: '#ffffff',
+      });
+      expect(databaseService.display.updateMany).toHaveBeenCalledWith({
+        where: { id: mockDisplayId, organizationId: mockOrganizationId },
+        data: {
+          metadata: {
+            brightness: 80,
+            qrOverlay: result,
+          },
+        },
+      });
+      expect(databaseService.display.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('removes QR overlay metadata without returning the full display row', async () => {
+      databaseService.display.findFirst.mockResolvedValue(mockDisplayWithMetadata as any);
+      databaseService.display.updateMany.mockResolvedValue({ count: 1 });
+
+      await expect(
+        service.removeQrOverlay(mockOrganizationId, mockDisplayId),
+      ).resolves.toBeUndefined();
+
+      expect(databaseService.display.updateMany).toHaveBeenCalledWith({
+        where: { id: mockDisplayId, organizationId: mockOrganizationId },
+        data: {
+          metadata: {
+            brightness: 80,
+          },
+        },
+      });
+      expect(databaseService.display.findUnique).not.toHaveBeenCalled();
     });
   });
 

--- a/middleware/src/modules/displays/displays.service.ts
+++ b/middleware/src/modules/displays/displays.service.ts
@@ -20,8 +20,7 @@ import { CreateDisplayDto } from './dto/create-display.dto';
 import { UpdateDisplayDto } from './dto/update-display.dto';
 import { UpdateQrOverlayDto } from './dto/update-qr-overlay.dto';
 import { PaginationDto, PaginatedResponse } from '../common/dto/pagination.dto';
-
-const MINIO_URL_PREFIX = 'minio://';
+import { DISPLAY_DETAIL_SELECT, DISPLAY_LIST_SELECT } from './display-response.select';
 
 /**
  * Hash a token using SHA-256 for secure storage
@@ -77,6 +76,7 @@ export class DisplaysService {
           nickname: name,
           organizationId,
         },
+        select: DISPLAY_DETAIL_SELECT,
       });
       this.emitDisplayEvent('created', display.id, organizationId);
       return display;
@@ -117,13 +117,7 @@ export class DisplaysService {
         skip,
         take: limit,
         orderBy: { createdAt: 'desc' },
-        include: {
-          tags: {
-            include: {
-              tag: true,
-            },
-          },
-        },
+        select: DISPLAY_LIST_SELECT,
       }),
       this.db.display.count({ where }),
     ]);
@@ -134,24 +128,7 @@ export class DisplaysService {
   async findOne(organizationId: string, id: string) {
     const display = await this.db.display.findFirst({
       where: { id, organizationId },
-      include: {
-        tags: {
-          include: {
-            tag: true,
-          },
-        },
-        groups: {
-          include: {
-            displayGroup: true,
-          },
-        },
-        schedules: {
-          where: { isActive: true },
-          include: {
-            playlist: true,
-          },
-        },
-      },
+      select: DISPLAY_DETAIL_SELECT,
     });
 
     if (!display) {
@@ -217,7 +194,10 @@ export class DisplaysService {
     if (updateResult.count === 0) {
       throw new NotFoundException('Display not found');
     }
-    const updatedDisplay = await this.db.display.findUnique({ where: { id } });
+    const updatedDisplay = await this.db.display.findUnique({
+      where: { id },
+      select: DISPLAY_DETAIL_SELECT,
+    });
 
     // If playlist was updated, notify the realtime service to push update to device
     // Fire-and-forget - don't block the response if realtime service is down
@@ -874,10 +854,17 @@ export class DisplaysService {
     );
   }
 
-  async updateQrOverlay(organizationId: string, id: string, dto: UpdateQrOverlayDto) {
-    const display = await this.findOne(organizationId, id);
-    const metadata = (display.metadata as Record<string, unknown>) || {};
-    metadata.qrOverlay = {
+  async updateQrOverlay(
+    organizationId: string,
+    id: string,
+    dto: UpdateQrOverlayDto,
+  ): Promise<UpdateQrOverlayDto>;
+  async updateQrOverlay(
+    organizationId: string,
+    id: string,
+    dto: UpdateQrOverlayDto,
+  ): Promise<UpdateQrOverlayDto> {
+    const qrOverlay = {
       enabled: dto.enabled,
       url: dto.url,
       position: dto.position || 'bottom-right',
@@ -885,24 +872,29 @@ export class DisplaysService {
       opacity: dto.opacity ?? 1,
       margin: dto.margin || 16,
       backgroundColor: dto.backgroundColor || '#ffffff',
-      label: dto.label,
+      ...(dto.label !== undefined ? { label: dto.label } : {}),
     };
 
-    // Defense-in-depth: include organizationId to prevent TOCTOU races
-    const result = await this.db.display.updateMany({
-      where: { id, organizationId },
-      data: { metadata: metadata as Prisma.InputJsonValue },
-    });
-    if (result.count === 0) {
-      throw new NotFoundException('Display not found');
-    }
-    return this.db.display.findUnique({ where: { id } });
+    await this.writeQrOverlay(organizationId, id, qrOverlay);
+    return qrOverlay;
   }
 
-  async removeQrOverlay(organizationId: string, id: string) {
+  async removeQrOverlay(organizationId: string, id: string): Promise<void> {
+    await this.writeQrOverlay(organizationId, id);
+  }
+
+  private async writeQrOverlay(
+    organizationId: string,
+    id: string,
+    qrOverlay?: UpdateQrOverlayDto,
+  ): Promise<void> {
     const display = await this.findOne(organizationId, id);
     const metadata = (display.metadata as Record<string, unknown>) || {};
-    delete metadata.qrOverlay;
+    if (qrOverlay) {
+      metadata.qrOverlay = qrOverlay;
+    } else {
+      delete metadata.qrOverlay;
+    }
 
     // Defense-in-depth: include organizationId to prevent TOCTOU races
     const result = await this.db.display.updateMany({
@@ -912,6 +904,5 @@ export class DisplaysService {
     if (result.count === 0) {
       throw new NotFoundException('Display not found');
     }
-    return this.db.display.findUnique({ where: { id } });
   }
 }

--- a/middleware/src/modules/displays/pairing.service.spec.ts
+++ b/middleware/src/modules/displays/pairing.service.spec.ts
@@ -16,6 +16,19 @@ describe('PairingService', () => {
   let mockRedisService: jest.Mocked<RedisService>;
   let redisClient: { scan: jest.Mock; mget: jest.Mock };
 
+  const sensitiveDisplayFields = ['jwtToken', 'pairingCode', 'pairingCodeExpiresAt', 'socketId'];
+  const pairingResultSelect = {
+    id: true,
+    nickname: true,
+    deviceIdentifier: true,
+    status: true,
+  };
+  const expectSelectToExcludeSensitiveDisplayFields = (select: Record<string, unknown>) => {
+    for (const field of sensitiveDisplayFields) {
+      expect(select).not.toHaveProperty(field);
+    }
+  };
+
   // In-memory store to simulate Redis behavior
   let redisStore: Map<string, { value: string; ttl: number; expiresAt: number }>;
 
@@ -134,6 +147,17 @@ describe('PairingService', () => {
       expect(result).toHaveProperty('pairingUrl');
     });
 
+    it('should check existing pairing state with token-only display select', async () => {
+      mockDatabaseService.display.findUnique.mockResolvedValue(null);
+
+      await service.requestPairingCode(mockRequestDto);
+
+      expect(mockDatabaseService.display.findUnique).toHaveBeenCalledWith({
+        where: { deviceIdentifier: 'device-123' },
+        select: { jwtToken: true },
+      });
+    });
+
     it('should store pairing request in Redis with TTL', async () => {
       mockDatabaseService.display.findUnique.mockResolvedValue(null);
 
@@ -247,8 +271,6 @@ describe('PairingService', () => {
   });
 
   describe('checkPairingStatus', () => {
-    const mockCode = 'ABC123';
-
     beforeEach(async () => {
       mockDatabaseService.display.findUnique.mockResolvedValue(null);
       // Create a pairing request first
@@ -319,6 +341,7 @@ describe('PairingService', () => {
       await service.completePairing('org-123', 'user-123', { code: pairingResult.code });
 
       // Now checkPairingStatus reads the plaintext token from Redis
+      mockDatabaseService.display.findUnique.mockClear();
       mockDatabaseService.display.findUnique.mockResolvedValue({
         id: 'display-id',
         organizationId: 'org-123',
@@ -326,6 +349,10 @@ describe('PairingService', () => {
 
       const status = await service.checkPairingStatus(pairingResult.code);
 
+      expect(mockDatabaseService.display.findUnique).toHaveBeenCalledWith({
+        where: { deviceIdentifier: 'device-paired' },
+        select: { id: true, organizationId: true },
+      });
       expect(status.status).toBe('paired');
       expect(status.deviceToken).toBe('mock-jwt-token'); // plaintext token from jwtService.sign mock
       expect(status.deviceId).toBe('display-id');
@@ -395,7 +422,21 @@ describe('PairingService', () => {
 
       expect(result.success).toBe(true);
       expect(result.display).toHaveProperty('id');
-      expect(mockDatabaseService.display.create).toHaveBeenCalled();
+      expect(mockDatabaseService.display.findUnique).toHaveBeenNthCalledWith(1, {
+        where: { deviceIdentifier: 'new-device' },
+        select: { jwtToken: true },
+      });
+      expect(mockDatabaseService.display.findUnique).toHaveBeenNthCalledWith(2, {
+        where: { deviceIdentifier: 'new-device' },
+        select: { id: true, location: true },
+      });
+      expect(mockDatabaseService.display.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          select: pairingResultSelect,
+        }),
+      );
+      const createArgs = mockDatabaseService.display.create.mock.calls[0][0] as any;
+      expectSelectToExcludeSensitiveDisplayFields(createArgs.select);
     });
 
     it('should update existing unpaired device', async () => {
@@ -403,7 +444,7 @@ describe('PairingService', () => {
         .mockResolvedValueOnce(null) // requestPairingCode check
         .mockResolvedValueOnce({
           id: 'existing-display-id',
-          jwtToken: null,
+          location: 'Lobby',
         } as any); // completePairing check
 
       const pairingResult = await service.requestPairingCode({
@@ -425,7 +466,17 @@ describe('PairingService', () => {
       });
 
       expect(result.success).toBe(true);
-      expect(mockDatabaseService.display.update).toHaveBeenCalled();
+      expect(mockDatabaseService.display.findUnique).toHaveBeenNthCalledWith(2, {
+        where: { deviceIdentifier: 'existing-device' },
+        select: { id: true, location: true },
+      });
+      expect(mockDatabaseService.display.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          select: pairingResultSelect,
+        }),
+      );
+      const updateArgs = mockDatabaseService.display.update.mock.calls[0][0] as any;
+      expectSelectToExcludeSensitiveDisplayFields(updateArgs.select);
     });
 
     it('should throw NotFoundException for non-existent code', async () => {

--- a/middleware/src/modules/displays/pairing.service.ts
+++ b/middleware/src/modules/displays/pairing.service.ts
@@ -13,6 +13,7 @@ import { RedisService } from '../redis/redis.service';
 import { ProvisioningTemplatesService } from '../provisioning-templates/provisioning-templates.service';
 import { RequestPairingDto } from './dto/request-pairing.dto';
 import { CompletePairingDto } from './dto/complete-pairing.dto';
+import type { Prisma } from '@vizora/database';
 import * as crypto from 'crypto';
 import * as QRCode from 'qrcode';
 
@@ -39,6 +40,27 @@ interface PairingRequestRecord {
   code: string;
   request: PairingRequest;
 }
+
+const PAIRING_TOKEN_CHECK_SELECT = {
+  jwtToken: true,
+} as const satisfies Prisma.DisplaySelect;
+
+const PAIRING_STATUS_SELECT = {
+  id: true,
+  organizationId: true,
+} as const satisfies Prisma.DisplaySelect;
+
+const PAIRING_EXISTING_DISPLAY_SELECT = {
+  id: true,
+  location: true,
+} as const satisfies Prisma.DisplaySelect;
+
+const PAIRING_RESULT_SELECT = {
+  id: true,
+  nickname: true,
+  deviceIdentifier: true,
+  status: true,
+} as const satisfies Prisma.DisplaySelect;
 
 @Injectable()
 export class PairingService implements OnModuleDestroy {
@@ -129,6 +151,7 @@ export class PairingService implements OnModuleDestroy {
     // Check if device already exists and is paired
     const existingDisplay = await this.db.display.findUnique({
       where: { deviceIdentifier },
+      select: PAIRING_TOKEN_CHECK_SELECT,
     });
 
     if (existingDisplay && existingDisplay.jwtToken) {
@@ -218,6 +241,7 @@ export class PairingService implements OnModuleDestroy {
     if (request.plaintextToken) {
       const display = await this.db.display.findUnique({
         where: { deviceIdentifier: request.deviceIdentifier },
+        select: PAIRING_STATUS_SELECT,
       });
 
       // Pairing complete! Clean up request and return plaintext token
@@ -268,13 +292,14 @@ export class PairingService implements OnModuleDestroy {
       : undefined;
 
     // Check if device already exists
-    let display = await this.db.display.findUnique({
+    const existingDisplay = await this.db.display.findUnique({
       where: { deviceIdentifier: request.deviceIdentifier },
+      select: PAIRING_EXISTING_DISPLAY_SELECT,
     });
 
     // Generate device JWT token
     const devicePayload = {
-      sub: display?.id || crypto.randomUUID(),
+      sub: existingDisplay?.id || crypto.randomUUID(),
       deviceIdentifier: request.deviceIdentifier,
       organizationId,
       type: 'device',
@@ -299,12 +324,13 @@ export class PairingService implements OnModuleDestroy {
     // Hash the token before storing in database for security
     // If database is compromised, attacker cannot use the hashed tokens
     const hashedToken = this.hashToken(jwtToken);
+    let display: Prisma.DisplayGetPayload<{ select: typeof PAIRING_RESULT_SELECT }>;
 
-    if (display) {
+    if (existingDisplay) {
       // Update existing display
       // Set status to 'pairing' - the WebSocket gateway will update to 'online' when device connects
       display = await this.db.display.update({
-        where: { id: display.id },
+        where: { id: existingDisplay.id },
         data: {
           nickname: nickname || request.nickname,
           organizationId,
@@ -312,11 +338,12 @@ export class PairingService implements OnModuleDestroy {
           pairedAt: new Date(),
           lastHeartbeat: new Date(),
           status: 'pairing',
-          location: completeDto.location || display.location,
+          location: completeDto.location || existingDisplay.location,
           // O6 — apply provisioning-template defaults. Spread last so they
           // override the Vizora-level defaults but NOT explicit fields above.
           ...(provisioningDefaults ?? {}),
         },
+        select: PAIRING_RESULT_SELECT,
       });
     } else {
       // Create new display
@@ -338,6 +365,7 @@ export class PairingService implements OnModuleDestroy {
           // 'landscape', timezone='UTC') with the operator's preference.
           ...(provisioningDefaults ?? {}),
         },
+        select: PAIRING_RESULT_SELECT,
       });
     }
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,114 @@
 # Vizora - Task Tracker
 
-## In Progress: Dashboard Customer Improvements Pass 20 (2026-06-01)
+## In Progress: Display Response Projection Pass 21 (2026-06-01)
+
+**Branch:** `feat/customer-dashboard-improvements-pass-21`
+
+**Why now:** PR #143 merged the shared dashboard socket pass and post-merge
+`main` CI is green, but deployment remains blocked by dirty/diverged prod-local
+state. A fresh customer/performance/release review found several valid next
+targets; local drift-check also found the authenticated display API still
+returns full Prisma `Display` rows, which can include hashed device JWTs,
+pairing-code fields, and transient socket IDs. This pass closes that sensitive
+response surface and reduces display list/detail payloads.
+
+**New primitives introduced:** one shared Prisma display response projection
+module. No new runtime service, route, database model, migration, agent, or
+infrastructure primitive.
+
+**Hermes-first analysis:** not applicable. This pass does not add business
+agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
+
+**Plan**
+- [x] Merge PR #143 after PR CI green and confirm post-merge `main` CI.
+- [x] Re-check production deploy gate after merge.
+- [x] Start fresh branch from `origin/main`.
+- [x] Dispatch read-only customer UX, backend/performance, and test/release
+  readiness reviewers.
+- [x] Drift-check display response shape against current code.
+- [x] Select highest-value bounded target.
+- [x] Write scoped plan/design before code.
+- [x] Add focused failing display response projection tests.
+- [x] Implement safe display list/detail/update projections.
+- [x] Run multi-subagent code review before broader tests.
+- [x] Run focused and broader affected verification.
+- [ ] PR, CI, merge.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Current merge/deploy state**
+- [x] PR #143 merged at
+  `384b584054446547ec3d64a37f7f6839dc10ac39`; PR checks green for audit,
+  build, e2e, lint, security, and test.
+- [x] Post-merge `main` CI for `384b584054446547ec3d64a37f7f6839dc10ac39`
+  completed successfully: build, test, lint, security, and e2e all green.
+- [x] Prod deploy remains blocked: `/opt/vizora/app` is at
+  `bb76aa1838740bff5b58623dfef7a906d44f46a6`, while its stale local
+  `origin/main` is `1618f31f9e151ca394f4e0471e457267805415a9`; prod is
+  `ahead 17, behind 77` with many tracked edits and untracked files. No
+  production pull, reset, stash, env edit, service restart, DB mutation, or
+  deploy performed.
+
+**Plan/design:**
+`docs/plans/2026-06-01-display-response-projection-pass-21.md`
+
+**Implementation notes**
+- [x] Added `middleware/src/modules/displays/display-response.select.ts` with
+  shared safe list/detail/embedded/member projections.
+- [x] Updated display create/list/detail/update response paths to use explicit
+  safe Prisma `select`s.
+- [x] Updated display-group nested display responses to reuse the safe embedded
+  projection.
+- [x] Changed QR overlay update/delete service contracts to return the saved
+  overlay config / `void` instead of re-reading and returning the display row.
+- [x] Tightened pairing-service internal queries to select only the fields each
+  path needs: token-only paired check, id/org status lookup, existing id/location
+  read, and safe result fields on create/update.
+
+**Review gate**
+- [x] Security/API reviewer CLEAN after pairing follow-up. Confirmed response
+  paths omit `jwtToken`, `pairingCode`, `pairingCodeExpiresAt`, and `socketId`;
+  tenant/API conventions remain intact; QR overlay return shape matches web/API.
+- [x] Regression/dashboard reviewer CLEAN except for expected low staging note:
+  new selector file must be staged before commit. This will be closed at commit
+  staging.
+
+**Verification so far**
+- [x] Red focused projection tests reproduced missing explicit safe selectors
+  before implementation.
+- [x] Focused display/pairing run passed:
+  `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/displays/pairing.service.spec.ts src/modules/displays/displays.service.spec.ts src/modules/displays/displays.controller.spec.ts src/modules/display-groups/display-groups.service.spec.ts src/modules/displays/displays.service.bulk.spec.ts`
+  - 5 suites / 137 tests.
+- [x] Broader display/display-group unit run passed:
+  `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/displays/pairing.service.spec.ts src/modules/displays/pairing.controller.spec.ts src/modules/displays/displays.controller.spec.ts src/modules/displays/displays.service.spec.ts src/modules/displays/displays.service.bulk.spec.ts src/modules/displays/displays.service.tag-events.spec.ts src/modules/display-groups/display-groups.service.spec.ts src/modules/display-groups/display-groups.controller.spec.ts`
+  - 8 suites / 166 tests.
+- [x] Middleware typecheck passed:
+  `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`.
+- [x] Changed-file ESLint passed with only the existing ESLintRC deprecation
+  notice:
+  `ESLINT_USE_FLAT_CONFIG=false npx eslint ...`.
+- [x] Middleware build passed:
+  `npx nx build @vizora/middleware`; existing webpack warnings remain.
+- [x] Full middleware unit suite passed:
+  `pnpm --filter @vizora/middleware test -- --runInBand` - 143 suites /
+  2,884 tests.
+- [x] `git diff --check` passed with Windows CRLF warnings only.
+
+**Reviewer target synthesis**
+- [x] Customer UX reviewer found valid current dashboard issues: inactive
+  schedules shown as active, dead schedule conflict warning UI, hardcoded
+  content tag filters, and synthetic analytics labels.
+- [x] Backend/performance reviewer found a valid next performance target:
+  dashboard-only org broadcasts still iterate device sockets and can trigger
+  per-device DB checks.
+- [x] Test/release reviewer found a larger release-gate target: middleware E2E
+  currently gates only the agents suite and older specs still use `/api`.
+- [x] Selected first bounded target for this pass: safe display response
+  projections, because it is a small high-severity security/payload fix in a
+  customer-facing API and does not require operator action.
+
+---
+
+## Completed: Dashboard Customer Improvements Pass 20 (2026-06-01)
 
 **Branch:** `feat/dashboard-customer-improvements-pass-20`
 
@@ -30,14 +138,19 @@ agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
 - [x] Implement dashboard shared Socket.IO provider.
 - [x] Run multi-subagent code review before broader tests.
 - [x] Run focused and broader affected verification.
-- [ ] PR, CI, merge.
-- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+- [x] PR, CI, merge. PR #143 merged at
+  `384b584054446547ec3d64a37f7f6839dc10ac39`.
+- [x] Re-check deployment gate; deploy only if prod checkout is safe.
 
 **Current merge/deploy state**
 - [x] PR #142 merged at
   `80463b2aaad1c041d14e4cfe55ffcdae627b7b09`; PR checks green for audit,
   build, e2e, lint, security, and test.
 - [x] Post-merge `main` CI for `80463b2aaad1c041d14e4cfe55ffcdae627b7b09`
+  completed successfully.
+- [x] PR #143 merged at
+  `384b584054446547ec3d64a37f7f6839dc10ac39`; PR CI green for audit, build,
+  e2e, lint, security, and test. Post-merge `main` CI for `384b584054` also
   completed successfully.
 - [x] Prod deploy remains blocked: `/opt/vizora/app` is at
   `bb76aa1838740bff5b58623dfef7a906d44f46a6`, while `origin/main` is


### PR DESCRIPTION
## Summary
- add shared safe Prisma display response projections for display list/detail/member responses
- project authenticated display and display-group response paths away from token, pairing-code, and socket fields
- align QR overlay responses with existing web/API contract and narrow pairing-service internal display queries

## Review
- Security/API reviewer: CLEAN
- Regression/dashboard reviewer: CLEAN, staging note closed by explicitly staging `display-response.select.ts`

## Tests
- `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/displays/pairing.service.spec.ts src/modules/displays/displays.service.spec.ts src/modules/displays/displays.controller.spec.ts src/modules/display-groups/display-groups.service.spec.ts src/modules/displays/displays.service.bulk.spec.ts` (5 suites / 137 tests)
- `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/displays/pairing.service.spec.ts src/modules/displays/pairing.controller.spec.ts src/modules/displays/displays.controller.spec.ts src/modules/displays/displays.service.spec.ts src/modules/displays/displays.service.bulk.spec.ts src/modules/displays/displays.service.tag-events.spec.ts src/modules/display-groups/display-groups.service.spec.ts src/modules/display-groups/display-groups.controller.spec.ts` (8 suites / 166 tests)
- `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
- `ESLINT_USE_FLAT_CONFIG=false npx eslint ...` (changed files)
- `npx nx build @vizora/middleware`
- `pnpm --filter @vizora/middleware test -- --runInBand` (143 suites / 2,884 tests)
- `git diff --cached --check`

## Deploy
- Not deployed from this PR. Production checkout was previously dirty/diverged and must be rechecked before any deploy.