### PR TITLE
Fix schedule conflict trust

### DIFF
--- a/docs/plans/2026-06-01-schedule-trust-polish-pass-23.md
+++ b/docs/plans/2026-06-01-schedule-trust-polish-pass-23.md
@@ -1,0 +1,125 @@
+# Schedule Trust Polish Pass 23
+
+**Date:** 2026-06-01
+**Branch:** `feat/customer-dashboard-improvements-pass-23`
+
+## Why Now
+
+After PR #145 merged with green post-merge `main` CI, production deployment
+remains blocked by the dirty/diverged production checkout. The next
+customer-dashboard review identified schedule trust as the most bounded
+customer-facing improvement: schedule cards currently render inactive schedules
+as active, and the conflict-warning UI exists but is never populated.
+
+## Customer Dashboard Analysis
+
+Ranked current improvement backlog from customer/release/performance review:
+
+1. Schedules page trust: inactive schedules shown as active.
+2. Schedules page trust: conflict warning panel is dead.
+3. Schedules page trust: timezone selector implies schedule timezone support,
+   while runtime uses the display timezone.
+4. Analytics empty states: fetch errors can look like "No Data Yet".
+5. Analytics labels: some uptime/availability labels are synthetic and
+   not signage-specific enough.
+6. Content filters: tag filters are hardcoded instead of driven by content
+   metadata.
+7. AI Designer affordance: prominent CTA can overpromise when backend
+   capability is unavailable.
+8. Performance: dashboard org broadcasts still inspect device sockets.
+9. Performance: playlist update fan-out can issue unbounded per-display
+   internal requests.
+10. Performance: content impressions are written synchronously per playback.
+11. Performance: dashboard status provider fetches up to 1000 displays.
+12. Performance: response sanitization is CPU-heavy on large payloads.
+13. Performance: content upload still does multiple full-file passes.
+14. Performance: pairing active-list scans Redis keyspace.
+
+## New Primitives Introduced
+
+None. This uses the existing dashboard schedules page and existing
+`apiClient.checkScheduleConflicts` endpoint.
+
+## Hermes-First Analysis
+
+Not applicable. This pass does not add or modify business agents, MCP tools,
+Hermes skills, AI/provider calls, or spend paths.
+
+## Scope
+
+- Render schedule status badges from actual `isActive`/`active` state.
+- Populate conflict warnings from `apiClient.checkScheduleConflicts` while the
+  create/edit modal has enough target/day/time input.
+- Send candidate date ranges to the conflict endpoint so expired/disjoint
+  schedules are not over-reported as conflicts.
+- Fix backend conflict and active-schedule time math for schedules that cross
+  midnight, including display-group overlap cases.
+- Show explicit conflict-verification failure state instead of silently clearing
+  warnings.
+- Keep the UI inside existing Cockpit/dashboard patterns.
+- Preserve existing create/update API shapes and tenant/auth boundaries.
+
+## TDD Red State
+
+Focused schedules page test failed before implementation:
+
+- Inactive schedule test expected two `Active` badges and one `Inactive` badge,
+  but received three `Active` badges.
+- Conflict-warning test expected `apiClient.checkScheduleConflicts` to be called
+  for the selected display/day/time candidate, but it was never called.
+- Review-follow-up middleware tests failed for group-target overlap, overnight
+  conflict detection, active overnight schedule lookup, and adjacent-day all-day
+  false positives before the service fixes.
+- Review-follow-up frontend tests failed for missing date range, raw minute
+  conflict display, missing conflict-check failure state, duplicate checked
+  device preview calls, and missing live-region roles before the dashboard fixes.
+
+## Verification Plan
+
+- Focused schedules page Jest test.
+- Focused schedules service Jest test.
+- Broader web and middleware verification after review is clean.
+- Changed-file lint/type/build checks as needed.
+- Browser verification if local web services are available.
+
+## Review Results
+
+- Schedule/runtime reviewer: CLEAN after fixes for display-group overlap,
+  overnight schedule math, and adjacent-day all-day false positives.
+- Dashboard UX/test reviewer: CLEAN after fixes for formatted conflict times,
+  explicit conflict-verification failure state, already-verified device request
+  dedupe, and live-region semantics.
+
+## Verification Results
+
+- `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/dashboard/schedules/__tests__/schedules-page.test.tsx`
+  passed: 1 suite / 20 tests.
+- `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/schedules/schedules.service.spec.ts`
+  passed: 1 suite / 37 tests.
+- `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=schedules`
+  passed: 2 suites / 55 tests.
+- `pnpm --filter @vizora/web test -- --runInBand --testPathPattern=schedules`
+  passed: 1 suite / 20 tests.
+- `pnpm --filter @vizora/web test -- --runInBand` passed: 96 suites / 1005
+  tests. Existing unrelated React `act(...)` warnings remain in other
+  dashboard suites.
+- `pnpm --filter @vizora/middleware test -- --runInBand` passed: 143 suites /
+  2887 tests / 1 snapshot.
+- `npx nx build @vizora/middleware --skip-nx-cache` passed with known webpack
+  optional-dependency warnings.
+- Web production build passed after setting required local build env:
+  `NODE_OPTIONS=--max-old-space-size=4096`,
+  `NEXT_PUBLIC_SOCKET_URL=http://localhost:3002`,
+  `NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1`, and
+  `BACKEND_URL=http://localhost:3000`. The first run without
+  `NEXT_PUBLIC_SOCKET_URL` failed at the expected production CSP env
+  precondition.
+- `ESLINT_USE_FLAT_CONFIG=false npx eslint --ext .ts,.tsx middleware/src realtime/src`
+  completed with 0 errors / 195 warnings. Warnings are pre-existing broad repo
+  warnings.
+- `pnpm security:no-hardcoded-jwts` passed.
+- `git diff --check` passed with Windows CRLF conversion warnings only.
+
+Browser verification was not run in this worktree because the local middleware,
+web, and realtime stack was not available; the UI behavior is covered by the
+focused React tests and production build.

--- a/middleware/src/modules/schedules/schedules.service.spec.ts
+++ b/middleware/src/modules/schedules/schedules.service.spec.ts
@@ -332,6 +332,7 @@ describe('SchedulesService', () => {
 
   describe('findActiveSchedules', () => {
     it('should return active schedules for a display', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-06-01T10:00:00Z')); // Monday 10:00 UTC
       const mockActiveSchedules = [
         {
           ...mockSchedule,
@@ -345,10 +346,14 @@ describe('SchedulesService', () => {
       databaseService.display.findFirst.mockResolvedValue({ timezone: 'UTC', isDisabled: false } as any);
       databaseService.schedule.findMany.mockResolvedValue(mockActiveSchedules);
 
-      const result = await service.findActiveSchedules(mockDisplayId, mockOrganizationId);
+      try {
+        const result = await service.findActiveSchedules(mockDisplayId, mockOrganizationId);
 
-      expect(databaseService.schedule.findMany).toHaveBeenCalled();
-      expect(result).toEqual(mockActiveSchedules);
+        expect(databaseService.schedule.findMany).toHaveBeenCalled();
+        expect(result).toEqual(mockActiveSchedules);
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     it('should filter by current date, time, day of week, and organizationId', async () => {
@@ -361,8 +366,44 @@ describe('SchedulesService', () => {
       expect(callArgs.where.organizationId).toBe(mockOrganizationId);
       expect(callArgs.where.isActive).toBe(true);
       expect(callArgs.where.startDate).toHaveProperty('lte');
-      expect(callArgs.where.daysOfWeek).toHaveProperty('has');
+      expect(callArgs.where.daysOfWeek).toHaveProperty('hasSome');
       expect(callArgs.orderBy).toEqual({ priority: 'desc' });
+    });
+
+    it('should keep overnight schedules active after midnight on the next local day', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-06-02T00:30:00Z')); // Tuesday 00:30 UTC
+      databaseService.display.findFirst.mockResolvedValue({ timezone: 'UTC', isDisabled: false } as any);
+      databaseService.schedule.findMany.mockResolvedValue([
+        {
+          ...mockSchedule,
+          id: 'overnight-monday',
+          name: 'Monday Overnight',
+          daysOfWeek: [1],
+          startTime: 1380, // 23:00
+          endTime: 120,    // 02:00 next day
+          playlist: { id: mockPlaylistId, items: [] },
+        },
+        {
+          ...mockSchedule,
+          id: 'future-tuesday',
+          name: 'Future Tuesday',
+          daysOfWeek: [2],
+          startTime: 60,  // 01:00
+          endTime: 120,   // 02:00
+          playlist: { id: mockPlaylistId, items: [] },
+        },
+      ] as any);
+
+      try {
+        const result = await service.findActiveSchedules(mockDisplayId, mockOrganizationId);
+
+        const callArgs = databaseService.schedule.findMany.mock.calls[0][0];
+        expect(callArgs.where.daysOfWeek).toEqual({ hasSome: [2, 1] });
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe('overnight-monday');
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     it('should reject missing displays before querying schedules', async () => {
@@ -735,7 +776,7 @@ describe('SchedulesService', () => {
       expect(result.conflicts).toHaveLength(2);
     });
 
-    it('should filter by displayGroupId when provided', async () => {
+    it('should check group schedules against direct display and overlapping group targets', async () => {
       databaseService.schedule.findMany.mockResolvedValue([]);
 
       await service.checkConflicts('org-123', {
@@ -748,10 +789,76 @@ describe('SchedulesService', () => {
       expect(databaseService.schedule.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
-            displayGroupId: 'group-1',
+            OR: expect.arrayContaining([
+              { displayGroupId: 'group-1' },
+              { display: { groups: { some: { displayGroupId: 'group-1' } } } },
+              {
+                displayGroup: {
+                  displays: {
+                    some: {
+                      display: {
+                        groups: { some: { displayGroupId: 'group-1' } },
+                      },
+                    },
+                  },
+                },
+              },
+            ]),
           }),
         }),
       );
+    });
+
+    it('should detect conflicts when a candidate schedule crosses midnight', async () => {
+      databaseService.schedule.findMany.mockResolvedValue([
+        {
+          id: 'tuesday-early',
+          name: 'Tuesday Early',
+          startTime: 60,   // 01:00
+          endTime: 180,    // 03:00
+          daysOfWeek: [2],
+          playlist: { id: 'p-1', name: 'Playlist 1' },
+          display: { id: 'display-1', nickname: 'Display 1' },
+          displayGroup: null,
+        },
+      ]);
+
+      const result = await service.checkConflicts('org-123', {
+        displayId: 'display-1',
+        daysOfWeek: [1],
+        startTime: 1380, // Monday 23:00
+        endTime: 120,    // Tuesday 02:00
+      });
+
+      const callArgs = databaseService.schedule.findMany.mock.calls[0][0];
+      expect(callArgs.where.daysOfWeek).toEqual({ hasSome: [1, 0, 2] });
+      expect(result.hasConflicts).toBe(true);
+      expect(result.conflicts[0].id).toBe('tuesday-early');
+    });
+
+    it('should not flag adjacent-day all-day schedules as conflicts after broad day prefiltering', async () => {
+      databaseService.schedule.findMany.mockResolvedValue([
+        {
+          id: 'sunday-all-day',
+          name: 'Sunday All Day',
+          startTime: null,
+          endTime: null,
+          daysOfWeek: [0],
+          playlist: { id: 'p-1', name: 'Playlist 1' },
+          display: { id: 'display-1', nickname: 'Display 1' },
+          displayGroup: null,
+        },
+      ]);
+
+      const result = await service.checkConflicts('org-123', {
+        displayId: 'display-1',
+        daysOfWeek: [1],
+        startTime: 540,
+        endTime: 600,
+      });
+
+      expect(result.hasConflicts).toBe(false);
+      expect(result.conflicts).toHaveLength(0);
     });
 
     it('should treat requests without times as always conflicting', async () => {

--- a/middleware/src/modules/schedules/schedules.service.ts
+++ b/middleware/src/modules/schedules/schedules.service.ts
@@ -7,6 +7,64 @@ import { UpdateScheduleDto } from './dto/update-schedule.dto';
 import { CheckConflictsDto } from './dto/check-conflicts.dto';
 import { PaginationDto, PaginatedResponse } from '../common/dto/pagination.dto';
 
+const MINUTES_PER_DAY = 24 * 60;
+const DAYS_PER_WEEK = 7;
+const MINUTES_PER_WEEK = DAYS_PER_WEEK * MINUTES_PER_DAY;
+
+type ScheduleWindow = {
+  daysOfWeek: number[];
+  startTime?: number | null;
+  endTime?: number | null;
+};
+
+const previousDay = (day: number) => (day + DAYS_PER_WEEK - 1) % DAYS_PER_WEEK;
+const nextDay = (day: number) => (day + 1) % DAYS_PER_WEEK;
+
+const expandAdjacentDays = (days: number[]): number[] => Array.from(new Set(
+  days.flatMap((day) => [day, previousDay(day), nextDay(day)]),
+));
+
+const expandWeeklyIntervals = (window: ScheduleWindow): Array<{ start: number; end: number }> => {
+  return window.daysOfWeek.flatMap((day) => {
+    if (window.startTime == null || window.endTime == null || window.startTime === window.endTime) {
+      return [{ start: day * MINUTES_PER_DAY, end: (day + 1) * MINUTES_PER_DAY }];
+    }
+
+    const start = day * MINUTES_PER_DAY + window.startTime;
+    const end = window.startTime < window.endTime
+      ? day * MINUTES_PER_DAY + window.endTime
+      : (day + 1) * MINUTES_PER_DAY + window.endTime;
+    return [{ start, end }];
+  });
+};
+
+const intervalsOverlap = (
+  left: { start: number; end: number },
+  right: { start: number; end: number },
+): boolean => {
+  return [-MINUTES_PER_WEEK, 0, MINUTES_PER_WEEK].some((shift) => {
+    const shiftedRight = { start: right.start + shift, end: right.end + shift };
+    return left.start < shiftedRight.end && shiftedRight.start < left.end;
+  });
+};
+
+const schedulesOverlapInTime = (candidate: ScheduleWindow, existing: ScheduleWindow): boolean => {
+  const candidateIntervals = expandWeeklyIntervals(candidate);
+  const existingIntervals = expandWeeklyIntervals(existing);
+  return candidateIntervals.some((candidateInterval) => (
+    existingIntervals.some((existingInterval) => intervalsOverlap(candidateInterval, existingInterval))
+  ));
+};
+
+const isScheduleActiveAt = (schedule: ScheduleWindow, dayOfWeek: number, currentTime: number): boolean => {
+  const point = dayOfWeek * MINUTES_PER_DAY + currentTime;
+  return expandWeeklyIntervals(schedule).some((interval) => (
+    [point - MINUTES_PER_WEEK, point, point + MINUTES_PER_WEEK].some((shiftedPoint) => (
+      interval.start <= shiftedPoint && shiftedPoint < interval.end
+    ))
+  ));
+};
+
 @Injectable()
 export class SchedulesService {
   constructor(
@@ -159,26 +217,16 @@ export class SchedulesService {
     const dayOfWeek = localNow.getDay();
     const currentTime = localNow.getHours() * 60 + localNow.getMinutes();
 
-    return this.db.schedule.findMany({
+    const candidateDays = [dayOfWeek, previousDay(dayOfWeek)];
+    const activeCandidates = await this.db.schedule.findMany({
       where: {
         organizationId,
         isActive: true,
         startDate: { lte: now },
-        daysOfWeek: { has: dayOfWeek },
+        daysOfWeek: { hasSome: candidateDays },
         AND: [
           {
             OR: [{ endDate: null }, { endDate: { gte: now } }],
-          },
-          {
-            OR: [
-              { startTime: null, endTime: null },
-              {
-                AND: [
-                  { startTime: { lte: currentTime } },
-                  { endTime: { gte: currentTime } },
-                ],
-              },
-            ],
           },
           {
             OR: [{ displayId }, { displayGroup: { displays: { some: { displayId } } } }],
@@ -201,6 +249,18 @@ export class SchedulesService {
         },
       },
     });
+
+    return activeCandidates.filter((schedule) => (
+      isScheduleActiveAt(
+        {
+          daysOfWeek: schedule.daysOfWeek,
+          startTime: schedule.startTime,
+          endTime: schedule.endTime,
+        },
+        dayOfWeek,
+        currentTime,
+      )
+    ));
   }
 
   async update(organizationId: string, id: string, updateScheduleDto: UpdateScheduleDto) {
@@ -303,12 +363,26 @@ export class SchedulesService {
         { displayGroup: { displays: { some: { displayId: dto.displayId } } } },
       ];
     } else if (dto.displayGroupId) {
-      where.displayGroupId = dto.displayGroupId;
+      where.OR = [
+        { displayGroupId: dto.displayGroupId },
+        { display: { groups: { some: { displayGroupId: dto.displayGroupId } } } },
+        {
+          displayGroup: {
+            displays: {
+              some: {
+                display: {
+                  groups: { some: { displayGroupId: dto.displayGroupId } },
+                },
+              },
+            },
+          },
+        },
+      ];
     }
 
     // Filter by overlapping days
     if (dto.daysOfWeek && dto.daysOfWeek.length > 0) {
-      where.daysOfWeek = { hasSome: dto.daysOfWeek };
+      where.daysOfWeek = { hasSome: expandAdjacentDays(dto.daysOfWeek) };
     }
 
     // Date-range overlap filter — without this, schedules in non-
@@ -358,11 +432,18 @@ export class SchedulesService {
 
     // Check time overlap
     const conflicts = potentialConflicts.filter(schedule => {
-      if (!dto.startTime || !dto.endTime || !schedule.startTime || !schedule.endTime) {
-        return true; // All-day schedules always conflict
-      }
-      // Time overlap check: NOT (newEnd <= existingStart OR newStart >= existingEnd)
-      return !(dto.endTime <= schedule.startTime || dto.startTime >= schedule.endTime);
+      return schedulesOverlapInTime(
+        {
+          daysOfWeek: dto.daysOfWeek,
+          startTime: dto.startTime,
+          endTime: dto.endTime,
+        },
+        {
+          daysOfWeek: schedule.daysOfWeek,
+          startTime: schedule.startTime,
+          endTime: schedule.endTime,
+        },
+      );
     });
 
     return {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,135 @@
 # Vizora - Task Tracker
 
-## In Progress: Security Token Guard Pass 22 (2026-06-01)
+## In Progress: Schedule Trust Polish Pass 23 (2026-06-01)
+
+**Branch:** `feat/customer-dashboard-improvements-pass-23`
+
+**Why now:** PR #145 merged with green post-merge `main` CI, but production
+deployment remains blocked by dirty/diverged prod-local state. The next
+customer-dashboard analysis found the schedules page is the highest-value
+bounded customer-facing target: inactive schedules are shown as active and the
+conflict-warning UI is never populated.
+
+**New primitives introduced:** none. This uses the existing schedules page and
+existing `apiClient.checkScheduleConflicts` endpoint.
+
+**Hermes-first analysis:** not applicable. This pass does not add or modify
+business agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
+
+**Plan**
+- [x] Merge PR #145 after PR CI green and confirm post-merge `main` CI.
+- [x] Re-check production deploy gate after merge.
+- [x] Start fresh branch from `origin/main`.
+- [x] Review current schedule UI/API/runtime evidence.
+- [x] Write focused failing tests for inactive status badges and conflict
+  warnings.
+- [x] Implement schedule status and conflict-warning fixes.
+- [x] Address first review pass: group-target conflict false negatives, missing
+  candidate date range, overnight schedule conflict/active math, raw conflict
+  times, silent conflict-check failures, and timezone test underfit.
+- [x] Address second review pass: adjacent-day all-day false positives,
+  duplicate already-verified device conflict checks, and missing live-region
+  semantics for dynamic conflict states.
+- [x] Run final multi-subagent code review before broader tests.
+- [x] Run focused and broader verification.
+- [ ] PR, CI, merge.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Plan/design:**
+`docs/plans/2026-06-01-schedule-trust-polish-pass-23.md`
+
+**Implementation notes**
+- [x] Schedule list badges now render `Active`/`Inactive` from actual
+  `isActive`/`active` state.
+- [x] Create/edit modal now calls the existing conflict endpoint when target,
+  days, and time are present; preview calls include candidate `startDate` and
+  edit `endDate` when available.
+- [x] Conflict warnings now format backend minute values as `HH:MM`, expose
+  `role="status"`, and show `role="alert"` when conflicts cannot be verified.
+- [x] Device-target conflict preview caches request/results per candidate so
+  adding another selected device does not re-check already verified devices.
+- [x] Middleware conflict detection now checks display-group schedules against
+  direct-display and overlapping-group schedules under the same organization.
+- [x] Middleware weekly time-window math now handles schedules crossing
+  midnight and avoids adjacent-day all-day false positives.
+
+**Focused verification**
+- [x] Web schedule page test passed:
+  `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/dashboard/schedules/__tests__/schedules-page.test.tsx`
+  - 20 tests / 1 suite.
+- [x] Middleware schedule service test passed:
+  `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/schedules/schedules.service.spec.ts`
+  - 37 tests / 1 suite.
+
+**Review gate**
+- [x] Schedule/runtime reviewer final pass: clean after group overlap,
+  overnight, and all-day-adjacency fixes.
+- [x] Dashboard UX/test reviewer final pass: clean after formatted conflict
+  times, explicit verification failure state, device-preview dedupe, and
+  live-region semantics.
+
+**Broader verification**
+- [x] Middleware schedules sweep passed:
+  `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=schedules`
+  - 2 suites / 55 tests.
+- [x] Web schedules sweep passed:
+  `pnpm --filter @vizora/web test -- --runInBand --testPathPattern=schedules`
+  - 1 suite / 20 tests.
+- [x] Full web Jest suite passed:
+  `pnpm --filter @vizora/web test -- --runInBand`
+  - 96 suites / 1005 tests. Existing unrelated React `act(...)` warnings
+    remain in other dashboard suites.
+- [x] Full middleware Jest suite passed:
+  `pnpm --filter @vizora/middleware test -- --runInBand`
+  - 143 suites / 2887 tests / 1 snapshot.
+- [x] Middleware build passed:
+  `npx nx build @vizora/middleware --skip-nx-cache`
+  - Build completed with known webpack optional-dependency warnings.
+- [x] Web production build passed with required local build env:
+  `NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 BACKEND_URL=http://localhost:3000 npx nx build @vizora/web --skip-nx-cache`
+  - Initial run without `NEXT_PUBLIC_SOCKET_URL` failed at the expected
+    production CSP env precondition; rerun with env passed.
+- [x] ESLint completed with no errors:
+  `ESLINT_USE_FLAT_CONFIG=false npx eslint --ext .ts,.tsx middleware/src realtime/src`
+  - 0 errors / 195 warnings. Warnings are pre-existing broad repo warnings.
+- [x] JWT secret guard passed:
+  `pnpm security:no-hardcoded-jwts`
+  - No hardcoded JWT-looking tokens found.
+- [x] Whitespace check passed:
+  `git diff --check`
+  - Exit 0; Windows CRLF conversion warnings only.
+
+**Current merge/deploy state**
+- [x] PR #145 merged at
+  `89a33b99d15abe82d99d1f767e6d5475f320c155`; PR checks green for audit,
+  build, e2e, lint, security, and test.
+- [x] Post-merge `main` CI run `26737775963` completed successfully: security,
+  lint, build, test, and e2e all green.
+- [x] Prod deploy remains blocked: `/opt/vizora/app` is at
+  `bb76aa1838740bff5b58623dfef7a906d44f46a6`, remote `main` is
+  `89a33b99d15abe82d99d1f767e6d5475f320c155`, and prod is
+  `ahead 17, behind 77` with many tracked edits and untracked files. No
+  production pull, reset, stash, env edit, service restart, DB mutation, or
+  deploy performed.
+
+**Customer dashboard analysis**
+- [x] Schedules page trust: inactive schedules shown as active.
+- [x] Schedules page trust: conflict warning panel is dead.
+- [x] Schedules page trust: timezone selector implies schedule timezone support,
+  while runtime uses display timezone.
+- [x] Analytics empty states can make fetch errors look like "No Data Yet".
+- [x] Analytics labels need more signage-specific wording.
+- [x] Content tag filters are hardcoded instead of metadata-driven.
+- [x] AI Designer CTA can overpromise when backend capability is unavailable.
+- [x] Performance backlog: dashboard org broadcasts inspect device sockets,
+  playlist fan-out is unbounded, content impressions write synchronously,
+  dashboard status fetches up to 1000 displays, response sanitization is
+  CPU-heavy, upload has multiple full-file passes, and pairing active-list scans
+  Redis keyspace.
+
+---
+
+## Completed: Security Token Guard Pass 22 (2026-06-01)
 
 **Branch:** `feat/customer-dashboard-improvements-pass-22`
 

--- a/web/src/app/dashboard/schedules/__tests__/schedules-page.test.tsx
+++ b/web/src/app/dashboard/schedules/__tests__/schedules-page.test.tsx
@@ -9,6 +9,7 @@ const mockGetDisplayGroups = jest.fn();
 const mockCreateSchedule = jest.fn();
 const mockUpdateSchedule = jest.fn();
 const mockDeleteSchedule = jest.fn();
+const mockCheckScheduleConflicts = jest.fn();
 
 jest.mock('@/lib/api', () => ({
   apiClient: {
@@ -19,6 +20,7 @@ jest.mock('@/lib/api', () => ({
     createSchedule: (...args: any[]) => mockCreateSchedule(...args),
     updateSchedule: (...args: any[]) => mockUpdateSchedule(...args),
     deleteSchedule: (...args: any[]) => mockDeleteSchedule(...args),
+    checkScheduleConflicts: (...args: any[]) => mockCheckScheduleConflicts(...args),
   },
 }));
 
@@ -167,9 +169,16 @@ describe('SchedulesClient', () => {
     mockCreateSchedule.mockResolvedValue({ id: 'new-1' });
     mockUpdateSchedule.mockImplementation((id, payload) => Promise.resolve({ id, ...payload, isActive: true }));
     mockDeleteSchedule.mockResolvedValue({});
+    mockCheckScheduleConflicts.mockResolvedValue({ hasConflicts: false, conflicts: [] });
   });
 
   it('renders loading spinner initially', () => {
+    const pending = new Promise<never>(() => {});
+    mockGetSchedules.mockReturnValue(pending);
+    mockGetPlaylists.mockReturnValue(pending);
+    mockGetDisplays.mockReturnValue(pending);
+    mockGetDisplayGroups.mockReturnValue(pending);
+
     render(<SchedulesClient />);
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
   });
@@ -250,6 +259,125 @@ describe('SchedulesClient', () => {
     await waitFor(() => {
       expect(screen.getByText('Holiday Schedule')).toBeInTheDocument();
     });
+    expect(screen.getAllByText('Active')).toHaveLength(2);
+    expect(screen.getByText('Inactive')).toBeInTheDocument();
+  });
+
+  it('checks candidate schedules for conflicts and displays warnings', async () => {
+    mockGetPlaylists.mockResolvedValue({ data: samplePlaylists });
+    mockGetDisplays.mockResolvedValue({ data: sampleDisplays });
+    mockCheckScheduleConflicts.mockResolvedValue({
+      hasConflicts: true,
+      conflicts: [
+        {
+          id: 's1',
+          name: 'Morning Announcements',
+          startTime: 480,
+          endTime: 720,
+        },
+      ],
+    });
+
+    render(<SchedulesClient />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByText('Create Schedule')[0]);
+    fireEvent.change(screen.getByPlaceholderText('e.g., Morning Content, Holiday Special'), {
+      target: { value: 'Lobby Morning' },
+    });
+    fireEvent.change(screen.getByDisplayValue('Select a playlist...'), {
+      target: { value: 'p1' },
+    });
+    fireEvent.click(screen.getByLabelText('Lobby Display'));
+
+    await waitFor(() => {
+      expect(mockCheckScheduleConflicts).toHaveBeenCalledWith(expect.objectContaining({
+        displayId: 'd1',
+        daysOfWeek: [1, 2, 3, 4, 5],
+        startTime: 540,
+        endTime: 600,
+        startDate: expect.any(String),
+      }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Schedule Conflicts Detected')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('status')).toHaveTextContent('Schedule Conflicts Detected');
+    expect(screen.getByText(/Morning Announcements/)).toBeInTheDocument();
+    expect(screen.getByText(/08:00 - 12:00/)).toBeInTheDocument();
+    expect(screen.queryByText(/480 - 720/)).not.toBeInTheDocument();
+  });
+
+  it('does not re-check already verified device targets when adding another device', async () => {
+    mockGetPlaylists.mockResolvedValue({ data: samplePlaylists });
+    mockGetDisplays.mockResolvedValue({ data: sampleDisplays });
+    mockCheckScheduleConflicts.mockResolvedValue({ hasConflicts: false, conflicts: [] });
+
+    render(<SchedulesClient />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByText('Create Schedule')[0]);
+    fireEvent.change(screen.getByDisplayValue('Select a playlist...'), {
+      target: { value: 'p1' },
+    });
+    fireEvent.click(screen.getByLabelText('Lobby Display'));
+
+    await waitFor(() => {
+      expect(mockCheckScheduleConflicts).toHaveBeenCalledWith(expect.objectContaining({ displayId: 'd1' }));
+    });
+
+    fireEvent.click(screen.getByLabelText('Conference Room'));
+
+    await waitFor(() => {
+      expect(mockCheckScheduleConflicts).toHaveBeenCalledWith(expect.objectContaining({ displayId: 'd2' }));
+    });
+
+    const callsByDisplay = mockCheckScheduleConflicts.mock.calls.map(([payload]) => payload.displayId);
+    expect(callsByDisplay.filter((displayId) => displayId === 'd1')).toHaveLength(1);
+    expect(callsByDisplay.filter((displayId) => displayId === 'd2')).toHaveLength(1);
+  });
+
+  it('warns when candidate schedule conflicts cannot be verified', async () => {
+    mockGetPlaylists.mockResolvedValue({ data: samplePlaylists });
+    mockGetDisplays.mockResolvedValue({ data: sampleDisplays });
+    mockCheckScheduleConflicts.mockRejectedValue(new Error('network down'));
+
+    render(<SchedulesClient />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByText('Create Schedule')[0]);
+    fireEvent.change(screen.getByDisplayValue('Select a playlist...'), {
+      target: { value: 'p1' },
+    });
+    fireEvent.click(screen.getByLabelText('Lobby Display'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Unable to verify schedule conflicts');
+    });
+  });
+
+  it('shows that schedules run in the target display timezone instead of a persisted schedule timezone', async () => {
+    render(<SchedulesClient />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByText('Create Schedule')[0]);
+
+    expect(screen.getByText('Target display timezone')).toBeInTheDocument();
+    expect(screen.getByText(/Each target display applies its own configured timezone/)).toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: /timezone/i })).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('Eastern (America/New_York)')).not.toBeInTheDocument();
   });
 
   it('renders page heading', async () => {
@@ -282,8 +410,7 @@ describe('SchedulesClient', () => {
     });
     fireEvent.click(screen.getByText('Select Weekdays'));
 
-    const selects = screen.getAllByRole('combobox');
-    fireEvent.change(selects[1], { target: { value: 'p1' } });
+    fireEvent.change(screen.getByDisplayValue('Select a playlist...'), { target: { value: 'p1' } });
     fireEvent.click(screen.getByLabelText('Lobby Display'));
     fireEvent.click(screen.getByLabelText('Conference Room'));
     fireEvent.click(screen.getByText('Create'));
@@ -315,8 +442,7 @@ describe('SchedulesClient', () => {
     });
     fireEvent.click(screen.getByText('Select Weekdays'));
 
-    const selects = screen.getAllByRole('combobox');
-    fireEvent.change(selects[1], { target: { value: 'p1' } });
+    fireEvent.change(screen.getByDisplayValue('Select a playlist...'), { target: { value: 'p1' } });
     fireEvent.click(screen.getByLabelText('Lobby Display'));
     fireEvent.click(screen.getByLabelText('Conference Room'));
     fireEvent.click(screen.getByText('Create'));

--- a/web/src/app/dashboard/schedules/page-client.tsx
+++ b/web/src/app/dashboard/schedules/page-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { apiClient } from '@/lib/api';
 import { fetchAllPaginated } from '@/lib/api/pagination';
 import { Display, PlaylistSummary } from '@/lib/types';
@@ -93,6 +93,22 @@ const getLoadFailureMessage = (reason: unknown): string => {
  return 'Request failed';
 };
 
+const getScheduleActiveState = (schedule: Schedule): boolean => {
+ return schedule.isActive ?? schedule.active ?? false;
+};
+
+const dateToIso = (date?: Date | string | null): string | undefined => {
+ if (!date) return undefined;
+ return typeof date === 'string' ? new Date(date).toISOString() : date.toISOString();
+};
+
+const formatConflictTimeRange = (conflict: { startTime?: number | string | null; endTime?: number | string | null }) => {
+ if (conflict.startTime == null || conflict.endTime == null) {
+ return 'all day';
+ }
+ return `${minutesToHHMM(conflict.startTime)} - ${minutesToHHMM(conflict.endTime)}`;
+};
+
 export default function SchedulesClient() {
  const toast = useToast();
  const [schedules, setSchedules] = useState<Schedule[]>([]);
@@ -105,6 +121,11 @@ export default function SchedulesClient() {
  const [targetType, setTargetType] = useState<'device' | 'group'>('device');
  const [displayGroups, setDisplayGroups] = useState<any[]>([]);
  const [conflictWarnings, setConflictWarnings] = useState<any[]>([]);
+ const conflictWarningsRef = useRef<any[]>([]);
+ const [conflictCheckFailed, setConflictCheckFailed] = useState(false);
+ const conflictCheckFailedRef = useRef(false);
+ const conflictResultCacheRef = useRef<Map<string, any[]>>(new Map());
+ const conflictRequestCacheRef = useRef<Map<string, Promise<any[]>>>(new Map());
  const [viewMode, setViewMode] = useState<'list' | 'calendar'>('list');
  const [loadError, setLoadError] = useState<string | null>(null);
 
@@ -126,6 +147,30 @@ export default function SchedulesClient() {
  });
 
  const [formErrors, setFormErrors] = useState<Record<string, string>>({});
+ const selectedTargetKey = formData.deviceIds.join('|');
+ const selectedDaysKey = formData.days.join('|');
+
+ const updateConflictWarnings = useCallback((nextWarnings: any[]) => {
+ const currentWarnings = conflictWarningsRef.current;
+ if (currentWarnings.length === nextWarnings.length && currentWarnings.every((warning, index) => warning === nextWarnings[index])) {
+ return;
+ }
+ conflictWarningsRef.current = nextWarnings;
+ setConflictWarnings(nextWarnings);
+ }, []);
+
+ const updateConflictCheckFailed = useCallback((failed: boolean) => {
+ if (conflictCheckFailedRef.current === failed) {
+ return;
+ }
+ conflictCheckFailedRef.current = failed;
+ setConflictCheckFailed(failed);
+ }, []);
+
+ const clearConflictCheckCache = useCallback(() => {
+ conflictResultCacheRef.current.clear();
+ conflictRequestCacheRef.current.clear();
+ }, []);
 
  // Real-time event handling for schedule status
  const { isConnected } = useRealtimeEvents({
@@ -138,6 +183,110 @@ export default function SchedulesClient() {
  useEffect(() => {
  loadData();
  }, []);
+
+ useEffect(() => {
+ const modalOpen = isCreateModalOpen || isEditModalOpen;
+ const daysOfWeek = dayNamesToNumbers(formData.days);
+ const targetIds = targetType === 'device' ? formData.deviceIds : formData.deviceIds.slice(0, 1);
+
+ if (!modalOpen || daysOfWeek.length === 0 || targetIds.length === 0) {
+ updateConflictWarnings([]);
+ updateConflictCheckFailed(false);
+ return;
+ }
+
+ const candidateStartDate = selectedSchedule?.startDate ? dateToIso(selectedSchedule.startDate) : new Date().toISOString().slice(0, 10);
+ const candidateEndDate = dateToIso(selectedSchedule?.endDate);
+
+ const requests = targetIds
+ .filter(Boolean)
+ .map((targetId) => ({
+ ...(targetType === 'device' ? { displayId: targetId } : { displayGroupId: targetId }),
+ daysOfWeek,
+ startTime: hhmmToMinutes(formData.startTime),
+ endTime: calculateEndTimeMinutes(formData.startTime, formData.duration),
+ startDate: candidateStartDate,
+ ...(candidateEndDate ? { endDate: candidateEndDate } : {}),
+ ...(selectedSchedule?.id ? { excludeScheduleId: selectedSchedule.id } : {}),
+ }));
+
+ if (requests.length === 0) {
+ updateConflictWarnings([]);
+ updateConflictCheckFailed(false);
+ return;
+ }
+
+ let cancelled = false;
+
+ const checkConflicts = async () => {
+ try {
+ const getConflictsForRequest = (request: typeof requests[number]) => {
+ const requestKey = JSON.stringify(request);
+ const cachedResult = conflictResultCacheRef.current.get(requestKey);
+ if (cachedResult) {
+ return Promise.resolve(cachedResult);
+ }
+
+ const cachedRequest = conflictRequestCacheRef.current.get(requestKey);
+ if (cachedRequest) {
+ return cachedRequest;
+ }
+
+ const requestPromise = apiClient.checkScheduleConflicts(request)
+ .then((result) => {
+ const conflicts = result.conflicts || [];
+ conflictResultCacheRef.current.set(requestKey, conflicts);
+ conflictRequestCacheRef.current.delete(requestKey);
+ return conflicts;
+ })
+ .catch((error) => {
+ conflictRequestCacheRef.current.delete(requestKey);
+ throw error;
+ });
+
+ conflictRequestCacheRef.current.set(requestKey, requestPromise);
+ return requestPromise;
+ };
+
+ const results = await Promise.all(
+ requests.map((request) => getConflictsForRequest(request)),
+ );
+ if (cancelled) return;
+
+ const conflictsById = new Map<string, any>();
+ results.flat().forEach((conflict: any, index) => {
+ const key = conflict.id || `${conflict.name || 'conflict'}-${conflict.startTime}-${conflict.endTime}-${index}`;
+ conflictsById.set(key, conflict);
+ });
+ updateConflictCheckFailed(false);
+ updateConflictWarnings(Array.from(conflictsById.values()));
+ } catch {
+ if (!cancelled) {
+ updateConflictWarnings([]);
+ updateConflictCheckFailed(true);
+ }
+ }
+ };
+
+ void checkConflicts();
+
+ return () => {
+ cancelled = true;
+ };
+ }, [
+ isCreateModalOpen,
+ isEditModalOpen,
+ targetType,
+ selectedTargetKey,
+ selectedDaysKey,
+ formData.startTime,
+ formData.duration,
+ selectedSchedule?.id,
+ selectedSchedule?.startDate,
+ selectedSchedule?.endDate,
+ updateConflictWarnings,
+ updateConflictCheckFailed,
+ ]);
 
  const loadData = async () => {
  try {
@@ -360,6 +509,7 @@ export default function SchedulesClient() {
  };
 
  const openEditModal = (schedule: Schedule) => {
+ clearConflictCheckCache();
  setSelectedSchedule(schedule);
  setFormData({
  name: schedule.name,
@@ -381,6 +531,7 @@ export default function SchedulesClient() {
  };
 
  const resetForm = () => {
+ clearConflictCheckCache();
  setFormData({
  name: '',
  startTime: '09:00',
@@ -393,7 +544,8 @@ export default function SchedulesClient() {
  setFormErrors({});
  setSelectedSchedule(null);
  setTargetType('device');
- setConflictWarnings([]);
+ updateConflictWarnings([]);
+ updateConflictCheckFailed(false);
  };
 
  const getPlaylistName = (playlistId: string) => {
@@ -548,21 +700,31 @@ export default function SchedulesClient() {
  ) : (
  /* Schedules List */
  <div className="space-y-4">
- {schedules.map(schedule => (
+ {schedules.map(schedule => {
+ const scheduleActive = getScheduleActiveState(schedule);
+ return (
  <div
  key={schedule.id}
- className="eh-dash-card border-l-4 border-l-[#00E5A0] p-6"
+ className={`eh-dash-card border-l-4 p-6 ${scheduleActive ? 'border-l-[#00E5A0]' : 'border-l-[var(--border)]'}`}
  >
  <div className="flex items-start justify-between">
  <div className="flex items-start gap-4 flex-1">
- <Icon name="schedules" size="2xl" className="text-[#00E5A0] dark:text-[#00E5A0]" />
+ <Icon
+ name="schedules"
+ size="2xl"
+ className={scheduleActive ? 'text-[#00E5A0] dark:text-[#00E5A0]' : 'text-[var(--foreground-tertiary)]'}
+ />
  <div className="flex-1 min-w-0">
  <div className="flex items-center gap-3 mb-3">
  <h3 className="text-xl font-semibold text-[var(--foreground)] truncate">
  {schedule.name}
  </h3>
- <span className="px-3 py-1 text-xs font-semibold rounded-full bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200">
- Active
+ <span className={`px-3 py-1 text-xs font-semibold rounded-full ${
+ scheduleActive
+ ? 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200'
+ : 'bg-[var(--background-secondary)] text-[var(--foreground-secondary)]'
+ }`}>
+ {scheduleActive ? 'Active' : 'Inactive'}
  </span>
  </div>
 
@@ -624,7 +786,8 @@ export default function SchedulesClient() {
  </button>
  </div>
  </div>
- ))}
+ );
+ })}
  </div>
  )}
 
@@ -715,19 +878,14 @@ export default function SchedulesClient() {
  {/* Timezone */}
  <div>
  <label className="block text-sm font-medium text-[var(--foreground)] mb-2">
- Timezone <span className="text-red-500">*</span>
+ Timezone
  </label>
- <select
- value={formData.timezone}
- onChange={e => setFormData({ ...formData, timezone: e.target.value })}
- className="eh-select w-full px-4 py-2 border border-[var(--border)] rounded-lg bg-[var(--surface)] text-[var(--foreground)] focus:ring-2 focus:ring-[#00E5A0] transition"
- >
- <option value="America/New_York">Eastern (America/New_York)</option>
- <option value="America/Chicago">Central (America/Chicago)</option>
- <option value="America/Denver">Mountain (America/Denver)</option>
- <option value="America/Los_Angeles">Pacific (America/Los_Angeles)</option>
- <option value="UTC">UTC</option>
- </select>
+ <div className="rounded-lg border border-[var(--border)] bg-[var(--background-secondary)] px-4 py-3">
+ <p className="text-sm font-medium text-[var(--foreground)]">Target display timezone</p>
+ <p className="mt-1 text-xs text-[var(--foreground-secondary)]">
+ Each target display applies its own configured timezone at playback time.
+ </p>
+ </div>
  </div>
 
  {/* Days */}
@@ -872,14 +1030,25 @@ export default function SchedulesClient() {
  )}
 
  {/* Conflict Warnings */}
+ {conflictCheckFailed && (
+ <div role="alert" className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3">
+ <p className="text-sm font-semibold text-red-800 dark:text-red-200 mb-1 flex items-center gap-2">
+ <Icon name="error" size="sm" className="text-red-600 dark:text-red-400" />
+ Unable to verify schedule conflicts
+ </p>
+ <p className="text-xs text-red-700 dark:text-red-300">
+ Check the schedule after saving or retry when the network is available.
+ </p>
+ </div>
+ )}
  {conflictWarnings.length > 0 && (
- <div className="bg-amber-50 dark:bg-amber-900/30 border border-amber-300 dark:border-amber-700 rounded-lg p-3">
+ <div role="status" aria-live="polite" className="bg-amber-50 dark:bg-amber-900/30 border border-amber-300 dark:border-amber-700 rounded-lg p-3">
  <p className="text-sm font-semibold text-amber-800 dark:text-amber-200 mb-1 flex items-center gap-2">
  <span className="text-amber-500">&#9888;</span> Schedule Conflicts Detected
  </p>
  {conflictWarnings.map((c: any, i: number) => (
  <p key={i} className="text-xs text-amber-700 dark:text-amber-300">
- Overlaps with &quot;{c.name}&quot; ({c.startTime} - {c.endTime})
+ Overlaps with &quot;{c.name}&quot; ({formatConflictTimeRange(c)})
  </p>
  ))}
  </div>

--- a/web/src/lib/api/schedules.ts
+++ b/web/src/lib/api/schedules.ts
@@ -10,7 +10,7 @@ declare module './client' {
     updateSchedule(id: string, data: Partial<ScheduleData>): Promise<Schedule>;
     deleteSchedule(id: string): Promise<void>;
     duplicateSchedule(id: string): Promise<Schedule>;
-    checkScheduleConflicts(data: { displayId?: string; displayGroupId?: string; daysOfWeek: number[]; startTime?: string; endTime?: string; excludeScheduleId?: string }): Promise<{ hasConflicts: boolean; conflicts: any[] }>;
+    checkScheduleConflicts(data: { displayId?: string; displayGroupId?: string; daysOfWeek: number[]; startTime?: number; endTime?: number; startDate?: string; endDate?: string; excludeScheduleId?: string }): Promise<{ hasConflicts: boolean; conflicts: any[] }>;
   }
 }
 
@@ -49,8 +49,10 @@ ApiClient.prototype.checkScheduleConflicts = async function (data: {
   displayId?: string;
   displayGroupId?: string;
   daysOfWeek: number[];
-  startTime?: string;
-  endTime?: string;
+  startTime?: number;
+  endTime?: number;
+  startDate?: string;
+  endDate?: string;
   excludeScheduleId?: string;
 }): Promise<{ hasConflicts: boolean; conflicts: any[] }> {
   return this.request<{ hasConflicts: boolean; conflicts: any[] }>('/schedules/check-conflicts', {


### PR DESCRIPTION
## Summary
- Fix schedule list status badges so inactive schedules render as inactive instead of always active.
- Wire the create/edit modal conflict preview to the existing schedule conflict API, including candidate date range, formatted time windows, failure state, live-region semantics, and duplicate-request suppression for already verified device targets.
- Harden middleware schedule conflict/active-time math for display-group overlap, overnight schedules, and adjacent all-day cases.

## Verification
- pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/dashboard/schedules/__tests__/schedules-page.test.tsx
- pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/schedules/schedules.service.spec.ts
- pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=schedules
- pnpm --filter @vizora/web test -- --runInBand --testPathPattern=schedules
- pnpm --filter @vizora/web test -- --runInBand
- pnpm --filter @vizora/middleware test -- --runInBand
- npx nx build @vizora/middleware --skip-nx-cache
- NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 BACKEND_URL=http://localhost:3000 npx nx build @vizora/web --skip-nx-cache
- ESLINT_USE_FLAT_CONFIG=false npx eslint --ext .ts,.tsx middleware/src realtime/src
- pnpm security:no-hardcoded-jwts
- git diff --check

## Review
- Schedule/runtime reviewer: CLEAN.
- Dashboard UX/test reviewer: CLEAN.

## Deploy
- Do not deploy from this PR automatically. Production checkout was last observed dirty/diverged and must be reconciled before a safe deploy.