### PR TITLE
Harden dashboard bulk actions

### DIFF
--- a/docs/plans/2026-06-01-dashboard-bulk-action-safety-pass-26.md
+++ b/docs/plans/2026-06-01-dashboard-bulk-action-safety-pass-26.md
@@ -1,0 +1,43 @@
+# Dashboard Bulk-Action Safety Pass 26
+
+**Goal:** Prevent destructive device bulk actions from firing without confirmation and make success feedback reflect authoritative backend counts.
+
+**New primitives introduced:** none. This pass reuses the existing dashboard client pages, existing `ConfirmDialog`, existing display bulk REST endpoints, and existing response envelope/API client behavior.
+
+**Hermes-first analysis:** not applicable. This pass does not add or modify business agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
+
+## Customer/Performance Findings From Pass 26 Review
+
+1. Playlist cards expose a `Publish` action that only updates the playlist name, so customers can believe content is live when nothing changed on any display.
+2. Device pairing copy conflicts between Help, the first-device pair page, and per-device repair tokens.
+3. Dashboard overview guidance disappears after the first device, even if content, playlist, assignment, and schedule readiness are incomplete.
+4. "Live on screen" actions rely mostly on toast feedback instead of visible delivery/preview confirmation.
+5. Schedule conflict warnings remain advisory and conflict verification failures do not block or require explicit acknowledgement.
+6. Devices/playlists/schedules still use load-all client-side pagination patterns with a hard 1,000-item cap.
+7. Analytics page performs seven independent initial API loads; an aggregate endpoint/hook can reduce this to one route-level request.
+8. Display image playback fetches images into JS blobs and bypasses the display preload/cache path.
+9. Content bulk delete is one-click and handles partial failures poorly.
+10. Device bulk actions ignore backend result counts and bulk delete has no confirmation.
+11. Shared confirmation dialogs close before async destructive actions finish.
+12. Dashboard auth/layout can render a protected shell after a syntactically valid but invalid cookie.
+
+## Build Scope
+
+This PR fixes findings 10 and 11. Findings 1-9 and 12 remain backlog for subsequent autonomous passes.
+
+## Files
+
+- Modify `web/src/components/ConfirmDialog.tsx`: await async confirmation handlers, disable buttons while pending, and close only after the handler resolves.
+- Modify `web/src/components/__tests__/ConfirmDialog.test.tsx`: prove the dialog stays open while async confirmation is pending and closes after success.
+- Modify `web/src/app/dashboard/devices/page-client.tsx`: add a bulk-delete confirmation dialog, use `{ deleted }`, `{ updated }`, and `{ added }` result counts in success toasts, and await reloads before clearing action loading.
+- Modify `web/src/app/dashboard/devices/__tests__/devices-page.test.tsx`: prove bulk delete waits for confirmation and that bulk action toasts use backend counts.
+
+## Plan
+
+- [ ] Add failing `ConfirmDialog` async-confirmation test.
+- [ ] Add failing devices page tests for bulk-delete confirmation and backend count toasts.
+- [ ] Implement the shared confirmation pending state.
+- [ ] Implement device bulk-action safety and authoritative feedback.
+- [ ] Run focused web tests for `ConfirmDialog` and devices page.
+- [ ] Request multi-vector review focused on UX/destructive-action safety and regression risk.
+- [ ] Run broader web verification and open/merge PR if clean.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,63 @@
 # Vizora - Task Tracker
 
+## In Progress: Dashboard Bulk-Action Safety Pass 26 (2026-06-01)
+
+**Branch:** `feat/customer-dashboard-pass-26`
+
+**Why now:** After Pass 25 merged with green CI, the next customer-dashboard
+analysis found multiple customer trust and performance gaps. The safest bounded
+first build target is destructive device bulk-action safety: currently device
+bulk delete fires immediately, bulk action toasts use selected row counts rather
+than backend result counts, and the shared confirmation dialog closes before
+async destructive actions finish.
+
+**New primitives introduced:** none. This pass reuses existing dashboard client
+pages, `ConfirmDialog`, display bulk endpoints, and API client methods.
+
+**Hermes-first analysis:** not applicable. This pass does not add or modify
+business agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
+
+**Plan**
+- [x] Start fresh branch from `origin/main`.
+- [x] Dispatch customer UX, frontend performance, and action-safety reviewers.
+- [x] Record Pass 26 findings and choose a bounded first build target.
+- [x] Write failing tests for async confirmation and device bulk-action safety.
+- [x] Implement shared confirmation pending state.
+- [x] Implement device bulk-delete confirmation and backend count toasts.
+- [x] Run focused tests.
+- [x] Run multi-vector review before broader verification.
+- [x] Run broader verification.
+- [ ] PR, CI, merge.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Plan/design:**
+`docs/plans/2026-06-01-dashboard-bulk-action-safety-pass-26.md`
+
+**Local evidence:**
+- TDD red: shared confirmation test failed because `onClose` fired before an
+  async confirm resolved; device tests failed because bulk delete called the API
+  before confirmation and bulk action toasts used selected row counts instead of
+  backend result counts.
+- Implementation: `ConfirmDialog` now awaits async confirm handlers, disables
+  actions while pending, keeps the dialog open until success, resets pending
+  state before close so reopen is usable, and exposes `role="dialog"` with
+  modal label/description semantics. Device bulk delete now opens a confirmation
+  dialog, and device bulk delete/playlist/group toasts use `{ deleted }`,
+  `{ updated }`, and `{ added }` counts returned by the backend.
+- Review: initial destructive-action and runtime reviewers both found a real
+  high issue where the shared dialog could reopen with buttons permanently
+  disabled; fixed with a reopen regression test. Re-review from both vectors was
+  CLEAN, with residual risk limited to no full browser/aXe focus-trap pass and
+  existing fire-and-forget ConfirmDialog consumers outside this scope.
+- Verification: focused `ConfirmDialog` suite 11/11 pass; focused devices page
+  suite 17/17 pass; full web Jest suite 96 suites / 1023 tests pass; web
+  `tsc --noEmit` pass; changed-file ESLint exits 0 with existing warnings only;
+  web production build pass with explicit local `NEXT_PUBLIC_SOCKET_URL`,
+  `NEXT_PUBLIC_API_URL`, `BACKEND_URL`, and memory env; repo JWT secret guard
+  pass; `git diff --check` pass with CRLF warnings only.
+
+---
+
 ## Completed: Realtime Status Catch-Up Performance Pass 25 (2026-06-01)
 
 **Branch:** `feat/performance-readiness-pass-25`

--- a/web/src/app/dashboard/devices/__tests__/devices-page.test.tsx
+++ b/web/src/app/dashboard/devices/__tests__/devices-page.test.tsx
@@ -8,6 +8,9 @@ const mockGetDisplayGroups = jest.fn();
 const mockDeleteDisplay = jest.fn();
 const mockUpdateDisplay = jest.fn();
 const mockGeneratePairingToken = jest.fn();
+const mockBulkDeleteDisplays = jest.fn();
+const mockBulkAssignPlaylist = jest.fn();
+const mockBulkAssignGroup = jest.fn();
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({
@@ -29,6 +32,9 @@ jest.mock('@/lib/api', () => ({
     deleteDisplay: (...args: any[]) => mockDeleteDisplay(...args),
     updateDisplay: (...args: any[]) => mockUpdateDisplay(...args),
     generatePairingToken: (...args: any[]) => mockGeneratePairingToken(...args),
+    bulkDeleteDisplays: (...args: any[]) => mockBulkDeleteDisplays(...args),
+    bulkAssignPlaylist: (...args: any[]) => mockBulkAssignPlaylist(...args),
+    bulkAssignGroup: (...args: any[]) => mockBulkAssignGroup(...args),
     getCurrentUser: jest.fn().mockRejectedValue(new Error('401')),
     setAuthenticated: jest.fn(),
     getActiveOverrides: jest.fn().mockResolvedValue([]),
@@ -213,6 +219,9 @@ describe('DevicesClient', () => {
     mockGetDisplayGroups.mockResolvedValue({ data: [] });
     mockDeleteDisplay.mockResolvedValue({});
     mockUpdateDisplay.mockResolvedValue({});
+    mockBulkDeleteDisplays.mockResolvedValue({ deleted: 0 });
+    mockBulkAssignPlaylist.mockResolvedValue({ updated: 0 });
+    mockBulkAssignGroup.mockResolvedValue({ added: 0 });
     mockGeneratePairingToken.mockResolvedValue({
       pairingToken: 'eyJ.mock.pairing-token',
       expiresIn: '30d',
@@ -390,6 +399,106 @@ describe('DevicesClient', () => {
       expect(screen.getByText('eyJ.mock.pairing-token')).toBeInTheDocument();
     });
     expect(screen.queryByText('N/A')).not.toBeInTheDocument();
+  });
+
+  it('requires confirmation before bulk deleting selected devices and reports the backend count', async () => {
+    mockBulkDeleteDisplays.mockResolvedValue({ deleted: 1 });
+
+    render(
+      <DevicesClient
+        initialDevices={sampleDevices as any}
+        initialPlaylists={samplePlaylists as any}
+        initialDevicesComplete
+        initialPlaylistsComplete
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Lobby Display')).toBeInTheDocument();
+    });
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[1]);
+    fireEvent.click(checkboxes[2]);
+
+    fireEvent.click(screen.getByText('Delete Selected'));
+
+    expect(mockBulkDeleteDisplays).not.toHaveBeenCalled();
+    expect(screen.getByTestId('confirm-dialog')).toHaveTextContent('Delete Selected Devices');
+
+    fireEvent.click(screen.getByText('Confirm'));
+
+    await waitFor(() => {
+      expect(mockBulkDeleteDisplays).toHaveBeenCalledWith(['d1', 'd2']);
+    });
+    expect(mockToast.success).toHaveBeenCalledWith('Deleted 1 device(s)');
+  });
+
+  it('reports backend updated count after bulk playlist assignment', async () => {
+    mockBulkAssignPlaylist.mockResolvedValue({ updated: 1 });
+
+    render(
+      <DevicesClient
+        initialDevices={sampleDevices as any}
+        initialPlaylists={samplePlaylists as any}
+        initialDevicesComplete
+        initialPlaylistsComplete
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Lobby Display')).toBeInTheDocument();
+    });
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[1]);
+    fireEvent.click(checkboxes[2]);
+    fireEvent.click(screen.getByText('Assign Playlist'));
+    fireEvent.change(screen.getAllByRole('combobox').at(-1)!, { target: { value: 'p1' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Assign' }));
+
+    await waitFor(() => {
+      expect(mockBulkAssignPlaylist).toHaveBeenCalledWith(['d1', 'd2'], 'p1');
+    });
+    expect(mockToast.success).toHaveBeenCalledWith('Playlist assigned to 1 device(s)');
+  });
+
+  it('reports backend added count after bulk group assignment', async () => {
+    mockGetDisplayGroups.mockResolvedValue({
+      data: [{ id: 'g1', name: 'Lobby Group', description: '', displays: [] }],
+      meta: { total: 1 },
+    });
+    mockBulkAssignGroup.mockResolvedValue({ added: 1 });
+
+    render(
+      <DevicesClient
+        initialDevices={sampleDevices as any}
+        initialPlaylists={samplePlaylists as any}
+        initialDevicesComplete
+        initialPlaylistsComplete
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Lobby Display')).toBeInTheDocument();
+    });
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[1]);
+    fireEvent.click(checkboxes[2]);
+    fireEvent.click(screen.getByText('Add to Group'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Lobby Group')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getAllByRole('combobox').at(-1)!, { target: { value: 'g1' } });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Add to Group' }).at(-1)!);
+
+    await waitFor(() => {
+      expect(mockBulkAssignGroup).toHaveBeenCalledWith(['d1', 'd2'], 'g1');
+    });
+    expect(mockToast.success).toHaveBeenCalledWith('Added 1 device(s) to group');
   });
 
   it('handles empty device list gracefully', async () => {

--- a/web/src/app/dashboard/devices/page-client.tsx
+++ b/web/src/app/dashboard/devices/page-client.tsx
@@ -46,6 +46,7 @@ export default function DevicesClient({
  const [selectedDevice, setSelectedDevice] = useState<Display | null>(null);
  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+ const [isBulkDeleteModalOpen, setIsBulkDeleteModalOpen] = useState(false);
  const [isPairingModalOpen, setIsPairingModalOpen] = useState(false);
  const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false);
  const [pairingCode, setPairingCode] = useState('');
@@ -314,12 +315,14 @@ export default function DevicesClient({
 
  const handleBulkDelete = async () => {
  if (selectedDeviceIds.size === 0) return;
+ const displayIds = Array.from(selectedDeviceIds);
  try {
  setActionLoading(true);
- await apiClient.bulkDeleteDisplays(Array.from(selectedDeviceIds));
- toast.success(`Deleted ${selectedDeviceIds.size} device(s)`);
+ const result = await apiClient.bulkDeleteDisplays(displayIds);
+ toast.success(`Deleted ${result.deleted} device(s)`);
  setSelectedDeviceIds(new Set());
- loadDevices();
+ setIsBulkDeleteModalOpen(false);
+ await loadDevices(false);
  } catch (error: any) {
  toast.error(error.message || 'Bulk delete failed');
  } finally {
@@ -329,14 +332,15 @@ export default function DevicesClient({
 
  const handleBulkAssignPlaylist = async () => {
  if (!bulkPlaylistId || selectedDeviceIds.size === 0) return;
+ const displayIds = Array.from(selectedDeviceIds);
  try {
  setActionLoading(true);
- await apiClient.bulkAssignPlaylist(Array.from(selectedDeviceIds), bulkPlaylistId);
- toast.success(`Playlist assigned to ${selectedDeviceIds.size} device(s)`);
+ const result = await apiClient.bulkAssignPlaylist(displayIds, bulkPlaylistId);
+ toast.success(`Playlist assigned to ${result.updated} device(s)`);
  setSelectedDeviceIds(new Set());
  setIsBulkPlaylistModalOpen(false);
  setBulkPlaylistId('');
- loadDevices();
+ await loadDevices(false);
  } catch (error: any) {
  toast.error(error.message || 'Bulk assign failed');
  } finally {
@@ -346,15 +350,16 @@ export default function DevicesClient({
 
  const handleBulkAssignGroup = async () => {
  if (!bulkGroupId || selectedDeviceIds.size === 0) return;
+ const displayIds = Array.from(selectedDeviceIds);
  try {
  setActionLoading(true);
- await apiClient.bulkAssignGroup(Array.from(selectedDeviceIds), bulkGroupId);
- toast.success(`Added ${selectedDeviceIds.size} device(s) to group`);
+ const result = await apiClient.bulkAssignGroup(displayIds, bulkGroupId);
+ toast.success(`Added ${result.added} device(s) to group`);
  setSelectedDeviceIds(new Set());
  setIsBulkGroupModalOpen(false);
  setBulkGroupId('');
- loadDevices();
- loadGroups();
+ await loadDevices(false);
+ await loadGroups();
  } catch (error: any) {
  toast.error(error.message || 'Bulk group assign failed');
  } finally {
@@ -541,7 +546,7 @@ export default function DevicesClient({
  <div className="flex gap-4 items-center">
  <button onClick={() => setIsBulkPlaylistModalOpen(true)} className="eh-btn-neon rounded-xl px-4 py-2 text-sm font-medium">Assign Playlist</button>
  <button onClick={() => setIsBulkGroupModalOpen(true)} className="px-4 py-2 text-sm bg-green-600 text-white rounded-lg hover:bg-green-700 transition font-medium">Add to Group</button>
- <button onClick={handleBulkDelete} disabled={actionLoading} className="px-4 py-2 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 transition font-medium disabled:opacity-50">Delete Selected</button>
+ <button onClick={() => setIsBulkDeleteModalOpen(true)} disabled={actionLoading} className="px-4 py-2 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 transition font-medium disabled:opacity-50">Delete Selected</button>
  <button onClick={() => setSelectedDeviceIds(new Set())} className="px-4 py-2 text-sm text-[var(--foreground-secondary)] hover:text-[var(--foreground)] transition">Clear</button>
  </div>
  </div>
@@ -661,6 +666,16 @@ export default function DevicesClient({
  </Modal>
 
  <ConfirmDialog isOpen={isDeleteModalOpen} onClose={() => setIsDeleteModalOpen(false)} onConfirm={confirmDelete} title="Delete Device" message={`Are you sure you want to delete "${selectedDevice?.nickname}"? This action cannot be undone.`} confirmText="Delete" type="danger" />
+
+ <ConfirmDialog
+ isOpen={isBulkDeleteModalOpen}
+ onClose={() => setIsBulkDeleteModalOpen(false)}
+ onConfirm={handleBulkDelete}
+ title="Delete Selected Devices"
+ message={`Delete ${selectedDeviceIds.size} selected device${selectedDeviceIds.size !== 1 ? 's' : ''}? This action cannot be undone.`}
+ confirmText="Delete Selected"
+ type="danger"
+ />
 
  <Modal isOpen={isBulkPlaylistModalOpen} onClose={() => { setIsBulkPlaylistModalOpen(false); setBulkPlaylistId(''); }} title="Assign Playlist to Selected Devices">
  <div className="space-y-5">

--- a/web/src/components/ConfirmDialog.tsx
+++ b/web/src/components/ConfirmDialog.tsx
@@ -1,11 +1,12 @@
 'use client';
 
+import { useId, useState } from 'react';
 import { Icon } from '@/theme/icons';
 
 interface ConfirmDialogProps {
   isOpen: boolean;
   onClose: () => void;
-  onConfirm: () => void;
+  onConfirm: () => void | Promise<void>;
   title: string;
   message: string;
   confirmText?: string;
@@ -23,7 +24,27 @@ export default function ConfirmDialog({
   cancelText = 'Cancel',
   type = 'danger',
 }: ConfirmDialogProps) {
+  const [isConfirming, setIsConfirming] = useState(false);
+  const titleId = useId();
+  const messageId = useId();
+
   if (!isOpen) return null;
+
+  const handleConfirm = async () => {
+    if (isConfirming) return;
+
+    setIsConfirming(true);
+    try {
+      await onConfirm();
+      setIsConfirming(false);
+      onClose();
+    } catch (error) {
+      if (process.env.NODE_ENV === 'development') {
+        console.error('Confirmation action failed:', error);
+      }
+      setIsConfirming(false);
+    }
+  };
 
   const buttonColors = {
     danger: 'bg-error-600 hover:bg-error-700',
@@ -43,11 +64,19 @@ export default function ConfirmDialog({
         {/* Backdrop */}
         <div
           className="fixed inset-0 bg-black bg-opacity-50 transition-opacity"
-          onClick={onClose}
+          onClick={() => {
+            if (!isConfirming) onClose();
+          }}
         />
 
         {/* Dialog */}
-        <div className="relative bg-[var(--surface)] rounded-lg shadow-xl max-w-md w-full transform transition-all">
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={titleId}
+          aria-describedby={messageId}
+          className="relative bg-[var(--surface)] rounded-lg shadow-xl max-w-md w-full transform transition-all"
+        >
           <div className="p-6">
             <div className="flex items-center gap-4">
               <div className={`flex-shrink-0 ${iconColors[type]}`}>
@@ -56,8 +85,8 @@ export default function ConfirmDialog({
                 {type === 'info' && <Icon name="info" size="2xl" />}
               </div>
               <div className="flex-1">
-                <h3 className="text-lg font-semibold text-[var(--foreground)] mb-2">{title}</h3>
-                <p className="text-sm text-[var(--foreground-secondary)]">{message}</p>
+                <h3 id={titleId} className="text-lg font-semibold text-[var(--foreground)] mb-2">{title}</h3>
+                <p id={messageId} className="text-sm text-[var(--foreground-secondary)]">{message}</p>
               </div>
             </div>
           </div>
@@ -65,16 +94,16 @@ export default function ConfirmDialog({
           <div className="bg-[var(--background)] px-6 py-4 flex justify-end gap-3 rounded-b-lg">
             <button
               onClick={onClose}
+              disabled={isConfirming}
               className="px-4 py-2 text-sm font-medium text-[var(--foreground-secondary)] bg-[var(--surface)] border border-[var(--border)] rounded-md hover:bg-[var(--surface-hover)] transition"
             >
               {cancelText}
             </button>
             <button
-              onClick={() => {
-                onConfirm();
-                onClose();
-              }}
-              className={`px-4 py-2 text-sm font-medium text-white rounded-md transition ${buttonColors[type]}`}
+              onClick={handleConfirm}
+              disabled={isConfirming}
+              aria-busy={isConfirming}
+              className={`px-4 py-2 text-sm font-medium text-white rounded-md transition disabled:cursor-not-allowed disabled:opacity-60 ${buttonColors[type]}`}
             >
               {confirmText}
             </button>

--- a/web/src/components/__tests__/ConfirmDialog.test.tsx
+++ b/web/src/components/__tests__/ConfirmDialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ConfirmDialog from '../ConfirmDialog';
 
 jest.mock('@/theme/icons', () => ({
@@ -36,13 +36,74 @@ describe('ConfirmDialog', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('calls onConfirm and onClose when Confirm button is clicked', () => {
+  it('calls onConfirm and onClose when Confirm button is clicked', async () => {
     const onConfirm = jest.fn();
     const onClose = jest.fn();
     render(<ConfirmDialog {...defaultProps} onConfirm={onConfirm} onClose={onClose} />);
-    fireEvent.click(screen.getByText('Confirm'));
+    await act(async () => {
+      fireEvent.click(screen.getByText('Confirm'));
+    });
     expect(onConfirm).toHaveBeenCalledTimes(1);
-    expect(onClose).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('keeps the dialog open while async confirmation is pending', async () => {
+    let resolveConfirm!: () => void;
+    const onConfirm = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveConfirm = resolve;
+        }),
+    );
+    const onClose = jest.fn();
+
+    render(<ConfirmDialog {...defaultProps} onConfirm={onConfirm} onClose={onClose} />);
+
+    fireEvent.click(screen.getByText('Confirm'));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByText('Confirm')).toBeDisabled();
+
+    await act(async () => {
+      resolveConfirm();
+    });
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('reopens with enabled actions after a successful async confirmation', async () => {
+    const onConfirm = jest.fn().mockResolvedValue(undefined);
+    const onClose = jest.fn();
+    const { rerender } = render(
+      <ConfirmDialog {...defaultProps} onConfirm={onConfirm} onClose={onClose} />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Confirm'));
+    });
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(<ConfirmDialog {...defaultProps} isOpen={false} onConfirm={onConfirm} onClose={onClose} />);
+    rerender(<ConfirmDialog {...defaultProps} onConfirm={onConfirm} onClose={onClose} />);
+
+    expect(screen.getByText('Cancel')).toBeEnabled();
+    expect(screen.getByText('Confirm')).toBeEnabled();
+  });
+
+  it('exposes modal dialog semantics to assistive technology', () => {
+    render(<ConfirmDialog {...defaultProps} />);
+
+    const dialog = screen.getByRole('dialog', { name: 'Delete Item' });
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAccessibleDescription('Are you sure you want to delete this item?');
   });
 
   it('renders custom button text', () => {


### PR DESCRIPTION
## Summary
- keep destructive confirmation dialogs open while async confirms are pending, reset pending state before close/reopen, and add modal ARIA semantics
- require confirmation before device bulk delete
- report backend authoritative counts for device bulk delete, playlist assignment, and group assignment toasts
- record Pass 26 findings and evidence in docs/tasks

## Verification
- pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/components/__tests__/ConfirmDialog.test.tsx
- pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/dashboard/devices/__tests__/devices-page.test.tsx
- pnpm --filter @vizora/web exec tsc --noEmit --pretty false
- pnpm --filter @vizora/web test -- --runInBand
- $env:ESLINT_USE_FLAT_CONFIG='false'; npx eslint --ext .ts,.tsx web/src/components/ConfirmDialog.tsx web/src/components/__tests__/ConfirmDialog.test.tsx web/src/app/dashboard/devices/page-client.tsx web/src/app/dashboard/devices/__tests__/devices-page.test.tsx
- pnpm security:no-hardcoded-jwts
- $env:NODE_OPTIONS='--max-old-space-size=4096'; $env:NEXT_PUBLIC_SOCKET_URL='http://localhost:3002'; $env:NEXT_PUBLIC_API_URL='http://localhost:3000/api/v1'; $env:BACKEND_URL='http://localhost:3000'; npx nx build @vizora/web --skip-nx-cache
- git diff --check

## Review
- destructive-action UX/accessibility reviewer: CLEAN after fixing stuck pending-state regression
- React/runtime reviewer: CLEAN after fixing stuck pending-state regression

## Deployment
- Not deployed by this PR. Production deploy remains gated on prod checkout state verification.