### PR TITLE
feat(content): use tenant tags for content filters

### DIFF
--- a/docs/plans/2026-06-01-content-tag-filter-trust-pass-28.md
+++ b/docs/plans/2026-06-01-content-tag-filter-trust-pass-28.md
@@ -1,0 +1,38 @@
+# Content Tag Filter Trust Pass 28
+
+**Branch:** `feat/customer-readiness-pass-28`
+
+**Goal:** Replace hardcoded content-library tag filter choices with real tenant-scoped content tags so customers do not filter by fake categories.
+
+**New primitives introduced:** one content-module read endpoint, `GET /api/v1/content/tags`, one web API client method, and a `tagIds` content-list query filter. No new database model, migration, process, queue, realtime path, MCP tool, Hermes skill, provider spend path, or deployment primitive.
+
+**Hermes-first analysis:** not applicable. This pass does not add or modify business agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
+
+## Current Evidence
+
+- `web/src/app/dashboard/content/page-client.tsx` initializes tag filters to hardcoded `Marketing`, `Seasonal`, `Featured`, and `Archive`.
+- Middleware already has real tenant-scoped tags via `Tag` and `ContentTag`, and content list filtering already accepts legacy `tagNames`.
+- There is no current tag-list endpoint for the dashboard, so the UI cannot populate real filter options.
+- Review found that serializing selected tag names breaks valid comma-bearing tag names, so the dashboard must filter by tag id while leaving `tagNames` available for legacy callers.
+
+## Plan
+
+- [x] Add failing middleware tests for `ContentService.listContentTags()` and `GET /content/tags`.
+- [x] Add failing web tests proving the content page fetches real tags, does not render hardcoded tags, and filters by `tagIds`.
+- [x] Implement a tenant-scoped content tag list using the existing Prisma `Tag`/`ContentTag` relations.
+- [x] Add `apiClient.getContentTags()` and replace hardcoded content-page tag state with fetched real tags.
+- [x] Hide or message the tag filter panel when no content tags exist.
+- [x] Run multi-vector review before broad tests.
+- [x] Run focused middleware/web tests, type checks, lint, and builds.
+- [ ] PR, wait for CI, merge if green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+## Test Plan
+
+- `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/content/content.service.spec.ts src/modules/content/content.controller.spec.ts src/modules/content/dto/content-query.dto.spec.ts src/modules/folders/folders.controller.spec.ts`
+- `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/dashboard/content/__tests__/content-page.test.tsx src/lib/api/__tests__/content.test.ts`
+- `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
+- `pnpm --filter @vizora/web exec tsc --noEmit --pretty false`
+- Changed-file ESLint and production builds for affected services.
+- `pnpm --filter @vizora/web test -- --runInBand`
+- `pnpm --filter @vizora/middleware test -- --runInBand`

--- a/middleware/src/modules/content/content-list-query.ts
+++ b/middleware/src/modules/content/content-list-query.ts
@@ -36,6 +36,7 @@ export interface ContentListFilters {
   search?: string;
   dateRange?: ContentDateRange;
   tagNames?: string[];
+  tagIds?: string[];
   folderId?: string;
 }
 
@@ -56,6 +57,15 @@ function normalizeTagNames(tagNames: string[] | undefined): string[] {
   return Array.from(new Set(
     tagNames
       .map((tagName) => tagName.trim())
+      .filter(Boolean),
+  ));
+}
+
+function normalizeTagIds(tagIds: string[] | undefined): string[] {
+  if (!tagIds) return [];
+  return Array.from(new Set(
+    tagIds
+      .map((tagId) => tagId.trim())
       .filter(Boolean),
   ));
 }
@@ -120,6 +130,20 @@ export function buildContentListWhere(
           },
         },
       ]),
+    });
+  }
+
+  const tagIds = normalizeTagIds(filters.tagIds);
+  if (tagIds.length > 0) {
+    andFilters.push({
+      tags: {
+        some: {
+          tag: {
+            organizationId,
+            id: { in: tagIds },
+          },
+        },
+      },
     });
   }
 

--- a/middleware/src/modules/content/content.controller.spec.ts
+++ b/middleware/src/modules/content/content.controller.spec.ts
@@ -34,6 +34,7 @@ describe('ContentController', () => {
     mockContentService = {
       create: jest.fn(),
       findAll: jest.fn(),
+      listContentTags: jest.fn(),
       findOne: jest.fn(),
       update: jest.fn(),
       archive: jest.fn(),
@@ -466,6 +467,7 @@ describe('ContentController', () => {
         search: 'menu',
         dateRange: '7days',
         tagNames: ['Marketing', 'Seasonal'],
+        tagIds: ['tag-menu', 'tag-seasonal'],
       } as any);
 
       expect(mockContentService.findAll).toHaveBeenCalledWith(
@@ -478,8 +480,23 @@ describe('ContentController', () => {
           search: 'menu',
           dateRange: '7days',
           tagNames: ['Marketing', 'Seasonal'],
+          tagIds: ['tag-menu', 'tag-seasonal'],
         },
       );
+    });
+  });
+
+  describe('listContentTags', () => {
+    it('should return tenant-scoped content tags for filters', async () => {
+      const expectedTags = [
+        { id: 'tag-menu', name: 'Menu', color: 'green', contentCount: 3 },
+      ];
+      mockContentService.listContentTags.mockResolvedValue(expectedTags as any);
+
+      const result = await controller.listContentTags(organizationId);
+
+      expect(result).toEqual(expectedTags);
+      expect(mockContentService.listContentTags).toHaveBeenCalledWith(organizationId);
     });
   });
 

--- a/middleware/src/modules/content/content.controller.ts
+++ b/middleware/src/modules/content/content.controller.ts
@@ -369,7 +369,7 @@ export class ContentController {
     @CurrentUser('organizationId') organizationId: string,
     @Query() query: ContentQueryDto,
   ) {
-    const { type, status, templateOrientation, search, dateRange, tagNames, ...pagination } = query;
+    const { type, status, templateOrientation, search, dateRange, tagNames, tagIds, ...pagination } = query;
     return this.contentService.findAll(organizationId, pagination, {
       type,
       status,
@@ -377,7 +377,13 @@ export class ContentController {
       search,
       dateRange,
       tagNames,
+      tagIds,
     });
+  }
+
+  @Get('tags')
+  listContentTags(@CurrentUser('organizationId') organizationId: string) {
+    return this.contentService.listContentTags(organizationId);
   }
 
   @Get(':id')

--- a/middleware/src/modules/content/content.service.spec.ts
+++ b/middleware/src/modules/content/content.service.spec.ts
@@ -83,6 +83,7 @@ describe('ContentService', () => {
       },
       tag: {
         count: jest.fn(),
+        findMany: jest.fn(),
       },
       contentTag: {
         createMany: jest.fn(),
@@ -304,6 +305,35 @@ describe('ContentService', () => {
         jest.useRealTimers();
       }
     });
+
+    it('should filter by tenant-scoped tag ids', async () => {
+      mockDatabaseService.content.findMany.mockResolvedValue([]);
+      mockDatabaseService.content.count.mockResolvedValue(0);
+
+      await service.findAll('org-123', { page: 1, limit: 10 }, {
+        tagIds: ['tag-menu', 'tag-lunch,dinner'],
+      } as any);
+
+      expect(mockDatabaseService.content.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            organizationId: 'org-123',
+            AND: expect.arrayContaining([
+              {
+                tags: {
+                  some: {
+                    tag: {
+                      organizationId: 'org-123',
+                      id: { in: ['tag-menu', 'tag-lunch,dinner'] },
+                    },
+                  },
+                },
+              },
+            ]),
+          }),
+        }),
+      );
+    });
   });
 
   describe('findOne', () => {
@@ -444,6 +474,63 @@ describe('ContentService', () => {
         }),
       );
       expect(zones[1].content).toBeUndefined();
+    });
+  });
+
+  describe('listContentTags', () => {
+    it('should return tenant-scoped content tags with tenant-scoped usage counts', async () => {
+      mockDatabaseService.tag.findMany.mockResolvedValue([
+        {
+          id: 'tag-menu',
+          name: 'Menu',
+          color: 'green',
+          _count: { content: 2 },
+        },
+        {
+          id: 'tag-promo',
+          name: 'Promo',
+          color: null,
+          _count: { content: 1 },
+        },
+      ]);
+
+      const result = await service.listContentTags('org-123');
+
+      expect(mockDatabaseService.tag.findMany).toHaveBeenCalledWith({
+        where: {
+          organizationId: 'org-123',
+          content: {
+            some: {
+              content: {
+                organizationId: 'org-123',
+              },
+            },
+          },
+        },
+        select: {
+          id: true,
+          name: true,
+          color: true,
+          _count: {
+            select: {
+              content: {
+                where: {
+                  content: {
+                    organizationId: 'org-123',
+                  },
+                },
+              },
+            },
+          },
+        },
+        orderBy: {
+          name: 'asc',
+        },
+      });
+      expect(result).toEqual([
+        { id: 'tag-menu', name: 'Menu', color: 'green', contentCount: 2 },
+        { id: 'tag-promo', name: 'Promo', color: null, contentCount: 1 },
+      ]);
     });
   });
 

--- a/middleware/src/modules/content/content.service.ts
+++ b/middleware/src/modules/content/content.service.ts
@@ -123,6 +123,47 @@ export class ContentService {
     return new PaginatedResponse(mappedData, total, page, limit);
   }
 
+  async listContentTags(organizationId: string) {
+    const tags = await this.db.tag.findMany({
+      where: {
+        organizationId,
+        content: {
+          some: {
+            content: {
+              organizationId,
+            },
+          },
+        },
+      },
+      select: {
+        id: true,
+        name: true,
+        color: true,
+        _count: {
+          select: {
+            content: {
+              where: {
+                content: {
+                  organizationId,
+                },
+              },
+            },
+          },
+        },
+      },
+      orderBy: {
+        name: 'asc',
+      },
+    });
+
+    return tags.map((tag) => ({
+      id: tag.id,
+      name: tag.name,
+      color: tag.color,
+      contentCount: tag._count.content,
+    }));
+  }
+
   /**
    * Find all widgets (content with type 'template' and metadata.isWidget = true)
    */

--- a/middleware/src/modules/content/dto/content-query.dto.spec.ts
+++ b/middleware/src/modules/content/dto/content-query.dto.spec.ts
@@ -82,4 +82,25 @@ describe('ContentQueryDto', () => {
 
     expect(errors.some((error) => error.property === 'tagNames')).toBe(true);
   });
+
+  it('normalizes repeated tag ids without splitting comma-bearing values', async () => {
+    const dto = plainToInstance(ContentQueryDto, {
+      tagIds: ['tag-menu', 'tag-lunch,dinner', ' '],
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors).toEqual([]);
+    expect(dto.tagIds).toEqual(['tag-menu', 'tag-lunch,dinner']);
+  });
+
+  it('rejects too many tag ids', async () => {
+    const dto = plainToInstance(ContentQueryDto, {
+      tagIds: Array.from({ length: 21 }, (_, index) => `tag-${index}`),
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors.some((error) => error.property === 'tagIds')).toBe(true);
+  });
 });

--- a/middleware/src/modules/content/dto/content-query.dto.ts
+++ b/middleware/src/modules/content/dto/content-query.dto.ts
@@ -24,6 +24,15 @@ const normalizeTagNames = ({ value }: { value: unknown }) => {
   return normalized.length > 0 ? normalized : undefined;
 };
 
+const normalizeRepeatedStrings = ({ value }: { value: unknown }) => {
+  if (value === undefined || value === null) return undefined;
+  const raw = Array.isArray(value) ? value : [value];
+  const normalized = raw
+    .map((item) => String(item).trim())
+    .filter(Boolean);
+  return normalized.length > 0 ? normalized : undefined;
+};
+
 export class ContentQueryDto extends PaginationDto {
   @IsOptional()
   @IsString()
@@ -58,4 +67,12 @@ export class ContentQueryDto extends PaginationDto {
   @IsString({ each: true })
   @MaxLength(64, { each: true })
   tagNames?: string[];
+
+  @IsOptional()
+  @Transform(normalizeRepeatedStrings)
+  @IsArray()
+  @ArrayMaxSize(20)
+  @IsString({ each: true })
+  @MaxLength(64, { each: true })
+  tagIds?: string[];
 }

--- a/middleware/src/modules/folders/folders.controller.spec.ts
+++ b/middleware/src/modules/folders/folders.controller.spec.ts
@@ -224,6 +224,7 @@ describe('FoldersController', () => {
           search: undefined,
           dateRange: undefined,
           tagNames: undefined,
+          tagIds: undefined,
         },
       );
     });
@@ -237,6 +238,7 @@ describe('FoldersController', () => {
         status: 'active',
         dateRange: '30days',
         tagNames: ['Marketing'],
+        tagIds: ['tag-menu'],
       };
       mockFoldersService.getContents.mockResolvedValue({
         data: [],
@@ -255,6 +257,7 @@ describe('FoldersController', () => {
           status: 'active',
           dateRange: '30days',
           tagNames: ['Marketing'],
+          tagIds: ['tag-menu'],
           templateOrientation: undefined,
         },
       );

--- a/middleware/src/modules/folders/folders.controller.ts
+++ b/middleware/src/modules/folders/folders.controller.ts
@@ -90,7 +90,7 @@ export class FoldersController {
     @Param('id', ParseIdPipe) id: string,
     @Query() query: ContentQueryDto,
   ) {
-    const { type, status, templateOrientation, search, dateRange, tagNames, ...pagination } = query;
+    const { type, status, templateOrientation, search, dateRange, tagNames, tagIds, ...pagination } = query;
     return this.foldersService.getContents(organizationId, id, pagination, {
       type,
       status,
@@ -98,6 +98,7 @@ export class FoldersController {
       search,
       dateRange,
       tagNames,
+      tagIds,
     });
   }
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,75 @@
 # Vizora - Task Tracker
 
+## Active: Content Tag Filter Trust Pass 28 (2026-06-01)
+
+**Branch:** `feat/customer-readiness-pass-28`
+
+**Why now:** Pass 27 is merged with green post-merge `main` CI, but production
+deploy remains blocked by dirty/diverged prod-local state. The next bounded
+customer-dashboard trust gap still present in current code is the content
+library's tag filter: it shows hardcoded `Marketing`, `Seasonal`, `Featured`,
+and `Archive` choices even though Vizora has tenant-scoped `Tag`/`ContentTag`
+data and server-side `tagNames` filtering.
+
+**New primitives introduced:** one content-module read endpoint,
+`GET /api/v1/content/tags`, one web API client method, and a `tagIds`
+content-list query filter. No new database model, migration, process, queue,
+realtime path, MCP tool, Hermes skill, provider spend path, or deployment
+primitive.
+
+**Hermes-first analysis:** not applicable. This pass does not add or modify
+business agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
+
+**Plan/design:**
+`docs/plans/2026-06-01-content-tag-filter-trust-pass-28.md`
+
+**Plan**
+- [x] Start fresh branch from `origin/main`.
+- [x] Reconcile backlog/current state after Pass 27.
+- [x] Add failing middleware tests for tenant-scoped content tag listing.
+- [x] Add failing web tests for real content-tag filter options.
+- [x] Implement the content tag list endpoint and web API client method.
+- [x] Replace hardcoded dashboard tag filters with fetched real tags.
+- [x] Run multi-subagent review before broader verification.
+- [x] Run focused and broader verification.
+- [ ] PR, CI, merge if green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Local evidence so far:**
+- TDD red: middleware content tests failed on missing
+  `ContentService.listContentTags` / `ContentController.listContentTags`; web
+  content test failed because `apiClient.getContentTags` was never called.
+- Implementation: added tenant-scoped `GET /api/v1/content/tags`, web API
+  client support, and content-library tag filter loading/error/empty states.
+  Removed the hardcoded `Marketing` / `Seasonal` / `Featured` / `Archive`
+  filter source.
+- Regression fix: initial tag metadata loading now keeps the empty selected
+  tag-name value stable, so mounting the content page does not duplicate the
+  first content fetch.
+- Focused web evidence:
+  `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/dashboard/content/__tests__/content-page.test.tsx`
+  passed 43/43.
+- Review findings fixed: content tag usage counts now filter the counted
+  content relation by `organizationId`; dashboard tag filtering now sends
+  `tagIds` so comma-bearing tenant tag names keep working; folder content
+  queries now forward `tagIds` as well.
+- Focused post-review evidence:
+  `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/content/content.service.spec.ts src/modules/content/content.controller.spec.ts src/modules/content/dto/content-query.dto.spec.ts src/modules/folders/folders.controller.spec.ts`
+  passed 196/196.
+- Focused post-review web evidence:
+  `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/dashboard/content/__tests__/content-page.test.tsx src/lib/api/__tests__/content.test.ts`
+  passed 45/45.
+- Broader evidence: `pnpm --filter @vizora/web test -- --runInBand` passed
+  96 suites / 1035 tests; `pnpm --filter @vizora/middleware test -- --runInBand`
+  passed 143 suites / 2892 tests. `tsc --noEmit` passed for middleware and
+  web. Changed-file ESLint exited 0 with existing warnings in touched files.
+  `npx nx build @vizora/middleware --skip-nx-cache` passed with existing
+  webpack warnings; `npx nx build @vizora/web --skip-nx-cache` passed with the
+  existing Next middleware/proxy warning. `git diff --check` and
+  `pnpm security:no-hardcoded-jwts` passed.
+
+---
+
 ## Completed: Playlist Publish Trust Pass 27 (2026-06-01)
 
 **Branch:** `feat/playlist-publish-trust-pass-27` -> PR #154 -> `main`

--- a/web/src/app/dashboard/content/__tests__/content-page.test.tsx
+++ b/web/src/app/dashboard/content/__tests__/content-page.test.tsx
@@ -3,6 +3,7 @@ import ContentClient from '../page-client';
 
 const mockGetContent = jest.fn();
 const mockGetContentItem = jest.fn();
+const mockGetContentTags = jest.fn();
 const mockGetFolderContent = jest.fn();
 const mockGetFolders = jest.fn();
 const mockGetDisplays = jest.fn();
@@ -21,6 +22,7 @@ jest.mock('@/lib/api', () => ({
   apiClient: {
     getContent: (...args: any[]) => mockGetContent(...args),
     getContentItem: (...args: any[]) => mockGetContentItem(...args),
+    getContentTags: (...args: any[]) => mockGetContentTags(...args),
     getFolderContent: (...args: any[]) => mockGetFolderContent(...args),
     getFolders: (...args: any[]) => mockGetFolders(...args),
     getDisplays: (...args: any[]) => mockGetDisplays(...args),
@@ -144,12 +146,14 @@ jest.mock('@/components/SearchFilter', () => {
 });
 
 jest.mock('@/components/ContentTagger', () => {
-  return function MockTagger({ selectedTags, onChange }: any) {
+  return function MockTagger({ tags, selectedTags, onChange }: any) {
     return (
       <div data-testid="content-tagger">
-        <button type="button" onClick={() => onChange(['1'])}>
-          Select Marketing Tag
-        </button>
+        {tags.map((tag: any) => (
+          <button key={tag.id} type="button" onClick={() => onChange([tag.id])}>
+            Select {tag.name} Tag
+          </button>
+        ))}
         <span data-testid="selected-tags">{selectedTags.join(',')}</span>
       </div>
     );
@@ -236,6 +240,9 @@ describe('ContentClient', () => {
     jest.clearAllMocks();
     mockGetContent.mockResolvedValue({ data: [], meta: { page: 1, limit: 50, total: 0, totalPages: 0 } });
     mockGetContentItem.mockResolvedValue(sampleContent[0]);
+    mockGetContentTags.mockResolvedValue([
+      { id: '1', name: 'Marketing', color: 'blue', contentCount: 1 },
+    ]);
     mockGetFolderContent.mockResolvedValue({ data: [], meta: { page: 1, limit: 50, total: 0, totalPages: 0 } });
     mockGetFolders.mockResolvedValue([]);
     mockGetDisplays.mockResolvedValue({ data: [] });
@@ -688,9 +695,44 @@ describe('ContentClient', () => {
       expect(mockGetFolderContent).toHaveBeenCalledWith('folder-1', expect.objectContaining({
         page: 1,
         limit: 50,
-        tagNames: ['Marketing'],
+        tagIds: ['1'],
       }));
     });
+  });
+
+  it('renders tenant content tags instead of hardcoded filter tags', async () => {
+    mockGetContentTags.mockResolvedValue([
+      { id: 'tag-menu', name: 'Lunch, Dinner', color: 'green', contentCount: 2 },
+    ]);
+    mockGetContent.mockResolvedValue({
+      data: sampleContent,
+      meta: { page: 1, limit: 50, total: 3, totalPages: 1 },
+    });
+
+    render(<ContentClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(mockGetContentTags).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByText(/Tags/));
+
+    expect(screen.getByText('Select Lunch, Dinner Tag')).toBeInTheDocument();
+    expect(screen.queryByText('Select Marketing Tag')).not.toBeInTheDocument();
+
+    mockGetContent.mockClear();
+    fireEvent.click(screen.getByText('Select Lunch, Dinner Tag'));
+
+    await waitFor(() => {
+      expect(mockGetContent).toHaveBeenCalledWith(expect.objectContaining({
+        page: 1,
+        limit: 50,
+        tagIds: ['tag-menu'],
+      }));
+    });
+    expect(screen.getByText('Tag: Lunch, Dinner')).toBeInTheDocument();
   });
 
   it('moves back to a valid page after deleting the only item on a later page', async () => {
@@ -805,7 +847,7 @@ describe('ContentClient', () => {
       expect(mockGetContent).toHaveBeenCalledWith(expect.objectContaining({
         page: 1,
         limit: 50,
-        tagNames: ['Marketing'],
+        tagIds: ['1'],
       }));
     });
     expect(screen.getByTestId('selected-tags')).toHaveTextContent('1');
@@ -815,7 +857,7 @@ describe('ContentClient', () => {
 
     await waitFor(() => {
       expect(mockGetContent).toHaveBeenCalledWith(expect.not.objectContaining({
-        tagNames: expect.anything(),
+        tagIds: expect.anything(),
       }));
     });
     expect(screen.getByTestId('selected-tags')).toHaveTextContent('');

--- a/web/src/app/dashboard/content/page-client.tsx
+++ b/web/src/app/dashboard/content/page-client.tsx
@@ -70,6 +70,7 @@ const FILE_UPLOAD_LIMITS: Record<FileUploadType, number> = {
  pdf: 50 * 1024 * 1024,
 };
 const FILE_UPLOAD_TYPES = new Set<UploadFormType>(['image', 'video', 'pdf']);
+const EMPTY_SELECTED_TAG_NAMES: string[] = [];
 
 const isFileUploadType = (type: UploadFormType): type is FileUploadType => FILE_UPLOAD_TYPES.has(type);
 
@@ -134,12 +135,9 @@ export default function ContentClient() {
  const [uploadProgress, setUploadProgress] = useState<number>(0);
  const [uploadQueue, setUploadQueue] = useState<UploadQueueItem[]>([]);
  const [uploadRejections, setUploadRejections] = useState<UploadRejectedItem[]>([]);
- const [tags] = useState<ContentTag[]>([
- { id: '1', name: 'Marketing', color: 'blue' },
- { id: '2', name: 'Seasonal', color: 'green' },
- { id: '3', name: 'Featured', color: 'red' },
- { id: '4', name: 'Archive', color: 'gray' },
- ]);
+ const [tags, setTags] = useState<ContentTag[]>([]);
+ const [tagsLoading, setTagsLoading] = useState(false);
+ const [tagsLoadError, setTagsLoadError] = useState<string | null>(null);
  const [selectedTags, setSelectedTags] = useState<string[]>([]);
  const [showTagFilter, setShowTagFilter] = useState(false);
  const [realtimeStatus, setRealtimeStatus] = useState<'connected' | 'reconnecting' | 'offline'>('offline');
@@ -222,9 +220,14 @@ export default function ContentClient() {
  },
  });
 
- const selectedTagNames = useMemo(() => tags
+ const selectedTagNames = useMemo(() => {
+ if (selectedTags.length === 0) {
+ return EMPTY_SELECTED_TAG_NAMES;
+ }
+ return tags
  .filter(tag => selectedTags.includes(tag.id))
- .map(tag => tag.name), [tags, selectedTags]);
+ .map(tag => tag.name);
+ }, [tags, selectedTags]);
 
  const buildContentListParams = useCallback((): ContentListParams => ({
  page: contentPage,
@@ -233,9 +236,9 @@ export default function ContentClient() {
  ...(filterStatus !== 'all' ? { status: filterStatus } : {}),
  ...(filterDateRange !== 'all' ? { dateRange: filterDateRange } : {}),
  ...(debouncedSearch.trim() ? { search: debouncedSearch.trim() } : {}),
- ...(selectedTagNames.length > 0 ? { tagNames: selectedTagNames } : {}),
- }), [contentPage, debouncedSearch, filterDateRange, filterStatus, filterType, selectedTagNames]);
- const contentFilterKey = `${selectedFolderId ?? 'root'}|${filterType}|${filterStatus}|${filterDateRange}|${debouncedSearch.trim()}|${selectedTagNames.join(',')}`;
+ ...(selectedTags.length > 0 ? { tagIds: selectedTags } : {}),
+ }), [contentPage, debouncedSearch, filterDateRange, filterStatus, filterType, selectedTags]);
+ const contentFilterKey = `${selectedFolderId ?? 'root'}|${filterType}|${filterStatus}|${filterDateRange}|${debouncedSearch.trim()}|${selectedTags.join(',')}`;
 
  const loadContent = useCallback(async () => {
  if (lastContentFilterKeyRef.current && lastContentFilterKeyRef.current !== contentFilterKey && contentPage !== 1) {
@@ -348,6 +351,38 @@ export default function ContentClient() {
  }
  }, []);
 
+ const loadContentTags = useCallback(async () => {
+ try {
+ setTagsLoading(true);
+ setTagsLoadError(null);
+ const tagList = await apiClient.getContentTags();
+ const nextTags = tagList.map((tag) => ({
+ id: tag.id,
+ name: tag.name,
+ color: tag.color || 'blue',
+ }));
+ setTags(nextTags);
+ setSelectedTags(prev => {
+ const nextSelected = prev.filter(id => nextTags.some(tag => tag.id === id));
+ if (
+ nextSelected.length === prev.length &&
+ nextSelected.every((id, index) => id === prev[index])
+ ) {
+ return prev;
+ }
+ return nextSelected;
+ });
+ } catch (error: any) {
+ const message = error.message || 'Could not load content tags';
+ setTagsLoadError(message);
+ if (process.env.NODE_ENV === 'development') {
+  console.error('[ContentPage] Failed to load content tags:', error);
+ }
+ } finally {
+ setTagsLoading(false);
+ }
+ }, []);
+
  const handleCreateFolder = async () => {
  if (!newFolderName.trim()) {
  toast.error('Folder name is required');
@@ -413,6 +448,10 @@ export default function ContentClient() {
  useEffect(() => {
  loadFolders();
  }, [loadFolders]);
+
+ useEffect(() => {
+ loadContentTags();
+ }, [loadContentTags]);
 
  useEffect(() => {
  loadContent();
@@ -1192,6 +1231,24 @@ export default function ContentClient() {
  {/* Tag filter panel - expands below toolbar */}
  {showTagFilter && (
  <div className="eh-dash-card p-4">
+ {tagsLoading ? (
+ <div className="text-sm text-[var(--foreground-secondary)]">Loading tags...</div>
+ ) : tagsLoadError ? (
+ <div className="flex items-center justify-between gap-3">
+ <p className="text-sm text-red-600 dark:text-red-400">{tagsLoadError}</p>
+ <button
+ type="button"
+ onClick={loadContentTags}
+ className="text-sm text-[var(--primary)] hover:underline"
+ >
+ Retry
+ </button>
+ </div>
+ ) : tags.length === 0 ? (
+ <div className="text-sm text-[var(--foreground-secondary)]">
+ No content tags yet. Add tags to content before using tag filters.
+ </div>
+ ) : (
  <ContentTagger
  tags={tags}
  selectedTags={selectedTags}
@@ -1202,6 +1259,7 @@ export default function ContentClient() {
  setContentPage(1);
  }}
  />
+ )}
  {selectedTags.length > 0 && (
  <button
  onClick={() => {
@@ -1269,6 +1327,7 @@ export default function ContentClient() {
  {filterStatus !== 'all' && <span className="eh-filter-chip">Status: {filterStatus}</span>}
  {filterDateRange !== 'all' && <span className="eh-filter-chip">Date: {filterDateRange}</span>}
  {searchQuery && <span className="eh-filter-chip">Search: &quot;{searchQuery}&quot;</span>}
+ {selectedTagNames.map(tagName => <span key={tagName} className="eh-filter-chip">Tag: {tagName}</span>)}
  </div>
  )}
 

--- a/web/src/lib/api/__tests__/content.test.ts
+++ b/web/src/lib/api/__tests__/content.test.ts
@@ -20,4 +20,23 @@ describe('content api methods', () => {
       metadata: { section: 'front' },
     });
   });
+
+  it('serializes array content filters as repeated query params', async () => {
+    const client = new ApiClient('/api/v1');
+    const requestSpy = jest.spyOn(client, 'request').mockResolvedValue({
+      data: [],
+      meta: { page: 1, limit: 50, total: 0, totalPages: 0 },
+    } as any);
+
+    await client.getContent({
+      page: 1,
+      limit: 50,
+      tagNames: ['Lunch, Dinner', 'Marketing'],
+      tagIds: ['tag-menu', 'tag-promo'],
+    });
+
+    expect(requestSpy).toHaveBeenCalledWith(
+      '/content?page=1&limit=50&tagNames=Lunch%2C+Dinner&tagNames=Marketing&tagIds=tag-menu&tagIds=tag-promo',
+    );
+  });
 });

--- a/web/src/lib/api/content.ts
+++ b/web/src/lib/api/content.ts
@@ -13,11 +13,20 @@ export interface ContentListParams {
   search?: string;
   dateRange?: '7days' | '30days' | '90days';
   tagNames?: string[];
+  tagIds?: string[];
+}
+
+export interface ContentTagSummary {
+  id: string;
+  name: string;
+  color: string | null;
+  contentCount: number;
 }
 
 declare module './client' {
   interface ApiClient {
     getContent(params?: ContentListParams): Promise<PaginatedResponse<Content>>;
+    getContentTags(): Promise<ContentTagSummary[]>;
     getContentItem(id: string): Promise<Content>;
     createContent(data: { title: string; type: string; url?: string; file?: File; metadata?: Record<string, unknown> }): Promise<Content>;
     updateContent(id: string, data: Partial<{ title: string; metadata?: Record<string, unknown> }>): Promise<Content>;
@@ -48,7 +57,7 @@ const buildContentListQuery = (params?: ContentListParams): string => {
     if (value === undefined || value === null) return;
     if (Array.isArray(value)) {
       if (value.length > 0) {
-        query.set(key, value.join(','));
+        value.forEach((item) => query.append(key, String(item)));
       }
       return;
     }
@@ -61,6 +70,10 @@ const buildContentListQuery = (params?: ContentListParams): string => {
 ApiClient.prototype.getContent = async function (params?: ContentListParams): Promise<PaginatedResponse<Content>> {
   const query = buildContentListQuery(params);
   return this.request<PaginatedResponse<Content>>(`/content${query ? `?${query}` : ''}`);
+};
+
+ApiClient.prototype.getContentTags = async function (): Promise<ContentTagSummary[]> {
+  return this.request<ContentTagSummary[]>('/content/tags');
 };
 
 ApiClient.prototype.getContentItem = async function (id: string): Promise<Content> {


### PR DESCRIPTION
## Summary
- add tenant-scoped `GET /api/v1/content/tags` for real content tag filter options
- add `tagIds` content-list filtering while preserving legacy `tagNames`
- replace hardcoded content-library tag filters with fetched tenant tags, including loading/error/empty states
- forward `tagIds` through folder content queries and guard comma-bearing tag names with tests

## Review
- backend/API reviewer found unscoped `contentCount`; fixed with organization-scoped relation count
- frontend reviewer found comma-bearing tag names would split through comma serialization; fixed by filtering by `tagIds` and repeated query params
- final frontend review: CLEAN
- final backend review found folder controller `tagIds` forwarding gap; fixed and retested

## Verification
- `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/content/content.service.spec.ts src/modules/content/content.controller.spec.ts src/modules/content/dto/content-query.dto.spec.ts src/modules/folders/folders.controller.spec.ts` (196/196)
- `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/dashboard/content/__tests__/content-page.test.tsx src/lib/api/__tests__/content.test.ts` (45/45)
- `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
- `pnpm --filter @vizora/web exec tsc --noEmit --pretty false`
- changed-file ESLint exited 0 with existing warnings
- `npx nx build @vizora/middleware --skip-nx-cache` (existing webpack warnings)
- `npx nx build @vizora/web --skip-nx-cache` (existing Next middleware/proxy warning)
- `pnpm --filter @vizora/web test -- --runInBand` (96 suites / 1035 tests)
- `pnpm --filter @vizora/middleware test -- --runInBand` (143 suites / 2892 tests)
- `pnpm security:no-hardcoded-jwts`
- `git diff --check`

## Deployment
- Not deployed by this PR. Production checkout was previously dirty/diverged; deploy gate must be rechecked after merge.