### PR TITLE
Fix playlist assignment trust flow

### DIFF
--- a/docs/plans/2026-06-01-playlist-publish-trust-pass-27.md
+++ b/docs/plans/2026-06-01-playlist-publish-trust-pass-27.md
@@ -1,0 +1,36 @@
+# Playlist Publish Trust Pass 27
+
+**Goal:** Replace the playlist page's misleading publish action with a real device-assignment flow or clearly block when assignment cannot happen.
+
+**New primitives introduced:** none. This pass reuses the existing dashboard playlists page, loaded display list, `apiClient.bulkAssignPlaylist`, middleware display bulk assignment endpoint, and realtime display notification path.
+
+**Hermes-first analysis:** not applicable. This pass does not add or modify business agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
+
+## Problem
+
+The playlist card currently exposes `Publish`, but the handler only calls `updatePlaylist(playlist.id, { name: playlist.name })` and shows `Playlist published successfully`. That does not assign the playlist, schedule it, push content, or change a meaningful publish state. Customers can believe content is live when nothing changed on any display.
+
+## Build Scope
+
+- Replace fake publish behavior with an assignment modal that lets the operator choose target devices.
+- Block assignment with clear messages when the playlist has no items, devices are still loading, device loading failed, or there are no paired devices.
+- Use `bulkAssignPlaylist` and show the backend `{ updated }` count in the success toast.
+- Use assignment copy instead of live-delivery copy, and make non-online targets explicit as updating when they come online.
+- Refresh devices after assignment so card device counts update.
+
+## Files
+
+- Modify `web/src/app/dashboard/playlists/page-client.tsx`: add assignment modal state, target selection, real bulk assignment, and safer button copy.
+- Modify `web/src/app/dashboard/playlists/__tests__/playlists-page.test.tsx`: cover no fake PATCH, modal target selection, backend count toast, non-online copy, device-load guards, in-flight close protection, and empty prerequisites.
+- Modify shared display status types and `DeviceStatusIndicator` so the frontend reflects backend statuses (`online`, `offline`, `pairing`, `error`).
+- Modify `tasks/todo.md`: track Pass 27 plan/evidence.
+
+## Plan
+
+- [x] Add failing playlist tests for fake publish removal and real device assignment.
+- [x] Implement assignment modal and bulk assignment using existing display API method.
+- [x] Run focused playlist tests.
+- [x] Request two review vectors before broader tests: customer trust/UX and runtime/API safety.
+- [x] Run broader web verification.
+- [ ] PR, CI, merge if clean.
+- [ ] Re-check production deploy gate; deploy only if prod checkout is safe.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,73 @@
 # Vizora - Task Tracker
 
+## In Progress: Playlist Publish Trust Pass 27 (2026-06-01)
+
+**Branch:** `feat/playlist-publish-trust-pass-27`
+
+**Why now:** Pass 26 is merged with green post-merge `main` CI, but production
+deploy remains blocked by dirty/diverged prod-local state. The next
+customer-trust blocker from the Pass 26 dashboard review is the playlist card's
+`Publish` action claiming success even though it only PATCHes the playlist name
+and does not put anything on a screen.
+
+**New primitives introduced:** none. This pass reuses the playlists dashboard,
+existing loaded display list, `apiClient.bulkAssignPlaylist`, middleware display
+bulk assignment endpoint, and realtime display notification path.
+
+**Hermes-first analysis:** not applicable. This pass does not add or modify
+business agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
+
+**Plan**
+- [x] Start fresh branch from `origin/main`.
+- [x] Drift-check playlist publish action and existing display assignment path.
+- [x] Write failing tests for fake publish removal and real device assignment.
+- [x] Implement assignment modal and bulk assignment through existing APIs.
+- [x] Run focused playlist tests.
+- [x] Run multi-vector review before broader verification.
+- [x] Run broader verification.
+- [ ] PR, CI, merge.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Plan/design:**
+`docs/plans/2026-06-01-playlist-publish-trust-pass-27.md`
+
+**Local evidence:**
+- TDD red: playlist tests failed because the card's `Publish` action called
+  `updatePlaylist(playlist.id, { name: playlist.name })` immediately, never
+  opened a device-targeting flow, and still claimed publish success when no
+  display assignment happened.
+- Implementation: playlist cards now use `Assign`; the modal selects target
+  devices and calls `apiClient.bulkAssignPlaylist`. It blocks empty playlists,
+  device-list loading, device-list load failure, and zero paired devices. The
+  success toast reports the backend `{ updated }` assignment count and adds
+  non-online device copy instead of implying live delivery. Already-assigned
+  devices render read-only, and close/selection changes are guarded while an
+  assignment is in flight.
+- Status-model follow-up: frontend `DisplayStatus` now matches backend reality
+  (`online | offline | pairing | error`), realtime event/device page types
+  propagate it, and `DeviceStatusIndicator` renders `Pairing` explicitly.
+- Review: customer-trust/UX reviewers initially found over-promising delivery
+  copy, misleading already-assigned checkboxes, false no-device messaging while
+  devices load/fail, in-flight close ambiguity, non-online status gaps, and
+  in-flight selection drift. All were fixed and final UX review was CLEAN.
+  Runtime/API reviewers were CLEAN throughout: assignment uses the existing
+  `bulkAssignPlaylist` API, backend auth/tenant checks remain unchanged, and no
+  parallel realtime/delivery path was added.
+- Verification: focused playlist suite 22/22 pass; focused playlist +
+  realtime-events + status-indicator suites 47/47 pass; status propagation
+  reviewer also ran 4 focused suites / 64 tests pass; web `tsc --noEmit` pass;
+  changed-file ESLint exits 0 with existing warnings only; full web Jest suite
+  96 suites / 1033 tests pass; web production build pass with explicit local
+  API/socket env and memory env; repo JWT secret guard pass; `git diff --check`
+  pass with CRLF warnings only.
+- Browser evidence: local Next production server on port 3001 with browser-
+  mocked `/api/v1` responses opened `/dashboard/playlists`, showed the
+  assignment modal and non-online copy, submitted `{ displayIds: ['display-2'],
+  playlistId: 'playlist-1' }`, displayed the non-online assignment toast, and
+  recorded zero page errors. Scratch screenshots were not committed.
+
+---
+
 ## Completed: Dashboard Bulk-Action Safety Pass 26 (2026-06-01)
 
 **Branch:** `feat/customer-dashboard-pass-26`

--- a/web/src/app/dashboard/devices/page-client.tsx
+++ b/web/src/app/dashboard/devices/page-client.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { apiClient } from '@/lib/api';
 import { fetchAllPaginated } from '@/lib/api/pagination';
-import { Display, PlaylistSummary, DisplayGroup } from '@/lib/types';
+import { Display, PlaylistSummary, DisplayGroup, DisplayStatus } from '@/lib/types';
 import Modal from '@/components/Modal';
 import ConfirmDialog from '@/components/ConfirmDialog';
 import LoadingSpinner from '@/components/LoadingSpinner';
@@ -70,7 +70,7 @@ export default function DevicesClient({
  const hasCompleteInitialPlaylists = initialPlaylistsComplete ?? initialPlaylists.length > 0;
 
  // Memoized callback for device status changes
- const handleDeviceStatusChange = useCallback((update: { deviceId: string; status: 'online' | 'offline'; lastSeen?: string; currentPlaylistId?: string }) => {
+ const handleDeviceStatusChange = useCallback((update: { deviceId: string; status: DisplayStatus; lastSeen?: string; currentPlaylistId?: string }) => {
  setDevices((prev) =>
  prev.map((d) =>
  d.id === update.deviceId

--- a/web/src/app/dashboard/playlists/__tests__/playlists-page.test.tsx
+++ b/web/src/app/dashboard/playlists/__tests__/playlists-page.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 const mockPush = jest.fn();
@@ -22,6 +22,7 @@ jest.mock('@/lib/api', () => ({
     deletePlaylist: jest.fn(),
     updatePlaylist: jest.fn(),
     duplicatePlaylist: jest.fn(),
+    bulkAssignPlaylist: jest.fn(),
   },
 }));
 
@@ -76,8 +77,14 @@ jest.mock('@/components/SearchFilter', () => {
 
 jest.mock('@/components/Modal', () => ({
   __esModule: true,
-  default: ({ isOpen, children, title }: any) =>
-    isOpen ? <div data-testid="modal"><span>{title}</span>{children}</div> : null,
+  default: ({ isOpen, children, title, onClose }: any) =>
+    isOpen ? (
+      <div data-testid="modal">
+        <span>{title}</span>
+        <button onClick={onClose} aria-label="Close modal">Close</button>
+        {children}
+      </div>
+    ) : null,
 }));
 
 jest.mock('@/components/ConfirmDialog', () => ({
@@ -156,12 +163,31 @@ const mockPlaylists = [
   },
 ];
 
+const mockDevices = [
+  {
+    id: 'display-1',
+    nickname: 'Lobby Screen',
+    status: 'online',
+    location: 'Lobby',
+    currentPlaylistId: null,
+  },
+  {
+    id: 'display-2',
+    nickname: 'Cafe Screen',
+    status: 'offline',
+    location: 'Cafe',
+    currentPlaylistId: 'playlist-2',
+  },
+];
+
 describe('PlaylistsClient', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (apiClient.getPlaylists as jest.Mock).mockResolvedValue({ data: mockPlaylists });
     (apiClient.getContent as jest.Mock).mockResolvedValue({ data: [] });
     (apiClient.getDisplays as jest.Mock).mockResolvedValue({ data: [] });
+    (apiClient.updatePlaylist as jest.Mock).mockResolvedValue({});
+    (apiClient.bulkAssignPlaylist as jest.Mock).mockResolvedValue({ updated: 0 });
   });
 
   it('renders playlists heading', async () => {
@@ -211,6 +237,197 @@ describe('PlaylistsClient', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Active')).toBeInTheDocument();
+    });
+  });
+
+  it('opens a device assignment modal instead of fake-updating the playlist name', async () => {
+    (apiClient.getDisplays as jest.Mock).mockResolvedValue({ data: mockDevices });
+
+    render(<PlaylistsClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Morning Promo')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByText('Assign')[0]);
+
+    expect(apiClient.updatePlaylist).not.toHaveBeenCalled();
+    expect(screen.getByTestId('modal')).toHaveTextContent('Assign Morning Promo to Devices');
+    expect(screen.getByLabelText('Lobby Screen')).toBeInTheDocument();
+    expect(screen.getByLabelText('Cafe Screen')).toBeInTheDocument();
+    expect(screen.getByText('Updates when online')).toBeInTheDocument();
+  });
+
+  it('assigns a playlist to selected devices and reports the backend count', async () => {
+    (apiClient.getDisplays as jest.Mock).mockResolvedValue({ data: mockDevices });
+    (apiClient.bulkAssignPlaylist as jest.Mock).mockResolvedValue({ updated: 1 });
+
+    render(<PlaylistsClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Morning Promo')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByText('Assign')[0]);
+    fireEvent.click(screen.getByLabelText('Lobby Screen'));
+    fireEvent.click(screen.getByRole('button', { name: 'Assign to 1 device' }));
+
+    await waitFor(() => {
+      expect(apiClient.bulkAssignPlaylist).toHaveBeenCalledWith(['display-1'], 'playlist-1');
+    });
+    expect(mockToast.success).toHaveBeenCalledWith('Playlist assigned to 1 device');
+    expect(apiClient.updatePlaylist).not.toHaveBeenCalled();
+  });
+
+  it('states non-online assignment correctly instead of promising live delivery', async () => {
+    (apiClient.getDisplays as jest.Mock).mockResolvedValue({
+      data: [{ ...mockDevices[1], status: 'pairing' }],
+    });
+    (apiClient.bulkAssignPlaylist as jest.Mock).mockResolvedValue({ updated: 1 });
+
+    render(<PlaylistsClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Morning Promo')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByText('Assign')[0]);
+    expect(screen.getByText('Updates when online')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Cafe Screen'));
+    fireEvent.click(screen.getByRole('button', { name: 'Assign to 1 device' }));
+
+    await waitFor(() => {
+      expect(apiClient.bulkAssignPlaylist).toHaveBeenCalledWith(['display-2'], 'playlist-1');
+    });
+    expect(mockToast.success).toHaveBeenCalledWith(
+      'Playlist assigned to 1 device. Non-online devices will update when they come online.',
+    );
+  });
+
+  it('shows already assigned devices as read-only instead of unpublish targets', async () => {
+    (apiClient.getDisplays as jest.Mock).mockResolvedValue({
+      data: [{ ...mockDevices[0], currentPlaylistId: 'playlist-1' }],
+    });
+
+    render(<PlaylistsClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Morning Promo')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByText('Assign')[0]);
+
+    expect(screen.getByText('Already assigned')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Lobby Screen')).not.toBeInTheDocument();
+    expect(screen.getByText('Lobby Screen')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Assign to 0 devices' })).toBeDisabled();
+    expect(apiClient.bulkAssignPlaylist).not.toHaveBeenCalled();
+  });
+
+  it('blocks assigning an empty playlist before opening the device modal', async () => {
+    (apiClient.getDisplays as jest.Mock).mockResolvedValue({ data: mockDevices });
+
+    render(<PlaylistsClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Evening Loop')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByText('Assign')[1]);
+
+    expect(mockToast.warning).toHaveBeenCalledWith('Add content to this playlist before assigning it');
+    expect(apiClient.bulkAssignPlaylist).not.toHaveBeenCalled();
+    expect(apiClient.updatePlaylist).not.toHaveBeenCalled();
+  });
+
+  it('blocks assignment when there are no paired devices', async () => {
+    render(<PlaylistsClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Morning Promo')).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(apiClient.getDisplays).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getAllByText('Assign')[0]);
+
+    expect(mockToast.warning).toHaveBeenCalledWith('Pair a device before assigning playlists to screens');
+    expect(apiClient.bulkAssignPlaylist).not.toHaveBeenCalled();
+    expect(apiClient.updatePlaylist).not.toHaveBeenCalled();
+  });
+
+  it('defers assignment while the device list is still loading', async () => {
+    (apiClient.getDisplays as jest.Mock).mockImplementation(() => new Promise(() => {}));
+
+    render(<PlaylistsClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Morning Promo')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByText('Assign')[0]);
+
+    expect(mockToast.info).toHaveBeenCalledWith('Devices are still loading. Try again in a moment.');
+    expect(apiClient.bulkAssignPlaylist).not.toHaveBeenCalled();
+  });
+
+  it('blocks assignment after device list load failure', async () => {
+    (apiClient.getDisplays as jest.Mock).mockRejectedValue(new Error('failed'));
+
+    render(<PlaylistsClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Morning Promo')).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith('Failed to load devices');
+    });
+
+    mockToast.error.mockClear();
+    fireEvent.click(screen.getAllByText('Assign')[0]);
+
+    expect(mockToast.error).toHaveBeenCalledWith(
+      'Device list failed to load. Refresh the page before assigning playlists.',
+    );
+    expect(apiClient.bulkAssignPlaylist).not.toHaveBeenCalled();
+  });
+
+  it('keeps the assignment modal open if close is requested during an in-flight assignment', async () => {
+    (apiClient.getDisplays as jest.Mock).mockResolvedValue({ data: mockDevices });
+    let resolveAssignment: (value: { updated: number }) => void = () => {};
+    (apiClient.bulkAssignPlaylist as jest.Mock).mockImplementation(
+      () => new Promise((resolve) => {
+        resolveAssignment = resolve;
+      }),
+    );
+
+    render(<PlaylistsClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Morning Promo')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByText('Assign')[0]);
+    fireEvent.click(screen.getByLabelText('Lobby Screen'));
+    fireEvent.click(screen.getByRole('button', { name: 'Assign to 1 device' }));
+    await waitFor(() => {
+      expect(screen.getByLabelText('Cafe Screen')).toBeDisabled();
+    });
+    fireEvent.click(screen.getByLabelText('Cafe Screen'));
+    expect(screen.getByRole('button', { name: /Assign to 1 device/ })).toBeDisabled();
+    fireEvent.click(screen.getByLabelText('Close modal'));
+
+    expect(screen.getByTestId('modal')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveAssignment({ updated: 1 });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('modal')).not.toBeInTheDocument();
     });
   });
 

--- a/web/src/app/dashboard/playlists/page-client.tsx
+++ b/web/src/app/dashboard/playlists/page-client.tsx
@@ -110,6 +110,8 @@ export default function PlaylistsClient() {
  const [playlists, setPlaylists] = useState<PlaylistSummary[]>([]);
  const [content, setContent] = useState<Content[]>([]);
  const [devices, setDevices] = useState<Display[]>([]);
+ const [devicesLoading, setDevicesLoading] = useState(true);
+ const [devicesLoadFailed, setDevicesLoadFailed] = useState(false);
  const [loading, setLoading] = useState(true);
  const [selectedPlaylist, setSelectedPlaylist] = useState<PlaylistSummary | null>(null);
  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
@@ -117,6 +119,8 @@ export default function PlaylistsClient() {
  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
  const [playlistThumbnails, setPlaylistThumbnails] = useState<Record<string, string[]>>({});
  const [isBuilderModalOpen, setIsBuilderModalOpen] = useState(false);
+ const [publishPlaylist, setPublishPlaylist] = useState<PlaylistSummary | null>(null);
+ const [selectedPublishDeviceIds, setSelectedPublishDeviceIds] = useState<Set<string>>(new Set());
  const [createForm, setCreateForm] = useState({ name: '', description: '' });
  const [actionLoading, setActionLoading] = useState(false);
  const [searchQuery, setSearchQuery] = useState('');
@@ -217,10 +221,16 @@ export default function PlaylistsClient() {
 
  const loadDevices = async () => {
  try {
+ setDevicesLoading(true);
+ setDevicesLoadFailed(false);
  const devicesList = await fetchAllPaginated((params) => apiClient.getDisplays(params));
  setDevices(devicesList);
  } catch (error) {
+ setDevices([]);
+ setDevicesLoadFailed(true);
  toast.error('Failed to load devices');
+ } finally {
+ setDevicesLoading(false);
  }
  };
 
@@ -295,13 +305,76 @@ export default function PlaylistsClient() {
  }
  };
 
- const handlePublish = async (playlist: PlaylistSummary) => {
+ const handlePublish = (playlist: PlaylistSummary) => {
+ if (!playlist.items || playlist.items.length === 0) {
+ toast.warning('Add content to this playlist before assigning it');
+ return;
+ }
+
+ if (devicesLoading) {
+ toast.info('Devices are still loading. Try again in a moment.');
+ return;
+ }
+
+ if (devicesLoadFailed) {
+ toast.error('Device list failed to load. Refresh the page before assigning playlists.');
+ return;
+ }
+
+ if (devices.length === 0) {
+ toast.warning('Pair a device before assigning playlists to screens');
+ return;
+ }
+
+ setPublishPlaylist(playlist);
+ setSelectedPublishDeviceIds(new Set());
+ };
+
+ const closePublishModal = () => {
+ setPublishPlaylist(null);
+ setSelectedPublishDeviceIds(new Set());
+ };
+
+ const requestClosePublishModal = () => {
+ if (actionLoading) return;
+ closePublishModal();
+ };
+
+ const togglePublishDevice = (deviceId: string) => {
+ if (actionLoading) return;
+
+ setSelectedPublishDeviceIds((current) => {
+ const next = new Set(current);
+ if (next.has(deviceId)) {
+ next.delete(deviceId);
+ } else {
+ next.add(deviceId);
+ }
+ return next;
+ });
+ };
+
+ const confirmPublish = async () => {
+ if (!publishPlaylist || selectedPublishDeviceIds.size === 0) return;
+
  try {
- await apiClient.updatePlaylist(playlist.id, { name: playlist.name });
- toast.success('Playlist published successfully');
- loadPlaylists();
+ setActionLoading(true);
+ const selectedDeviceIds = Array.from(selectedPublishDeviceIds);
+ const selectedDelayedCount = devices.filter(
+ (device) => selectedPublishDeviceIds.has(device.id) && device.status !== 'online',
+ ).length;
+ const result = await apiClient.bulkAssignPlaylist(selectedDeviceIds, publishPlaylist.id);
+ const delayedSuffix = selectedDelayedCount > 0
+ ? '. Non-online devices will update when they come online.'
+ : '';
+ toast.success(`Playlist assigned to ${formatDeviceCount(result.updated)}${delayedSuffix}`);
+ closePublishModal();
+ await loadDevices();
+ await loadPlaylists();
  } catch (error: any) {
- toast.error(error.message || 'Failed to publish playlist');
+ toast.error(error.message || 'Failed to assign playlist to devices');
+ } finally {
+ setActionLoading(false);
  }
  };
 
@@ -322,6 +395,8 @@ export default function PlaylistsClient() {
  const seconds = total % 60;
  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
  };
+
+ const formatDeviceCount = (count: number) => `${count} ${count === 1 ? 'device' : 'devices'}`;
 
  const handleDragEnd = async (event: DragEndEvent) => {
  const { active, over } = event;
@@ -521,7 +596,7 @@ export default function PlaylistsClient() {
  className="flex-1 px-4 py-2 text-sm bg-green-500/10 text-green-600 dark:text-green-400 rounded-lg hover:bg-green-500/20 transition font-medium flex items-center justify-center gap-1"
  >
  <Icon name="power" size="sm" className="text-green-600 dark:text-green-400" />
- Publish
+ Assign
  </button>
  <button
  onClick={async () => {
@@ -725,6 +800,133 @@ export default function PlaylistsClient() {
  className="eh-btn-neon rounded-xl px-6 py-2 text-sm font-medium transition"
  >
  Done
+ </button>
+ </div>
+ </div>
+ </Modal>
+
+ {/* Assign Modal */}
+ <Modal
+ isOpen={!!publishPlaylist}
+ onClose={requestClosePublishModal}
+ title={`Assign ${publishPlaylist?.name || 'Playlist'} to Devices`}
+ size="lg"
+ >
+ <div className="space-y-5" aria-busy={actionLoading}>
+ <div>
+ <p className="text-sm text-[var(--foreground-secondary)]">
+ Select paired devices to assign this playlist to now.
+ </p>
+ <p className="mt-1 text-xs text-[var(--foreground-tertiary)]">
+ {formatDeviceCount(selectedPublishDeviceIds.size)} selected
+ </p>
+ </div>
+
+ <div className="space-y-2 max-h-80 overflow-y-auto">
+ {devices.map((device) => {
+ const deviceLabel = device.nickname || device.deviceId || 'Unnamed device';
+ const isCurrentlyAssigned = publishPlaylist?.id === device.currentPlaylistId;
+ const isSelected = selectedPublishDeviceIds.has(device.id);
+ const isChecked = isCurrentlyAssigned || isSelected;
+ const isNonOnline = device.status !== 'online';
+
+ if (isCurrentlyAssigned) {
+ return (
+ <div
+ key={device.id}
+ className="flex items-start gap-3 rounded-lg border border-[#00E5A0] bg-[#00E5A0]/10 p-4"
+ >
+ <Icon name="check" size="sm" className="mt-1 text-[#00E5A0]" />
+ <span className="flex-1 min-w-0">
+ <span className="flex flex-wrap items-center gap-2">
+ <span className="font-medium text-[var(--foreground)]">{deviceLabel}</span>
+ <span className={`px-2 py-0.5 text-xs font-medium rounded-full ${
+ device.status === 'online'
+ ? 'bg-green-500/10 text-green-600 dark:text-green-400'
+ : 'bg-[var(--surface)] text-[var(--foreground-tertiary)]'
+ }`}>
+ {device.status}
+ </span>
+ <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-[#00E5A0]/10 text-[#00E5A0]">
+ Already assigned
+ </span>
+ {isNonOnline && (
+ <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-amber-500/10 text-amber-700 dark:text-amber-300">
+ Updates when online
+ </span>
+ )}
+ </span>
+ {device.location && (
+ <span className="mt-1 block text-xs text-[var(--foreground-tertiary)] truncate">
+ {device.location}
+ </span>
+ )}
+ </span>
+ </div>
+ );
+ }
+
+ return (
+ <label
+ key={device.id}
+ className={`flex items-start gap-3 rounded-lg border p-4 transition ${
+ actionLoading ? 'cursor-not-allowed opacity-75' : 'cursor-pointer'
+ } ${
+ isChecked
+ ? 'border-[#00E5A0] bg-[#00E5A0]/10'
+ : 'border-[var(--border)] bg-[var(--background)] hover:bg-[var(--surface-hover)]'
+ }`}
+ >
+ <input
+ type="checkbox"
+ aria-label={deviceLabel}
+ checked={isChecked}
+ disabled={actionLoading}
+ onChange={() => togglePublishDevice(device.id)}
+ className="mt-1 h-4 w-4 rounded border-[var(--border)] text-[#00E5A0] focus:ring-[#00E5A0]"
+ />
+ <span className="flex-1 min-w-0">
+ <span className="flex flex-wrap items-center gap-2">
+ <span className="font-medium text-[var(--foreground)]">{deviceLabel}</span>
+ <span className={`px-2 py-0.5 text-xs font-medium rounded-full ${
+ device.status === 'online'
+ ? 'bg-green-500/10 text-green-600 dark:text-green-400'
+ : 'bg-[var(--surface)] text-[var(--foreground-tertiary)]'
+ }`}>
+ {device.status}
+ </span>
+ {isNonOnline && (
+ <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-amber-500/10 text-amber-700 dark:text-amber-300">
+ Updates when online
+ </span>
+ )}
+ </span>
+ {device.location && (
+ <span className="mt-1 block text-xs text-[var(--foreground-tertiary)] truncate">
+ {device.location}
+ </span>
+ )}
+ </span>
+ </label>
+ );
+ })}
+ </div>
+
+ <div className="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
+ <button
+ onClick={requestClosePublishModal}
+ className="px-4 py-2 text-sm font-medium text-[var(--foreground-secondary)] bg-[var(--surface)] border border-[var(--border)] rounded-lg hover:bg-[var(--surface-hover)] transition"
+ disabled={actionLoading}
+ >
+ Cancel
+ </button>
+ <button
+ onClick={confirmPublish}
+ className="eh-btn-neon rounded-xl px-4 py-2 text-sm font-medium transition disabled:opacity-50 flex items-center gap-2"
+ disabled={actionLoading || selectedPublishDeviceIds.size === 0}
+ >
+ {actionLoading && <LoadingSpinner size="sm" />}
+ Assign to {formatDeviceCount(selectedPublishDeviceIds.size)}
  </button>
  </div>
  </div>

--- a/web/src/components/DeviceStatusIndicator.tsx
+++ b/web/src/components/DeviceStatusIndicator.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from 'react';
 import { useDeviceStatus, DeviceStatus } from '@/lib/context/DeviceStatusContext';
-import { Icon } from '@/theme/icons';
 
 interface DeviceStatusIndicatorProps {
   deviceId: string;
@@ -32,6 +31,13 @@ const statusConfig = {
     dotColor: 'bg-yellow-500',
     label: 'Idle',
     icon: 'pause',
+  },
+  pairing: {
+    color: 'text-blue-600 dark:text-blue-400',
+    bgColor: 'bg-blue-100 dark:bg-blue-900',
+    dotColor: 'bg-blue-500',
+    label: 'Pairing',
+    icon: 'clock',
   },
   error: {
     color: 'text-orange-600 dark:text-orange-400',
@@ -72,8 +78,6 @@ export default function DeviceStatusIndicator({
     }
 
     return unsubscribe;
-    // Only depend on deviceId - subscribeToDevice and getDeviceStatus are stable from context
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [deviceId]);
 
   const config = statusConfig[status] || statusConfig.offline;

--- a/web/src/components/__tests__/DeviceStatusIndicator.test.tsx
+++ b/web/src/components/__tests__/DeviceStatusIndicator.test.tsx
@@ -45,6 +45,12 @@ describe('DeviceStatusIndicator', () => {
     expect(screen.getByText('Online')).toBeInTheDocument();
   });
 
+  it('shows pairing status from context', () => {
+    mockGetDeviceStatus.mockReturnValue({ status: 'pairing', timestamp: Date.now() });
+    render(<DeviceStatusIndicator deviceId="device-1" />);
+    expect(screen.getByText('Pairing')).toBeInTheDocument();
+  });
+
   it('hides label when showLabel is false', () => {
     render(<DeviceStatusIndicator deviceId="device-1" showLabel={false} />);
     expect(screen.queryByText('Offline')).not.toBeInTheDocument();

--- a/web/src/lib/context/DeviceStatusContext.tsx
+++ b/web/src/lib/context/DeviceStatusContext.tsx
@@ -4,8 +4,9 @@ import React, { createContext, useContext, useEffect, useRef, useState, useCallb
 import { useSocket } from '@/lib/hooks/useSocket';
 import { apiClient } from '@/lib/api';
 import { fetchAllPaginated } from '@/lib/api/pagination';
+import type { DisplayStatus } from '@/lib/types';
 
-export type DeviceStatus = 'online' | 'offline' | 'idle' | 'error';
+export type DeviceStatus = DisplayStatus | 'idle';
 
 export interface DeviceStatusUpdate {
   deviceId: string;

--- a/web/src/lib/hooks/useRealtimeEvents.ts
+++ b/web/src/lib/hooks/useRealtimeEvents.ts
@@ -4,12 +4,12 @@
 import { useEffect, useCallback, useRef, useState } from 'react';
 import { useSocket } from './useSocket';
 import { devLog, devWarn } from '@/lib/logger';
-import type { Playlist } from '../types';
+import type { DisplayStatus, Playlist } from '../types';
 
 // Event types
 export type DeviceStatusUpdate = {
   deviceId: string;
-  status: 'online' | 'offline';
+  status: DisplayStatus;
   lastSeen: string;
   currentPlaylistId?: string;
 };

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,13 +1,14 @@
 // Type definitions for Vizora
 
 export type DisplayOrientation = 'landscape' | 'portrait' | 'landscape_flipped' | 'portrait_flipped';
+export type DisplayStatus = 'online' | 'offline' | 'pairing' | 'error';
 
 export interface Display {
   id: string;
   nickname: string;
   deviceId: string;
   location?: string;
-  status: 'online' | 'offline';
+  status: DisplayStatus;
   lastSeen?: Date | string;
   lastHeartbeat?: Date | string;
   currentPlaylistId?: string;


### PR DESCRIPTION
﻿## Summary
- replace the misleading playlist card `Publish` action with explicit device assignment through existing `bulkAssignPlaylist`
- block assignment when playlist/device prerequisites are not ready, and avoid claiming live delivery for non-online devices
- align frontend display status typing with backend-supported `online | offline | pairing | error` and render `Pairing` in the shared status indicator

## Review
- Customer-trust/UX reviewers found and re-reviewed: delivery over-promise, already-assigned read-only state, device load/failure guards, in-flight close/selection guards, and non-online status copy. Final review: CLEAN.
- Runtime/API reviewers found no architecture drift: existing bulk assignment API only, backend auth/tenant boundaries unchanged, no parallel realtime/delivery path. Final review: CLEAN.
- Status propagation reviewer: CLEAN after type-check follow-up.

## Verification
- `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/dashboard/playlists/__tests__/playlists-page.test.tsx`
- `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/components/__tests__/DeviceStatusIndicator.test.tsx src/app/dashboard/playlists/__tests__/playlists-page.test.tsx src/lib/hooks/__tests__/useRealtimeEvents.test.ts`
- `pnpm --filter @vizora/web exec tsc --noEmit --pretty false`
- Changed-file ESLint: exits 0 with existing warnings only
- `pnpm --filter @vizora/web test -- --runInBand` (96 suites / 1033 tests pass; existing unrelated React act warnings remain)
- `pnpm security:no-hardcoded-jwts`
- `git diff --check` (CRLF notices only)
- `npx nx build @vizora/web --skip-nx-cache` with local API/socket env and `NODE_OPTIONS=--max-old-space-size=4096`
- Browser sanity: local Next production server on port 3001 with mocked `/api/v1` responses opened `/dashboard/playlists`, showed assignment modal/non-online copy, submitted `{ displayIds: ['display-2'], playlistId: 'playlist-1' }`, showed assignment toast, and recorded zero page errors.

## Deployment
- Not deployed by this PR. Production deploy remains gated until the dirty/diverged prod checkout is reconciled.
