### PR TITLE
Record Pass 27 handoff

### DIFF
--- a/docs/plans/2026-06-01-playlist-publish-trust-pass-27.md
+++ b/docs/plans/2026-06-01-playlist-publish-trust-pass-27.md
@@ -32,5 +32,12 @@ The playlist card currently exposes `Publish`, but the handler only calls `updat
 - [x] Run focused playlist tests.
 - [x] Request two review vectors before broader tests: customer trust/UX and runtime/API safety.
 - [x] Run broader web verification.
-- [ ] PR, CI, merge if clean.
-- [ ] Re-check production deploy gate; deploy only if prod checkout is safe.
+- [x] PR, CI, merge if clean.
+- [x] Re-check production deploy gate; deploy only if prod checkout is safe.
+
+## Result
+
+PR #154 merged as `cd1e7681d86f29ce89f0c7fe4d8828d477d81268` with audit,
+build, lint, security, test, and e2e checks green. Deployment was not performed:
+the production checkout is dirty/diverged and must be reconciled before any
+deploy.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,8 +1,8 @@
 # Vizora - Task Tracker
 
-## In Progress: Playlist Publish Trust Pass 27 (2026-06-01)
+## Completed: Playlist Publish Trust Pass 27 (2026-06-01)
 
-**Branch:** `feat/playlist-publish-trust-pass-27`
+**Branch:** `feat/playlist-publish-trust-pass-27` -> PR #154 -> `main`
 
 **Why now:** Pass 26 is merged with green post-merge `main` CI, but production
 deploy remains blocked by dirty/diverged prod-local state. The next
@@ -25,8 +25,8 @@ business agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
 - [x] Run focused playlist tests.
 - [x] Run multi-vector review before broader verification.
 - [x] Run broader verification.
-- [ ] PR, CI, merge.
-- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+- [x] PR, CI, merge.
+- [x] Re-check deployment gate; deploy only if prod checkout is safe.
 
 **Plan/design:**
 `docs/plans/2026-06-01-playlist-publish-trust-pass-27.md`
@@ -65,6 +65,17 @@ business agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
   assignment modal and non-online copy, submitted `{ displayIds: ['display-2'],
   playlistId: 'playlist-1' }`, displayed the non-online assignment toast, and
   recorded zero page errors. Scratch screenshots were not committed.
+- PR #154 merged as `cd1e7681d86f29ce89f0c7fe4d8828d477d81268`. PR CI passed
+  audit, build, lint, security, test, and e2e. Remote feature branch was deleted
+  manually because `gh pr merge` merged remotely but could not check out local
+  `main` while `C:/projects/vizora` had `main` checked out.
+- Deployment was not performed. Read-only prod gate still blocks deploy:
+  `/opt/vizora/app` is on `bb76aa1838740bff5b58623dfef7a906d44f46a6`,
+  its local `origin/main` is stale at `84e572f2ee0c86230ef42b0817266a1a8a1f2e43`,
+  and the checkout remains 17 commits ahead / 96 behind that stale ref with many
+  tracked and untracked local changes. Core prod probes remain up: middleware
+  200, web 200; realtime `/health` returns the known 404. Many ops/agent PM2
+  jobs remain stopped; no services were restarted.
 
 ---
 


### PR DESCRIPTION
﻿## Summary
- mark Pass 27 complete in `tasks/todo.md`
- record PR #154 merge SHA, CI result, browser/local verification, and deployment gate
- update the Pass 27 plan result section

## Verification
- `git diff --check` (CRLF notices only)

## Deployment
- Not deployed. Read-only prod gate still blocks deploy because `/opt/vizora/app` is dirty/diverged from current `main`.
