### PR TITLE
fix: sanitize widget metadata in realtime payloads

### DIFF
--- a/docs/plans/2026-06-01-realtime-widget-secret-boundary-pass-30.md
+++ b/docs/plans/2026-06-01-realtime-widget-secret-boundary-pass-30.md
@@ -1,0 +1,69 @@
+# Realtime Widget Secret Boundary Pass 30
+
+**Date:** 2026-06-01
+
+**Branch:** `feat/customer-readiness-pass-30`
+
+**Goal:** Prevent generic API widget secrets from crossing the realtime/device delivery boundary while preserving display-compatible widget playback metadata.
+
+**Current evidence:** Pass 29 redacts generic API widget headers from middleware HTTP content responses, but realtime still builds device payloads from raw Prisma `content.metadata` in:
+- `realtime/src/services/playlist.service.ts`
+- `realtime/src/gateways/device.gateway.ts`
+
+That means saved `metadata.widgetConfig` secrets can still be sent to display clients through cached playlists, initial state, pending playlist replay, or admin-triggered playlist pushes.
+
+**New primitives introduced:** one realtime-local payload sanitizer helper for device-bound content metadata. No new database model, migration, route, queue, realtime room model, MCP tool, Hermes skill, provider spend path, or production process.
+
+## Hermes-First Analysis
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Realtime device payload sanitization | None applicable in official bundled catalog; available Hermes skills are agent workflow/tooling skills, not Vizora runtime sanitizers. | Build inside existing realtime service path. |
+| Secret redaction for content metadata | None applicable; this is an in-process payload projection concern and must stay in Vizora auth/tenant boundary. | Build from scratch with focused tests. |
+
+Awesome Hermes ecosystem check: searched current `awesome-hermes-agent` listings; no reusable runtime payload sanitizer exists or applies to NestJS/Socket.IO device payload projection, so this remains native Vizora code.
+
+## Drift Check
+
+- Middleware response redaction exists for HTTP content/widget responses after Pass 29.
+- Realtime raw metadata remains in `PlaylistService.getDevicePlaylist()` for primary and fallback playlists.
+- Realtime raw metadata remains in `DeviceGateway.sendInitialState()`.
+- `DeviceGateway.resolveLayoutContent()` spreads layout metadata into device payloads; sanitization must apply before returning layout content.
+- Cached playlists can predate the fix, so cached reads and `updateDevicePlaylist()` must sanitize as well.
+
+## Implementation Plan
+
+- [ ] Add failing `PlaylistService` tests proving generic API widget header values are redacted from cached, DB primary, DB fallback, and admin-updated playlists.
+- [ ] Add failing `DeviceGateway` tests proving initial-state playlist payloads and layout metadata redact generic API widget headers before `client.emit()`.
+- [ ] Add `realtime/src/services/device-content-payload.ts` with:
+  - record-safe cloning
+  - `redactDeviceContentMetadata()`
+  - `redactDevicePlaylist()`
+  - generic API `widgetConfig` stripping for device-bound payloads
+- [ ] Wire sanitizer into:
+  - cached playlist return path
+  - DB playlist construction and cache writes
+  - `updateDevicePlaylist()`
+  - `sendPlaylistUpdate()`
+  - `sendInitialState()`
+  - `resolveLayoutContent()`
+- [ ] Run focused realtime tests.
+- [ ] Request security/realtime subagent review before broader verification.
+- [ ] Run broader realtime verification and CI-safe checks.
+- [ ] Commit, PR, wait for CI, merge if green, then re-check deploy gate without changing prod state.
+
+## Test Plan
+
+- `pnpm --filter @vizora/realtime test -- --runInBand --runTestsByPath src/services/playlist.service.spec.ts src/gateways/device.gateway.spec.ts`
+- `pnpm --filter @vizora/realtime test -- --runInBand`
+- `npx nx build @vizora/realtime --skip-nx-cache`
+- `pnpm security:no-hardcoded-jwts`
+- `git diff --check`
+
+## Risks
+
+- Devices may depend on non-secret widget metadata for template rendering. The sanitizer strips only generic API `widgetConfig` and preserves sibling metadata such as `isWidget`, `widgetType`, `renderedHtml`, `templateName`, layout `zones`, `resolvedPlaylist`, and `resolvedContent`.
+- Cached and pending playlist payloads may contain stale raw metadata. Return-time/replay-time sanitization is required even if cache writes are fixed.
+- Layout rendering paths must preserve `metadata.zones`, `resolvedPlaylist`, and `resolvedContent` shapes.
+
+**Type-check note:** do not use `pnpm --filter @vizora/realtime exec tsc --noEmit` as a gate; the package tsconfig has empty `files`/`include`, so that command can exit 0 without checking the app. Use the Nx realtime build for compile coverage until a dedicated typecheck config exists.

--- a/realtime/src/gateways/device.gateway.spec.ts
+++ b/realtime/src/gateways/device.gateway.spec.ts
@@ -32,6 +32,20 @@ describe('DeviceGateway', () => {
   const hashToken = (token: string) =>
     createHash('sha256').update(token).digest('hex');
 
+  const genericApiWidgetMetadata = {
+    isWidget: true,
+    widgetType: 'generic-api',
+    widgetConfig: {
+      endpoint: 'https://api.example.com/menu?api_key=live-query-key',
+      headers: {
+        Authorization: 'Bearer live-secret',
+        'X-Api-Key': 'live-api-key',
+      },
+      method: 'GET',
+    },
+    renderedHtml: '<div>Menu</div>',
+  };
+
   const mockRedisService = {
     setDeviceStatus: jest.fn().mockResolvedValue(undefined),
     getDeviceCommands: jest.fn().mockResolvedValue([]),
@@ -322,6 +336,102 @@ describe('DeviceGateway', () => {
           where: { id: 'other-org-content', organizationId: 'org-1' },
         }),
       );
+    });
+
+    it('redacts generic API widget headers from layout metadata before returning device payloads', async () => {
+      const result = await (gateway as any).resolveLayoutContent({
+        id: 'layout-1',
+        type: 'layout',
+        metadata: {
+          ...genericApiWidgetMetadata,
+          zones: [
+            {
+              id: 'zone-content',
+              gridArea: 'main',
+              resolvedContent: {
+                id: 'content-1',
+                name: 'API Menu',
+                type: 'template',
+                url: '/api/v1/device-content/content-1/file',
+                metadata: genericApiWidgetMetadata,
+              },
+            },
+            {
+              id: 'zone-playlist',
+              gridArea: 'side',
+              resolvedPlaylist: {
+                id: 'playlist-1',
+                name: 'Widget Loop',
+                items: [
+                  {
+                    id: 'item-1',
+                    contentId: 'content-2',
+                    duration: 10,
+                    content: {
+                      id: 'content-2',
+                      name: 'API Menu 2',
+                      type: 'template',
+                      url: '/api/v1/device-content/content-2/file',
+                      metadata: genericApiWidgetMetadata,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }, 'org-1');
+
+      expect(result.metadata.widgetConfig).toBeUndefined();
+      expect(result.metadata.zones[0].resolvedContent.metadata.widgetConfig).toBeUndefined();
+      expect(result.metadata.zones[1].resolvedPlaylist.items[0].content.metadata.widgetConfig).toBeUndefined();
+      expect(JSON.stringify(result)).not.toContain('live-secret');
+      expect(JSON.stringify(result)).not.toContain('live-api-key');
+      expect(JSON.stringify(result)).not.toContain('live-query-key');
+    });
+  });
+
+  describe('sendInitialState', () => {
+    it('redacts generic API widget headers from the initial playlist payload', async () => {
+      mockDatabaseService.display.findUnique.mockResolvedValueOnce({
+        id: 'device-1',
+        organizationId: 'org-1',
+        metadata: {},
+        currentPlaylistId: 'p-1',
+        currentPlaylist: {
+          id: 'p-1',
+          name: 'Current Playlist',
+          items: [
+            {
+              id: 'item-1',
+              contentId: 'content-1',
+              duration: 10,
+              order: 0,
+              content: {
+                id: 'content-1',
+                name: 'API Menu',
+                type: 'template',
+                url: '/api/v1/device-content/content-1/file',
+                thumbnail: null,
+                mimeType: 'text/html',
+                duration: 10,
+                metadata: genericApiWidgetMetadata,
+              },
+            },
+          ],
+        },
+      });
+      const client = createMockSocket();
+
+      await (gateway as any).sendInitialState(client, 'device-1', 'org-1');
+
+      const playlistCall = client.emit.mock.calls.find(([event]) => event === 'playlist:update');
+      expect(playlistCall).toBeDefined();
+      const payload = playlistCall![1];
+      expect(payload.playlist.items[0].content.metadata.widgetConfig).toBeUndefined();
+      expect(JSON.stringify(payload)).not.toContain('live-secret');
+      expect(JSON.stringify(payload)).not.toContain('live-api-key');
+      expect(JSON.stringify(payload)).not.toContain('live-query-key');
     });
   });
 
@@ -813,6 +923,51 @@ describe('DeviceGateway', () => {
       expect(mockRedisService.addDeviceCommand).not.toHaveBeenCalledWith('device-1', pendingCommand);
     });
 
+    it('should redact stale pending playlist metadata before heartbeat replay emits it', async () => {
+      const emit = jest.fn((_event: string, _payload: any, ackCb?: (ack?: { ok: boolean }) => void) => {
+        ackCb?.({ ok: true });
+      });
+      const client = createMockSocket({
+        connected: true,
+        data: {
+          deviceId: 'device-1',
+          organizationId: 'org-1',
+          deviceTokenHash: hashToken('valid-token'),
+          deliveryAckCapable: true,
+        },
+        emit,
+      });
+      const pendingPlaylist = {
+        id: 'playlist-pending',
+        items: [
+          {
+            id: 'item-1',
+            contentId: 'content-1',
+            duration: 10,
+            content: {
+              id: 'content-1',
+              name: 'API Menu',
+              type: 'template',
+              url: '/api/v1/device-content/content-1/file',
+              metadata: genericApiWidgetMetadata,
+            },
+          },
+        ],
+      };
+      mockRedisService.getPendingPlaylist.mockResolvedValueOnce(pendingPlaylist);
+      (gateway as any).deviceSockets.set('device-1', 'socket-1');
+
+      const result = await (gateway as any).deliverPendingPlaylist(client, 'device-1');
+
+      expect(result).toBe('delivered');
+      const playlistCall = emit.mock.calls.find(([event]) => event === 'playlist:update');
+      expect(playlistCall).toBeDefined();
+      const payload = playlistCall![1];
+      expect(payload.playlist.items[0].content.metadata.widgetConfig).toBeUndefined();
+      expect(JSON.stringify(payload)).not.toContain('live-secret');
+      expect(JSON.stringify(payload)).not.toContain('live-query-key');
+    });
+
     it('should not drain pending deliveries from stale socket heartbeats', async () => {
       const client = createMockSocket({
         id: 'socket-old',
@@ -884,16 +1039,33 @@ describe('DeviceGateway', () => {
         emit,
       });
       (gateway as any).deviceSockets.set('device-1', 'socket-1');
-      mockRedisService.getPendingPlaylist.mockResolvedValueOnce({ id: 'playlist-pending', items: [] });
+      mockRedisService.getPendingPlaylist.mockResolvedValueOnce({
+        id: 'playlist-pending',
+        items: [
+          {
+            id: 'item-1',
+            contentId: 'content-1',
+            duration: 10,
+            content: {
+              id: 'content-1',
+              name: 'API Menu',
+              type: 'template',
+              url: '/api/v1/device-content/content-1/file',
+              metadata: genericApiWidgetMetadata,
+            },
+          },
+        ],
+      });
 
       await gateway.handleHeartbeat(client as any, {} as any);
       for (let i = 0; i < 8; i += 1) {
         await Promise.resolve();
       }
-      expect(mockRedisService.setPendingPlaylist).toHaveBeenCalledWith(
-        'device-1',
-        expect.objectContaining({ id: 'playlist-pending' }),
-      );
+      const requeued = mockRedisService.setPendingPlaylist.mock.calls[0][1];
+      expect(requeued.id).toBe('playlist-pending');
+      expect(requeued.items[0].content.metadata.widgetConfig).toBeUndefined();
+      expect(JSON.stringify(requeued)).not.toContain('live-secret');
+      expect(JSON.stringify(requeued)).not.toContain('live-query-key');
 
       mockRedisService.getPendingPlaylist.mockClear();
       await gateway.handleHeartbeat(client as any, {} as any);
@@ -1250,6 +1422,43 @@ describe('DeviceGateway', () => {
         }),
         expect.any(Function),
       );
+    });
+
+    it('should redact generic API widget headers before emitting playlist updates', async () => {
+      const playlist = {
+        id: 'p-1',
+        name: 'Test',
+        organizationId: 'org-1',
+        isActive: true,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        items: [
+          {
+            id: 'item-1',
+            contentId: 'c-1',
+            order: 0,
+            duration: 10,
+            content: {
+              id: 'c-1',
+              name: 'API Menu',
+              type: 'template',
+              url: '/api/v1/device-content/c-1/file',
+              metadata: genericApiWidgetMetadata,
+            },
+          },
+        ],
+      };
+
+      const result = await gateway.sendPlaylistUpdate('device-1', playlist as any);
+
+      expect(result).toEqual({ delivered: true });
+      const playlistCall = mockRemoteSocket.emit.mock.calls.find(([event]) => event === 'playlist:update');
+      expect(playlistCall).toBeDefined();
+      const payload = playlistCall![1];
+      expect(payload.playlist.items[0].content.metadata.widgetConfig).toBeUndefined();
+      expect(JSON.stringify(payload)).not.toContain('live-secret');
+      expect(JSON.stringify(payload)).not.toContain('live-api-key');
+      expect(JSON.stringify(payload)).not.toContain('live-query-key');
     });
 
     it('should emit playlist:update to device room', async () => {

--- a/realtime/src/gateways/device.gateway.ts
+++ b/realtime/src/gateways/device.gateway.ts
@@ -42,6 +42,11 @@ import { WsAllExceptionsFilter } from './filters/ws-exception.filter';
 import { WsAuthGuard, WsDeviceGuard } from './guards/ws-auth.guard';
 import { redactSensitiveTokens } from '../utils/redact-sensitive-url';
 import { hashDeviceToken, isCurrentDeviceToken } from './device-token-hash';
+import {
+  redactDeviceContentMetadata,
+  redactDevicePayload,
+  redactDevicePlaylist,
+} from '../services/device-content-payload';
 
 interface DevicePayload {
   sub: string; // device ID
@@ -384,7 +389,7 @@ export class DeviceGateway
       return 'skipped';
     }
 
-    await this.redisService.setPendingPlaylist(deviceId, playlist);
+    await this.redisService.setPendingPlaylist(deviceId, redactDevicePlaylist(playlist));
     return status;
   }
 
@@ -989,7 +994,7 @@ export class DeviceGateway
                 thumbnail: item.content.thumbnail,
                 mimeType: item.content.mimeType,
                 duration: item.content.duration,
-                metadata: item.content.metadata,
+                metadata: redactDeviceContentMetadata(item.content.metadata),
               } : null,
             };
 
@@ -1002,7 +1007,7 @@ export class DeviceGateway
           }),
         );
 
-        const playlist = {
+        const playlist = redactDevicePlaylist({
           id: display.currentPlaylist.id,
           name: display.currentPlaylist.name,
           items: resolvedItems,
@@ -1011,7 +1016,7 @@ export class DeviceGateway
             0
           ),
           loopPlaylist: true,
-        };
+        });
 
         client.emit('playlist:update', {
           playlist,
@@ -1456,13 +1461,14 @@ export class DeviceGateway
     const replayVersion = this.pendingPlaylistReplayVersions.get(deviceId) ?? 0;
     const pendingPlaylist = await this.redisService.getPendingPlaylist(deviceId);
     if (!pendingPlaylist) return 'none';
+    const safePendingPlaylist = redactDevicePlaylist(pendingPlaylist);
 
     this.logger.log(`Delivering pending playlist to device ${deviceId} (queued while offline)`);
 
     // Re-queue if the active client changed or disconnected after the atomic Redis consume.
     if (!this.isActiveDeviceSocket(client, deviceId) || !client.connected) {
       this.logger.warn(`Device ${deviceId} disconnected before pending playlist delivery - re-queuing`);
-      return this.requeuePendingPlaylistIfCurrent(deviceId, pendingPlaylist, replayVersion, 'deferred');
+      return this.requeuePendingPlaylistIfCurrent(deviceId, safePendingPlaylist, replayVersion, 'deferred');
     }
 
     // Fetch display metadata for config (qrOverlay etc.)
@@ -1478,7 +1484,7 @@ export class DeviceGateway
 
     if (!this.isActiveDeviceSocket(client, deviceId) || !client.connected) {
       this.logger.warn(`Device ${deviceId} disconnected before pending playlist delivery - re-queuing`);
-      return this.requeuePendingPlaylistIfCurrent(deviceId, pendingPlaylist, replayVersion, 'deferred');
+      return this.requeuePendingPlaylistIfCurrent(deviceId, safePendingPlaylist, replayVersion, 'deferred');
     }
 
     const configMetadata = (displayForConfig?.metadata as Record<string, any>) || {};
@@ -1495,7 +1501,7 @@ export class DeviceGateway
     }
 
     const result = await this.emitWithDeliveryAck(client, 'playlist:update', {
-      playlist: pendingPlaylist,
+      playlist: safePendingPlaylist,
       timestamp: new Date().toISOString(),
     });
 
@@ -1506,7 +1512,7 @@ export class DeviceGateway
 
     if (!this.isActiveDeviceSocket(client, deviceId) || !client.connected) {
       this.logger.warn(`Device ${deviceId} changed sockets during pending playlist delivery - re-queuing`);
-      return this.requeuePendingPlaylistIfCurrent(deviceId, pendingPlaylist, replayVersion, 'deferred');
+      return this.requeuePendingPlaylistIfCurrent(deviceId, safePendingPlaylist, replayVersion, 'deferred');
     }
 
     if (result.delivered) {
@@ -1517,7 +1523,7 @@ export class DeviceGateway
       );
     } else {
       this.logger.warn(`Pending playlist ${result.reason || 'delivery failure'} for device ${deviceId} - re-queuing`);
-      return this.requeuePendingPlaylistIfCurrent(deviceId, pendingPlaylist, replayVersion);
+      return this.requeuePendingPlaylistIfCurrent(deviceId, safePendingPlaylist, replayVersion);
     }
     return 'delivered';
   }
@@ -1598,7 +1604,7 @@ export class DeviceGateway
   async sendPlaylistUpdate(deviceId: string, playlist: Playlist): Promise<{ delivered: boolean; reason?: string }> {
     // Resolve minio:// URLs to API-served URLs before sending to device
     // Devices authenticate content requests via Authorization header with their stored JWT
-    const resolvedPlaylist = {
+    const resolvedPlaylist = redactDevicePlaylist({
       ...playlist,
       items: (playlist.items || []).map((item: PlaylistContentItem) => {
         const resolvedUrl = this.resolveContentUrl(item);
@@ -1610,7 +1616,7 @@ export class DeviceGateway
           } : item.content,
         };
       }),
-    };
+    });
 
     // Get all sockets in the device room
     const roomName = `device:${deviceId}`;
@@ -1953,7 +1959,7 @@ export class DeviceGateway
    * additional API calls.
    */
   private async resolveLayoutContent(content: any, organizationId: string): Promise<any> {
-    const metadata = (content.metadata as Record<string, any>) || {};
+    const metadata = (redactDeviceContentMetadata(content.metadata) as Record<string, any>) || {};
     const zones = metadata.zones || [];
 
     const resolvedZones = await Promise.all(
@@ -2037,12 +2043,12 @@ export class DeviceGateway
       }),
     );
 
-    return {
+    return redactDevicePayload({
       ...content,
       metadata: {
         ...metadata,
         zones: resolvedZones,
       },
-    };
+    });
   }
 }

--- a/realtime/src/services/device-content-payload.ts
+++ b/realtime/src/services/device-content-payload.ts
@@ -1,0 +1,57 @@
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function redactWidgetSecrets(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    let changed = false;
+    const redacted = value.map((item) => {
+      const next = redactWidgetSecrets(item);
+      changed = changed || next !== item;
+      return next;
+    });
+    return changed ? redacted : value;
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  let copy: JsonRecord | null = null;
+  const mutableCopy = () => {
+    copy ??= { ...value };
+    return copy;
+  };
+
+  if (
+    value.isWidget === true
+    && value.widgetType === 'generic-api'
+    && Object.prototype.hasOwnProperty.call(value, 'widgetConfig')
+  ) {
+    delete mutableCopy().widgetConfig;
+  }
+
+  const source = copy ?? value;
+  for (const [key, child] of Object.entries(source)) {
+    const redactedChild = redactWidgetSecrets(child);
+    if (redactedChild !== child) {
+      mutableCopy()[key] = redactedChild;
+    }
+  }
+
+  return copy ?? value;
+}
+
+export function redactDevicePayload<T>(payload: T): T {
+  return redactWidgetSecrets(payload) as T;
+}
+
+export function redactDeviceContentMetadata<T>(metadata: T): T {
+  return redactDevicePayload(metadata);
+}
+
+export function redactDevicePlaylist<T>(playlist: T): T {
+  return redactDevicePayload(playlist);
+}

--- a/realtime/src/services/playlist.service.spec.ts
+++ b/realtime/src/services/playlist.service.spec.ts
@@ -6,6 +6,20 @@ import { DatabaseService } from '../database/database.service';
 describe('PlaylistService', () => {
   let service: PlaylistService;
 
+  const genericApiWidgetMetadata = {
+    isWidget: true,
+    widgetType: 'generic-api',
+    widgetConfig: {
+      endpoint: 'https://api.example.com/menu?api_key=live-query-key',
+      headers: {
+        Authorization: 'Bearer live-secret',
+        'X-Api-Key': 'live-api-key',
+      },
+      method: 'GET',
+    },
+    renderedHtml: '<div>Menu</div>',
+  };
+
   const mockRedisService = {
     getCachedPlaylist: jest.fn().mockResolvedValue(null),
     cachePlaylist: jest.fn().mockResolvedValue(undefined),
@@ -59,6 +73,37 @@ describe('PlaylistService', () => {
       expect(mockDatabaseService.display.findUnique).not.toHaveBeenCalled();
     });
 
+    it('should redact generic API widget headers from cached playlists before returning them', async () => {
+      const cachedPlaylist = {
+        id: 'p-1',
+        name: 'Cached',
+        items: [
+          {
+            id: 'item-1',
+            contentId: 'c-1',
+            order: 0,
+            duration: 10,
+            content: {
+              id: 'c-1',
+              name: 'API Menu',
+              type: 'template',
+              url: '/api/v1/device-content/c-1/file',
+              metadata: genericApiWidgetMetadata,
+            },
+          },
+        ],
+      };
+      mockRedisService.getCachedPlaylist.mockResolvedValueOnce(cachedPlaylist);
+
+      const result = await service.getDevicePlaylist('device-1');
+
+      expect(result!.items[0].content.metadata!.widgetConfig).toBeUndefined();
+      expect(JSON.stringify(result)).not.toContain('live-secret');
+      expect(JSON.stringify(result)).not.toContain('live-api-key');
+      expect(JSON.stringify(result)).not.toContain('live-query-key');
+      expect(mockDatabaseService.display.findUnique).not.toHaveBeenCalled();
+    });
+
     it('should bypass cache when forceRefresh is true', async () => {
       mockDatabaseService.display.findUnique.mockResolvedValueOnce(null);
 
@@ -104,6 +149,45 @@ describe('PlaylistService', () => {
       expect(result!.items).toHaveLength(1);
       expect(result!.items[0].duration).toBe(15);
       expect(mockRedisService.cachePlaylist).toHaveBeenCalled();
+    });
+
+    it('should redact generic API widget headers from assigned DB playlists before returning and caching them', async () => {
+      const dbDisplay = {
+        organizationId: 'org-1',
+        currentPlaylist: {
+          id: 'p-1',
+          name: 'DB Playlist',
+          createdAt: new Date('2024-01-01'),
+          updatedAt: new Date('2024-01-02'),
+          items: [
+            {
+              id: 'item-1',
+              contentId: 'c-1',
+              order: 1,
+              duration: 15,
+              content: {
+                id: 'c-1',
+                name: 'API Menu',
+                type: 'template',
+                url: 'https://cdn.example.com/widget.html',
+                thumbnail: 'thumb.jpg',
+                metadata: genericApiWidgetMetadata,
+              },
+            },
+          ],
+        },
+      };
+      mockDatabaseService.display.findUnique.mockResolvedValueOnce(dbDisplay);
+
+      const result = await service.getDevicePlaylist('device-1');
+
+      expect(result!.items[0].content.metadata!.widgetConfig).toBeUndefined();
+      expect(JSON.stringify(result)).not.toContain('live-secret');
+      expect(JSON.stringify(result)).not.toContain('live-query-key');
+      const cached = mockRedisService.cachePlaylist.mock.calls[0][1];
+      expect(cached.items[0].content.metadata.widgetConfig).toBeUndefined();
+      expect(JSON.stringify(cached)).not.toContain('live-secret');
+      expect(JSON.stringify(cached)).not.toContain('live-query-key');
     });
 
     it('should default item duration to 10 when not set', async () => {
@@ -158,6 +242,47 @@ describe('PlaylistService', () => {
           where: { organizationId: 'org-1' },
         }),
       );
+    });
+
+    it('should redact generic API widget headers from organization fallback playlists', async () => {
+      mockDatabaseService.display.findUnique.mockResolvedValueOnce({
+        organizationId: 'org-1',
+        currentPlaylist: null,
+      });
+
+      const orgPlaylist = {
+        id: 'org-p-1',
+        name: 'Org Default',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        items: [
+          {
+            id: 'item-1',
+            contentId: 'c-1',
+            order: 0,
+            duration: 10,
+            content: {
+              id: 'c-1',
+              name: 'API Menu',
+              type: 'template',
+              url: 'https://cdn.example.com/widget.html',
+              thumbnail: null,
+              metadata: genericApiWidgetMetadata,
+            },
+          },
+        ],
+      };
+      mockDatabaseService.playlist.findFirst.mockResolvedValueOnce(orgPlaylist);
+
+      const result = await service.getDevicePlaylist('device-1');
+
+      expect(result!.items[0].content!.metadata!.widgetConfig).toBeUndefined();
+      expect(JSON.stringify(result)).not.toContain('live-secret');
+      expect(JSON.stringify(result)).not.toContain('live-query-key');
+      const cached = mockRedisService.cachePlaylist.mock.calls[0][1];
+      expect(cached.items[0].content.metadata.widgetConfig).toBeUndefined();
+      expect(JSON.stringify(cached)).not.toContain('live-secret');
+      expect(JSON.stringify(cached)).not.toContain('live-query-key');
     });
 
     it('should return null when no playlist found anywhere', async () => {
@@ -232,6 +357,35 @@ describe('PlaylistService', () => {
       await service.updateDevicePlaylist('device-1', playlist);
 
       expect(mockRedisService.cachePlaylist).toHaveBeenCalledWith('device-1', playlist);
+    });
+
+    it('should redact generic API widget headers before caching admin-updated playlists', async () => {
+      const playlist = {
+        id: 'p-1',
+        name: 'Updated',
+        items: [
+          {
+            id: 'item-1',
+            contentId: 'c-1',
+            order: 0,
+            duration: 10,
+            content: {
+              id: 'c-1',
+              name: 'API Menu',
+              type: 'template',
+              url: '/api/v1/device-content/c-1/file',
+              metadata: genericApiWidgetMetadata,
+            },
+          },
+        ],
+      } as any;
+
+      await service.updateDevicePlaylist('device-1', playlist);
+
+      const cached = mockRedisService.cachePlaylist.mock.calls[0][1];
+      expect(cached.items[0].content.metadata.widgetConfig).toBeUndefined();
+      expect(JSON.stringify(cached)).not.toContain('live-secret');
+      expect(JSON.stringify(cached)).not.toContain('live-query-key');
     });
 
     it('should throw on Redis error', async () => {

--- a/realtime/src/services/playlist.service.ts
+++ b/realtime/src/services/playlist.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { RedisService } from './redis.service';
 import { DatabaseService } from '../database/database.service';
 import { Playlist } from '../types';
+import { redactDevicePlaylist } from './device-content-payload';
 
 interface InstantPublish {
   playlistId: string;
@@ -32,7 +33,7 @@ export class PlaylistService {
 
         if (cached) {
           this.logger.debug(`Returning cached playlist for device: ${deviceId}`);
-          return cached;
+          return redactDevicePlaylist(cached);
         }
       }
 
@@ -79,11 +80,13 @@ export class PlaylistService {
           updatedAt: display.currentPlaylist.updatedAt?.toISOString?.() || new Date().toISOString(),
         };
 
+        const safePlaylist = redactDevicePlaylist(playlist);
+
         // Cache the playlist
-        await this.redisService.cachePlaylist(deviceId, playlist);
+        await this.redisService.cachePlaylist(deviceId, safePlaylist);
 
         this.logger.debug(`Returning DB playlist for device: ${deviceId} (playlist: ${playlist.name})`);
-        return playlist;
+        return safePlaylist;
       }
 
       // Fallback: try the organization's default playlist
@@ -131,11 +134,13 @@ export class PlaylistService {
             updatedAt: orgPlaylist.updatedAt?.toISOString?.() || new Date().toISOString(),
           };
 
+          const safePlaylist = redactDevicePlaylist(playlist);
+
           // Cache the fallback playlist
-          await this.redisService.cachePlaylist(deviceId, playlist);
+          await this.redisService.cachePlaylist(deviceId, safePlaylist);
 
           this.logger.debug(`Returning org fallback playlist for device: ${deviceId} (playlist: ${playlist.name})`);
-          return playlist;
+          return safePlaylist;
         }
       }
 
@@ -154,7 +159,7 @@ export class PlaylistService {
   async updateDevicePlaylist(deviceId: string, playlist: Playlist): Promise<void> {
     try {
       // Cache the playlist
-      await this.redisService.cachePlaylist(deviceId, playlist);
+      await this.redisService.cachePlaylist(deviceId, redactDevicePlaylist(playlist));
 
       this.logger.log(`Updated playlist for device: ${deviceId}`);
     } catch (error: unknown) {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,40 @@
 # Vizora - Task Tracker
 
+## Active: Realtime Widget Secret Boundary Pass 30 (2026-06-01)
+
+**Branch:** `feat/customer-readiness-pass-30`
+
+**Why now:** Pass 29 fixed widget truthfulness and HTTP response redaction, but security review found the realtime/device path still builds playlist payloads from raw content metadata. A generic API widget can therefore leak saved API headers to display clients even though dashboard/API responses are redacted.
+
+**New primitives introduced:** one realtime-local device payload sanitizer. No new database model, migration, route, queue, realtime room model, MCP tool, Hermes skill, provider spend path, or production process.
+
+**Hermes-first analysis:** not applicable to runtime delivery code. Official Hermes bundled skills and the current awesome-Hermes ecosystem do not provide a reusable NestJS/Socket.IO payload sanitizer; this is an in-process Vizora secret-boundary concern and must stay in the realtime service.
+
+**Plan/design:** `docs/plans/2026-06-01-realtime-widget-secret-boundary-pass-30.md`
+
+**Plan**
+- [x] Start fresh branch from `origin/main`.
+- [x] Dispatch customer, performance, and architecture/security reviewers for the next pass.
+- [x] Select the highest-risk bounded target from review: generic API widget header leakage through realtime/device payloads.
+- [x] Add failing realtime tests for cached, primary, fallback, update, initial-state, and layout metadata redaction.
+- [x] Implement realtime-side payload sanitizer and wire existing delivery paths.
+- [x] Run focused tests.
+- [x] Run multi-subagent review before broader verification.
+- [x] Run broader verification.
+- [ ] PR, CI, merge if green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Evidence so far:**
+- Drift evidence: middleware HTTP responses redact generic API widget headers, but `realtime/src/services/playlist.service.ts` and `realtime/src/gateways/device.gateway.ts` still copy raw `item.content.metadata` into device-bound payloads.
+- TDD red: focused realtime specs failed on raw `Bearer live-secret` / `live-api-key` values in cached playlists, DB playlists, fallback playlists, admin-updated playlists, initial-state payloads, direct `playlist:update` emissions, and layout metadata.
+- Focused green after implementation: `pnpm --filter @vizora/realtime test -- --runInBand --runTestsByPath src/services/playlist.service.spec.ts src/gateways/device.gateway.spec.ts` passed 128/128.
+- Review findings fixed: stale pending playlist replay now sanitizes Redis payloads on read/requeue, and generic API widget `widgetConfig` is stripped entirely from device-bound metadata so query-string secrets do not survive. Focused specs now pass 129/129.
+- Final follow-up review: security and realtime/display reviewers both returned CLEAN.
+- Broader local verification: full realtime Jest passed 12 suites / 285 tests; `npx nx build @vizora/realtime --skip-nx-cache` passed with existing third-party webpack warnings; `pnpm security:no-hardcoded-jwts` passed; changed-file ESLint exited 0 with existing warnings; `git diff --check` passed with CRLF warnings only.
+- Deploy gate is still expected blocked by dirty/diverged prod checkout; no prod state changes are authorized for this pass.
+
+---
+
 ## Completed: Widget Truthfulness Pass 29 (2026-06-01)
 
 **Branch:** `feat/widget-truthfulness-pass-29`


### PR DESCRIPTION
## Summary
- add realtime-local device payload sanitizer for generic API widget metadata
- strip generic API `widgetConfig` from device-bound playlist/layout payloads, including cached and pending replay paths
- add regression tests for cached, DB, fallback, admin push, initial state, layout metadata, and stale pending playlist replay

## Verification
- `pnpm --filter @vizora/realtime test -- --runInBand --runTestsByPath src/services/playlist.service.spec.ts src/gateways/device.gateway.spec.ts` passed 129/129
- `pnpm --filter @vizora/realtime test -- --runInBand` passed 12 suites / 285 tests
- `npx nx build @vizora/realtime --skip-nx-cache` passed with existing third-party webpack warnings
- `pnpm security:no-hardcoded-jwts` passed
- changed-file ESLint exited 0 with existing warnings
- `git diff --check` passed with CRLF warnings only

## Reviews
- Security follow-up reviewer: CLEAN
- Realtime/display follow-up reviewer: CLEAN

## Deploy
- Not deployed from this branch. Prod deploy remains gated on a clean/safe production checkout.