### PR TITLE
Batch dashboard status catch-up

### DIFF
--- a/docs/plans/2026-06-01-realtime-status-catchup-performance-pass-25.md
+++ b/docs/plans/2026-06-01-realtime-status-catchup-performance-pass-25.md
@@ -1,0 +1,80 @@
+# Realtime Status Catch-Up Performance Pass 25
+
+**Date:** 2026-06-01
+**Branch:** `feat/performance-readiness-pass-25`
+
+## Why Now
+
+The customer/performance review after Pass 24 identified dashboard reconnect
+status catch-up as a bounded hot path. Every dashboard connection currently
+joins the org room and receives up to 500 individual `device:status` events from
+the realtime gateway, while the dashboard provider already supports
+`device:status:batch`.
+
+## New Primitives Introduced
+
+None. This uses the existing realtime gateway, Socket.IO room model, and
+existing dashboard `device:status:batch` event handler.
+
+## Hermes-First Analysis
+
+Not applicable. This pass does not add or modify business agents, MCP tools,
+Hermes skills, AI/provider calls, or spend paths.
+
+## Scope
+
+- Keep the existing tenant-scoped dashboard connection and organization-room
+  authorization behavior.
+- Keep the existing catch-up query cap of 500 devices plus one peek row.
+- Replace per-device dashboard catch-up emits with a single
+  `device:status:batch` emit containing the same status records.
+- Preserve truncation logging when more than 500 displays exist for the org.
+- Do not change live incremental `device:status` broadcasts for actual device
+  online/offline changes.
+- Ensure dashboard consumers that use `useRealtimeEvents` receive the catch-up
+  batch, not only the global `DeviceStatusProvider`.
+
+## TDD Plan
+
+- Update the large-fleet catch-up test to expect one `device:status:batch` emit
+  with 500 records instead of 500 individual emits.
+- Update the small-fleet catch-up test to expect one batch with all devices.
+- Keep assertions on the database query cap and truncation warning.
+- Add hook coverage proving `useRealtimeEvents` fans out
+  `device:status:batch` updates to existing `onDeviceStatusChange` consumers.
+- Add gateway coverage for cached status precedence, payload shape, and empty
+  fleet no-emit behavior.
+
+## Review Notes
+
+- Realtime correctness/security reviewer: CLEAN.
+- Dashboard compatibility reviewer: initially found that `useRealtimeEvents`
+  still subscribed only to `device:status`, which would leave Devices page row
+  state stale after reconnect catch-up. Fixed by adding `device:status:batch`
+  handling in the hook, then re-reviewed CLEAN.
+- Local Claude Code review: CLEAN before the web compatibility fix; the post-fix
+  rerun exited without usable output and is not counted as final evidence.
+
+## Verification Plan
+
+- Focused realtime catch-up test: 4/4 pass.
+- Full realtime gateway spec: 98/98 pass.
+- Full realtime suite: 277/277 pass.
+- Focused web realtime hook suite: 18/18 pass.
+- Full web suite: 1017/1017 pass.
+- Realtime production build: pass.
+- Web production build: pass with explicit local `NEXT_PUBLIC_SOCKET_URL`,
+  `NEXT_PUBLIC_API_URL`, and `BACKEND_URL`.
+- Changed-file ESLint: exit 0 with pre-existing warnings only.
+- Security JWT guard: pass.
+- `git diff --check`: pass with CRLF warnings only.
+
+## Residual Risks
+
+- The dashboard provider and hook both handle `device:status:batch`. The hook
+  still fans out the capped batch as per-device callbacks to preserve existing
+  page contracts, so local client CPU work is reduced less than socket fan-out.
+- Dashboard still also performs REST status initialization on mount. This pass
+  reduces socket fan-out but does not remove the duplicate REST fetch.
+- No Devices page integration test proves status sorting/last-seen columns from
+  a batch event; hook-level batch fan-out is covered.

--- a/realtime/src/gateways/device.gateway.spec.ts
+++ b/realtime/src/gateways/device.gateway.spec.ts
@@ -1660,9 +1660,9 @@ describe('DeviceGateway', () => {
   describe('sendDeviceStatusCatchUp (catch-up cap)', () => {
     it('should cap a large fleet at 500 devices and warn about truncation', async () => {
       const client = createMockSocket();
-      // Simulate 501 devices for one org — the cap is 500, so the
+      // Simulate 501 devices for one org - the cap is 500, so the
       // query should request take=501 (cap + 1 peek) and the function
-      // should emit only the first 500 + a warning.
+      // should emit only the first 500 in one batch + a warning.
       const fleet = Array.from({ length: 501 }, (_, i) => ({
         id: `dev-${i}`,
         status: 'offline',
@@ -1680,7 +1680,26 @@ describe('DeviceGateway', () => {
           take: 501,
         }),
       );
-      expect(client.emit).toHaveBeenCalledTimes(500);
+      expect(client.emit).toHaveBeenCalledTimes(1);
+      expect(client.emit).toHaveBeenCalledWith(
+        'device:status:batch',
+        expect.arrayContaining([
+          expect.objectContaining({
+            deviceId: 'dev-0',
+            status: 'offline',
+            lastSeen: expect.any(String),
+            timestamp: expect.any(String),
+          }),
+          expect.objectContaining({
+            deviceId: 'dev-499',
+            status: 'offline',
+            lastSeen: expect.any(String),
+            timestamp: expect.any(String),
+          }),
+        ]),
+      );
+      const batch = (client.emit as jest.Mock).mock.calls[0][1];
+      expect(batch).toHaveLength(500);
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('truncated at 500'));
     });
 
@@ -1695,7 +1714,58 @@ describe('DeviceGateway', () => {
 
       await (gateway as any).sendDeviceStatusCatchUp(client, 'org-small');
 
-      expect(client.emit).toHaveBeenCalledTimes(7);
+      expect(client.emit).toHaveBeenCalledTimes(1);
+      expect(client.emit).toHaveBeenCalledWith(
+        'device:status:batch',
+        expect.arrayContaining([
+          expect.objectContaining({
+            deviceId: 'dev-0',
+            status: 'offline',
+            lastSeen: expect.any(String),
+            timestamp: expect.any(String),
+          }),
+          expect.objectContaining({
+            deviceId: 'dev-6',
+            status: 'offline',
+            lastSeen: expect.any(String),
+            timestamp: expect.any(String),
+          }),
+        ]),
+      );
+      const batch = (client.emit as jest.Mock).mock.calls[0][1];
+      expect(batch).toHaveLength(7);
+    });
+
+    it('should prefer cached status values in the catch-up batch', async () => {
+      const client = createMockSocket();
+      databaseService.display.findMany.mockResolvedValue([
+        {
+          id: 'dev-1',
+          status: 'offline',
+          lastHeartbeat: new Date(),
+        },
+      ] as any);
+      (gateway as any).deviceStatusCache.set('dev-1', 'online');
+
+      await (gateway as any).sendDeviceStatusCatchUp(client, 'org-small');
+
+      expect(client.emit).toHaveBeenCalledWith('device:status:batch', [
+        expect.objectContaining({
+          deviceId: 'dev-1',
+          status: 'online',
+          lastSeen: expect.any(String),
+          timestamp: expect.any(String),
+        }),
+      ]);
+    });
+
+    it('should not emit a batch when no devices exist for the organization', async () => {
+      const client = createMockSocket();
+      databaseService.display.findMany.mockResolvedValue([]);
+
+      await (gateway as any).sendDeviceStatusCatchUp(client, 'org-empty');
+
+      expect(client.emit).not.toHaveBeenCalled();
     });
   });
 

--- a/realtime/src/gateways/device.gateway.ts
+++ b/realtime/src/gateways/device.gateway.ts
@@ -1113,16 +1113,20 @@ export class DeviceGateway
       const toSend = truncated ? devices.slice(0, cap) : devices;
 
       const now = new Date().toISOString();
-      for (const device of toSend) {
+      const statusBatch = toSend.map((device) => {
         // Check in-memory cache first (most accurate for connected devices)
         const cachedStatus = this.deviceStatusCache.get(device.id);
         const status = cachedStatus || device.status || 'offline';
-        client.emit('device:status', {
+        return {
           deviceId: device.id,
           status,
           lastSeen: device.lastHeartbeat?.toISOString() || now,
           timestamp: now,
-        });
+        };
+      });
+
+      if (statusBatch.length > 0) {
+        client.emit('device:status:batch', statusBatch);
       }
 
       if (truncated) {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,63 @@
 # Vizora - Task Tracker
 
+## In Progress: Realtime Status Catch-Up Performance Pass 25 (2026-06-01)
+
+**Branch:** `feat/performance-readiness-pass-25`
+
+**Why now:** Pass 24 is merged with green post-merge `main` CI, but production
+deploy remains blocked by dirty/diverged prod-local state. The next
+repo-side performance review found dashboard reconnect catch-up emits one socket
+event per display even though the dashboard already handles batch status events.
+
+**New primitives introduced:** none. This reuses the existing realtime gateway,
+Socket.IO room model, and `device:status:batch` client event path.
+
+**Hermes-first analysis:** not applicable. This pass does not add or modify
+business agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
+
+**Plan**
+- [x] Start fresh branch from `origin/main`.
+- [x] Dispatch performance reviewers for upload, pairing/status,
+  streaming/realtime, and dashboard bottlenecks.
+- [x] Drift-check realtime catch-up code and dashboard batch handler.
+- [x] Write focused failing realtime tests proving catch-up emits one batch.
+- [x] Implement batched dashboard status catch-up.
+- [x] Run multi-vector review before broader verification.
+- [x] Run focused and broader verification.
+- [ ] PR, CI, merge.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Local evidence:**
+- TDD red: realtime catch-up tests failed because large/small fleets still
+  emitted one `device:status` socket event per display; web hook test failed
+  because `useRealtimeEvents` ignored `device:status:batch`.
+- Implementation: realtime dashboard catch-up now emits one capped
+  `device:status:batch` payload with the same per-device fields; the dashboard
+  hook subscribes to batch updates and fans them through the existing
+  single-update handler so Devices page row state remains current.
+- Review: realtime correctness/security reviewer CLEAN; dashboard
+  compatibility reviewer initially found the missing `useRealtimeEvents` batch
+  listener, then re-reviewed the fixed diff as CLEAN. Local Claude Code review
+  was CLEAN before the web compatibility fix but the post-fix Claude rerun
+  exited without usable output, so it is not counted as evidence.
+- Verification: focused realtime catch-up test 4/4 pass; full gateway spec
+  98/98 pass; full realtime suite 277/277 pass; focused web realtime hook suite
+  18/18 pass; full web suite 1017/1017 pass; realtime production build pass;
+  web production build pass with explicit local `NEXT_PUBLIC_SOCKET_URL`,
+  `NEXT_PUBLIC_API_URL`, and `BACKEND_URL`; changed-file ESLint exits 0 with
+  pre-existing warnings only; repo security JWT guard pass; `git diff --check`
+  pass with CRLF warnings only.
+- Known unrelated verification noise: existing React `act(...)` warnings in
+  broader web suites; realtime/web builds show known package/source-map and
+  Next middleware deprecation warnings. The first realtime build attempt failed
+  with a Windows file-lock in `@vizora/database:build` while tests were running
+  in parallel; sequential rerun passed.
+
+**Plan/design:**
+`docs/plans/2026-06-01-realtime-status-catchup-performance-pass-25.md`
+
+---
+
 ## Completed: Analytics Empty-State Trust Pass 24 (2026-06-01)
 
 **Branch:** `feat/analytics-empty-state-trust-pass-24`

--- a/web/src/lib/hooks/__tests__/useRealtimeEvents.test.ts
+++ b/web/src/lib/hooks/__tests__/useRealtimeEvents.test.ts
@@ -137,6 +137,40 @@ describe('useRealtimeEvents', () => {
         expect(onDeviceStatusChange).toHaveBeenCalledTimes(2);
       });
     });
+
+    it('should fan out device:status:batch updates to the device status callback', async () => {
+      const onDeviceStatusChange = jest.fn();
+
+      renderHook(() =>
+        useRealtimeEvents({
+          enabled: true,
+          onDeviceStatusChange,
+        })
+      );
+
+      const updates = [
+        {
+          deviceId: 'device-1',
+          status: 'online' as const,
+          lastSeen: new Date().toISOString(),
+        },
+        {
+          deviceId: 'device-2',
+          status: 'offline' as const,
+          lastSeen: new Date().toISOString(),
+        },
+      ];
+
+      act(() => {
+        mockSocket?.simulateEvent('device:status:batch', updates);
+      });
+
+      await waitFor(() => {
+        expect(onDeviceStatusChange).toHaveBeenCalledTimes(2);
+        expect(onDeviceStatusChange).toHaveBeenNthCalledWith(1, updates[0]);
+        expect(onDeviceStatusChange).toHaveBeenNthCalledWith(2, updates[1]);
+      });
+    });
   });
 
   describe('Playlist Updates', () => {

--- a/web/src/lib/hooks/useRealtimeEvents.ts
+++ b/web/src/lib/hooks/useRealtimeEvents.ts
@@ -4,7 +4,7 @@
 import { useEffect, useCallback, useRef, useState } from 'react';
 import { useSocket } from './useSocket';
 import { devLog, devWarn } from '@/lib/logger';
-import type { Display, Content, Playlist, Schedule } from '../types';
+import type { Playlist } from '../types';
 
 // Event types
 export type DeviceStatusUpdate = {
@@ -71,7 +71,6 @@ export function useRealtimeEvents(options: UseRealtimeEventsOptions = {}) {
   });
 
   // Offline sync queue
-  const syncQueueRef = useRef<SyncQueueItem[]>([]);
   const offlineQueueRef = useRef<SyncQueueItem[]>([]);
 
   // Emit event with optimistic update support
@@ -205,6 +204,13 @@ export function useRealtimeEvents(options: UseRealtimeEventsOptions = {}) {
     [onDeviceStatusChange]
   );
 
+  const handleDeviceStatusBatch = useCallback(
+    (updates: DeviceStatusUpdate[]) => {
+      updates.forEach(handleDeviceStatusUpdate);
+    },
+    [handleDeviceStatusUpdate]
+  );
+
   // Playlist update handler with conflict resolution
   const handlePlaylistUpdate = useCallback(
     (update: PlaylistUpdate) => {
@@ -220,7 +226,7 @@ export function useRealtimeEvents(options: UseRealtimeEventsOptions = {}) {
         );
 
         if (conflicted.length > 0) {
-          const resolved = resolveConflict(conflicted[0][1], update.payload);
+          resolveConflict(conflicted[0][1], update.payload);
           return {
             ...prev,
             pendingChanges: new Map(
@@ -239,8 +245,9 @@ export function useRealtimeEvents(options: UseRealtimeEventsOptions = {}) {
   useEffect(() => {
     if (!enabled || !socket) return;
 
-    // Device status updates (gateway emits 'device:status')
+    // Device status updates (gateway emits singles for live updates and batches for catch-up)
     const unsubDeviceStatus = on('device:status', handleDeviceStatusUpdate);
+    const unsubDeviceStatusBatch = on('device:status:batch', handleDeviceStatusBatch);
 
     // Playlist changes
     const unsubPlaylist = on('playlist:updated', handlePlaylistUpdate);
@@ -271,6 +278,7 @@ export function useRealtimeEvents(options: UseRealtimeEventsOptions = {}) {
 
     return () => {
       unsubDeviceStatus?.();
+      unsubDeviceStatusBatch?.();
       unsubPlaylist?.();
       unsubConnect?.();
       unsubDisconnect?.();
@@ -280,6 +288,7 @@ export function useRealtimeEvents(options: UseRealtimeEventsOptions = {}) {
     socket,
     on,
     handleDeviceStatusUpdate,
+    handleDeviceStatusBatch,
     handlePlaylistUpdate,
     onConnectionChange,
     onSyncStateChange,


### PR DESCRIPTION
## Summary
- replace dashboard reconnect catch-up per-device `device:status` emits with one capped `device:status:batch` emit
- add `useRealtimeEvents` batch handling so Devices page row state receives catch-up updates
- harden gateway and hook tests for batch payload shape, cached status precedence, empty fleet, and hook fan-out

## Review
- Realtime correctness/security reviewer: CLEAN
- Dashboard compatibility reviewer: initially found missing `useRealtimeEvents` batch listener; fixed and re-reviewed CLEAN
- Local Claude Code review: CLEAN before compatibility fix; post-fix rerun exited without usable output and is not counted

## Verification
- `pnpm --filter @vizora/realtime test -- --runInBand --runTestsByPath src/gateways/device.gateway.spec.ts --testNamePattern=sendDeviceStatusCatchUp` (4/4)
- `pnpm --filter @vizora/realtime test -- --runInBand --runTestsByPath src/gateways/device.gateway.spec.ts` (98/98)
- `pnpm --filter @vizora/realtime test -- --runInBand` (277/277)
- `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/lib/hooks/__tests__/useRealtimeEvents.test.ts` (18/18)
- `pnpm --filter @vizora/web test -- --runInBand` (1017/1017)
- `npx nx build @vizora/realtime --skip-nx-cache`
- `NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 BACKEND_URL=http://localhost:3000 npx nx build @vizora/web --skip-nx-cache`
- `npx eslint --ext .ts,.tsx realtime/src/gateways/device.gateway.ts realtime/src/gateways/device.gateway.spec.ts web/src/lib/hooks/useRealtimeEvents.ts web/src/lib/hooks/__tests__/useRealtimeEvents.test.ts` (exit 0, pre-existing warnings only)
- `pnpm security:no-hardcoded-jwts`
- `git diff --check` (CRLF warnings only)

## Deploy note
Production deploy is still gated by the existing dirty/diverged `/opt/vizora/app` checkout. This PR should not be deployed by pulling over prod-local changes until that state is classified.