### PR TITLE
Clarify analytics failure states

### DIFF
--- a/docs/plans/2026-06-01-analytics-empty-state-trust-pass-24.md
+++ b/docs/plans/2026-06-01-analytics-empty-state-trust-pass-24.md
@@ -1,0 +1,96 @@
+# Analytics Empty-State Trust Pass 24
+
+**Date:** 2026-06-01
+**Branch:** `feat/analytics-empty-state-trust-pass-24`
+
+## Why Now
+
+The customer-dashboard review after Pass 23 ranked analytics trust as the next
+bounded customer-facing issue. Current analytics hooks catch API failures and
+turn them into empty/mock states, so a customer can see "No Data Yet" when the
+dashboard actually failed to load metrics.
+
+## New Primitives Introduced
+
+None. This uses the existing analytics API client hooks and dashboard page.
+
+## Hermes-First Analysis
+
+Not applicable. This pass does not add or modify business agents, MCP tools,
+Hermes skills, AI/provider calls, or spend paths.
+
+## Scope
+
+- Preserve true empty states when analytics endpoints return empty arrays.
+- Preserve loading and chart behavior for populated API responses.
+- Surface API failures as explicit analytics unavailable states instead of
+  `No Data Yet`.
+- Show section-level errors for failed chart data and suppress the global
+  "No Data Yet" notice whenever any analytics section failed.
+- Capture analytics summary load failure so KPI placeholders do not silently
+  masquerade as no data.
+
+## TDD Plan
+
+- Add hook tests proving rejected analytics API calls return `error` and do not
+  set `isMockData`.
+- Add hook tests proving successful empty arrays still produce true empty state.
+- Add page tests proving a section error renders an alert and does not render
+  the global "No Data Yet" notice.
+
+## TDD Results
+
+- Red hook tests reproduced the root problem: rejected analytics API calls still
+  returned empty/mock states instead of errors.
+- Red page tests reproduced the customer-visible failure mode: analytics load
+  failure did not render an unavailable alert and could still show "No Data Yet."
+- Green implementation keeps successful empty arrays as true empty state while
+  failed calls surface as explicit analytics-unavailable states.
+
+## Implementation Notes
+
+- `useAnalyticsData` now shares a typed dataset helper for analytics endpoints,
+  maps rejected calls through the existing user-safe error-message helper, and
+  ignores stale date-range responses after cleanup.
+- The analytics dashboard renders global and per-section `role="alert"` failure
+  states, suppresses the global "No Data Yet" notice when any analytics section
+  failed, and treats summary load failure as unavailable rather than below-target
+  KPI data.
+- CSV export typing was tightened while preserving the existing export behavior.
+
+## Review Results
+
+- UX/accessibility/test reviewer: CLEAN.
+- Hook/API-state reviewer: CLEAN.
+- Final sanity review after type/lint cleanup: CLEAN from both reviewers.
+
+## Verification Plan
+
+- Focused analytics hook tests.
+- Focused analytics page tests.
+- Broader web analytics test sweep.
+- Web build if code changes affect production compilation.
+
+## Verification Results
+
+- `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/lib/hooks/__tests__/useAnalyticsData.test.ts`:
+  15/15 tests pass.
+- `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/dashboard/analytics/__tests__/analytics-page.test.tsx`:
+  9/9 tests pass.
+- `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="analytics|useAnalyticsData"`:
+  34/34 tests pass.
+- `pnpm --filter @vizora/web test -- --runInBand`: 1016/1016 tests pass.
+  Existing unrelated React `act(...)` warnings remain in broader suites.
+- `npx nx build @vizora/web --skip-nx-cache` with production web env defaults:
+  pass.
+- Changed-file ESLint via direct `npx eslint`: pass with no file warnings or
+  errors.
+- `pnpm security:no-hardcoded-jwts`: pass.
+- `git diff --check`: pass with CRLF warnings only.
+
+## Residual Risk
+
+- Package-level lint scripts remain stale for Next 16 and Windows POSIX env var
+  syntax, so equivalent direct ESLint commands were used for this pass.
+- Production deploy remains blocked unless the prod checkout is no longer dirty
+  or diverged at deploy-gate time.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,54 @@
 # Vizora - Task Tracker
 
+## In Progress: Analytics Empty-State Trust Pass 24 (2026-06-01)
+
+**Branch:** `feat/analytics-empty-state-trust-pass-24`
+
+**Why now:** Pass 23 is merged and `main` CI is green, but production deploy
+remains blocked by dirty/diverged prod-local state. The next bounded
+customer-dashboard trust issue is analytics failures being presented as "No
+Data Yet."
+
+**New primitives introduced:** none. This uses the existing analytics API
+client hooks and dashboard page.
+
+**Hermes-first analysis:** not applicable. This pass does not add or modify
+business agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
+
+**Plan**
+- [x] Start fresh branch from `origin/main`.
+- [x] Drift-check analytics dashboard hooks, page states, and tests.
+- [x] Write focused failing tests for analytics API failures vs true empty
+  responses.
+- [x] Implement explicit section/global analytics failure states.
+- [x] Run reviewer pass before broader verification.
+- [x] Run focused and broader verification.
+- [ ] PR, CI, merge.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Local evidence:**
+- TDD red: analytics hook/page tests failed before implementation because rejected
+  API calls were treated as empty/mock states and summary failure rendered "No
+  Data Yet."
+- Implementation: `useAnalyticsData` now preserves successful empty arrays as
+  true empty state, reports rejected calls as errors, uses user-safe error
+  messages, and ignores stale date-range responses. The analytics page now shows
+  global and section-level unavailable states and suppresses "No Data Yet" on
+  failed loads.
+- Review: UX/accessibility/test reviewer CLEAN; hook/API-state reviewer CLEAN.
+- Verification: focused hook tests 15/15 pass; focused analytics page tests 9/9
+  pass; analytics sweep 34/34 pass; full web Jest 1016/1016 pass; web
+  production build pass; changed-file ESLint pass; repo security JWT guard pass;
+  `git diff --check` pass with CRLF warnings only.
+- Known unrelated verification noise: existing React `act(...)` warnings in
+  broader web suites; stale package lint scripts still fail on Next 16/Windows,
+  so equivalent ESLint commands were run directly.
+
+**Plan/design:**
+`docs/plans/2026-06-01-analytics-empty-state-trust-pass-24.md`
+
+---
+
 ## Completed: Schedule Trust Polish Pass 23 (2026-06-01)
 
 **Branch:** `feat/customer-dashboard-improvements-pass-23`

--- a/web/src/app/dashboard/analytics/__tests__/analytics-page.test.tsx
+++ b/web/src/app/dashboard/analytics/__tests__/analytics-page.test.tsx
@@ -1,5 +1,13 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import AnalyticsClient from '../page-client';
+import { apiClient } from '@/lib/api';
+
+const mockUseDeviceMetrics = jest.fn();
+const mockUseContentPerformance = jest.fn();
+const mockUseUsageTrends = jest.fn();
+const mockUseDeviceDistribution = jest.fn();
+const mockUseBandwidthUsage = jest.fn();
+const mockUsePlaylistPerformance = jest.fn();
 
 jest.mock('@/components/charts', () => ({
   LineChart: () => <div data-testid="line-chart">LineChart</div>,
@@ -60,55 +68,111 @@ jest.mock('@/lib/hooks/useToast', () => ({
 }));
 
 jest.mock('@/lib/hooks/useAnalyticsData', () => ({
-  useDeviceMetrics: () => ({ data: [], loading: false, error: null, isMockData: true }),
-  useContentPerformance: () => ({ data: [], loading: false, error: null, isMockData: true }),
-  useUsageTrends: () => ({ data: [], loading: false, error: null, isMockData: true }),
-  useDeviceDistribution: () => ({ data: [], loading: false, error: null, isMockData: true }),
-  useBandwidthUsage: () => ({ data: [], loading: false, error: null, isMockData: true }),
-  usePlaylistPerformance: () => ({ data: [], loading: false, error: null, isMockData: true }),
+  useDeviceMetrics: (...args: unknown[]) => mockUseDeviceMetrics(...args),
+  useContentPerformance: (...args: unknown[]) => mockUseContentPerformance(...args),
+  useUsageTrends: (...args: unknown[]) => mockUseUsageTrends(...args),
+  useDeviceDistribution: (...args: unknown[]) => mockUseDeviceDistribution(...args),
+  useBandwidthUsage: (...args: unknown[]) => mockUseBandwidthUsage(...args),
+  usePlaylistPerformance: (...args: unknown[]) => mockUsePlaylistPerformance(...args),
 }));
 
 describe('AnalyticsClient', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (apiClient.getAnalyticsSummary as jest.Mock).mockResolvedValue({
+      totalDevices: 10,
+      onlineDevices: 8,
+      totalContent: 50,
+      totalPlaylists: 5,
+      totalContentSize: 1073741824,
+      uptimePercent: 98,
+    });
+
+    const emptyState = { data: [], loading: false, error: null, isMockData: true };
+    mockUseDeviceMetrics.mockReturnValue(emptyState);
+    mockUseContentPerformance.mockReturnValue(emptyState);
+    mockUseUsageTrends.mockReturnValue(emptyState);
+    mockUseDeviceDistribution.mockReturnValue(emptyState);
+    mockUseBandwidthUsage.mockReturnValue(emptyState);
+    mockUsePlaylistPerformance.mockReturnValue(emptyState);
   });
 
-  it('renders analytics heading', () => {
+  const renderLoadedAnalytics = async () => {
     render(<AnalyticsClient />);
+    await screen.findByText('10');
+  };
+
+  it('renders analytics heading', async () => {
+    await renderLoadedAnalytics();
     expect(screen.getByText('Analytics')).toBeInTheDocument();
   });
 
-  it('renders date range buttons', () => {
-    render(<AnalyticsClient />);
+  it('renders date range buttons', async () => {
+    await renderLoadedAnalytics();
     expect(screen.getByText('week')).toBeInTheDocument();
     expect(screen.getByText('month')).toBeInTheDocument();
     expect(screen.getByText('year')).toBeInTheDocument();
   });
 
-  it('renders Export CSV button', () => {
-    render(<AnalyticsClient />);
+  it('renders Export CSV button', async () => {
+    await renderLoadedAnalytics();
     expect(screen.getByText('Export CSV')).toBeInTheDocument();
   });
 
   it('renders KPI cards', async () => {
-    render(<AnalyticsClient />);
-    await waitFor(() => {
-      expect(screen.getByText('Total Devices')).toBeInTheDocument();
-      expect(screen.getByText('Content Items')).toBeInTheDocument();
-      expect(screen.getByText('System Uptime')).toBeInTheDocument();
-    });
+    await renderLoadedAnalytics();
+    expect(screen.getByText('Total Devices')).toBeInTheDocument();
+    expect(screen.getByText('Content Items')).toBeInTheDocument();
+    expect(screen.getByText('System Uptime')).toBeInTheDocument();
   });
 
-  it('renders chart section titles', () => {
-    render(<AnalyticsClient />);
+  it('renders chart section titles', async () => {
+    await renderLoadedAnalytics();
     expect(screen.getByText('Device Uptime Timeline')).toBeInTheDocument();
     expect(screen.getByText('Content Performance')).toBeInTheDocument();
     expect(screen.getByText('Device Distribution')).toBeInTheDocument();
   });
 
-  it('changes date range when button clicked', () => {
-    render(<AnalyticsClient />);
+  it('changes date range when button clicked', async () => {
+    await renderLoadedAnalytics();
     fireEvent.click(screen.getByText('week'));
     expect(screen.getByText('week')).toBeInTheDocument();
+  });
+
+  it('shows true empty analytics states when API calls succeed with no rows', async () => {
+    await renderLoadedAnalytics();
+
+    expect(screen.getByText('No Data Yet')).toBeInTheDocument();
+    expect(screen.getByText('No device uptime data available yet.')).toBeInTheDocument();
+    expect(screen.getByText('No content performance data yet. Upload content to track views.')).toBeInTheDocument();
+    expect(screen.queryByRole('alert', { name: /analytics data unavailable/i })).not.toBeInTheDocument();
+  });
+
+  it('surfaces chart load failures instead of empty chart states', async () => {
+    mockUseDeviceMetrics.mockReturnValue({
+      data: [],
+      loading: false,
+      error: 'Network unavailable',
+      isMockData: false,
+    });
+
+    await renderLoadedAnalytics();
+
+    expect(screen.getByRole('alert', { name: /analytics data unavailable/i })).toHaveTextContent(
+      'Device uptime timeline'
+    );
+    expect(screen.getByText('Unable to load device uptime data.').closest('[role="alert"]')).toBeInTheDocument();
+    expect(screen.queryByText('No Data Yet')).not.toBeInTheDocument();
+    expect(screen.queryByText('No device uptime data available yet.')).not.toBeInTheDocument();
+  });
+
+  it('surfaces summary load failures instead of only showing no data notice', async () => {
+    (apiClient.getAnalyticsSummary as jest.Mock).mockRejectedValueOnce(new Error('Summary down'));
+
+    render(<AnalyticsClient />);
+
+    const alert = await screen.findByRole('alert', { name: /analytics data unavailable/i });
+    expect(alert).toHaveTextContent('Analytics summary');
+    expect(screen.queryByText('No Data Yet')).not.toBeInTheDocument();
   });
 });

--- a/web/src/app/dashboard/analytics/page-client.tsx
+++ b/web/src/app/dashboard/analytics/page-client.tsx
@@ -4,10 +4,11 @@ import React, { useState, useEffect } from 'react';
 import { LineChart, BarChart, PieChart, AreaChart, ComposedChart } from '@/components/charts';
 import { Card } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
-import { Icon } from '@/theme/icons';
+import { Icon, type IconName } from '@/theme/icons';
 import { useRealtimeEvents } from '@/lib/hooks';
 import { apiClient } from '@/lib/api';
 import { useToast } from '@/lib/hooks/useToast';
+import type { AnalyticsSummary } from '@/lib/types';
 import {
  useDeviceMetrics,
  useContentPerformance,
@@ -24,12 +25,34 @@ const EmptyChartState: React.FC<{ message?: string }> = ({ message }) => (
  </div>
 );
 
+const ChartErrorState: React.FC<{ message: string; detail?: string | null }> = ({ message, detail }) => (
+ <div
+ role="alert"
+ className="h-80 flex flex-col items-center justify-center text-center text-[var(--foreground-secondary)] px-6"
+ >
+ <Icon name="error" size="lg" className="mb-3 text-[var(--error)]" />
+ <p className="text-sm font-medium text-[var(--foreground)]">{message}</p>
+ {detail && (
+ <p className="mt-2 text-xs text-[var(--foreground-tertiary)] max-w-md">
+ {detail}
+ </p>
+ )}
+ </div>
+);
+
 interface KPICardProps {
  label: string;
  value: string;
  change?: string;
  changeType?: 'positive' | 'negative' | 'neutral';
- icon?: string;
+ icon?: IconName;
+}
+
+interface AnalyticsCsvExport {
+ summary?: Partial<AnalyticsSummary>;
+ deviceMetrics?: Array<{ date: string; mobile?: number; tablet?: number; desktop?: number }>;
+ contentPerformance?: Array<{ title?: string; name?: string; views?: number; engagement?: number; shares?: number }>;
+ playlistPerformance?: Array<{ name: string; plays?: number; engagement?: number; uniqueDevices?: number; completion?: number }>;
 }
 
 const KPICard: React.FC<KPICardProps> = ({
@@ -67,7 +90,7 @@ const KPICard: React.FC<KPICardProps> = ({
  </div>
  {icon && (
  <Icon
- name={icon as any}
+ name={icon}
  size="lg"
  className="text-[var(--foreground-tertiary)]"
  />
@@ -85,18 +108,37 @@ const formatBytes = (bytes: number) => {
  return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
 };
 
+const csvCell = (value: unknown): string => `"${String(value ?? '').replace(/"/g, '""')}"`;
+const fixedCell = (value: number | undefined): string => typeof value === 'number' ? value.toFixed(1) : '';
+
 export default function AnalyticsClient() {
  const toast = useToast();
  const [dateRange, setDateRange] = useState<'week' | 'month' | 'year'>('month');
  const [exporting, setExporting] = useState(false);
  const [realtimeStatus, setRealtimeStatus] = useState<'connected' | 'offline'>('offline');
  const [lastUpdate, setLastUpdate] = useState<Date | null>(null);
- const [summary, setSummary] = useState<any>(null);
+ const [summary, setSummary] = useState<AnalyticsSummary | null>(null);
+ const [summaryError, setSummaryError] = useState<string | null>(null);
 
  useEffect(() => {
+ let cancelled = false;
  apiClient.getAnalyticsSummary()
- .then(data => setSummary(data))
- .catch(() => {/* fall back to defaults */});
+ .then(data => {
+ if (!cancelled) {
+ setSummary(data);
+ setSummaryError(null);
+ }
+ })
+ .catch(() => {
+ if (!cancelled) {
+ setSummary(null);
+ setSummaryError('Unable to load analytics summary.');
+ }
+ });
+
+ return () => {
+ cancelled = true;
+ };
  }, []);
 
  const deviceMetrics = useDeviceMetrics(dateRange);
@@ -106,7 +148,20 @@ export default function AnalyticsClient() {
  const bandwidthUsage = useBandwidthUsage(dateRange);
  const playlistPerformance = usePlaylistPerformance(dateRange);
 
- const allMockData = deviceMetrics.isMockData && contentPerformance.isMockData &&
+ const analyticsErrorSections = [
+ { label: 'Analytics summary', error: summaryError },
+ { label: 'Device uptime timeline', error: deviceMetrics.error },
+ { label: 'Content performance', error: contentPerformance.error },
+ { label: 'Device distribution', error: deviceDistribution.error },
+ { label: 'Usage trends', error: usageTrends.error },
+ { label: 'Bandwidth usage', error: bandwidthUsage.error },
+ { label: 'Playlist performance', error: playlistPerformance.error },
+ ].filter((section) => Boolean(section.error));
+
+ const hasAnalyticsErrors = analyticsErrorSections.length > 0;
+
+ const allMockData = !hasAnalyticsErrors &&
+   deviceMetrics.isMockData && contentPerformance.isMockData &&
    usageTrends.isMockData && deviceDistribution.isMockData &&
    bandwidthUsage.isMockData && playlistPerformance.isMockData;
 
@@ -125,7 +180,7 @@ export default function AnalyticsClient() {
  const handleExportCSV = async () => {
  try {
  setExporting(true);
- const data = await apiClient.exportAnalytics(dateRange) as any;
+ const data = await apiClient.exportAnalytics(dateRange) as unknown as AnalyticsCsvExport;
 
  // Build CSV sections
  const sections: string[] = [];
@@ -146,8 +201,8 @@ export default function AnalyticsClient() {
  if (data.deviceMetrics?.length) {
  sections.push('DEVICE METRICS');
  sections.push(['Date', 'Mobile', 'Tablet', 'Desktop'].join(','));
- data.deviceMetrics.forEach((d: any) => {
- sections.push([`"${d.date}"`, d.mobile?.toFixed(1), d.tablet?.toFixed(1), d.desktop?.toFixed(1)].join(','));
+ data.deviceMetrics.forEach((d) => {
+ sections.push([csvCell(d.date), fixedCell(d.mobile), fixedCell(d.tablet), fixedCell(d.desktop)].join(','));
  });
  sections.push('');
  }
@@ -156,8 +211,8 @@ export default function AnalyticsClient() {
  if (data.contentPerformance?.length) {
  sections.push('CONTENT PERFORMANCE');
  sections.push(['Title', 'Views', 'Engagement', 'Shares'].join(','));
- data.contentPerformance.forEach((c: any) => {
- sections.push([`"${String(c.title).replace(/"/g, '""')}"`, c.views, c.engagement, c.shares].join(','));
+ data.contentPerformance.forEach((c) => {
+ sections.push([csvCell(c.title ?? c.name), c.views ?? '', c.engagement ?? '', c.shares ?? ''].join(','));
  });
  sections.push('');
  }
@@ -166,8 +221,8 @@ export default function AnalyticsClient() {
  if (data.playlistPerformance?.length) {
  sections.push('PLAYLIST PERFORMANCE');
  sections.push(['Name', 'Plays', 'Engagement', 'Unique Devices', 'Completion'].join(','));
- data.playlistPerformance.forEach((p: any) => {
- sections.push([`"${String(p.name).replace(/"/g, '""')}"`, p.plays, p.engagement, p.uniqueDevices, p.completion].join(','));
+ data.playlistPerformance.forEach((p) => {
+ sections.push([csvCell(p.name), p.plays ?? '', p.engagement ?? '', p.uniqueDevices ?? '', p.completion ?? ''].join(','));
  });
  sections.push('');
  }
@@ -181,8 +236,8 @@ export default function AnalyticsClient() {
  URL.revokeObjectURL(link.href);
 
  toast.success('Analytics exported successfully');
- } catch (error: any) {
- toast.error(error.message || 'Export failed');
+ } catch (error: unknown) {
+ toast.error(error instanceof Error && error.message ? error.message : 'Export failed');
  } finally {
  setExporting(false);
  }
@@ -263,11 +318,32 @@ export default function AnalyticsClient() {
  <KPICard
  label="System Uptime"
  value={summary ? `${summary.uptimePercent}%` : '---'}
- change={summary?.uptimePercent >= 95 ? 'Above target' : 'Below target'}
- changeType={summary?.uptimePercent >= 95 ? 'positive' : 'negative'}
+ change={summary ? (summary.uptimePercent >= 95 ? 'Above target' : 'Below target') : summaryError ? 'Unavailable' : ''}
+ changeType={summary ? (summary.uptimePercent >= 95 ? 'positive' : 'negative') : 'neutral'}
  icon="overview"
  />
  </div>
+
+ {hasAnalyticsErrors && (
+ <div
+ role="alert"
+ aria-label="Analytics data unavailable"
+ className="bg-[var(--error)]/10 border border-[var(--error)]/30 rounded-lg px-4 py-3 flex flex-col gap-2"
+ >
+ <div className="flex items-center gap-2">
+ <Icon name="error" size="sm" className="text-[var(--error)]" />
+ <span className="text-sm font-medium text-[var(--foreground)]">
+ Analytics data unavailable
+ </span>
+ </div>
+ <p className="text-sm text-[var(--foreground-secondary)]">
+ Some analytics could not be loaded. Showing any available sections, but do not treat missing charts as no data.
+ </p>
+ <p className="text-xs text-[var(--foreground-tertiary)]">
+ Unavailable: {analyticsErrorSections.map((section) => section.label).join(', ')}
+ </p>
+ </div>
+ )}
 
  {/* Empty data notice */}
  {allMockData && (
@@ -300,6 +376,8 @@ export default function AnalyticsClient() {
  <div className="w-8 h-8 border-4 border-[var(--border)] border-t-primary-600 dark:border-t-primary-400 rounded-full" />
  </div>
  </div>
+ ) : deviceMetrics.error ? (
+ <ChartErrorState message="Unable to load device uptime data." detail={deviceMetrics.error} />
  ) : deviceMetrics.data.length === 0 ? (
  <EmptyChartState message="No device uptime data available yet." />
  ) : (
@@ -332,6 +410,8 @@ export default function AnalyticsClient() {
  <div className="w-8 h-8 border-4 border-[var(--border)] border-t-primary-600 dark:border-t-primary-400 rounded-full" />
  </div>
  </div>
+ ) : contentPerformance.error ? (
+ <ChartErrorState message="Unable to load content performance data." detail={contentPerformance.error} />
  ) : contentPerformance.data.length === 0 ? (
  <EmptyChartState message="No content performance data yet. Upload content to track views." />
  ) : (
@@ -360,6 +440,8 @@ export default function AnalyticsClient() {
  <div className="w-8 h-8 border-4 border-[var(--border)] border-t-primary-600 dark:border-t-primary-400 rounded-full" />
  </div>
  </div>
+ ) : deviceDistribution.error ? (
+ <ChartErrorState message="Unable to load device distribution data." detail={deviceDistribution.error} />
  ) : deviceDistribution.data.length === 0 ? (
  <EmptyChartState message="No devices registered yet. Pair devices to see distribution." />
  ) : (
@@ -388,6 +470,8 @@ export default function AnalyticsClient() {
  <div className="w-8 h-8 border-4 border-[var(--border)] border-t-primary-600 dark:border-t-primary-400 rounded-full" />
  </div>
  </div>
+ ) : usageTrends.error ? (
+ <ChartErrorState message="Unable to load usage trends." detail={usageTrends.error} />
  ) : usageTrends.data.length === 0 ? (
  <EmptyChartState message="No usage data yet. Trends will appear as content is played on devices." />
  ) : (
@@ -422,6 +506,8 @@ export default function AnalyticsClient() {
  <div className="w-8 h-8 border-4 border-[var(--border)] border-t-primary-600 dark:border-t-primary-400 rounded-full" />
  </div>
  </div>
+ ) : bandwidthUsage.error ? (
+ <ChartErrorState message="Unable to load bandwidth usage." detail={bandwidthUsage.error} />
  ) : bandwidthUsage.data.length === 0 ? (
  <EmptyChartState message="No bandwidth data yet. Usage will be tracked as devices stream content." />
  ) : (
@@ -454,6 +540,8 @@ export default function AnalyticsClient() {
  <div className="w-8 h-8 border-4 border-[var(--border)] border-t-primary-600 dark:border-t-primary-400 rounded-full" />
  </div>
  </div>
+ ) : playlistPerformance.error ? (
+ <ChartErrorState message="Unable to load playlist performance data." detail={playlistPerformance.error} />
  ) : playlistPerformance.data.length === 0 ? (
  <EmptyChartState message="No playlist data yet. Create playlists and assign them to devices." />
  ) : (

--- a/web/src/lib/hooks/__tests__/useAnalyticsData.test.ts
+++ b/web/src/lib/hooks/__tests__/useAnalyticsData.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import {
   useDeviceMetrics,
   useContentPerformance,
@@ -7,6 +7,8 @@ import {
   useBandwidthUsage,
   usePlaylistPerformance,
 } from '../useAnalyticsData';
+import { apiClient } from '@/lib/api';
+import { ApiError } from '@/lib/error-handler';
 
 jest.mock('@/lib/api', () => ({
   apiClient: {
@@ -20,78 +22,213 @@ jest.mock('@/lib/api', () => ({
 }));
 
 describe('useAnalyticsData hooks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (apiClient.getDeviceMetrics as jest.Mock).mockRejectedValue(new Error('Not available'));
+    (apiClient.getContentPerformance as jest.Mock).mockRejectedValue(new Error('Not available'));
+    (apiClient.getUsageTrends as jest.Mock).mockRejectedValue(new Error('Not available'));
+    (apiClient.getDeviceDistribution as jest.Mock).mockRejectedValue(new Error('Not available'));
+    (apiClient.getBandwidthUsage as jest.Mock).mockRejectedValue(new Error('Not available'));
+    (apiClient.getPlaylistPerformance as jest.Mock).mockRejectedValue(new Error('Not available'));
+  });
+
+  function createDeferred<T>() {
+    let resolve: (value: T) => void = () => {};
+    let reject: (error: unknown) => void = () => {};
+    const promise = new Promise<T>((promiseResolve, promiseReject) => {
+      resolve = promiseResolve;
+      reject = promiseReject;
+    });
+    return { promise, resolve, reject };
+  }
+
+  async function expectEmptySuccess(
+    useHook: () => { data: any[]; loading: boolean; error: string | null; isMockData: boolean },
+    mockMethod: jest.Mock,
+  ) {
+    mockMethod.mockResolvedValueOnce([]);
+
+    const { result } = renderHook(useHook);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual([]);
+    expect(result.current.isMockData).toBe(true);
+    expect(result.current.error).toBeNull();
+  }
+
   describe('useDeviceMetrics', () => {
-    it('returns empty data when API unavailable', async () => {
+    it('returns an error when API unavailable', async () => {
       const { result } = renderHook(() => useDeviceMetrics('month'));
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
       });
       expect(result.current.data).toEqual([]);
-      expect(result.current.isMockData).toBe(true);
-      expect(result.current.error).toBeNull();
+      expect(result.current.isMockData).toBe(false);
+      expect(result.current.error).toBe('Not available');
+    });
+
+    it('returns empty data when the API succeeds with no rows', async () => {
+      await expectEmptySuccess(
+        () => useDeviceMetrics('month'),
+        apiClient.getDeviceMetrics as jest.Mock,
+      );
     });
 
     it('returns empty data for week range', async () => {
+      (apiClient.getDeviceMetrics as jest.Mock).mockResolvedValueOnce([]);
+
       const { result } = renderHook(() => useDeviceMetrics('week'));
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
       });
       expect(result.current.data).toEqual([]);
     });
+
+    it('uses user-safe API error messages', async () => {
+      (apiClient.getDeviceMetrics as jest.Mock).mockRejectedValueOnce(
+        new ApiError(500, 'database connection failed', 'A server error occurred. Please try again later.'),
+      );
+
+      const { result } = renderHook(() => useDeviceMetrics('month'));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.error).toBe('A server error occurred. Please try again later.');
+    });
+
+    it('ignores stale rejected requests after a newer range succeeds', async () => {
+      const staleMonth = createDeferred<any[]>();
+      const currentWeek = createDeferred<any[]>();
+      const currentData = [{ date: 'Mon', mobile: 99, tablet: 98, desktop: 97 }];
+      (apiClient.getDeviceMetrics as jest.Mock)
+        .mockReturnValueOnce(staleMonth.promise)
+        .mockReturnValueOnce(currentWeek.promise);
+
+      const { result, rerender } = renderHook(
+        ({ range }) => useDeviceMetrics(range),
+        { initialProps: { range: 'month' as const } },
+      );
+
+      rerender({ range: 'week' });
+
+      await act(async () => {
+        currentWeek.resolve(currentData);
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      await act(async () => {
+        staleMonth.reject(new Error('Old request failed'));
+        await Promise.resolve();
+      });
+
+      expect(result.current.dateRange).toBe('week');
+      expect(result.current.data).toEqual(currentData);
+      expect(result.current.error).toBeNull();
+      expect(result.current.isMockData).toBe(false);
+    });
   });
 
   describe('useContentPerformance', () => {
-    it('returns empty data when API unavailable', async () => {
+    it('returns an error when API unavailable', async () => {
       const { result } = renderHook(() => useContentPerformance('month'));
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
       });
       expect(result.current.data).toEqual([]);
-      expect(result.current.isMockData).toBe(true);
+      expect(result.current.isMockData).toBe(false);
+      expect(result.current.error).toBe('Not available');
+    });
+
+    it('returns empty data when the API succeeds with no rows', async () => {
+      await expectEmptySuccess(
+        () => useContentPerformance('month'),
+        apiClient.getContentPerformance as jest.Mock,
+      );
     });
   });
 
   describe('useUsageTrends', () => {
-    it('returns empty data when API unavailable', async () => {
+    it('returns an error when API unavailable', async () => {
       const { result } = renderHook(() => useUsageTrends('month'));
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
       });
       expect(result.current.data).toEqual([]);
-      expect(result.current.isMockData).toBe(true);
+      expect(result.current.isMockData).toBe(false);
+      expect(result.current.error).toBe('Not available');
+    });
+
+    it('returns empty data when the API succeeds with no rows', async () => {
+      await expectEmptySuccess(
+        () => useUsageTrends('month'),
+        apiClient.getUsageTrends as jest.Mock,
+      );
     });
   });
 
   describe('useDeviceDistribution', () => {
-    it('returns empty data when API unavailable', async () => {
+    it('returns an error when API unavailable', async () => {
       const { result } = renderHook(() => useDeviceDistribution());
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
       });
       expect(result.current.data).toEqual([]);
-      expect(result.current.isMockData).toBe(true);
+      expect(result.current.isMockData).toBe(false);
+      expect(result.current.error).toBe('Not available');
+    });
+
+    it('returns empty data when the API succeeds with no rows', async () => {
+      await expectEmptySuccess(
+        () => useDeviceDistribution(),
+        apiClient.getDeviceDistribution as jest.Mock,
+      );
     });
   });
 
   describe('useBandwidthUsage', () => {
-    it('returns empty data when API unavailable', async () => {
+    it('returns an error when API unavailable', async () => {
       const { result } = renderHook(() => useBandwidthUsage('month'));
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
       });
       expect(result.current.data).toEqual([]);
-      expect(result.current.isMockData).toBe(true);
+      expect(result.current.isMockData).toBe(false);
+      expect(result.current.error).toBe('Not available');
+    });
+
+    it('returns empty data when the API succeeds with no rows', async () => {
+      await expectEmptySuccess(
+        () => useBandwidthUsage('month'),
+        apiClient.getBandwidthUsage as jest.Mock,
+      );
     });
   });
 
   describe('usePlaylistPerformance', () => {
-    it('returns empty data when API unavailable', async () => {
+    it('returns an error when API unavailable', async () => {
       const { result } = renderHook(() => usePlaylistPerformance('month'));
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
       });
       expect(result.current.data).toEqual([]);
-      expect(result.current.isMockData).toBe(true);
+      expect(result.current.isMockData).toBe(false);
+      expect(result.current.error).toBe('Not available');
+    });
+
+    it('returns empty data when the API succeeds with no rows', async () => {
+      await expectEmptySuccess(
+        () => usePlaylistPerformance('month'),
+        apiClient.getPlaylistPerformance as jest.Mock,
+      );
     });
   });
 });

--- a/web/src/lib/hooks/useAnalyticsData.ts
+++ b/web/src/lib/hooks/useAnalyticsData.ts
@@ -1,309 +1,152 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useEffect, useState, type DependencyList } from 'react';
 import { apiClient } from '@/lib/api';
+import { getUserFriendlyMessage } from '@/lib/error-handler';
 import { devLog } from '@/lib/logger';
 
 type DateRange = 'week' | 'month' | 'year';
 
-// apiClient now has proper analytics methods
+interface AnalyticsDatasetState<T> {
+  data: T[];
+  loading: boolean;
+  error: string | null;
+  isMockData: boolean;
+}
+
+function useAnalyticsDataset<T>(
+  fetcher: () => Promise<T[]>,
+  dependencies: DependencyList,
+  logMessage: string,
+): AnalyticsDatasetState<T> {
+  const [data, setData] = useState<T[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isMockData, setIsMockData] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        setIsMockData(false);
+
+        const response = await fetcher();
+        if (cancelled) return;
+
+        if (response && response.length > 0) {
+          setData(response);
+          return;
+        }
+
+        setIsMockData(true);
+        setData([]);
+      } catch (err) {
+        if (cancelled) return;
+
+        if (process.env.NODE_ENV === 'development') {
+          devLog(logMessage);
+        }
+        setError(getUserFriendlyMessage(err));
+        setIsMockData(false);
+        setData([]);
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchData();
+
+    return () => {
+      cancelled = true;
+    };
+  }, dependencies);
+
+  return { data, loading, error, isMockData };
+}
 
 /**
  * Device Metrics Hook - Real API Integration
  * Fetches device uptime/status metrics over time
  */
 export function useDeviceMetrics(dateRange: DateRange = 'month') {
-  const [data, setData] = useState<any[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [isMockData, setIsMockData] = useState(false);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        setIsMockData(false);
-
-        // Map date range to days
-        const daysMap: Record<DateRange, number> = {
-          week: 7,
-          month: 30,
-          year: 365,
-        };
-        const days = daysMap[dateRange];
-
-        // Try to fetch from API
-        try {
-          const response = await apiClient.getDeviceMetrics(dateRange);
-          if (response && response.length > 0) {
-            setData(response);
-            return;
-          }
-        } catch (apiError) {
-          // Fall through to empty state if API not available
-          if (process.env.NODE_ENV === 'development') {
-            devLog('Analytics API not available, showing empty state');
-          }
-        }
-
-        // No real data available — show empty state
-        setIsMockData(true);
-        setData([]);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to fetch device metrics');
-        setData([]);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchData();
-  }, [dateRange]);
-
-  return { data, loading, error, dateRange, isMockData };
+  return {
+    ...useAnalyticsDataset(
+      () => apiClient.getDeviceMetrics(dateRange),
+      [dateRange],
+      'Analytics API not available',
+    ),
+    dateRange,
+  };
 }
 
 /**
  * Content Performance Hook - Real API Integration
  */
 export function useContentPerformance(dateRange: DateRange = 'month') {
-  const [data, setData] = useState<any[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [isMockData, setIsMockData] = useState(false);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        setIsMockData(false);
-
-        // Try to fetch from API
-        try {
-          const response = await apiClient.getContentPerformance(dateRange);
-          if (response && response.length > 0) {
-            setData(response);
-            return;
-          }
-        } catch (apiError) {
-          if (process.env.NODE_ENV === 'development') {
-            devLog('Content performance API not available, showing empty state');
-          }
-        }
-
-        // No real data available — show empty state
-        setIsMockData(true);
-        setData([]);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to fetch content performance');
-        setData([]);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchData();
-  }, [dateRange]);
-
-  return { data, loading, error, dateRange, isMockData };
+  return {
+    ...useAnalyticsDataset(
+      () => apiClient.getContentPerformance(dateRange),
+      [dateRange],
+      'Content performance API not available',
+    ),
+    dateRange,
+  };
 }
 
 /**
  * Usage Trends Hook - Real API Integration
  */
 export function useUsageTrends(dateRange: DateRange = 'month') {
-  const [data, setData] = useState<any[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [isMockData, setIsMockData] = useState(false);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        setIsMockData(false);
-
-        const daysMap: Record<DateRange, number> = {
-          week: 7,
-          month: 30,
-          year: 365,
-        };
-        const days = daysMap[dateRange];
-
-        // Try to fetch from API
-        try {
-          const response = await apiClient.getUsageTrends(dateRange);
-          if (response && response.length > 0) {
-            setData(response);
-            return;
-          }
-        } catch (apiError) {
-          if (process.env.NODE_ENV === 'development') {
-            devLog('Usage trends API not available, showing empty state');
-          }
-        }
-
-        // No real data available — show empty state
-        setIsMockData(true);
-        setData([]);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to fetch usage trends');
-        setData([]);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchData();
-  }, [dateRange]);
-
-  return { data, loading, error, dateRange, isMockData };
+  return {
+    ...useAnalyticsDataset(
+      () => apiClient.getUsageTrends(dateRange),
+      [dateRange],
+      'Usage trends API not available',
+    ),
+    dateRange,
+  };
 }
 
 /**
  * Device Distribution Hook - Real API Integration
  */
 export function useDeviceDistribution() {
-  const [data, setData] = useState<any[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [isMockData, setIsMockData] = useState(false);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        setIsMockData(false);
-
-        // Try to fetch from API
-        try {
-          const response = await apiClient.getDeviceDistribution();
-          if (response && response.length > 0) {
-            setData(response);
-            return;
-          }
-        } catch (apiError) {
-          if (process.env.NODE_ENV === 'development') {
-            devLog('Device distribution API not available, showing empty state');
-          }
-        }
-
-        // No real data available — show empty state
-        setIsMockData(true);
-        setData([]);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to fetch device distribution');
-        setData([]);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchData();
-  }, []);
-
-  return { data, loading, error, isMockData };
+  return useAnalyticsDataset(
+    () => apiClient.getDeviceDistribution(),
+    [],
+    'Device distribution API not available',
+  );
 }
 
 /**
  * Bandwidth Usage Hook - Real API Integration
  */
 export function useBandwidthUsage(dateRange: DateRange = 'month') {
-  const [data, setData] = useState<any[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [isMockData, setIsMockData] = useState(false);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        setIsMockData(false);
-
-        const daysMap: Record<DateRange, number> = {
-          week: 7,
-          month: 30,
-          year: 365,
-        };
-        const days = daysMap[dateRange];
-
-        // Try to fetch from API
-        try {
-          const response = await apiClient.getBandwidthUsage(dateRange);
-          if (response && response.length > 0) {
-            setData(response);
-            return;
-          }
-        } catch (apiError) {
-          if (process.env.NODE_ENV === 'development') {
-            devLog('Bandwidth usage API not available, showing empty state');
-          }
-        }
-
-        // No real data available — show empty state
-        setIsMockData(true);
-        setData([]);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to fetch bandwidth usage');
-        setData([]);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchData();
-  }, [dateRange]);
-
-  return { data, loading, error, dateRange, isMockData };
+  return {
+    ...useAnalyticsDataset(
+      () => apiClient.getBandwidthUsage(dateRange),
+      [dateRange],
+      'Bandwidth usage API not available',
+    ),
+    dateRange,
+  };
 }
 
 /**
  * Playlist Performance Hook - Real API Integration
  */
 export function usePlaylistPerformance(dateRange: DateRange = 'month') {
-  const [data, setData] = useState<any[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [isMockData, setIsMockData] = useState(false);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        setIsMockData(false);
-
-        // Try to fetch from API
-        try {
-          const response = await apiClient.getPlaylistPerformance(dateRange);
-          if (response && response.length > 0) {
-            setData(response);
-            return;
-          }
-        } catch (apiError) {
-          if (process.env.NODE_ENV === 'development') {
-            devLog('Playlist performance API not available, showing empty state');
-          }
-        }
-
-        // No real data available — show empty state
-        setIsMockData(true);
-        setData([]);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to fetch playlist performance');
-        setData([]);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchData();
-  }, [dateRange]);
-
-  return { data, loading, error, dateRange, isMockData };
+  return {
+    ...useAnalyticsDataset(
+      () => apiClient.getPlaylistPerformance(dateRange),
+      [dateRange],
+      'Playlist performance API not available',
+    ),
+    dateRange,
+  };
 }


### PR DESCRIPTION
﻿## Summary
- Keep successful empty analytics responses as true empty states while surfacing rejected analytics API calls as explicit unavailable states.
- Add global and per-section analytics failure alerts so customers do not read load failures as "No Data Yet".
- Add regression coverage for rejected hooks, successful empty arrays, stale date-range requests, section alerts, and summary failure.

## Review
- UX/accessibility/test reviewer: CLEAN.
- Hook/API-state reviewer: CLEAN.
- Final sanity after type/lint cleanup: CLEAN from both reviewers.

## Verification
- `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/lib/hooks/__tests__/useAnalyticsData.test.ts`: 15/15 pass.
- `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/dashboard/analytics/__tests__/analytics-page.test.tsx`: 9/9 pass.
- `pnpm --filter @vizora/web test -- --runInBand --testPathPattern="analytics|useAnalyticsData"`: 34/34 pass.
- `pnpm --filter @vizora/web test -- --runInBand`: 1016/1016 pass; existing unrelated React act warnings remain in broader suites.
- `npx nx build @vizora/web --skip-nx-cache` with production web env defaults: pass.
- Changed-file direct ESLint: pass.
- `pnpm security:no-hardcoded-jwts`: pass.
- `git diff --check`: pass with CRLF warnings only.

## Deployment
- Not deployed by this PR. Production deploy gate remains separate and must verify prod checkout safety first.
