### PR TITLE
fix: make analytics metrics truthfully sourced

### DIFF
--- a/docs/plans/2026-06-01-analytics-truthfulness-pass-31.md
+++ b/docs/plans/2026-06-01-analytics-truthfulness-pass-31.md
@@ -1,0 +1,77 @@
+# Analytics Truthfulness Pass 31 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the customer-facing analytics dashboard and analytics API honest about metrics that are estimated from current state instead of measured from historical telemetry, and close analytics relation lookups that can expose cross-tenant names from malformed impression rows.
+
+**Architecture:** Preserve the existing NestJS analytics module, `/api/v1/analytics/*` routes, response envelope, web analytics hooks, and chart components. Add non-breaking provenance fields to analytics DTOs, keep array response shapes intact, add tenant predicates to related-row lookups, and update dashboard copy/export labels so estimated values are explicitly labeled rather than presented as live measured uptime, bandwidth, shares, unique playback devices, or engagement rankings.
+
+**Tech Stack:** NestJS 11, Prisma via `@vizora/database`, Next.js 16 App Router, React Testing Library, Jest, Nx/pnpm.
+
+---
+
+## New Primitives Introduced
+
+None. This pass adds optional metadata fields to existing analytics response shapes, tenant predicates to existing relation lookups, and copy/label changes in the existing dashboard. No migration, route, module, queue, realtime path, notification path, MCP tool, Hermes skill, provider spend path, or production process.
+
+## Hermes-First Analysis
+
+Not applicable. This pass does not add or modify business agents, MCP tools, Hermes skills, AI/provider calls, or spend paths. The issue is an in-process analytics DTO and dashboard truthfulness concern.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Analytics dashboard copy/provenance | none applicable | Build in existing Vizora web/API code because this is product UI/API contract work. |
+| Telemetry estimation labeling | none applicable | Build in existing analytics DTOs and consumers; do not introduce an agent/runtime. |
+
+Awesome-Hermes ecosystem check: no applicable reusable skill for NestJS analytics provenance or Vizora dashboard copy; this remains native Vizora code.
+
+## Drift Evidence
+
+- `middleware/src/modules/analytics/analytics.service.ts` generates device metric history from display creation/current inventory and comments that uptime categories are simulated.
+- `middleware/src/modules/analytics/analytics.service.ts` documents bandwidth as estimated from content file sizes and device count.
+- `web/src/app/dashboard/analytics/page-client.tsx` currently labels the page as real-time performance metrics, labels the KPI as system uptime, titles the chart as device uptime timeline, and labels bandwidth as MB/s.
+- `middleware/src/modules/analytics/analytics.service.ts` looks up related content, playlists, and display names by ID only after grouping impression rows by `organizationId`, so malformed rows can expose another tenant's related-row names.
+- `web/src/lib/types.ts` analytics interfaces are out of sync with the current middleware DTOs, so frontend type safety does not describe the real API contract.
+
+## Plan
+
+- [ ] Capture plan-review findings from two subagents before test edits.
+- [ ] Add failing middleware tests for analytics provenance:
+  - `getSummary` returns `uptimePercentSource: 'current_online_ratio'`.
+  - `getDeviceMetrics` marks points as estimated inventory-derived availability.
+  - `getBandwidthUsage` marks points as estimated transfer volume with `unit: 'MB/day'`.
+  - heartbeat-derived uptime endpoints mark 95/80/20 calculations as heuristic estimates.
+  - content performance marks shares as untracked and impression/completion fields as measured from proof-of-play.
+  - playlist performance marks assigned display count separately from unique playback devices.
+  - `exportAnalytics` preserves those provenance fields.
+- [ ] Add failing middleware tests for analytics tenant isolation:
+  - content performance does not map a grouped impression to content owned by another organization.
+  - playlist performance does not map a grouped impression to a playlist owned by another organization.
+  - content metrics top-device names do not resolve displays owned by another organization.
+  - proof-of-play CSV rows do not emit cross-tenant content or display names when a malformed impression points across orgs.
+- [ ] Add failing web tests for customer-facing truthfulness:
+  - Page subtitle no longer says "Real-time performance metrics and insights".
+  - KPI label no longer says "System Uptime"; it says "Online Now" and uses current device count copy.
+  - Device timeline title/note make estimation explicit.
+  - Bandwidth title/note make estimation explicit and axis no longer says `MB/s`.
+  - Content and playlist chart/export labels use impressions, average completion, assigned screens, and estimated transfer wording instead of views, shares, unique devices, top engagement, or measured throughput.
+  - CSV export uses "Online Now %" rather than "Uptime %".
+- [ ] Implement non-breaking analytics DTO metadata fields in `middleware/src/modules/analytics/dto/analytics-response.dto.ts`.
+- [ ] Populate provenance fields in `AnalyticsService` and add tenant predicates to related-row lookups without changing roles, routes, or response envelope behavior.
+- [ ] Update frontend analytics types to match current API shapes and new provenance fields.
+- [ ] Update dashboard copy, chart labels, and CSV labels.
+- [ ] Run two subagent diff reviews before broader verification.
+- [ ] Run focused middleware and web tests.
+- [ ] Run broader verification: relevant full Jest suites, TypeScript, lint, builds, `git diff --check`, and security guard.
+- [ ] Open PR, wait for CI, merge if green.
+- [ ] Re-check deployment gate; deploy only if production dirty/diverged state is resolved or explicitly approved with a reviewed runbook.
+
+## Acceptance Criteria
+
+- Customers can distinguish current-state ratios from true historical uptime.
+- Estimated bandwidth cannot be confused with measured network throughput.
+- Content and playlist charts do not claim shares, views, unique playback devices, or top engagement when those are not tracked.
+- Malformed impression rows cannot leak other-tenant content, playlist, or display names through analytics endpoints or CSV.
+- Empty/error states still distinguish "no data" from API failures.
+- Existing analytics endpoints remain backward-compatible for current clients.
+- No new telemetry, external provider, storage system, or background process is introduced.

--- a/middleware/src/modules/analytics/analytics.service.spec.ts
+++ b/middleware/src/modules/analytics/analytics.service.spec.ts
@@ -15,6 +15,7 @@ describe('AnalyticsService', () => {
       },
       content: {
         findMany: jest.fn().mockResolvedValue([]),
+        findFirst: jest.fn().mockResolvedValue(null),
         groupBy: jest.fn().mockResolvedValue([]),
         aggregate: jest.fn().mockResolvedValue({ _sum: { fileSize: 0 }, _count: { id: 0 } }),
         count: jest.fn().mockResolvedValue(0),
@@ -57,6 +58,20 @@ describe('AnalyticsService', () => {
       expect(result[0]).toHaveProperty('mobile');
     });
 
+    it('marks inventory-derived device metrics as estimated availability', async () => {
+      mockDb.display.findMany.mockResolvedValue([
+        { id: '1', status: 'online', lastHeartbeat: new Date(), createdAt: new Date('2025-01-01') },
+      ]);
+
+      const result = await service.getDeviceMetrics('org-123', 'week');
+
+      expect(result[0]).toEqual(expect.objectContaining({
+        isEstimated: true,
+        metricSource: 'display_inventory_estimate',
+        unit: 'percent',
+      }));
+    });
+
     it('should respect range parameter', async () => {
       mockDb.display.findMany.mockResolvedValue([
         { id: '1', status: 'online', lastHeartbeat: new Date(), createdAt: new Date('2025-01-01') },
@@ -92,7 +107,50 @@ describe('AnalyticsService', () => {
       expect(result).toHaveLength(1);
       expect(result[0].title).toBe('Test Content');
       expect(result[0].views).toBe(15);
+      expect(result[0].impressions).toBe(15);
       expect(result[0].engagement).toBe(85);
+      expect(result[0].averageCompletion).toBe(85);
+    });
+
+    it('does not resolve content names from another organization', async () => {
+      mockDb.contentImpression.groupBy.mockResolvedValue([
+        {
+          contentId: 'foreign-content',
+          _count: { id: 4 },
+          _avg: { duration: 10, completionPercentage: 50 },
+        },
+      ]);
+      mockDb.content.findMany.mockImplementation((args: any) => {
+        if (args.where?.organizationId === 'org-123') return Promise.resolve([]);
+        return Promise.resolve([{ id: 'foreign-content', name: 'Other Tenant Menu' }]);
+      });
+
+      const result = await service.getContentPerformance('org-123', 'month');
+
+      expect(result[0].title).toBe('Unknown');
+      expect(mockDb.content.findMany).toHaveBeenCalledWith({
+        where: { id: { in: ['foreign-content'] }, organizationId: 'org-123' },
+        select: { id: true, name: true },
+      });
+    });
+
+    it('marks untracked shares and measured proof-of-play fields', async () => {
+      mockDb.contentImpression.groupBy.mockResolvedValue([
+        {
+          contentId: 'content-1',
+          _count: { id: 15 },
+          _avg: { duration: 30, completionPercentage: 85 },
+        },
+      ]);
+      mockDb.content.findMany.mockResolvedValue([{ id: 'content-1', name: 'Promo' }]);
+
+      const result = await service.getContentPerformance('org-123', 'month');
+
+      expect(result[0]).toEqual(expect.objectContaining({
+        impressionsSource: 'content_impressions',
+        engagementSource: 'content_impressions',
+        sharesTracked: false,
+      }));
     });
   });
 
@@ -110,6 +168,15 @@ describe('AnalyticsService', () => {
       expect(result[0]).toHaveProperty('date');
       expect(result[0]).toHaveProperty('video');
       expect(result[0]).toHaveProperty('image');
+      expect(result[0]).toHaveProperty('other');
+    });
+
+    it('joins content by organization as well as content id', async () => {
+      await service.getUsageTrends('org-123', 'week');
+
+      const queryArg = mockDb.$queryRaw.mock.calls[0][0];
+      const queryText = Array.isArray(queryArg) ? queryArg.join('') : String(queryArg);
+      expect(queryText).toContain('c."organizationId" = ci."organizationId"');
     });
   });
 
@@ -160,6 +227,19 @@ describe('AnalyticsService', () => {
       expect(result[0]).toHaveProperty('peak');
     });
 
+    it('marks bandwidth as estimated daily transfer volume', async () => {
+      mockDb.content.aggregate.mockResolvedValue({ _sum: { fileSize: 1048576 }, _count: { id: 1 } });
+      mockDb.display.count.mockResolvedValue(5);
+
+      const result = await service.getBandwidthUsage('org-123', 'week');
+
+      expect(result[0]).toEqual(expect.objectContaining({
+        isEstimated: true,
+        metricSource: 'content_size_device_count_estimate',
+        unit: 'MB/day',
+      }));
+    });
+
     it('should return zero bandwidth when no devices', async () => {
       mockDb.content.aggregate.mockResolvedValue({ _sum: { fileSize: 1048576 }, _count: { id: 1 } });
       mockDb.display.count.mockResolvedValue(0);
@@ -196,7 +276,57 @@ describe('AnalyticsService', () => {
       expect(result).toHaveLength(1);
       expect(result[0].name).toBe('Test Playlist');
       expect(result[0].plays).toBe(20);
+      expect(result[0].proofOfPlayImpressions).toBe(20);
       expect(result[0].uniqueDevices).toBe(3);
+      expect(result[0].assignedScreens).toBe(3);
+    });
+
+    it('does not resolve playlist names from another organization', async () => {
+      mockDb.contentImpression.groupBy.mockResolvedValue([
+        {
+          playlistId: 'foreign-playlist',
+          _count: { id: 7 },
+          _avg: { completionPercentage: 80 },
+        },
+      ]);
+      mockDb.playlist.findMany.mockImplementation((args: any) => {
+        if (args.where?.organizationId === 'org-123') return Promise.resolve([]);
+        return Promise.resolve([
+          { id: 'foreign-playlist', name: 'Other Tenant Loop', _count: { assignedDisplays: 9 } },
+        ]);
+      });
+
+      const result = await service.getPlaylistPerformance('org-123', 'month');
+
+      expect(result[0].name).toBe('Unknown');
+      expect(result[0].uniqueDevices).toBe(0);
+      expect(result[0].assignedScreens).toBe(0);
+      expect(mockDb.playlist.findMany).toHaveBeenCalledWith({
+        where: { id: { in: ['foreign-playlist'] }, organizationId: 'org-123' },
+        include: { _count: { select: { assignedDisplays: true } } },
+      });
+    });
+
+    it('marks assigned displays separately from unique playback devices', async () => {
+      mockDb.contentImpression.groupBy.mockResolvedValue([
+        {
+          playlistId: 'playlist-1',
+          _count: { id: 20 },
+          _avg: { completionPercentage: 75 },
+        },
+      ]);
+      mockDb.playlist.findMany.mockResolvedValue([
+        { id: 'playlist-1', name: 'Test Playlist', _count: { assignedDisplays: 3 } },
+      ]);
+
+      const result = await service.getPlaylistPerformance('org-123', 'month');
+
+      expect(result[0]).toEqual(expect.objectContaining({
+        playsSource: 'content_impressions',
+        completionSource: 'content_impressions',
+        uniqueDevicesSource: 'assigned_displays',
+        uniquePlaybackDevicesTracked: false,
+      }));
     });
   });
 
@@ -232,6 +362,9 @@ describe('AnalyticsService', () => {
       expect(result.totalDevices).toBe(10);
       expect(result.onlineDevices).toBe(8);
       expect(result.uptimePercent).toBe(80);
+      expect(result.onlineNowPercent).toBe(80);
+      expect(result.uptimePercentSource).toBe('current_online_ratio');
+      expect(result.uptimePercentIsHistorical).toBe(false);
       expect(result.totalContent).toBe(50);
       expect(result.processingContent).toBe(4);
       expect(result.totalPlaylists).toBe(5);
@@ -323,6 +456,8 @@ describe('AnalyticsService', () => {
 
       expect(result.deviceId).toBe('device-123');
       expect(result.uptimePercent).toBe(95); // Online device gets 95%
+      expect(result.isEstimated).toBe(true);
+      expect(result.metricSource).toBe('heartbeat_status_heuristic');
       expect(result.totalOnlineMinutes).toBeGreaterThan(0);
       expect(result.totalOfflineMinutes).toBeGreaterThan(0);
       expect(result.lastHeartbeat).toEqual(now);
@@ -395,6 +530,8 @@ describe('AnalyticsService', () => {
       expect(result.deviceCount).toBe(2);
       expect(result.onlineCount).toBe(1);
       expect(result.offlineCount).toBe(1);
+      expect(result.isEstimated).toBe(true);
+      expect(result.metricSource).toBe('heartbeat_status_heuristic');
       expect(result.devices).toHaveLength(2);
     });
 
@@ -476,6 +613,8 @@ describe('AnalyticsService', () => {
       expect(result).toHaveProperty('deviceDistribution');
       expect(result).toHaveProperty('bandwidthUsage');
       expect(result).toHaveProperty('playlistPerformance');
+      expect(result.summary.uptimePercentSource).toBe('current_online_ratio');
+      expect(result.bandwidthUsage[0]?.metricSource).toBe('content_size_device_count_estimate');
     });
 
     it('should respect range parameter', async () => {

--- a/middleware/src/modules/analytics/analytics.service.ts
+++ b/middleware/src/modules/analytics/analytics.service.ts
@@ -43,7 +43,6 @@ export class AnalyticsService {
    * Uses Display table heartbeat data
    */
   async getDeviceMetrics(organizationId: string, range: string): Promise<DeviceMetricDataPoint[]> {
-    const { startDate } = this.getDateRange(range);
     const days = this.getRangeDays(range);
 
     // Get all devices for this org
@@ -82,6 +81,9 @@ export class AnalyticsService {
         mobile: Math.min(100, Math.max(0, baseUptime * 0.85)),
         tablet: Math.min(100, Math.max(0, baseUptime * 0.92)),
         desktop: Math.min(100, Math.max(0, baseUptime * 0.98)),
+        isEstimated: true,
+        metricSource: 'display_inventory_estimate',
+        unit: 'percent',
       });
     }
 
@@ -108,16 +110,21 @@ export class AnalyticsService {
 
     const contentIds = impressions.map(i => i.contentId);
     const contents = await this.db.content.findMany({
-      where: { id: { in: contentIds } },
+      where: { id: { in: contentIds }, organizationId },
       select: { id: true, name: true },
     });
     const contentMap = new Map(contents.map(c => [c.id, c.name]));
 
     return impressions.map(i => ({
       title: contentMap.get(i.contentId) || 'Unknown',
+      impressions: i._count.id,
+      averageCompletion: Math.round(i._avg.completionPercentage || 0),
       views: i._count.id,
       engagement: Math.round(i._avg.completionPercentage || 0),
       shares: 0,
+      impressionsSource: 'content_impressions',
+      engagementSource: 'content_impressions',
+      sharesTracked: false,
     }));
   }
 
@@ -134,18 +141,20 @@ export class AnalyticsService {
     >`
       SELECT ci.date, c.type, COUNT(*)::bigint as count
       FROM content_impressions ci
-      LEFT JOIN "Content" c ON ci."contentId" = c.id
+      LEFT JOIN "Content" c
+        ON ci."contentId" = c.id
+       AND c."organizationId" = ci."organizationId"
       WHERE ci."organizationId" = ${organizationId}
         AND ci.timestamp >= ${startDate}
       GROUP BY ci.date, c.type
     `;
 
-    // Build lookup map: dateStr -> { video, image, text, interactive }
+    // Build lookup map: dateStr -> { video, image, text, interactive, other }
     const dailyData = new Map<string, Record<string, number>>();
     for (const row of typeBreakdown) {
       const dateStr = new Date(row.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
       if (!dailyData.has(dateStr)) {
-        dailyData.set(dateStr, { video: 0, image: 0, text: 0, interactive: 0 });
+        dailyData.set(dateStr, { video: 0, image: 0, text: 0, interactive: 0, other: 0 });
       }
       const dayData = dailyData.get(dateStr)!;
       const count = Number(row.count);
@@ -154,6 +163,7 @@ export class AnalyticsService {
       else if (type === 'image') dayData.image += count;
       else if (type === 'html') dayData.text += count;
       else if (type === 'url') dayData.interactive += count;
+      else dayData.other += count;
     }
 
     // Generate data points for all days in range
@@ -162,7 +172,7 @@ export class AnalyticsService {
       const date = new Date();
       date.setDate(date.getDate() - (days - 1 - i));
       const dateStr = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-      const data = dailyData.get(dateStr) || { video: 0, image: 0, text: 0, interactive: 0 };
+      const data = dailyData.get(dateStr) || { video: 0, image: 0, text: 0, interactive: 0, other: 0 };
       dataPoints.push({ date: dateStr, ...data });
     }
 
@@ -233,6 +243,9 @@ export class AnalyticsService {
         current: avgDailyMB,
         average: avgDailyMB,
         peak: avgDailyMB * 1.5,
+        isEstimated: true,
+        metricSource: 'content_size_device_count_estimate',
+        unit: 'MB/day',
       });
     }
 
@@ -258,20 +271,30 @@ export class AnalyticsService {
 
     const playlistIds = impressions.map(i => i.playlistId).filter(Boolean) as string[];
     const playlists = await this.db.playlist.findMany({
-      where: { id: { in: playlistIds } },
+      where: { id: { in: playlistIds }, organizationId },
       include: { _count: { select: { assignedDisplays: true } } },
     });
     const playlistMap = new Map(playlists.map(p => [p.id, p]));
 
     return impressions.map(i => {
       const playlist = playlistMap.get(i.playlistId!);
+      const proofOfPlayImpressions = i._count.id;
+      const averageCompletion = Math.round(i._avg.completionPercentage || 0);
+      const assignedScreens = playlist?._count?.assignedDisplays || 0;
       return {
         name: playlist?.name || 'Unknown',
-        plays: i._count.id,
-        engagement: Math.round(i._avg.completionPercentage || 0),
-        uniqueDevices: playlist?._count?.assignedDisplays || 0,
-        views: i._count.id,
-        completion: Math.round(i._avg.completionPercentage || 0),
+        proofOfPlayImpressions,
+        averageCompletion,
+        assignedScreens,
+        plays: proofOfPlayImpressions,
+        engagement: averageCompletion,
+        uniqueDevices: assignedScreens,
+        views: proofOfPlayImpressions,
+        completion: averageCompletion,
+        playsSource: 'content_impressions',
+        completionSource: 'content_impressions',
+        uniqueDevicesSource: 'assigned_displays',
+        uniquePlaybackDevicesTracked: false,
       };
     });
   }
@@ -326,6 +349,9 @@ export class AnalyticsService {
       activePlaylists,
       totalContentSize: contentSize._sum.fileSize || 0,
       uptimePercent: parseFloat(uptimePercent),
+      onlineNowPercent: parseFloat(uptimePercent),
+      uptimePercentSource: 'current_online_ratio',
+      uptimePercentIsHistorical: false,
       totalImpressions,
     };
   }
@@ -370,7 +396,7 @@ export class AnalyticsService {
 
     const deviceIds = topDevices.map(d => d.displayId);
     const devices = await this.db.display.findMany({
-      where: { id: { in: deviceIds } },
+      where: { id: { in: deviceIds }, organizationId },
       select: { id: true, nickname: true },
     });
     const deviceMap = new Map(devices.map(d => [d.id, d.nickname || 'Unnamed']));
@@ -426,6 +452,8 @@ export class AnalyticsService {
       totalOnlineMinutes: Math.round((totalMinutes * uptimePercent) / 100),
       totalOfflineMinutes: Math.round((totalMinutes * (100 - uptimePercent)) / 100),
       lastHeartbeat: device.lastHeartbeat,
+      isEstimated: true,
+      metricSource: 'heartbeat_status_heuristic',
     };
   }
 
@@ -434,7 +462,7 @@ export class AnalyticsService {
    */
   async getUptimeSummary(
     organizationId: string,
-    days: number = 30,
+    _days: number = 30,
   ): Promise<UptimeSummaryResult> {
     const devices = await this.db.display.findMany({
       where: { organizationId },
@@ -471,6 +499,8 @@ export class AnalyticsService {
         nickname,
         uptimePercent,
       })),
+      isEstimated: true,
+      metricSource: 'heartbeat_status_heuristic',
     };
   }
 
@@ -581,15 +611,15 @@ export class AnalyticsService {
         take: limit,
         orderBy: { timestamp: 'desc' },
         include: {
-          content: { select: { id: true, name: true } },
-          display: { select: { id: true, nickname: true, deviceIdentifier: true } },
+          content: { select: { id: true, name: true, organizationId: true } },
+          display: { select: { id: true, nickname: true, deviceIdentifier: true, organizationId: true } },
         },
       }),
       this.db.contentImpression.count({ where }),
     ]);
 
     return {
-      data,
+      data: data.map((row) => this.sanitizeProofOfPlayRelations(row, organizationId)),
       meta: { page, limit, total, totalPages: Math.ceil(total / limit) },
     };
   }
@@ -643,15 +673,15 @@ export class AnalyticsService {
         take: BATCH,
         orderBy: { timestamp: 'asc' }, // ascending so the CSV is chronological
         include: {
-          content: { select: { id: true, name: true } },
-          display: { select: { id: true, nickname: true, deviceIdentifier: true } },
+          content: { select: { id: true, name: true, organizationId: true } },
+          display: { select: { id: true, nickname: true, deviceIdentifier: true, organizationId: true } },
         },
       });
       if (batch.length === 0) break;
 
       for (const r of batch) {
         if (emitted >= MAX_ROWS) break;
-        yield this.formatProofOfPlayCsvRow(r, tz);
+        yield this.formatProofOfPlayCsvRow(this.sanitizeProofOfPlayRelations(r, organizationId), tz);
         emitted++;
       }
       skip += BATCH;
@@ -693,10 +723,42 @@ export class AnalyticsService {
     if (f.displayId) where.displayId = f.displayId;
     if (f.playlistId) where.playlistId = f.playlistId;
     if (f.displayTagId) {
-      where.display = { tags: { some: { tagId: f.displayTagId } } };
+      where.display = { organizationId: orgId, tags: { some: { tagId: f.displayTagId } } };
     }
 
     return where;
+  }
+
+  private sanitizeProofOfPlayRelations<T extends {
+    contentId: string;
+    displayId: string;
+    content?: { id?: string; name: string; organizationId?: string | null } | null;
+    display?: {
+      id?: string;
+      nickname: string | null;
+      deviceIdentifier: string;
+      organizationId?: string | null;
+    } | null;
+  }>(row: T, organizationId: string): T & {
+    content: { id: string; name: string };
+    display: { id: string; nickname: string | null; deviceIdentifier: string };
+  } {
+    const contentBelongsToOrg = row.content?.organizationId === organizationId;
+    const displayBelongsToOrg = row.display?.organizationId === organizationId;
+
+    return {
+      ...row,
+      content: contentBelongsToOrg && row.content
+        ? { id: row.content.id ?? row.contentId, name: row.content.name }
+        : { id: row.contentId, name: 'Unknown' },
+      display: displayBelongsToOrg && row.display
+        ? {
+            id: row.display.id ?? row.displayId,
+            nickname: row.display.nickname,
+            deviceIdentifier: row.display.deviceIdentifier,
+          }
+        : { id: row.displayId, nickname: null, deviceIdentifier: 'Unknown' },
+    };
   }
 
   /**

--- a/middleware/src/modules/analytics/dto/analytics-response.dto.ts
+++ b/middleware/src/modules/analytics/dto/analytics-response.dto.ts
@@ -3,13 +3,24 @@ export interface DeviceMetricDataPoint {
   mobile: number;
   tablet: number;
   desktop: number;
+  isEstimated?: boolean;
+  metricSource?: 'display_inventory_estimate';
+  unit?: 'percent';
 }
 
 export interface ContentPerformanceItem {
   title: string;
+  impressions: number;
+  averageCompletion: number;
+  /** @deprecated Legacy alias for impressions. */
   views: number;
+  /** @deprecated Legacy alias for averageCompletion. */
   engagement: number;
+  /** @deprecated Shares are not tracked; kept as zero for response compatibility. */
   shares: number;
+  impressionsSource?: 'content_impressions';
+  engagementSource?: 'content_impressions';
+  sharesTracked?: boolean;
 }
 
 export interface UsageTrendDataPoint {
@@ -18,6 +29,7 @@ export interface UsageTrendDataPoint {
   image: number;
   text: number;
   interactive: number;
+  other: number;
 }
 
 export interface DeviceDistributionItem {
@@ -31,15 +43,30 @@ export interface BandwidthDataPoint {
   current: number;
   average: number;
   peak: number;
+  isEstimated?: boolean;
+  metricSource?: 'content_size_device_count_estimate';
+  unit?: 'MB/day';
 }
 
 export interface PlaylistPerformanceItem {
   name: string;
+  proofOfPlayImpressions: number;
+  averageCompletion: number;
+  assignedScreens: number;
+  /** @deprecated Legacy alias for proofOfPlayImpressions. */
   plays: number;
+  /** @deprecated Legacy alias for averageCompletion. */
   engagement: number;
+  /** @deprecated Assigned screen count, not unique playback devices. */
   uniqueDevices: number;
+  /** @deprecated Legacy alias for proofOfPlayImpressions. */
   views: number;
+  /** @deprecated Legacy alias for averageCompletion. */
   completion: number;
+  playsSource?: 'content_impressions';
+  completionSource?: 'content_impressions';
+  uniqueDevicesSource?: 'assigned_displays';
+  uniquePlaybackDevicesTracked?: boolean;
 }
 
 export interface AnalyticsSummary {
@@ -51,6 +78,9 @@ export interface AnalyticsSummary {
   activePlaylists: number;
   totalContentSize: number;
   uptimePercent: number;
+  onlineNowPercent?: number;
+  uptimePercentSource?: 'current_online_ratio';
+  uptimePercentIsHistorical?: boolean;
   totalImpressions: number;
 }
 
@@ -68,6 +98,8 @@ export interface DeviceUptimeResult {
   totalOnlineMinutes: number;
   totalOfflineMinutes: number;
   lastHeartbeat: Date | null;
+  isEstimated?: boolean;
+  metricSource?: 'heartbeat_status_heuristic';
 }
 
 export interface UptimeSummaryResult {
@@ -76,6 +108,8 @@ export interface UptimeSummaryResult {
   onlineCount: number;
   offlineCount: number;
   devices: Array<{ id: string; nickname: string; uptimePercent: number }>;
+  isEstimated?: boolean;
+  metricSource?: 'heartbeat_status_heuristic';
 }
 
 export interface ExportAnalyticsResult {

--- a/middleware/src/modules/analytics/proof-of-play.service.spec.ts
+++ b/middleware/src/modules/analytics/proof-of-play.service.spec.ts
@@ -38,8 +38,8 @@ describe('AnalyticsService — Proof of play (O2)', () => {
           playlistId: 'pl1',
           duration: 30,
           completionPercentage: 100,
-          content: { id: 'c1', name: 'Promo' },
-          display: { id: 'd1', nickname: 'Lobby', deviceIdentifier: 'mac-1' },
+          content: { id: 'c1', name: 'Promo', organizationId: orgId },
+          display: { id: 'd1', nickname: 'Lobby', deviceIdentifier: 'mac-1', organizationId: orgId },
         },
       ]);
       db.contentImpression.count.mockResolvedValue(1);
@@ -76,7 +76,10 @@ describe('AnalyticsService — Proof of play (O2)', () => {
       expect(where.contentId).toBe('c1');
       expect(where.displayId).toBe('d1');
       expect(where.playlistId).toBe('pl1');
-      expect(where.display).toEqual({ tags: { some: { tagId: 'tag-lobby' } } });
+      expect(where.display).toEqual({
+        organizationId: orgId,
+        tags: { some: { tagId: 'tag-lobby' } },
+      });
     });
 
     it('applies date-range filter only when at least one bound is provided', async () => {
@@ -103,6 +106,65 @@ describe('AnalyticsService — Proof of play (O2)', () => {
       expect(result.data).toEqual([]);
       expect(result.meta.total).toBe(0);
       expect(result.meta.totalPages).toBe(0);
+    });
+
+    it('redacts cross-tenant related names from malformed impression rows', async () => {
+      db.contentImpression.findMany.mockResolvedValue([
+        {
+          id: 'i1',
+          timestamp: new Date(),
+          organizationId: orgId,
+          contentId: 'foreign-content',
+          displayId: 'foreign-display',
+          playlistId: null,
+          duration: 30,
+          completionPercentage: 100,
+          content: { id: 'foreign-content', name: 'Other Tenant Promo', organizationId: 'org-other' },
+          display: {
+            id: 'foreign-display',
+            nickname: 'Other Tenant Lobby',
+            deviceIdentifier: 'other-device',
+            organizationId: 'org-other',
+          },
+        },
+      ]);
+      db.contentImpression.count.mockResolvedValue(1);
+
+      const result = await service.getProofOfPlay(orgId, { page: 1, limit: 50 });
+
+      expect(result.data[0].content).toEqual({ id: 'foreign-content', name: 'Unknown' });
+      expect(result.data[0].display).toEqual({
+        id: 'foreign-display',
+        nickname: null,
+        deviceIdentifier: 'Unknown',
+      });
+    });
+
+    it('fails closed when relation organization ids are missing', async () => {
+      db.contentImpression.findMany.mockResolvedValue([
+        {
+          id: 'i1',
+          timestamp: new Date(),
+          organizationId: orgId,
+          contentId: 'c1',
+          displayId: 'd1',
+          playlistId: null,
+          duration: 30,
+          completionPercentage: 100,
+          content: { id: 'c1', name: 'Promo' },
+          display: { id: 'd1', nickname: 'Lobby', deviceIdentifier: 'mac-1' },
+        },
+      ]);
+      db.contentImpression.count.mockResolvedValue(1);
+
+      const result = await service.getProofOfPlay(orgId, { page: 1, limit: 50 });
+
+      expect(result.data[0].content).toEqual({ id: 'c1', name: 'Unknown' });
+      expect(result.data[0].display).toEqual({
+        id: 'd1',
+        nickname: null,
+        deviceIdentifier: 'Unknown',
+      });
     });
   });
 
@@ -133,8 +195,8 @@ describe('AnalyticsService — Proof of play (O2)', () => {
         playlistId: 'pl1',
         duration: 30,
         completionPercentage: 100,
-        content: { id: 'c1', name: 'Promo' },
-        display: { id: 'd1', nickname: 'Lobby', deviceIdentifier: 'mac-1' },
+        content: { id: 'c1', name: 'Promo', organizationId: orgId },
+        display: { id: 'd1', nickname: 'Lobby', deviceIdentifier: 'mac-1', organizationId: orgId },
       };
       db.contentImpression.findMany
         .mockResolvedValueOnce([row])
@@ -154,8 +216,8 @@ describe('AnalyticsService — Proof of play (O2)', () => {
         playlistId: null,
         duration: null,
         completionPercentage: null,
-        content: { id: 'c1', name: '=SUM(A1:A2)' }, // attacker-controlled content name
-        display: { id: 'd1', nickname: '+CMD|calc.exe', deviceIdentifier: 'mac-1' },
+        content: { id: 'c1', name: '=SUM(A1:A2)', organizationId: orgId }, // attacker-controlled content name
+        display: { id: 'd1', nickname: '+CMD|calc.exe', deviceIdentifier: 'mac-1', organizationId: orgId },
       };
       db.contentImpression.findMany.mockResolvedValueOnce([row]).mockResolvedValueOnce([]);
 
@@ -176,8 +238,8 @@ describe('AnalyticsService — Proof of play (O2)', () => {
         playlistId: null,
         duration: 30,
         completionPercentage: 100,
-        content: { id: 'c1', name: 'Promo' },
-        display: { id: 'd1', nickname: 'NY Lobby', deviceIdentifier: 'mac-1' },
+        content: { id: 'c1', name: 'Promo', organizationId: orgId },
+        display: { id: 'd1', nickname: 'NY Lobby', deviceIdentifier: 'mac-1', organizationId: orgId },
       };
       db.contentImpression.findMany
         .mockResolvedValueOnce([row])
@@ -203,8 +265,8 @@ describe('AnalyticsService — Proof of play (O2)', () => {
         playlistId: null,
         duration: null,
         completionPercentage: null,
-        content: { id: 'c1', name: 'Promo' },
-        display: { id: 'd1', nickname: 'Foo', deviceIdentifier: 'mac-1' },
+        content: { id: 'c1', name: 'Promo', organizationId: orgId },
+        display: { id: 'd1', nickname: 'Foo', deviceIdentifier: 'mac-1', organizationId: orgId },
       };
       db.contentImpression.findMany
         .mockResolvedValueOnce([row])
@@ -226,8 +288,8 @@ describe('AnalyticsService — Proof of play (O2)', () => {
         playlistId: null,
         duration: null,
         completionPercentage: null,
-        content: { id: 'c1', name: 'Promo, "Awesome" Edition' },
-        display: { id: 'd1', nickname: 'Lobby\nTV', deviceIdentifier: 'mac-1' },
+        content: { id: 'c1', name: 'Promo, "Awesome" Edition', organizationId: orgId },
+        display: { id: 'd1', nickname: 'Lobby\nTV', deviceIdentifier: 'mac-1', organizationId: orgId },
       };
       db.contentImpression.findMany.mockResolvedValueOnce([row]).mockResolvedValueOnce([]);
 
@@ -236,6 +298,31 @@ describe('AnalyticsService — Proof of play (O2)', () => {
       expect(out).toContain('"Promo, ""Awesome"" Edition"');
       // Newline cell gets quoted
       expect(out).toContain('"Lobby\nTV"');
+    });
+
+    it('does not emit cross-tenant related names from malformed impression rows', async () => {
+      const row = {
+        timestamp: new Date('2026-05-19T10:00:00Z'),
+        contentId: 'foreign-content',
+        displayId: 'foreign-display',
+        playlistId: null,
+        duration: 30,
+        completionPercentage: 100,
+        content: { id: 'foreign-content', name: 'Other Tenant Promo', organizationId: 'org-other' },
+        display: {
+          id: 'foreign-display',
+          nickname: 'Other Tenant Lobby',
+          deviceIdentifier: 'other-device',
+          organizationId: 'org-other',
+        },
+      };
+      db.contentImpression.findMany.mockResolvedValueOnce([row]).mockResolvedValueOnce([]);
+
+      const out = await collect(service.streamProofOfPlayCsv(orgId, {}));
+
+      expect(out).not.toContain('Other Tenant Promo');
+      expect(out).not.toContain('Other Tenant Lobby');
+      expect(out).toContain('foreign-content,Unknown,foreign-display,Unknown');
     });
 
     it('respects the 100k row safety cap', async () => {
@@ -247,15 +334,16 @@ describe('AnalyticsService — Proof of play (O2)', () => {
         playlistId: null,
         duration: 1,
         completionPercentage: 100,
-        content: { id: 'c', name: 'x' },
-        display: { id: 'd', nickname: 'y', deviceIdentifier: 'z' },
+        content: { id: 'c', name: 'x', organizationId: orgId },
+        display: { id: 'd', nickname: 'y', deviceIdentifier: 'z', organizationId: orgId },
       };
       const fullBatch = Array(1000).fill(fakeRow);
       db.contentImpression.findMany.mockResolvedValue(fullBatch);
 
       const gen = service.streamProofOfPlayCsv(orgId, {});
       let count = 0;
-      for await (const _ of gen) {
+      for await (const chunk of gen) {
+        expect(typeof chunk).toBe('string');
         count++;
         if (count > 100_002) break; // safety break for the test itself
       }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,86 @@
 # Vizora - Task Tracker
 
+## Active: Analytics Truthfulness Pass 31 (2026-06-01)
+
+**Branch:** `feat/analytics-truthfulness-pass-31`
+
+**Why now:** Pass 30 is merged with green PR and post-merge `main` CI, but
+production deploy remains blocked by dirty/diverged prod-local state. The next
+highest customer-trust issue from dashboard review is the analytics page
+presenting current-state or estimated metrics as real-time measured uptime and
+bandwidth. Plan review also found a P1 analytics data-isolation gap: malformed
+impression rows can carry the caller's `organizationId` while pointing at
+another tenant's content, playlist, or display IDs, and current analytics
+relation lookups resolve those related names by ID only.
+
+**New primitives introduced:** none. This pass only adds optional provenance
+metadata to existing analytics response shapes, tenant predicates to existing
+relation lookups, and updates existing dashboard copy/labels. No migration,
+route, module, queue, realtime path, notification path, MCP tool, Hermes skill,
+provider spend path, or production process.
+
+**Hermes-first analysis:** not applicable. This pass does not add or modify
+business agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
+
+**Plan/design:**
+`docs/plans/2026-06-01-analytics-truthfulness-pass-31.md`
+
+**Plan**
+- [x] Start fresh branch from `origin/main`.
+- [x] Dispatch customer-copy/UX and API-contract/backcompat reviewers.
+- [x] Capture plan-review findings before test edits.
+- [x] Add failing middleware tests for analytics provenance.
+- [x] Add failing middleware tests for analytics tenant-isolated relation lookups.
+- [x] Add failing web tests for customer-facing truthfulness.
+- [x] Implement analytics DTO provenance and dashboard copy/label updates.
+- [x] Run multiple subagent diff reviews before broader verification.
+- [x] Run focused middleware and web tests.
+- [x] Run broader verification.
+- [ ] PR, CI, merge if green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Evidence so far:**
+- Drift evidence: `AnalyticsService.getDeviceMetrics` simulates category
+  uptime from device inventory, `getBandwidthUsage` estimates transfer from
+  content sizes and device count, while the dashboard labels the page as
+  real-time performance metrics, shows a `System Uptime` KPI, and charts
+  bandwidth as `MB/s`.
+- Plan-review evidence: two read-only reviewers found misleading real-time,
+  uptime, bandwidth, views/shares/unique-device/top-engagement copy; stale web
+  analytics types; and analytics relation lookups that need organization
+  predicates before returning related names.
+- TDD red evidence: focused middleware analytics tests failed on missing
+  provenance fields and cross-tenant content/playlist/proof-of-play name
+  redaction; focused web analytics tests failed on `System Uptime`, `Device
+  Uptime Timeline`, real-time analytics copy, `MB/s`, views/shares/unique-device
+  CSV labels, and old chart titles.
+- Focused green evidence: middleware analytics service/proof-of-play suites
+  passed 55/55; web analytics page suite passed 12/12.
+- Diff review findings fixed: usage-trends raw SQL now joins `Content` by both
+  content ID and organization ID; proof-of-play relation sanitization fails
+  closed when relation `organizationId` is absent; realtime device-status events
+  no longer render a stale analytics `Updated Ns ago` freshness claim; frontend
+  analytics types now expose honest required aliases with legacy fields optional
+  for response compatibility; usage trends include an `other` bucket and clearer
+  reported-content-type copy.
+- Post-review focused green evidence: middleware analytics service/proof-of-play
+  suites passed 57/57; web analytics page suite passed 13/13.
+- Follow-up backend and frontend diff reviewers both returned CLEAN.
+- Broader local verification:
+  - `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/analytics/analytics.controller.spec.ts src/modules/analytics/analytics.service.spec.ts src/modules/analytics/proof-of-play.service.spec.ts` passed 70/70.
+  - `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/dashboard/analytics/__tests__/analytics-page.test.tsx src/lib/hooks/__tests__/useAnalyticsData.test.ts` passed 28/28.
+  - `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` passed.
+  - `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` passed.
+  - `pnpm --filter @vizora/middleware test -- --runInBand` passed 146 suites / 2930 tests.
+  - `pnpm --filter @vizora/web test -- --runInBand` passed 96 suites / 1045 tests with unrelated existing React `act()` warnings.
+  - `ESLINT_USE_FLAT_CONFIG=false npx eslint ...changed analytics files...` passed with 0 errors / 0 warnings; only the ESLint config deprecation notice remains.
+  - `pnpm security:no-hardcoded-jwts` passed.
+  - `npx nx build @vizora/middleware --skip-nx-cache` passed with existing webpack dependency warnings.
+  - `NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 BACKEND_URL=http://localhost:3000 npx nx build @vizora/web --skip-nx-cache` passed with existing Next middleware/proxy and TS project-reference warnings.
+  - `git diff --check` passed with CRLF warnings only.
+
+---
+
 ## Completed: Realtime Widget Secret Boundary Pass 30 (2026-06-01)
 
 **Branch:** `feat/customer-readiness-pass-30`

--- a/web/src/app/dashboard/analytics/__tests__/analytics-page.test.tsx
+++ b/web/src/app/dashboard/analytics/__tests__/analytics-page.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import AnalyticsClient from '../page-client';
 import { apiClient } from '@/lib/api';
+import { useRealtimeEvents } from '@/lib/hooks';
 
 const mockUseDeviceMetrics = jest.fn();
 const mockUseContentPerformance = jest.fn();
@@ -10,11 +11,31 @@ const mockUseBandwidthUsage = jest.fn();
 const mockUsePlaylistPerformance = jest.fn();
 
 jest.mock('@/components/charts', () => ({
-  LineChart: () => <div data-testid="line-chart">LineChart</div>,
-  BarChart: () => <div data-testid="bar-chart">BarChart</div>,
+  LineChart: ({ yAxisLabel, dataKeys }: any) => (
+    <div data-testid="line-chart">
+      <span>{yAxisLabel}</span>
+      {dataKeys?.map((key: any) => <span key={key.key}>{key.name}</span>)}
+    </div>
+  ),
+  BarChart: ({ yAxisLabel, dataKeys }: any) => (
+    <div data-testid="bar-chart">
+      <span>{yAxisLabel}</span>
+      {dataKeys?.map((key: any) => <span key={key.key}>{key.name}</span>)}
+    </div>
+  ),
   PieChart: () => <div data-testid="pie-chart">PieChart</div>,
-  AreaChart: () => <div data-testid="area-chart">AreaChart</div>,
-  ComposedChart: () => <div data-testid="composed-chart">ComposedChart</div>,
+  AreaChart: ({ yAxisLabel, dataKeys }: any) => (
+    <div data-testid="area-chart">
+      <span>{yAxisLabel}</span>
+      {dataKeys?.map((key: any) => <span key={key.key}>{key.name}</span>)}
+    </div>
+  ),
+  ComposedChart: ({ yAxisLabel, series }: any) => (
+    <div data-testid="composed-chart">
+      <span>{yAxisLabel}</span>
+      {series?.map((item: any) => <span key={item.key}>{item.name}</span>)}
+    </div>
+  ),
 }));
 
 jest.mock('@/components/ui/Card', () => ({
@@ -48,6 +69,9 @@ jest.mock('@/lib/api', () => ({
       totalPlaylists: 5,
       totalContentSize: 1073741824,
       uptimePercent: 98,
+      onlineNowPercent: 98,
+      uptimePercentSource: 'current_online_ratio',
+      uptimePercentIsHistorical: false,
     }),
     exportAnalytics: jest.fn().mockResolvedValue({
       summary: { totalDevices: 10 },
@@ -86,6 +110,9 @@ describe('AnalyticsClient', () => {
       totalPlaylists: 5,
       totalContentSize: 1073741824,
       uptimePercent: 98,
+      onlineNowPercent: 98,
+      uptimePercentSource: 'current_online_ratio',
+      uptimePercentIsHistorical: false,
     });
 
     const emptyState = { data: [], loading: false, error: null, isMockData: true };
@@ -95,6 +122,7 @@ describe('AnalyticsClient', () => {
     mockUseDeviceDistribution.mockReturnValue(emptyState);
     mockUseBandwidthUsage.mockReturnValue(emptyState);
     mockUsePlaylistPerformance.mockReturnValue(emptyState);
+    (useRealtimeEvents as jest.Mock).mockImplementation(() => {});
   });
 
   const renderLoadedAnalytics = async () => {
@@ -123,14 +151,80 @@ describe('AnalyticsClient', () => {
     await renderLoadedAnalytics();
     expect(screen.getByText('Total Devices')).toBeInTheDocument();
     expect(screen.getByText('Content Items')).toBeInTheDocument();
-    expect(screen.getByText('System Uptime')).toBeInTheDocument();
+    expect(screen.getByText('Online Now')).toBeInTheDocument();
+    expect(screen.queryByText('System Uptime')).not.toBeInTheDocument();
   });
 
   it('renders chart section titles', async () => {
     await renderLoadedAnalytics();
-    expect(screen.getByText('Device Uptime Timeline')).toBeInTheDocument();
-    expect(screen.getByText('Content Performance')).toBeInTheDocument();
+    expect(screen.getByText('Estimated Availability Trend')).toBeInTheDocument();
+    expect(screen.getByText('Content Proof-of-Play')).toBeInTheDocument();
     expect(screen.getByText('Device Distribution')).toBeInTheDocument();
+    expect(screen.getByText('Usage Trends by Reported Content Type')).toBeInTheDocument();
+  });
+
+  it('labels current-state and estimated analytics honestly', async () => {
+    mockUseDeviceMetrics.mockReturnValue({
+      data: [{ date: 'Jan 1', mobile: 85, tablet: 92, desktop: 98, isEstimated: true }],
+      loading: false,
+      error: null,
+      isMockData: false,
+    });
+    mockUseBandwidthUsage.mockReturnValue({
+      data: [{ time: 'Jan 1', current: 10, average: 10, peak: 15, isEstimated: true, unit: 'MB/day' }],
+      loading: false,
+      error: null,
+      isMockData: false,
+    });
+
+    await renderLoadedAnalytics();
+
+    expect(screen.queryByText('Real-time performance metrics and insights')).not.toBeInTheDocument();
+    expect(screen.getByText('Current device status and proof-of-play reporting')).toBeInTheDocument();
+    expect(screen.getByText('Online Now')).toBeInTheDocument();
+    expect(screen.getByText(/Current online ratio from display status/i)).toBeInTheDocument();
+    expect(screen.getByText('Estimated Availability Trend')).toBeInTheDocument();
+    expect(screen.getByText(/Estimated from display inventory/i)).toBeInTheDocument();
+    expect(screen.getByText('Estimated Transfer Volume')).toBeInTheDocument();
+    expect(screen.getByText(/Estimated from stored content size and assigned screens/i)).toBeInTheDocument();
+    expect(screen.getByText('MB/day')).toBeInTheDocument();
+    expect(screen.queryByText('MB/s')).not.toBeInTheDocument();
+  });
+
+  it('uses proof-of-play labels for content and playlist charts', async () => {
+    mockUseContentPerformance.mockReturnValue({
+      data: [{ title: 'Promo', impressions: 5, averageCompletion: 80, sharesTracked: false }],
+      loading: false,
+      error: null,
+      isMockData: false,
+    });
+    mockUsePlaylistPerformance.mockReturnValue({
+      data: [{ name: 'Morning Loop', proofOfPlayImpressions: 5, averageCompletion: 80, assignedScreens: 2 }],
+      loading: false,
+      error: null,
+      isMockData: false,
+    });
+
+    await renderLoadedAnalytics();
+
+    expect(screen.getByText('Content Proof-of-Play')).toBeInTheDocument();
+    expect(screen.getAllByText('Impressions').length).toBeGreaterThan(0);
+    expect(screen.getByText('Playlist Playback Summary')).toBeInTheDocument();
+    expect(screen.getByText('Average Completion')).toBeInTheDocument();
+    expect(screen.queryByText('Shares')).not.toBeInTheDocument();
+    expect(screen.queryByText('Top Playlists by Engagement')).not.toBeInTheDocument();
+  });
+
+  it('does not imply analytics refreshed on realtime device-status events', async () => {
+    const realtimeOptionsRef: { current?: { onDeviceStatusChange?: () => void } } = {};
+    (useRealtimeEvents as jest.Mock).mockImplementation((options) => {
+      realtimeOptionsRef.current = options as { onDeviceStatusChange?: () => void };
+    });
+
+    await renderLoadedAnalytics();
+    realtimeOptionsRef.current?.onDeviceStatusChange?.();
+
+    expect(screen.queryByText(/Updated \d+s ago/)).not.toBeInTheDocument();
   });
 
   it('changes date range when button clicked', async () => {
@@ -143,8 +237,8 @@ describe('AnalyticsClient', () => {
     await renderLoadedAnalytics();
 
     expect(screen.getByText('No Data Yet')).toBeInTheDocument();
-    expect(screen.getByText('No device uptime data available yet.')).toBeInTheDocument();
-    expect(screen.getByText('No content performance data yet. Upload content to track views.')).toBeInTheDocument();
+    expect(screen.getByText('No availability estimate available yet.')).toBeInTheDocument();
+    expect(screen.getByText('No content proof-of-play data yet. Playback impressions appear as displays report content playback.')).toBeInTheDocument();
     expect(screen.queryByRole('alert', { name: /analytics data unavailable/i })).not.toBeInTheDocument();
   });
 
@@ -159,11 +253,11 @@ describe('AnalyticsClient', () => {
     await renderLoadedAnalytics();
 
     expect(screen.getByRole('alert', { name: /analytics data unavailable/i })).toHaveTextContent(
-      'Device uptime timeline'
+      'Estimated availability trend'
     );
-    expect(screen.getByText('Unable to load device uptime data.').closest('[role="alert"]')).toBeInTheDocument();
+    expect(screen.getByText('Unable to load estimated availability data.').closest('[role="alert"]')).toBeInTheDocument();
     expect(screen.queryByText('No Data Yet')).not.toBeInTheDocument();
-    expect(screen.queryByText('No device uptime data available yet.')).not.toBeInTheDocument();
+    expect(screen.queryByText('No availability estimate available yet.')).not.toBeInTheDocument();
   });
 
   it('surfaces summary load failures instead of only showing no data notice', async () => {
@@ -174,5 +268,56 @@ describe('AnalyticsClient', () => {
     const alert = await screen.findByRole('alert', { name: /analytics data unavailable/i });
     expect(alert).toHaveTextContent('Analytics summary');
     expect(screen.queryByText('No Data Yet')).not.toBeInTheDocument();
+  });
+
+  it('exports CSV with honest current-state and proof-of-play labels', async () => {
+    const originalBlob = global.Blob;
+    const originalCreateObjectUrl = URL.createObjectURL;
+    const originalRevokeObjectUrl = URL.revokeObjectURL;
+    const blobParts: BlobPart[][] = [];
+    class MockBlob {
+      constructor(parts: BlobPart[]) {
+        blobParts.push(parts);
+      }
+    }
+    Object.defineProperty(global, 'Blob', { value: MockBlob, configurable: true });
+    Object.defineProperty(URL, 'createObjectURL', { value: jest.fn(() => 'blob:test'), configurable: true });
+    Object.defineProperty(URL, 'revokeObjectURL', { value: jest.fn(), configurable: true });
+    const click = jest.fn();
+    let createElementSpy: jest.SpyInstance | null = null;
+
+    try {
+      (apiClient.exportAnalytics as jest.Mock).mockResolvedValueOnce({
+        summary: { totalDevices: 10, onlineDevices: 8, uptimePercent: 80, onlineNowPercent: 80 },
+        deviceMetrics: [{ date: 'Jan 1', mobile: 85, tablet: 92, desktop: 98 }],
+        contentPerformance: [{ title: 'Promo', impressions: 3, averageCompletion: 90 }],
+        playlistPerformance: [{ name: 'Morning Loop', proofOfPlayImpressions: 3, averageCompletion: 90, assignedScreens: 2 }],
+      });
+
+      await renderLoadedAnalytics();
+      createElementSpy = jest.spyOn(document, 'createElement').mockReturnValue({
+        click,
+        set href(_value: string) {},
+        get href() { return 'blob:test'; },
+        set download(_value: string) {},
+      } as unknown as HTMLAnchorElement);
+      fireEvent.click(screen.getByText('Export CSV'));
+
+      await waitFor(() => expect(apiClient.exportAnalytics).toHaveBeenCalledWith('month'));
+      const csv = String(blobParts[0][0]);
+      expect(csv).toContain('"Online Now %","80"');
+      expect(csv).not.toContain('"Uptime %"');
+      expect(csv).toContain('Proof-of-Play Impressions');
+      expect(csv).toContain('Average Completion');
+      expect(csv).toContain('Assigned Screens');
+      expect(csv).not.toContain('Shares');
+      expect(csv).not.toContain('Unique Devices');
+      expect(click).toHaveBeenCalled();
+    } finally {
+      createElementSpy?.mockRestore();
+      Object.defineProperty(global, 'Blob', { value: originalBlob, configurable: true });
+      Object.defineProperty(URL, 'createObjectURL', { value: originalCreateObjectUrl, configurable: true });
+      Object.defineProperty(URL, 'revokeObjectURL', { value: originalRevokeObjectUrl, configurable: true });
+    }
   });
 });

--- a/web/src/app/dashboard/analytics/page-client.tsx
+++ b/web/src/app/dashboard/analytics/page-client.tsx
@@ -51,8 +51,24 @@ interface KPICardProps {
 interface AnalyticsCsvExport {
  summary?: Partial<AnalyticsSummary>;
  deviceMetrics?: Array<{ date: string; mobile?: number; tablet?: number; desktop?: number }>;
- contentPerformance?: Array<{ title?: string; name?: string; views?: number; engagement?: number; shares?: number }>;
- playlistPerformance?: Array<{ name: string; plays?: number; engagement?: number; uniqueDevices?: number; completion?: number }>;
+ contentPerformance?: Array<{
+  title?: string;
+  name?: string;
+  impressions?: number;
+  averageCompletion?: number;
+  views?: number;
+  engagement?: number;
+ }>;
+ playlistPerformance?: Array<{
+  name: string;
+  proofOfPlayImpressions?: number;
+  averageCompletion?: number;
+  assignedScreens?: number;
+  plays?: number;
+  engagement?: number;
+  uniqueDevices?: number;
+  completion?: number;
+ }>;
 }
 
 const KPICard: React.FC<KPICardProps> = ({
@@ -110,13 +126,17 @@ const formatBytes = (bytes: number) => {
 
 const csvCell = (value: unknown): string => `"${String(value ?? '').replace(/"/g, '""')}"`;
 const fixedCell = (value: number | undefined): string => typeof value === 'number' ? value.toFixed(1) : '';
+const rangeBadgeLabel = (range: 'week' | 'month' | 'year') => {
+ if (range === 'week') return 'Last 7 Days';
+ if (range === 'year') return '30 sampled days';
+ return 'Last 30 Days';
+};
 
 export default function AnalyticsClient() {
  const toast = useToast();
  const [dateRange, setDateRange] = useState<'week' | 'month' | 'year'>('month');
  const [exporting, setExporting] = useState(false);
  const [realtimeStatus, setRealtimeStatus] = useState<'connected' | 'offline'>('offline');
- const [lastUpdate, setLastUpdate] = useState<Date | null>(null);
  const [summary, setSummary] = useState<AnalyticsSummary | null>(null);
  const [summaryError, setSummaryError] = useState<string | null>(null);
 
@@ -150,12 +170,12 @@ export default function AnalyticsClient() {
 
  const analyticsErrorSections = [
  { label: 'Analytics summary', error: summaryError },
- { label: 'Device uptime timeline', error: deviceMetrics.error },
- { label: 'Content performance', error: contentPerformance.error },
+ { label: 'Estimated availability trend', error: deviceMetrics.error },
+ { label: 'Content proof-of-play', error: contentPerformance.error },
  { label: 'Device distribution', error: deviceDistribution.error },
  { label: 'Usage trends', error: usageTrends.error },
- { label: 'Bandwidth usage', error: bandwidthUsage.error },
- { label: 'Playlist performance', error: playlistPerformance.error },
+ { label: 'Estimated transfer volume', error: bandwidthUsage.error },
+ { label: 'Playlist playback summary', error: playlistPerformance.error },
  ].filter((section) => Boolean(section.error));
 
  const hasAnalyticsErrors = analyticsErrorSections.length > 0;
@@ -168,10 +188,6 @@ export default function AnalyticsClient() {
  // Real-time analytics updates
  useRealtimeEvents({
  enabled: true,
- onDeviceStatusChange: () => {
- // Device status changes may affect uptime metrics
- setLastUpdate(new Date());
- },
  onConnectionChange: (connected) => {
  setRealtimeStatus(connected ? 'connected' : 'offline');
  },
@@ -193,14 +209,14 @@ export default function AnalyticsClient() {
  sections.push(`"Online Devices","${data.summary.onlineDevices}"`);
  sections.push(`"Total Content","${data.summary.totalContent}"`);
  sections.push(`"Total Playlists","${data.summary.totalPlaylists}"`);
- sections.push(`"Uptime %","${data.summary.uptimePercent}"`);
+ sections.push(`"Online Now %","${data.summary.onlineNowPercent ?? data.summary.uptimePercent}"`);
  sections.push('');
  }
 
  // Device Metrics section
  if (data.deviceMetrics?.length) {
- sections.push('DEVICE METRICS');
- sections.push(['Date', 'Mobile', 'Tablet', 'Desktop'].join(','));
+ sections.push('ESTIMATED AVAILABILITY');
+ sections.push(['Date', 'Lower Estimate %', 'Mid Estimate %', 'Upper Estimate %'].join(','));
  data.deviceMetrics.forEach((d) => {
  sections.push([csvCell(d.date), fixedCell(d.mobile), fixedCell(d.tablet), fixedCell(d.desktop)].join(','));
  });
@@ -209,20 +225,29 @@ export default function AnalyticsClient() {
 
  // Content Performance section
  if (data.contentPerformance?.length) {
- sections.push('CONTENT PERFORMANCE');
- sections.push(['Title', 'Views', 'Engagement', 'Shares'].join(','));
+ sections.push('CONTENT PROOF-OF-PLAY');
+ sections.push(['Title', 'Proof-of-Play Impressions', 'Average Completion'].join(','));
  data.contentPerformance.forEach((c) => {
- sections.push([csvCell(c.title ?? c.name), c.views ?? '', c.engagement ?? '', c.shares ?? ''].join(','));
+ sections.push([
+  csvCell(c.title ?? c.name),
+  c.impressions ?? c.views ?? '',
+  c.averageCompletion ?? c.engagement ?? '',
+ ].join(','));
  });
  sections.push('');
  }
 
  // Playlist Performance section
  if (data.playlistPerformance?.length) {
- sections.push('PLAYLIST PERFORMANCE');
- sections.push(['Name', 'Plays', 'Engagement', 'Unique Devices', 'Completion'].join(','));
+ sections.push('PLAYLIST PLAYBACK SUMMARY');
+ sections.push(['Name', 'Proof-of-Play Impressions', 'Average Completion', 'Assigned Screens'].join(','));
  data.playlistPerformance.forEach((p) => {
- sections.push([csvCell(p.name), p.plays ?? '', p.engagement ?? '', p.uniqueDevices ?? '', p.completion ?? ''].join(','));
+ sections.push([
+  csvCell(p.name),
+  p.proofOfPlayImpressions ?? p.plays ?? '',
+  p.averageCompletion ?? p.completion ?? p.engagement ?? '',
+  p.assignedScreens ?? p.uniqueDevices ?? '',
+ ].join(','));
  });
  sections.push('');
  }
@@ -252,16 +277,11 @@ export default function AnalyticsClient() {
  Analytics
  </h2>
  <p className="mt-2 text-[var(--foreground-secondary)]">
- Real-time performance metrics and insights
+ Current device status and proof-of-play reporting
  {realtimeStatus === 'connected' && (
  <span className="ml-2 inline-flex items-center gap-1 text-xs text-green-600 dark:text-green-400">
  <span className="w-2 h-2 bg-green-600 dark:bg-green-400 rounded-full animate-pulse"></span>
- Real-time active
- </span>
- )}
- {lastUpdate && (
- <span className="ml-2 text-xs text-[var(--foreground-tertiary)]">
- Updated {Math.round((Date.now() - lastUpdate.getTime()) / 1000)}s ago
+ Realtime connection active
  </span>
  )}
  </p>
@@ -316,13 +336,19 @@ export default function AnalyticsClient() {
  icon="analytics"
  />
  <KPICard
- label="System Uptime"
- value={summary ? `${summary.uptimePercent}%` : '---'}
- change={summary ? (summary.uptimePercent >= 95 ? 'Above target' : 'Below target') : summaryError ? 'Unavailable' : ''}
- changeType={summary ? (summary.uptimePercent >= 95 ? 'positive' : 'negative') : 'neutral'}
+ label="Online Now"
+ value={summary ? `${summary.onlineNowPercent ?? summary.uptimePercent}%` : '---'}
+ change={summary ? `${summary.onlineDevices}/${summary.totalDevices} devices online` : summaryError ? 'Unavailable' : ''}
+ changeType="neutral"
  icon="overview"
  />
  </div>
+
+ {summary && (
+ <p className="text-xs text-[var(--foreground-tertiary)]">
+ Current online ratio from display status. Historical uptime is not tracked by this KPI.
+ </p>
+ )}
 
  {hasAnalyticsErrors && (
  <div
@@ -357,17 +383,20 @@ export default function AnalyticsClient() {
 
  {/* Charts Grid */}
  <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
- {/* Device Uptime Timeline */}
+ {/* Estimated Availability Trend */}
  <Card className="eh-dash-card lg:col-span-2">
  <Card.Header>
  <div className="flex items-center justify-between">
  <h3 className="eh-dash-subtitle text-lg font-semibold text-[var(--foreground)]">
- Device Uptime Timeline
+ Estimated Availability Trend
  </h3>
  <Badge variant="info" size="sm" className="eh-badge">
- Last 30 Days
+ {rangeBadgeLabel(dateRange)}
  </Badge>
  </div>
+ <p className="mt-1 text-xs text-[var(--foreground-tertiary)]">
+ Estimated from display inventory and creation dates. This is not measured historical uptime.
+ </p>
  </Card.Header>
  <Card.Body>
  {deviceMetrics.loading ? (
@@ -377,31 +406,34 @@ export default function AnalyticsClient() {
  </div>
  </div>
  ) : deviceMetrics.error ? (
- <ChartErrorState message="Unable to load device uptime data." detail={deviceMetrics.error} />
+ <ChartErrorState message="Unable to load estimated availability data." detail={deviceMetrics.error} />
  ) : deviceMetrics.data.length === 0 ? (
- <EmptyChartState message="No device uptime data available yet." />
+ <EmptyChartState message="No availability estimate available yet." />
  ) : (
  <LineChart
  data={deviceMetrics.data}
  dataKeys={[
- { key: 'mobile', name: 'Mobile Displays' },
- { key: 'tablet', name: 'Tablets' },
- { key: 'desktop', name: 'Desktop Screens' },
+ { key: 'mobile', name: 'Lower availability estimate' },
+ { key: 'tablet', name: 'Mid availability estimate' },
+ { key: 'desktop', name: 'Upper availability estimate' },
  ]}
  xAxisKey="date"
- yAxisLabel="Uptime %"
+ yAxisLabel="Estimated availability %"
  height={300}
  />
  )}
  </Card.Body>
  </Card>
 
- {/* Content Performance */}
+ {/* Content Proof-of-Play */}
  <Card className="eh-dash-card">
  <Card.Header>
  <h3 className="eh-dash-subtitle text-lg font-semibold text-[var(--foreground)]">
- Content Performance
+ Content Proof-of-Play
  </h3>
+ <p className="mt-1 text-xs text-[var(--foreground-tertiary)]">
+ Impressions and completion are measured from display playback reports. Shares are not tracked.
+ </p>
  </Card.Header>
  <Card.Body>
  {contentPerformance.loading ? (
@@ -411,13 +443,13 @@ export default function AnalyticsClient() {
  </div>
  </div>
  ) : contentPerformance.error ? (
- <ChartErrorState message="Unable to load content performance data." detail={contentPerformance.error} />
+ <ChartErrorState message="Unable to load content proof-of-play data." detail={contentPerformance.error} />
  ) : contentPerformance.data.length === 0 ? (
- <EmptyChartState message="No content performance data yet. Upload content to track views." />
+ <EmptyChartState message="No content proof-of-play data yet. Playback impressions appear as displays report content playback." />
  ) : (
  <BarChart
  data={contentPerformance.data}
- dataKeys={[{ key: 'views', name: 'Views' }]}
+ dataKeys={[{ key: 'impressions', name: 'Impressions' }]}
  xAxisKey="title"
  height={300}
  layout="vertical"
@@ -460,8 +492,11 @@ export default function AnalyticsClient() {
  <Card className="eh-dash-card lg:col-span-2">
  <Card.Header>
  <h3 className="eh-dash-subtitle text-lg font-semibold text-[var(--foreground)]">
- Usage Trends by Content Type
+ Usage Trends by Reported Content Type
  </h3>
+ <p className="mt-1 text-xs text-[var(--foreground-tertiary)]">
+ Proof-of-play impressions grouped into video, image, HTML, URL, and other content types.
+ </p>
  </Card.Header>
  <Card.Body>
  {usageTrends.loading ? (
@@ -478,13 +513,14 @@ export default function AnalyticsClient() {
  <AreaChart
  data={usageTrends.data}
  dataKeys={[
- { key: 'video', name: 'Video' },
- { key: 'image', name: 'Images' },
- { key: 'text', name: 'Text' },
- { key: 'interactive', name: 'Interactive' },
+ { key: 'video', name: 'Video impressions' },
+ { key: 'image', name: 'Image impressions' },
+ { key: 'text', name: 'HTML impressions' },
+ { key: 'interactive', name: 'URL impressions' },
+ { key: 'other', name: 'Other impressions' },
  ]}
  xAxisKey="date"
- yAxisLabel="Views"
+ yAxisLabel="Impressions"
  height={300}
  stacked={true}
  />
@@ -492,12 +528,15 @@ export default function AnalyticsClient() {
  </Card.Body>
  </Card>
 
- {/* Bandwidth Usage */}
+ {/* Estimated Transfer Volume */}
  <Card className="eh-dash-card lg:col-span-2">
  <Card.Header>
  <h3 className="eh-dash-subtitle text-lg font-semibold text-[var(--foreground)]">
- Bandwidth Usage (24h)
+ Estimated Transfer Volume
  </h3>
+ <p className="mt-1 text-xs text-[var(--foreground-tertiary)]">
+ Estimated from stored content size and assigned screens. This is not measured network throughput.
+ </p>
  </Card.Header>
  <Card.Body>
  {bandwidthUsage.loading ? (
@@ -507,31 +546,34 @@ export default function AnalyticsClient() {
  </div>
  </div>
  ) : bandwidthUsage.error ? (
- <ChartErrorState message="Unable to load bandwidth usage." detail={bandwidthUsage.error} />
+ <ChartErrorState message="Unable to load estimated transfer volume." detail={bandwidthUsage.error} />
  ) : bandwidthUsage.data.length === 0 ? (
- <EmptyChartState message="No bandwidth data yet. Usage will be tracked as devices stream content." />
+ <EmptyChartState message="No transfer estimate yet. Upload content and pair screens to estimate daily transfer volume." />
  ) : (
  <ComposedChart
  data={bandwidthUsage.data}
  series={[
- { type: 'line', key: 'current', name: 'Current Usage' },
- { type: 'line', key: 'average', name: 'Average' },
- { type: 'bar', key: 'peak', name: 'Peak' },
+ { type: 'line', key: 'current', name: 'Estimated current volume' },
+ { type: 'line', key: 'average', name: 'Estimated average volume' },
+ { type: 'bar', key: 'peak', name: 'Estimated peak volume' },
  ]}
  xAxisKey="time"
- yAxisLabel="MB/s"
+ yAxisLabel="MB/day"
  height={300}
  />
  )}
  </Card.Body>
  </Card>
 
- {/* Playlist Performance */}
+ {/* Playlist Playback Summary */}
  <Card className="eh-dash-card lg:col-span-2">
  <Card.Header>
  <h3 className="eh-dash-subtitle text-lg font-semibold text-[var(--foreground)]">
- Top Playlists by Engagement
+ Playlist Playback Summary
  </h3>
+ <p className="mt-1 text-xs text-[var(--foreground-tertiary)]">
+ Plays and completion come from proof-of-play reports. Assigned screens are not unique playback devices.
+ </p>
  </Card.Header>
  <Card.Body>
  {playlistPerformance.loading ? (
@@ -541,15 +583,15 @@ export default function AnalyticsClient() {
  </div>
  </div>
  ) : playlistPerformance.error ? (
- <ChartErrorState message="Unable to load playlist performance data." detail={playlistPerformance.error} />
+ <ChartErrorState message="Unable to load playlist playback data." detail={playlistPerformance.error} />
  ) : playlistPerformance.data.length === 0 ? (
- <EmptyChartState message="No playlist data yet. Create playlists and assign them to devices." />
+ <EmptyChartState message="No playlist playback data yet. Assign playlists and wait for proof-of-play reports." />
  ) : (
  <BarChart
  data={playlistPerformance.data}
  dataKeys={[
- { key: 'views', name: 'Views' },
- { key: 'completion', name: 'Completion %' },
+ { key: 'proofOfPlayImpressions', name: 'Impressions' },
+ { key: 'averageCompletion', name: 'Average Completion' },
  ]}
  xAxisKey="name"
  height={300}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -26,7 +26,7 @@ export interface Content {
   status: 'ready' | 'processing' | 'error' | 'active' | 'archived' | 'flagged' | 'rejected';
   duration?: number;
   fileSize?: number | null;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
   folderId?: string;
   createdAt: Date | string;
   updatedAt: Date | string;
@@ -297,7 +297,7 @@ export interface PlatformStats {
 export interface SystemConfig {
   id: string;
   key: string;
-  value: any;
+  value: unknown;
   dataType: string;
   category: string;
   description: string | null;
@@ -310,7 +310,7 @@ export interface AdminAuditLog {
   action: string;
   targetType: string | null;
   targetId: string | null;
-  details: any;
+  details: unknown;
   ipAddress: string | null;
   createdAt: string;
 }
@@ -345,54 +345,91 @@ export interface AnalyticsSummary {
   totalImpressions: number;
   totalContentSize: number;
   uptimePercent: number;
+  onlineNowPercent?: number;
+  uptimePercentSource?: 'current_online_ratio';
+  uptimePercentIsHistorical?: boolean;
   avgUptimePercent?: number;
 }
 
 export interface DeviceMetric {
   date: string;
-  onlineCount: number;
-  offlineCount: number;
-  avgUptime: number;
+  mobile: number;
+  tablet: number;
+  desktop: number;
+  isEstimated?: boolean;
+  metricSource?: 'display_inventory_estimate';
+  unit?: 'percent';
 }
 
 export interface ContentPerformance {
-  contentId: string;
-  name: string;
-  type: string;
+  title: string;
   impressions: number;
-  avgDuration: number;
+  averageCompletion: number;
+  /** @deprecated Legacy alias for impressions. */
+  views?: number;
+  /** @deprecated Legacy alias for averageCompletion. */
+  engagement?: number;
+  /** @deprecated Shares are not tracked; kept as zero for response compatibility. */
+  shares?: number;
+  impressionsSource?: 'content_impressions';
+  engagementSource?: 'content_impressions';
+  sharesTracked?: boolean;
 }
 
 export interface UsageTrend {
   date: string;
-  impressions: number;
-  activeDevices: number;
-  contentUploads: number;
+  video: number;
+  image: number;
+  text: number;
+  interactive: number;
+  other: number;
 }
 
 export interface DeviceDistribution {
-  status: string;
-  count: number;
-  percentage: number;
+  name: string;
+  value: number;
+  color: string;
 }
 
 export interface BandwidthUsage {
-  date: string;
-  bytesTransferred: number;
-  requestCount: number;
+  time: string;
+  current: number;
+  average: number;
+  peak: number;
+  isEstimated?: boolean;
+  metricSource?: 'content_size_device_count_estimate';
+  unit?: 'MB/day';
 }
 
 export interface PlaylistPerformance {
-  playlistId: string;
   name: string;
-  impressions: number;
-  deviceCount: number;
+  proofOfPlayImpressions: number;
+  averageCompletion: number;
+  assignedScreens: number;
+  /** @deprecated Legacy alias for proofOfPlayImpressions. */
+  plays?: number;
+  /** @deprecated Legacy alias for averageCompletion. */
+  engagement?: number;
+  /** @deprecated Assigned screen count, not unique playback devices. */
+  uniqueDevices?: number;
+  /** @deprecated Legacy alias for proofOfPlayImpressions. */
+  views?: number;
+  /** @deprecated Legacy alias for averageCompletion. */
+  completion?: number;
+  playsSource?: 'content_impressions';
+  completionSource?: 'content_impressions';
+  uniqueDevicesSource?: 'assigned_displays';
+  uniquePlaybackDevicesTracked?: boolean;
 }
 
 export interface AnalyticsExport {
-  data: Record<string, unknown>;
-  exportedAt: string;
-  format: string;
+  summary?: Partial<AnalyticsSummary>;
+  deviceMetrics?: DeviceMetric[];
+  contentPerformance?: ContentPerformance[];
+  playlistPerformance?: PlaylistPerformance[];
+  bandwidthUsage?: BandwidthUsage[];
+  usageTrends?: UsageTrend[];
+  deviceDistribution?: DeviceDistribution[];
 }
 
 // Team / User types


### PR DESCRIPTION
## Summary
- add analytics metric provenance and honest response aliases while preserving legacy fields
- scope analytics related-name lookups by organization and fail closed on proof-of-play relation mismatches
- update dashboard analytics copy, charts, empty states, and CSV export labels to avoid claiming estimated/current-state metrics are measured realtime history

## Reviews
- plan UX/customer truthfulness reviewer: misleading realtime/uptime/bandwidth/views/shares/unique-device labels identified
- plan backend API/security reviewer: analytics relation lookup tenant-scope gap identified
- diff backend reviewer: found raw SQL org join and fail-open proof-of-play sanitizer gaps; fixed; follow-up CLEAN
- diff frontend reviewer: found stale realtime freshness label, stale types, content-type coverage, and CSV test gap; fixed; follow-up CLEAN

## Tests
- pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/analytics/analytics.service.spec.ts src/modules/analytics/proof-of-play.service.spec.ts
- pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/dashboard/analytics/__tests__/analytics-page.test.tsx
- pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/analytics/analytics.controller.spec.ts src/modules/analytics/analytics.service.spec.ts src/modules/analytics/proof-of-play.service.spec.ts
- pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/dashboard/analytics/__tests__/analytics-page.test.tsx src/lib/hooks/__tests__/useAnalyticsData.test.ts
- pnpm --filter @vizora/middleware test -- --runInBand
- pnpm --filter @vizora/web test -- --runInBand
- pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false
- pnpm --filter @vizora/web exec tsc --noEmit --pretty false
- ESLINT_USE_FLAT_CONFIG=false npx eslint ...changed analytics files...
- pnpm security:no-hardcoded-jwts
- npx nx build @vizora/middleware --skip-nx-cache
- NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 BACKEND_URL=http://localhost:3000 npx nx build @vizora/web --skip-nx-cache
- git diff --check

## Deploy
- Not deployed by this PR. Production deploy remains gated on clean/safe prod checkout verification.