### PR TITLE
chore: block hardcoded jwt test tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,24 @@ JWT_EXPIRES_IN=7d
 # Device authentication secret (separate from user auth)
 DEVICE_JWT_SECRET=GENERATE_ANOTHER_SECURE_64_CHAR_HEX_SECRET_HERE
 
+# =============================================================================
+# Manual Verification Tokens (local scripts only)
+# =============================================================================
+# Required only when running manual helper scripts such as:
+#   realtime/test-device-realtime.js
+#   realtime/test-content-delivery.js
+#   realtime/test-end-to-end-streaming.js
+#   scripts/test-thumbnails-http.js
+#
+# Generate fresh local tokens through the login/pairing flow. User and device
+# tokens must belong to the same local organization and test data set. Do not
+# commit real token values.
+VIZORA_TEST_USER_TOKEN=
+VIZORA_TEST_DEVICE_TOKEN=
+VIZORA_TEST_DEVICE_IDENTIFIER=
+VIZORA_TEST_PLAYLIST_ID=
+VIZORA_TEST_CONTENT_ID=
+
 # Next.js Server Actions encryption key (stable value, NOT a secret to
 # generate fresh). Keeps Server Action IDs deterministic across rebuilds
 # so cached browser bundles don't break with "Failed to find Server Action"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,8 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
+      - name: Check for hardcoded JWTs
+        run: pnpm security:no-hardcoded-jwts
       - name: Security audit
         continue-on-error: true
         run: pnpm audit --audit-level=high

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -14,6 +14,8 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
+      - name: Check for hardcoded JWTs
+        run: pnpm security:no-hardcoded-jwts
       - name: Security audit
         continue-on-error: true
         run: pnpm audit --audit-level=high

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,20 @@ NEXT_PUBLIC_GOOGLE_CLIENT_ID  # Same value, exposed to frontend for GSI button (
 NEXT_SERVER_ACTIONS_ENCRYPTION_KEY  # Stable Next.js Server-Action key — KEEP CONSTANT across deploys
 ```
 
+### Manual verification scripts
+
+```
+VIZORA_TEST_USER_TOKEN          # Fresh local user JWT for manual helper scripts; never commit real values
+VIZORA_TEST_DEVICE_TOKEN        # Fresh local device JWT for realtime/device-content manual helper scripts
+VIZORA_TEST_DEVICE_IDENTIFIER   # Optional device identifier override for manual realtime scripts
+VIZORA_TEST_PLAYLIST_ID         # Optional playlist id override for manual content-delivery script
+VIZORA_TEST_CONTENT_ID          # Optional content id override for manual heartbeat/impression payloads
+```
+
+These variables are for local manual verification only. Generate tokens through
+the local login/pairing flow; user and device tokens must belong to the same
+local organization and test data set.
+
 ### Web frontend (NEXT_PUBLIC_*)
 
 ```

--- a/docs/plans/2026-06-01-security-token-guard-pass-22.md
+++ b/docs/plans/2026-06-01-security-token-guard-pass-22.md
@@ -1,0 +1,95 @@
+# Security Token Guard Pass 22
+
+**Date:** 2026-06-01
+**Branch:** `feat/customer-dashboard-improvements-pass-22`
+
+## Why Now
+
+After PR #144 merged with green CI, the next customer-readiness review found a
+small but high-severity release hygiene gap: several manual verification
+scripts committed long-lived JWT-looking tokens. This pass removes those token
+values and adds a CI guard so the same class of secret regression fails before
+merge.
+
+## New Primitives Introduced
+
+One repository-local security scan script:
+`scripts/security/check-no-hardcoded-jwts.js`.
+
+No new runtime service, route, database model, migration, agent, MCP tool,
+Hermes skill, provider, or infrastructure primitive.
+
+## Hermes-First Analysis
+
+Not applicable. This pass does not introduce or modify business agents, MCP
+tools, Hermes skills, AI/provider calls, or spend paths.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Secret hygiene guard | none applicable | Build repository-local static guard; no agent runtime needed. |
+
+Awesome-Hermes-agent ecosystem check: not applicable because this is CI/repo
+secret hygiene, not an agent capability.
+
+## Drift Check
+
+Evidence from `pnpm security:no-hardcoded-jwts` red run before remediation:
+
+- `realtime/test-content-delivery.js:7`
+- `realtime/test-content-delivery.js:8`
+- `realtime/test-device-realtime.js:4`
+- `realtime/test-end-to-end-streaming.js:7`
+- `scripts/test-thumbnails-http.js:94`
+
+The existing security audit job was advisory because `pnpm audit` uses
+`continue-on-error`; it did not block this secret class.
+
+## Scope
+
+- Replace committed manual-script JWTs with required environment variables.
+- Keep manual script behavior explicit: missing tokens fail fast with a clear
+  message.
+- Preserve local manual workflows by deriving playlist data from the
+  authenticated API state where possible instead of requiring a repo-hardcoded
+  playlist ID.
+- Add a repository scan script that checks tracked text files for full
+  JWT-shaped tokens.
+- Run that script in the main CI security job and the scheduled security audit
+  workflow before the advisory dependency audit.
+
+## Manual Script Inputs
+
+- `realtime/test-device-realtime.js`: `VIZORA_TEST_DEVICE_TOKEN`
+- `realtime/test-end-to-end-streaming.js`: `VIZORA_TEST_DEVICE_TOKEN`
+- `realtime/test-content-delivery.js`: `VIZORA_TEST_DEVICE_TOKEN`,
+  `VIZORA_TEST_USER_TOKEN`; optional `VIZORA_TEST_DEVICE_IDENTIFIER`,
+  `VIZORA_TEST_PLAYLIST_ID`, `VIZORA_TEST_CONTENT_ID`
+- `scripts/test-thumbnails-http.js`: `VIZORA_TEST_DEVICE_TOKEN`
+
+Fresh user/device tokens must belong to the same local organization and test
+data set. If no playlist is available locally, set `VIZORA_TEST_PLAYLIST_ID` or
+create a local playlist first.
+
+The env source of truth is updated in `.env.example` and `CLAUDE.md`. There is
+no tracked `AGENTS.md` file in this worktree to update.
+
+## Out Of Scope
+
+- Rotating any real token or secret. If these tokens were ever valid in shared
+  or production-like environments, operator-owned revocation/rotation remains
+  required.
+- Making `pnpm audit` blocking. The dependency vulnerability backlog is larger
+  than this pass and needs separate dependency-risk triage.
+- Production deploy. Current production checkout is dirty/diverged and remains
+  unsafe to deploy over.
+
+## Verification Plan
+
+- `pnpm security:no-hardcoded-jwts`
+- `node --check scripts/security/check-no-hardcoded-jwts.js`
+- `node --check` on each modified manual script.
+- Realtime unit suite, because three changed scripts live under `realtime/`.
+- `git diff --check`
+- Multi-vector reviewer pass before broader tests:
+  - Security/CI reviewer.
+  - Script/runtime usability reviewer.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "nx run-many --target=test --all",
     "test:ops": "node --import tsx --test \"scripts/ops/**/*.test.ts\"",
     "test:e2e": "pnpm --filter @vizora/middleware test:e2e",
+    "security:no-hardcoded-jwts": "node scripts/security/check-no-hardcoded-jwts.js",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint --ext .ts,.tsx middleware/src realtime/src",
     "lint:web": "pnpm --filter @vizora/web exec next lint"
   },

--- a/realtime/test-content-delivery.js
+++ b/realtime/test-content-delivery.js
@@ -2,12 +2,24 @@ const { io } = require('socket.io-client');
 const http = require('http');
 
 const API_URL = 'http://127.0.0.1:3000';
+const API_PREFIX = '/api/v1';
 const REALTIME_URL = 'ws://127.0.0.1:3002';
-const DEVICE_IDENTIFIER = '00:15:5d:05:a2:cb';
-const DEVICE_TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmYzVmZjk4Mi1hNmUxLTRmNDYtYjQyNS01MjJjMWQ3NThjOTkiLCJkZXZpY2VJZGVudGlmaWVyIjoiMDA6MTU6NWQ6MDU6YTI6Y2IiLCJvcmdhbml6YXRpb25JZCI6IjJmZDY4OTY4LTAyYjAtNGM0MC05ZmM4LWU2MmE2MWRkNWVkYyIsInR5cGUiOiJkZXZpY2UiLCJpYXQiOjE3Njk3ODIzOTcsImV4cCI6MTgwMTMxODM5N30.F6LRyNtGTBCS3gsMUaHBMSezW6VSpHaxBtuGsaousp8';
-const USER_TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmNGQwOWFjMy04MmMwLTQ3ODAtOGVhMi03MWZmYjU4YzgzYWEiLCJlbWFpbCI6InRlc3QtMTc2OTc4MzI1OTc2NUBleGFtcGxlLmNvbSIsIm9yZ2FuaXphdGlvbklkIjoiMzVhMTBjMmYtODZiZS00MjkzLTk5ODgtNmM2NDBhM2ExZTYzIiwicm9sZSI6ImFkbWluIiwidHlwZSI6InVzZXIiLCJpYXQiOjE3Njk3ODMyNjAsImV4cCI6MTc3MDM4ODA2MH0.MEP4Kiy09Z_n-Ln_6BTxPp4lIELnNNJiAVCMI60_kHQ';
+const DEVICE_IDENTIFIER = process.env.VIZORA_TEST_DEVICE_IDENTIFIER || '00:15:5d:05:a2:cb';
+const DEVICE_TOKEN = requiredEnv('VIZORA_TEST_DEVICE_TOKEN');
+const USER_TOKEN = requiredEnv('VIZORA_TEST_USER_TOKEN');
+const TEST_PLAYLIST_ID = process.env.VIZORA_TEST_PLAYLIST_ID;
+const TEST_CONTENT_ID = process.env.VIZORA_TEST_CONTENT_ID;
 
 const results = [];
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`${name} is required. Generate a fresh local token and pass it through the environment.`);
+    process.exit(1);
+  }
+  return value;
+}
 
 function httpRequest(method, path, body, headers = {}, useAuth = true) {
   return new Promise((resolve, reject) => {
@@ -57,15 +69,66 @@ function httpRequest(method, path, body, headers = {}, useAuth = true) {
   });
 }
 
+function unwrapResponseData(responseData) {
+  return responseData && typeof responseData === 'object' && 'data' in responseData
+    ? responseData.data
+    : responseData;
+}
+
+function extractCollection(payload) {
+  const queue = [payload];
+  const seen = new Set();
+
+  while (queue.length > 0) {
+    const value = queue.shift();
+    if (Array.isArray(value)) return value;
+    if (!value || typeof value !== 'object' || seen.has(value)) continue;
+
+    seen.add(value);
+    for (const key of ['data', 'items', 'playlists', 'results']) {
+      if (key in value) queue.push(value[key]);
+    }
+  }
+
+  return [];
+}
+
+async function fetchPlaylistDetail(playlistId) {
+  const playlistResp = await httpRequest('GET', `${API_PREFIX}/playlists/${playlistId}`);
+  if (playlistResp.status !== 200) {
+    throw new Error(`Could not fetch playlist ${playlistId}: HTTP ${playlistResp.status}`);
+  }
+  return unwrapResponseData(playlistResp.data);
+}
+
+async function loadTestPlaylist() {
+  if (TEST_PLAYLIST_ID) {
+    return fetchPlaylistDetail(TEST_PLAYLIST_ID);
+  }
+
+  const listResp = await httpRequest('GET', `${API_PREFIX}/playlists`);
+  if (listResp.status !== 200) {
+    throw new Error(`Could not list playlists: HTTP ${listResp.status}`);
+  }
+
+  const playlists = extractCollection(listResp.data);
+  const playlist = playlists.find((candidate) => candidate?.id);
+  if (!playlist) {
+    throw new Error('No playlist found. Create a local playlist or set VIZORA_TEST_PLAYLIST_ID.');
+  }
+
+  return fetchPlaylistDetail(playlist.id);
+}
+
 async function testDeviceStatus() {
   console.log('\n💻 TEST 1: Check Device Status Before Playlist Push');
   console.log('=====================================');
 
   try {
-    const response = await httpRequest('GET', '/api/devices/status');
+    const response = await httpRequest('GET', `${API_PREFIX}/displays`);
 
     if (response.status === 200) {
-      const devices = response.data.devices || response.data || [];
+      const devices = extractCollection(response.data);
       const testDevice = devices.find((d) => d.deviceIdentifier === DEVICE_IDENTIFIER);
 
       if (testDevice) {
@@ -91,6 +154,8 @@ async function testDeviceStatus() {
         });
         return null;
       }
+    } else {
+      console.log(`âš  Could not check device status: HTTP ${response.status}`);
     }
   } catch (error) {
     console.log('⚠ Could not check device status');
@@ -102,17 +167,9 @@ async function testPushPlaylist() {
   console.log('\n📡 TEST 2: Push Playlist to Device via Realtime');
   console.log('=====================================');
 
-  const PLAYLIST_ID = 'cml0z5rvu000nqji6s9o6m3gu';
-
   try {
-    // First, fetch the playlist from the API
-    const playlistResp = await httpRequest('GET', `/api/playlists/${PLAYLIST_ID}`);
-
-    if (playlistResp.status !== 200) {
-      throw new Error(`Could not fetch playlist: HTTP ${playlistResp.status}`);
-    }
-
-    const playlist = playlistResp.data;
+    // First, fetch the playlist from the API.
+    const playlist = await loadTestPlaylist();
     console.log('✓ Playlist fetched from API');
     console.log(`  Playlist ID: ${playlist.id}`);
     console.log(`  Name: ${playlist.name}`);
@@ -183,7 +240,7 @@ async function testPushPlaylist() {
             name: 'Playlist Push via Realtime',
             status: 'PENDING',
             message: 'Playlist structure verified, delivery flow ready',
-            details: { playlistId: PLAYLIST_ID },
+            details: { playlistId: playlist.id },
           });
           socket.disconnect();
           resolve();
@@ -240,8 +297,8 @@ async function testDeviceHeartbeat() {
         console.log('\n📤 Sending device heartbeat with content impression...');
         socket.emit('heartbeat', {
           timestamp: Date.now(),
-          contentId: 'cml0z5rvu000nqji6s9o6m3gu',
-          playlistId: 'cml0z5rvu000nqji6s9o6m3gu',
+          contentId: TEST_CONTENT_ID || TEST_PLAYLIST_ID || 'manual-test-content',
+          playlistId: TEST_PLAYLIST_ID || 'manual-test-playlist',
           currentItem: 0,
           totalItems: 1,
           metrics: {

--- a/realtime/test-device-realtime.js
+++ b/realtime/test-device-realtime.js
@@ -1,7 +1,16 @@
 const { io } = require('socket.io-client');
 
 const REALTIME_URL = 'ws://127.0.0.1:3002';
-const DEVICE_TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmYzVmZjk4Mi1hNmUxLTRmNDYtYjQyNS01MjJjMWQ3NThjOTkiLCJkZXZpY2VJZGVudGlmaWVyIjoiMDA6MTU6NWQ6MDU6YTI6Y2IiLCJvcmdhbml6YXRpb25JZCI6IjJmZDY4OTY4LTAyYjAtNGM0MC05ZmM4LWU2MmE2MWRkNWVkYyIsInR5cGUiOiJkZXZpY2UiLCJpYXQiOjE3Njk3ODIzOTcsImV4cCI6MTgwMTMxODM5N30.F6LRyNtGTBCS3gsMUaHBMSezW6VSpHaxBtuGsaousp8';
+const DEVICE_TOKEN = requiredEnv('VIZORA_TEST_DEVICE_TOKEN');
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`${name} is required. Generate a fresh local device token and pass it through the environment.`);
+    process.exit(1);
+  }
+  return value;
+}
 
 console.log('╔════════════════════════════════════════════════════════╗');
 console.log('║      TEST DEVICE REALTIME GATEWAY CONNECTION           ║');

--- a/realtime/test-end-to-end-streaming.js
+++ b/realtime/test-end-to-end-streaming.js
@@ -2,12 +2,22 @@ const { io } = require('socket.io-client');
 const http = require('http');
 
 const API_URL = 'http://127.0.0.1:3000';
+const API_PREFIX = '/api/v1';
 const REALTIME_URL = 'ws://127.0.0.1:3002';
 const DEVICE_IDENTIFIER = '00:15:5d:05:a2:cb';
-const DEVICE_TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmYzVmZjk4Mi1hNmUxLTRmNDYtYjQyNS01MjJjMWQ3NThjOTkiLCJkZXZpY2VJZGVudGlmaWVyIjoiMDA6MTU6NWQ6MDU6YTI6Y2IiLCJvcmdhbml6YXRpb25JZCI6IjJmZDY4OTY4LTAyYjAtNGM0MC05ZmM4LWU2MmE2MWRkNWVkYyIsInR5cGUiOiJkZXZpY2UiLCJpYXQiOjE3Njk3ODIzOTcsImV4cCI6MTgwMTMxODM5N30.F6LRyNtGTBCS3gsMUaHBMSezW6VSpHaxBtuGsaousp8';
+const DEVICE_TOKEN = requiredEnv('VIZORA_TEST_DEVICE_TOKEN');
 
 const results = [];
 let userToken = null;
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`${name} is required. Generate a fresh local device token and pass it through the environment.`);
+    process.exit(1);
+  }
+  return value;
+}
 
 function httpRequest(method, path, body, headers = {}, useAuth = true) {
   return new Promise((resolve, reject) => {
@@ -57,6 +67,12 @@ function httpRequest(method, path, body, headers = {}, useAuth = true) {
   });
 }
 
+function unwrapResponseData(responseData) {
+  return responseData && typeof responseData === 'object' && 'data' in responseData
+    ? responseData.data
+    : responseData;
+}
+
 async function testRegisterUser() {
   console.log('\n👤 STEP 1: Register Test User');
   console.log('=====================================');
@@ -64,7 +80,7 @@ async function testRegisterUser() {
   try {
     const uniqueId = Date.now();
     const email = `test-streaming-${uniqueId}@example.com`;
-    const response = await httpRequest('POST', '/api/auth/register', {
+    const response = await httpRequest('POST', `${API_PREFIX}/auth/register`, {
       email: email,
       password: 'Test123!@#',
       firstName: 'Test',
@@ -73,7 +89,8 @@ async function testRegisterUser() {
     }, {}, false);
 
     if (response.status === 201) {
-      userToken = response.data.data?.token || response.data.token;
+      const authData = unwrapResponseData(response.data);
+      userToken = authData.access_token || authData.token;
       console.log('✓ User registered');
       console.log(`  Email: ${email}`);
       console.log(`  Token: ${userToken?.substring(0, 30)}...`);
@@ -93,7 +110,7 @@ async function testCreateContent() {
   console.log('=====================================');
 
   try {
-    const response = await httpRequest('POST', '/api/content', {
+    const response = await httpRequest('POST', `${API_PREFIX}/content`, {
       name: 'Streaming Test Image',
       description: 'Image for realtime streaming test',
       type: 'image',
@@ -103,11 +120,12 @@ async function testCreateContent() {
     });
 
     if (response.status === 200 || response.status === 201) {
-      const contentId = response.data.id || response.data.contentId;
+      const content = unwrapResponseData(response.data);
+      const contentId = content.id || content.contentId;
       console.log('✓ Content created');
       console.log(`  Content ID: ${contentId}`);
-      console.log(`  Name: ${response.data.name}`);
-      console.log(`  Duration: ${response.data.duration}ms`);
+      console.log(`  Name: ${content.name}`);
+      console.log(`  Duration: ${content.duration}ms`);
       return contentId;
     } else {
       throw new Error(`HTTP ${response.status}: ${response.data?.message}`);
@@ -124,7 +142,7 @@ async function testCreatePlaylist(contentId) {
   console.log('=====================================');
 
   try {
-    const response = await httpRequest('POST', '/api/playlists', {
+    const response = await httpRequest('POST', `${API_PREFIX}/playlists`, {
       name: 'Streaming Test Playlist',
       description: 'Playlist for realtime delivery test',
       isDefault: false,
@@ -138,11 +156,12 @@ async function testCreatePlaylist(contentId) {
     });
 
     if (response.status === 200 || response.status === 201) {
-      const playlistId = response.data.id || response.data.playlistId;
+      const playlist = unwrapResponseData(response.data);
+      const playlistId = playlist.id || playlist.playlistId;
       console.log('✓ Playlist created');
       console.log(`  Playlist ID: ${playlistId}`);
-      console.log(`  Name: ${response.data.name}`);
-      console.log(`  Items: ${response.data.items?.length || 1}`);
+      console.log(`  Name: ${playlist.name}`);
+      console.log(`  Items: ${playlist.items?.length || 1}`);
       return playlistId;
     } else {
       throw new Error(`HTTP ${response.status}: ${response.data?.message}`);
@@ -240,13 +259,13 @@ async function testPlaylistDelivery(playlistId) {
 
   try {
     // Fetch the playlist
-    const playlistResp = await httpRequest('GET', `/api/playlists/${playlistId}`);
+    const playlistResp = await httpRequest('GET', `${API_PREFIX}/playlists/${playlistId}`);
 
     if (playlistResp.status !== 200) {
       throw new Error(`Could not fetch playlist: HTTP ${playlistResp.status}`);
     }
 
-    const playlist = playlistResp.data;
+    const playlist = unwrapResponseData(playlistResp.data);
     console.log('✓ Playlist fetched from API');
     console.log(`  Playlist ID: ${playlist.id}`);
     console.log(`  Items: ${playlist.items?.length || 0}`);

--- a/scripts/security/check-no-hardcoded-jwts.js
+++ b/scripts/security/check-no-hardcoded-jwts.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+const { execFileSync } = require('node:child_process');
+const { readFileSync } = require('node:fs');
+const { extname } = require('node:path');
+
+const JWT_PATTERN = /\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g;
+const SKIPPED_EXTENSIONS = new Set([
+  '.avif',
+  '.gif',
+  '.ico',
+  '.jpeg',
+  '.jpg',
+  '.mov',
+  '.mp4',
+  '.pdf',
+  '.png',
+  '.webp',
+  '.zip',
+]);
+
+const files = execFileSync('git', ['ls-files', '-z'], { encoding: 'buffer' })
+  .toString('utf8')
+  .split('\0')
+  .filter(Boolean);
+
+const findings = [];
+
+for (const file of files) {
+  if (SKIPPED_EXTENSIONS.has(extname(file).toLowerCase())) {
+    continue;
+  }
+
+  let text;
+  try {
+    text = readFileSync(file, 'utf8');
+  } catch {
+    continue;
+  }
+
+  if (text.includes('\0')) {
+    continue;
+  }
+
+  const lines = text.split(/\r?\n/);
+  lines.forEach((line, index) => {
+    const matches = line.match(JWT_PATTERN);
+    if (!matches) return;
+
+    findings.push({
+      file,
+      line: index + 1,
+      count: matches.length,
+    });
+  });
+}
+
+if (findings.length > 0) {
+  console.error('Hardcoded JWT-looking tokens found. Use env vars or generated test fixtures instead.');
+  for (const finding of findings) {
+    console.error(`${finding.file}:${finding.line} (${finding.count})`);
+  }
+  process.exit(1);
+}
+
+console.log('No hardcoded JWT-looking tokens found.');

--- a/scripts/test-thumbnails-http.js
+++ b/scripts/test-thumbnails-http.js
@@ -1,4 +1,39 @@
 const http = require('http');
+const DEVICE_TOKEN = requiredEnv('VIZORA_TEST_DEVICE_TOKEN');
+const API_PREFIX = '/api/v1';
+let failures = 0;
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`${name} is required. Generate a fresh local device token and pass it through the environment.`);
+    process.exit(1);
+  }
+  return value;
+}
+
+function recordFailure(message) {
+  failures += 1;
+  console.log(message);
+}
+
+function extractCollection(payload) {
+  const queue = [payload];
+  const seen = new Set();
+
+  while (queue.length > 0) {
+    const value = queue.shift();
+    if (Array.isArray(value)) return value;
+    if (!value || typeof value !== 'object' || seen.has(value)) continue;
+
+    seen.add(value);
+    for (const key of ['data', 'items', 'content', 'results']) {
+      if (key in value) queue.push(value[key]);
+    }
+  }
+
+  return [];
+}
 
 function makeRequest(options) {
   return new Promise((resolve, reject) => {
@@ -24,7 +59,7 @@ async function run() {
   const loginData = JSON.stringify({ email: 'admin@vizora.test', password: 'Test1234!' });
   const loginRes = await new Promise((resolve, reject) => {
     const req = http.request({
-      hostname: 'localhost', port: 3000, path: '/api/auth/login', method: 'POST',
+      hostname: 'localhost', port: 3000, path: `${API_PREFIX}/auth/login`, method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Content-Length': loginData.length }
     }, (res) => {
       let body = '';
@@ -45,7 +80,7 @@ async function run() {
   // Get content list
   const contentRes = await new Promise((resolve, reject) => {
     const req = http.request({
-      hostname: 'localhost', port: 3000, path: '/api/content', method: 'GET',
+      hostname: 'localhost', port: 3000, path: `${API_PREFIX}/content`, method: 'GET',
       headers: { 'Cookie': cookieHeader }
     }, (res) => {
       let body = '';
@@ -56,13 +91,13 @@ async function run() {
     req.end();
   });
 
-  const items = contentRes.data || contentRes;
+  const items = extractCollection(contentRes);
   console.log(`\n=== Thumbnail HTTP Verification (${items.length} items) ===\n`);
 
   for (const item of items) {
     const thumbnailPath = item.thumbnail || item.thumbnailUrl;
     if (!thumbnailPath) {
-      console.log(`[FAIL] ${item.name} - No thumbnail path set`);
+      recordFailure(`[FAIL] ${item.name} - No thumbnail path set`);
       continue;
     }
 
@@ -77,41 +112,47 @@ async function run() {
       });
 
       const status = thumbRes.status === 200 ? 'PASS' : 'FAIL';
+      if (status === 'FAIL') failures += 1;
       console.log(`[${status}] ${item.name}`);
       console.log(`   Path: ${thumbnailPath}`);
       console.log(`   HTTP Status: ${thumbRes.status}`);
       console.log(`   Content-Type: ${thumbRes.contentType}`);
       console.log(`   Size: ${thumbRes.bodyLength} bytes`);
     } catch (e) {
-      console.log(`[FAIL] ${item.name} - Error: ${e.message}`);
+      recordFailure(`[FAIL] ${item.name} - Error: ${e.message}`);
     }
   }
 
   // Also test content file serving via device endpoint
   console.log('\n=== Device Content File Access Verification ===\n');
 
-  // Use the device token from the pairing flow
-  const deviceToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJlZDc3NmU5Zi1hNWI3LTQ1OTQtYjI1NS1kMDYzMjFhMTUwNmUiLCJkZXZpY2VJZGVudGlmaWVyIjoiYW5kcm9pZC0xMDgweDE5MjAtMTc3MDU1ODQ5NzMzMiIsIm9yZ2FuaXphdGlvbklkIjoiNjJhNTVmZTItMzIyNC00MDQ0LTgxODctNzQ3MWVkZDUyOWIyIiwidHlwZSI6ImRldmljZSIsImlhdCI6MTc3MDU1ODQ5NywiZXhwIjoxODAyMDk0NDk3fQ.oOuTGNqWbapKhR3fYHbiZY1mzzJUn2Xo2okFMOH4Gc4';
-
   for (const item of items.slice(0, 2)) {  // Test first 2
     try {
       const fileRes = await makeRequest({
         hostname: 'localhost',
         port: 3000,
-        path: `/api/device-content/${item.id}/file?token=${deviceToken}`,
+        path: `${API_PREFIX}/device-content/${item.id}/file?token=${DEVICE_TOKEN}`,
         method: 'GET',
         headers: {}
       });
 
       const status = fileRes.status === 200 ? 'PASS' : 'FAIL';
+      if (status === 'FAIL') failures += 1;
       console.log(`[${status}] ${item.name}`);
       console.log(`   HTTP Status: ${fileRes.status}`);
       console.log(`   Content-Type: ${fileRes.contentType}`);
       console.log(`   Size: ${fileRes.bodyLength} bytes`);
     } catch (e) {
-      console.log(`[FAIL] ${item.name} - Error: ${e.message}`);
+      recordFailure(`[FAIL] ${item.name} - Error: ${e.message}`);
     }
+  }
+
+  if (failures > 0) {
+    throw new Error(`${failures} thumbnail/content verification checks failed`);
   }
 }
 
-run().catch(console.error);
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,104 @@
 # Vizora - Task Tracker
 
-## In Progress: Display Response Projection Pass 21 (2026-06-01)
+## In Progress: Security Token Guard Pass 22 (2026-06-01)
+
+**Branch:** `feat/customer-dashboard-improvements-pass-22`
+
+**Why now:** PR #144 merged with green PR checks and green post-merge `main`
+CI, but production deployment remains blocked by a dirty/diverged checkout. The
+next read-only customer/performance/release review found several valid targets;
+the smallest high-severity repo-side gap is committed long-lived JWT-looking
+tokens in manual verification scripts plus no blocking CI guard for that class.
+
+**New primitives introduced:** one repository-local security scan script,
+`scripts/security/check-no-hardcoded-jwts.js`. No new runtime service, route,
+database model, migration, agent, MCP tool, Hermes skill, provider, or
+infrastructure primitive.
+
+**Hermes-first analysis:** not applicable. This pass does not add or modify
+business agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
+
+**Plan**
+- [x] Dispatch read-only customer UX, backend/performance, and release/security
+  reviewers after PR #144.
+- [x] Select highest-value bounded target.
+- [x] Add red hardcoded-JWT guard and confirm it catches existing committed
+  tokens.
+- [x] Replace manual-script committed JWTs with required environment variables.
+- [x] Wire the guard into CI security workflows before advisory dependency
+  audit.
+- [x] Address first review pass: stage/include the new guard script at commit
+  time, derive `test-content-delivery` playlist data from local API state or
+  env, and make thumbnail device-token validation fail fast/nonzero.
+- [x] Address re-review pass: support nested playlist list envelopes and
+  document `VIZORA_TEST_*` variables in `.env.example` and `CLAUDE.md` (no
+  tracked `AGENTS.md` exists in this worktree).
+- [x] Address final manual-script review: use direct `/api/v1` middleware
+  paths and make thumbnail/content verification failures exit nonzero.
+- [x] Address final response-shape review: unwrap current response envelopes in
+  older manual scripts and use the actual `/api/v1/displays` status source.
+- [x] Run multi-subagent code review before broader tests.
+- [x] Run focused and broader verification.
+- [ ] PR, CI, merge.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Plan/design:**
+`docs/plans/2026-06-01-security-token-guard-pass-22.md`
+
+**Reviewer target synthesis**
+- [x] Customer UX reviewer found valid current dashboard issues: inactive
+  schedules shown as active, dead schedule conflict warning UI, fictional
+  schedule timezone selector, hardcoded content tag filters, synthetic
+  analytics labels, and AI Designer CTA prominence while backend capability is
+  unavailable.
+- [x] Backend/performance reviewer found valid performance targets: dashboard
+  org broadcasts still inspect device sockets, playlist fan-out can send
+  unbounded per-display internal requests, content impressions write
+  synchronously, dashboard status fetches up to 1000 displays, response
+  sanitization is CPU-heavy, upload does multiple full-file passes, and pairing
+  active-list scans Redis keyspace.
+- [x] Release/security reviewer found valid launch-readiness targets: CI E2E is
+  still thin for customer-1, dependency audit is advisory, long-lived JWTs were
+  committed in manual scripts, prod deploy is unsafe until prod checkout is
+  reconciled, and customer-1 operator gates remain open.
+- [x] Selected first bounded target for this pass: committed JWT cleanup plus a
+  blocking CI guard, because it is high-severity, repo-side, testable, and does
+  not require operator credentials.
+
+**Operator-only residual**
+- [ ] If any removed token was ever valid in shared, staging, or production-like
+  environments, revoke/rotate it outside the repo. This pass prevents future
+  commits but cannot invalidate already-issued tokens.
+
+**Review gate**
+- [x] Security/CI reviewer CLEAN after staging follow-up. Confirmed the guard
+  script is staged, package script is wired, both CI security workflows run it
+  before advisory audit, `.env.example` / `CLAUDE.md` document the
+  `VIZORA_TEST_*` inputs, no full JWT-shaped tracked tokens remain, and diff
+  check passes.
+- [x] Manual-script/runtime reviewer CLEAN after follow-ups. Confirmed direct
+  middleware paths use `/api/v1`, `test-content-delivery` uses
+  `/api/v1/displays` and nested playlist envelopes, `test-end-to-end-streaming`
+  unwraps current auth/content/playlist response shapes, and
+  `test-thumbnails-http` unwraps paginated content and exits nonzero on check
+  failures.
+
+**Verification**
+- [x] Hardcoded JWT guard passed:
+  `pnpm security:no-hardcoded-jwts`.
+- [x] Syntax checks passed:
+  `node --check scripts/security/check-no-hardcoded-jwts.js`,
+  `node --check realtime/test-content-delivery.js`,
+  `node --check realtime/test-device-realtime.js`,
+  `node --check realtime/test-end-to-end-streaming.js`,
+  `node --check scripts/test-thumbnails-http.js`.
+- [x] Diff hygiene passed: `git diff --check` and `git diff --cached --check`.
+- [x] Realtime unit suite passed:
+  `pnpm --filter @vizora/realtime test -- --runInBand` - 12 suites / 275 tests.
+
+---
+
+## Completed: Display Response Projection Pass 21 (2026-06-01)
 
 **Branch:** `feat/customer-dashboard-improvements-pass-21`
 
@@ -92,6 +190,15 @@ agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
   `pnpm --filter @vizora/middleware test -- --runInBand` - 143 suites /
   2,884 tests.
 - [x] `git diff --check` passed with Windows CRLF warnings only.
+- [x] PR #144 merged at
+  `929b95764a96dcca2786a5e36606be457207f47b`; PR checks green for audit,
+  build, e2e, lint, security, and test.
+- [x] Post-merge `main` CI run `26735439846` completed successfully: audit,
+  build, e2e, lint, security, and test all green.
+- [x] Post-merge prod deploy gate re-checked and remains blocked:
+  `/opt/vizora/app` is dirty/diverged (`ahead 17, behind 77`) with many tracked
+  edits and untracked files. No production pull, reset, stash, env edit, service
+  restart, DB mutation, or deploy performed.
 
 **Reviewer target synthesis**
 - [x] Customer UX reviewer found valid current dashboard issues: inactive


### PR DESCRIPTION
## Summary
- remove committed long-lived JWT-looking tokens from manual verification scripts
- add `pnpm security:no-hardcoded-jwts` and run it in CI/security audit before advisory dependency audit
- document local `VIZORA_TEST_*` manual-script token inputs in `.env.example` and `CLAUDE.md`
- update older manual scripts for `/api/v1`, response-envelope unwrapping, and nonzero failure exits

## Verification
- `pnpm security:no-hardcoded-jwts`
- `node --check scripts/security/check-no-hardcoded-jwts.js`
- `node --check realtime/test-content-delivery.js`
- `node --check realtime/test-device-realtime.js`
- `node --check realtime/test-end-to-end-streaming.js`
- `node --check scripts/test-thumbnails-http.js`
- `git diff --check`
- `git diff --cached --check`
- `pnpm --filter @vizora/realtime test -- --runInBand` (12 suites / 275 tests)

## Review
- Security/CI staged-diff reviewer: CLEAN
- Manual-script/runtime staged-diff reviewer: CLEAN

## Residual / operator action
- If any removed token was ever valid in shared, staging, or production-like environments, revoke/rotate it outside the repo. This PR prevents future commits but cannot invalidate already-issued tokens.
- Production deploy remains gated on reconciling the dirty/diverged production checkout.