### PR TITLE
fix(middleware): tighten display tenant guardrails

### DIFF
--- a/docs/plans/2026-06-01-sanitize-fast-path-performance-pass-32.md
+++ b/docs/plans/2026-06-01-sanitize-fast-path-performance-pass-32.md
@@ -1,0 +1,110 @@
+# Middleware Guardrail + Sanitize Fast Path Pass 32
+
+**Date:** 2026-06-01
+**Branch:** `feat/customer-experience-pass-32`
+
+## Why Now
+
+Recent customer-readiness passes fixed higher-trust dashboard issues and
+several payload/realtime bottlenecks. The initial target for this pass was a
+remaining repo-wide middleware hot path: the global `SanitizeInterceptor`
+recursively walks every response object and passes every ordinary string
+through `sanitize-html`, even when the string contains no HTML or entity
+characters. Large content, display, playlist, or schedule list responses are
+mostly safe identifiers, names, statuses, URLs, and timestamps, so this work is
+repeated on the common case.
+
+Synthetic baseline on 20,000 safe rows using the current sanitizer call pattern:
+about 190 ms on this workstation. This is not a production metric, but it
+confirms the cost is in the `sanitize-html` safe-string path.
+
+Parallel customer/security review also found two bounded middleware tenant
+guardrail gaps that are more urgent than opening a narrow performance-only PR:
+
+- `PairingService.getActivePairings()` exposes brand-new unclaimed pairing
+  requests to every tenant dashboard until the code is completed by an org.
+- `DisplaysService.addTags()` validates the display's organization but writes
+  `DisplayTag` rows for arbitrary tag IDs without proving those tags belong to
+  the same organization.
+
+## New Primitives Introduced
+
+None. This pass changes only existing middleware service/interceptor behavior
+and tests. No route, module, middleware ordering, process, database schema,
+response envelope, realtime path, notification path, MCP tool, Hermes skill, or
+provider spend path changes.
+
+## Hermes-First Analysis
+
+Not applicable. This pass does not add or modify business agents, MCP tools,
+Hermes skills, AI/provider calls, or spend paths.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| NestJS response sanitizer performance | none applicable | Optimize the existing Vizora interceptor in place. |
+| Display pairing tenant visibility | none applicable | Tighten existing Vizora pairing service filtering. |
+| Display tag tenant ownership | none applicable | Tighten existing Vizora display service validation. |
+
+Awesome-Hermes ecosystem check: no applicable reusable skill for in-process
+NestJS JSON sanitizer fast paths; keep this native to Vizora middleware.
+
+## Scope
+
+- Preserve global interceptor order and the existing input/output sanitation
+  contract.
+- Add a safe-string fast path that trims strings and returns immediately when
+  no sanitizer-triggering characters are present.
+- Keep `sanitize-html` for strings containing `<`, `>`, or `&`, because those
+  can carry HTML tags or encoded entities.
+- Keep template HTML field behavior unchanged: input template fields pass
+  through for service-layer validation; output template fields use the existing
+  permissive sanitizer.
+- Add tests proving safe plain strings do not call `sanitize-html`, unsafe
+  strings still do, whitespace trimming stays intact, and entity decoding still
+  only applies to `&amp;` on output.
+- Change active pairing dashboard visibility so completed pairings for the org
+  still show, unclaimed requests for already-owned displays still show, and
+  brand-new unclaimed requests stay hidden from tenant dashboards.
+- Validate all tag IDs in `addTags()` with `organizationId` before any
+  `DisplayTag` upsert. Reject the whole call if any tag is missing or belongs
+  to another org. Deduplicate IDs before writing.
+- Filter display tag relation reads by tag `organizationId` so any polluted
+  historical `DisplayTag` rows cannot leak another org's tag metadata through
+  display list/detail/update/create responses or `getTags()`.
+
+## Implementation Plan
+
+- Update `middleware/src/modules/common/interceptors/sanitize.interceptor.spec.ts`
+  to mock `sanitize-html` while preserving its real behavior, then add red tests
+  for safe-string fast-path behavior and unsafe-string fallback behavior.
+- Update `middleware/src/modules/common/interceptors/sanitize.interceptor.ts`
+  with a small `needsSanitizeHtml` helper and use it from `sanitizeString`.
+- Update `middleware/src/modules/displays/pairing.service.spec.ts` with red
+  tenant-visibility tests, then tighten `getActivePairings()`.
+- Update `middleware/src/modules/displays/displays.service.spec.ts` with red
+  cross-org tag tests, then validate tags in `addTags()`.
+- Replace unscoped display tag relation selects with organization-scoped select
+  builders and update `getTags()` with the same relation filter.
+- Run focused interceptor tests, then broader middleware verification and build.
+- Request multi-vector review before broader tests: security/XSS/tenant
+  behavior and performance/regression impact.
+
+## Risks
+
+- Missing a sanitizer-triggering character would be a security regression.
+  Mitigation: only skip when the trimmed string lacks `<`, `>`, and `&`; all
+  actual HTML/entity cases still use the existing sanitizer.
+- Changing trimming behavior would be a subtle API contract change. Mitigation:
+  tests keep the existing whitespace trimming assertion.
+- Template fields have special behavior. Mitigation: leave template field logic
+  untouched and keep existing tests.
+- Pairing dashboards may previously have shown nearby brand-new display codes.
+  Mitigation: devices still poll their own code through the pairing status path;
+  dashboards only lose cross-tenant visibility to requests not yet claimed by
+  any organization.
+- Tag validation adds one `tag.findMany` call per `addTags()` request. This is
+  acceptable because tag assignment is a low-frequency write path and prevents
+  cross-tenant joins.
+- Display list/detail tag relation filtering adds an indexed relation predicate.
+  The display query is already org-scoped and tag fanout is small, so this is
+  preferable to returning and filtering cross-tenant rows in application code.

--- a/middleware/src/modules/common/interceptors/sanitize.interceptor.spec.ts
+++ b/middleware/src/modules/common/interceptors/sanitize.interceptor.spec.ts
@@ -1,16 +1,28 @@
+jest.mock('sanitize-html', () => {
+  const actual = jest.requireActual('sanitize-html');
+  const mockSanitizeHtml = jest.fn((dirty: string, options: unknown) =>
+    actual(dirty, options),
+  );
+  Object.assign(mockSanitizeHtml, actual);
+  return mockSanitizeHtml;
+});
+
 import { SanitizeInterceptor, SKIP_OUTPUT_SANITIZE_KEY } from './sanitize.interceptor';
 import { ExecutionContext, CallHandler } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { of } from 'rxjs';
+import { lastValueFrom, of } from 'rxjs';
+import sanitizeHtml from 'sanitize-html';
 
 describe('SanitizeInterceptor', () => {
   let interceptor: SanitizeInterceptor;
   let mockExecutionContext: ExecutionContext;
   let mockCallHandler: CallHandler;
   let mockRequest: { body: unknown; query: unknown; params: unknown };
+  const sanitizeHtmlMock = sanitizeHtml as unknown as jest.Mock;
 
   beforeEach(() => {
     interceptor = new SanitizeInterceptor();
+    sanitizeHtmlMock.mockClear();
 
     mockRequest = { body: {}, query: {}, params: {} };
 
@@ -258,6 +270,82 @@ describe('SanitizeInterceptor', () => {
         name: 'John',
         middleName: null,
       });
+    });
+
+    it('should skip sanitize-html for safe plain request and response strings', async () => {
+      mockRequest.body = {
+        name: '  Lobby Menu  ',
+        nested: {
+          status: 'active',
+          location: 'Main Entrance',
+        },
+      };
+      mockRequest.query = {
+        search: 'Breakfast Specials',
+      };
+      mockRequest.params = {
+        id: 'content-123',
+      };
+      mockCallHandler.handle = jest.fn().mockReturnValue(
+        of({
+          data: [
+            {
+              id: 'content-123',
+              name: 'Lobby Menu',
+              type: 'image',
+              status: 'active',
+            },
+          ],
+        }),
+      );
+
+      const response = await lastValueFrom(
+        interceptor.intercept(mockExecutionContext, mockCallHandler),
+      );
+
+      expect(mockRequest.body).toEqual({
+        name: 'Lobby Menu',
+        nested: {
+          status: 'active',
+          location: 'Main Entrance',
+        },
+      });
+      expect(response).toEqual({
+        data: [
+          {
+            id: 'content-123',
+            name: 'Lobby Menu',
+            type: 'image',
+            status: 'active',
+          },
+        ],
+      });
+      expect(sanitizeHtmlMock).not.toHaveBeenCalled();
+    });
+
+    it('should still use sanitize-html for strings with HTML or entity trigger characters', async () => {
+      mockRequest.body = {
+        name: '<b>Lobby Menu</b>',
+        encoded: 'Fish &amp; Chips',
+      };
+      mockCallHandler.handle = jest.fn().mockReturnValue(
+        of({
+          name: '<script>alert(1)</script>Clean',
+        }),
+      );
+
+      const response = await lastValueFrom(
+        interceptor.intercept(mockExecutionContext, mockCallHandler),
+      );
+
+      expect(mockRequest.body).toEqual({
+        name: 'Lobby Menu',
+        encoded: 'Fish &amp; Chips',
+      });
+      expect(response).toEqual({
+        name: 'Clean',
+      });
+      expect(sanitizeHtmlMock).toHaveBeenCalled();
     });
   });
 

--- a/middleware/src/modules/common/interceptors/sanitize.interceptor.ts
+++ b/middleware/src/modules/common/interceptors/sanitize.interceptor.ts
@@ -189,6 +189,12 @@ export class SanitizeInterceptor implements NestInterceptor {
 
 
   private sanitizeString(str: string, decodeEntities = false): string {
+    const trimmed = str.trim();
+
+    if (!this.needsSanitizeHtml(trimmed)) {
+      return trimmed;
+    }
+
     // First strip HTML tags
     let sanitized = sanitizeHtml(str, this.sanitizeOptions);
 
@@ -203,6 +209,10 @@ export class SanitizeInterceptor implements NestInterceptor {
     }
 
     return sanitized;
+  }
+
+  private needsSanitizeHtml(str: string): boolean {
+    return str.includes('<') || str.includes('>') || str.includes('&');
   }
 
   private decodeHtmlEntities(str: string): string {

--- a/middleware/src/modules/displays/display-response.select.ts
+++ b/middleware/src/modules/displays/display-response.select.ts
@@ -90,15 +90,16 @@ export const DISPLAY_EMBEDDED_SELECT = {
   unpairedAt: true,
 } satisfies Prisma.DisplaySelect;
 
-export const DISPLAY_LIST_SELECT = {
+export const getDisplayListSelect = (organizationId: string) => ({
   ...DISPLAY_EMBEDDED_SELECT,
   tags: {
+    where: { tag: { organizationId } },
     select: DISPLAY_TAG_SELECT,
   },
-} satisfies Prisma.DisplaySelect;
+}) satisfies Prisma.DisplaySelect;
 
-export const DISPLAY_DETAIL_SELECT = {
-  ...DISPLAY_LIST_SELECT,
+export const getDisplayDetailSelect = (organizationId: string) => ({
+  ...getDisplayListSelect(organizationId),
   metadata: true,
   lastScreenshot: true,
   lastScreenshotAt: true,
@@ -109,7 +110,7 @@ export const DISPLAY_DETAIL_SELECT = {
     where: { isActive: true },
     select: ACTIVE_SCHEDULE_SELECT,
   },
-} satisfies Prisma.DisplaySelect;
+}) satisfies Prisma.DisplaySelect;
 
 export const DISPLAY_GROUP_MEMBER_WITH_DISPLAY_SELECT = {
   id: true,

--- a/middleware/src/modules/displays/displays.service.spec.ts
+++ b/middleware/src/modules/displays/displays.service.spec.ts
@@ -61,6 +61,16 @@ describe('DisplaysService', () => {
     }
   }
 
+  function expectDisplayTagSelectScopedToOrganization(
+    select: Record<string, any> | undefined,
+    organizationId: string,
+  ) {
+    expect(select?.tags).toEqual(expect.objectContaining({
+      where: { tag: { organizationId } },
+      select: expect.any(Object),
+    }));
+  }
+
   beforeEach(async () => {
     process.env.INTERNAL_API_SECRET = 'test-internal-secret';
 
@@ -78,6 +88,14 @@ describe('DisplaysService', () => {
       },
       content: {
         findFirst: jest.fn(),
+      },
+      displayTag: {
+        upsert: jest.fn(),
+        findMany: jest.fn(),
+        deleteMany: jest.fn(),
+      },
+      tag: {
+        findMany: jest.fn(),
       },
     };
 
@@ -169,6 +187,7 @@ describe('DisplaysService', () => {
       });
       const query = databaseService.display.create.mock.calls[0][0] as any;
       expectSafeDisplaySelect(query.select);
+      expectDisplayTagSelectScopedToOrganization(query.select, mockOrganizationId);
       expect(result).toEqual(mockDisplay);
     });
 
@@ -205,6 +224,7 @@ describe('DisplaysService', () => {
       const query = databaseService.display.findMany.mock.calls[0][0] as any;
       expect(query).not.toHaveProperty('include');
       expectSafeDisplaySelect(query.select);
+      expectDisplayTagSelectScopedToOrganization(query.select, mockOrganizationId);
       expect(databaseService.display.count).toHaveBeenCalledWith({
         where: { organizationId: mockOrganizationId },
       });
@@ -263,6 +283,7 @@ describe('DisplaysService', () => {
       const query = databaseService.display.findFirst.mock.calls[0][0] as any;
       expect(query).not.toHaveProperty('include');
       expectSafeDisplaySelect(query.select);
+      expectDisplayTagSelectScopedToOrganization(query.select, mockOrganizationId);
       expect(query.select).toEqual(expect.objectContaining({
         metadata: true,
         lastScreenshot: true,
@@ -331,6 +352,7 @@ describe('DisplaysService', () => {
         select: expect.any(Object),
       });
       expectSafeDisplaySelect(findUniqueQuery.select);
+      expectDisplayTagSelectScopedToOrganization(findUniqueQuery.select, mockOrganizationId);
       expect(result.nickname).toBe('Updated Display');
     });
 
@@ -732,6 +754,85 @@ describe('DisplaysService', () => {
           lastScreenshotAt: expect.any(Date),
         },
       });
+    });
+  });
+
+  describe('addTags', () => {
+    it('should filter getTags by tag organization to avoid leaking polluted display tag rows', async () => {
+      databaseService.display.findFirst.mockResolvedValue(mockDisplay as any);
+      (databaseService as any).displayTag.findMany.mockResolvedValue([
+        { tag: { id: 'tag-owned', organizationId: mockOrganizationId, name: 'Lobby' } },
+      ]);
+
+      const result = await service.getTags(mockOrganizationId, mockDisplayId);
+
+      expect((databaseService as any).displayTag.findMany).toHaveBeenCalledWith({
+        where: {
+          displayId: mockDisplayId,
+          tag: { organizationId: mockOrganizationId },
+        },
+        include: { tag: true },
+      });
+      expect(result).toEqual([
+        { id: 'tag-owned', organizationId: mockOrganizationId, name: 'Lobby' },
+      ]);
+    });
+
+    it('should reject tag ids outside the display organization before writing display tags', async () => {
+      databaseService.display.findFirst.mockResolvedValue(mockDisplay as any);
+      (databaseService as any).tag.findMany.mockResolvedValue([
+        { id: 'tag-owned' },
+      ]);
+      (databaseService as any).displayTag.upsert.mockResolvedValue({
+        tag: { id: 'tag-owned', name: 'Lobby' },
+      });
+
+      await expect(
+        service.addTags(mockOrganizationId, mockDisplayId, ['tag-owned', 'tag-other-org']),
+      ).rejects.toThrow(NotFoundException);
+
+      expect((databaseService as any).tag.findMany).toHaveBeenCalledWith({
+        where: {
+          id: { in: ['tag-owned', 'tag-other-org'] },
+          organizationId: mockOrganizationId,
+        },
+        select: { id: true },
+      });
+      expect((databaseService as any).displayTag.upsert).not.toHaveBeenCalled();
+      expect((service as any).eventEmitter.emit).not.toHaveBeenCalledWith(
+        'display.tags.changed',
+        expect.anything(),
+      );
+    });
+
+    it('should validate tags by organization and create display tags for unique ids', async () => {
+      databaseService.display.findFirst.mockResolvedValue(mockDisplay as any);
+      (databaseService as any).tag.findMany.mockResolvedValue([
+        { id: 'tag-1' },
+        { id: 'tag-2' },
+      ]);
+      (databaseService as any).displayTag.upsert
+        .mockResolvedValueOnce({ tag: { id: 'tag-1', name: 'Lobby' } })
+        .mockResolvedValueOnce({ tag: { id: 'tag-2', name: 'Window' } });
+
+      const result = await service.addTags(mockOrganizationId, mockDisplayId, [
+        'tag-1',
+        'tag-1',
+        'tag-2',
+      ]);
+
+      expect((databaseService as any).tag.findMany).toHaveBeenCalledWith({
+        where: {
+          id: { in: ['tag-1', 'tag-2'] },
+          organizationId: mockOrganizationId,
+        },
+        select: { id: true },
+      });
+      expect((databaseService as any).displayTag.upsert).toHaveBeenCalledTimes(2);
+      expect(result).toEqual([
+        { id: 'tag-1', name: 'Lobby' },
+        { id: 'tag-2', name: 'Window' },
+      ]);
     });
   });
 

--- a/middleware/src/modules/displays/displays.service.tag-events.spec.ts
+++ b/middleware/src/modules/displays/displays.service.tag-events.spec.ts
@@ -21,6 +21,11 @@ describe('DisplaysService — display.tags.changed emission (O4)', () => {
         upsert: jest.fn().mockResolvedValue({ tag: { id: 'tag-1', name: 'lobby' } }),
         deleteMany: jest.fn().mockResolvedValue({ count: 1 }),
       },
+      tag: {
+        findMany: jest.fn().mockImplementation(({ where }: any) =>
+          Promise.resolve(where.id.in.map((id: string) => ({ id }))),
+        ),
+      },
     };
     eventEmitter = { emit: jest.fn() };
 

--- a/middleware/src/modules/displays/displays.service.ts
+++ b/middleware/src/modules/displays/displays.service.ts
@@ -20,7 +20,7 @@ import { CreateDisplayDto } from './dto/create-display.dto';
 import { UpdateDisplayDto } from './dto/update-display.dto';
 import { UpdateQrOverlayDto } from './dto/update-qr-overlay.dto';
 import { PaginationDto, PaginatedResponse } from '../common/dto/pagination.dto';
-import { DISPLAY_DETAIL_SELECT, DISPLAY_LIST_SELECT } from './display-response.select';
+import { getDisplayDetailSelect, getDisplayListSelect } from './display-response.select';
 
 /**
  * Hash a token using SHA-256 for secure storage
@@ -76,7 +76,7 @@ export class DisplaysService {
           nickname: name,
           organizationId,
         },
-        select: DISPLAY_DETAIL_SELECT,
+        select: getDisplayDetailSelect(organizationId),
       });
       this.emitDisplayEvent('created', display.id, organizationId);
       return display;
@@ -117,7 +117,7 @@ export class DisplaysService {
         skip,
         take: limit,
         orderBy: { createdAt: 'desc' },
-        select: DISPLAY_LIST_SELECT,
+        select: getDisplayListSelect(organizationId),
       }),
       this.db.display.count({ where }),
     ]);
@@ -128,7 +128,7 @@ export class DisplaysService {
   async findOne(organizationId: string, id: string) {
     const display = await this.db.display.findFirst({
       where: { id, organizationId },
-      select: DISPLAY_DETAIL_SELECT,
+      select: getDisplayDetailSelect(organizationId),
     });
 
     if (!display) {
@@ -196,7 +196,7 @@ export class DisplaysService {
     }
     const updatedDisplay = await this.db.display.findUnique({
       where: { id },
-      select: DISPLAY_DETAIL_SELECT,
+      select: getDisplayDetailSelect(organizationId),
     });
 
     // If playlist was updated, notify the realtime service to push update to device
@@ -433,7 +433,7 @@ export class DisplaysService {
     await this.findOne(organizationId, displayId);
 
     const displayTags = await this.db.displayTag.findMany({
-      where: { displayId },
+      where: { displayId, tag: { organizationId } },
       include: { tag: true },
     });
 
@@ -443,8 +443,23 @@ export class DisplaysService {
   async addTags(organizationId: string, displayId: string, tagIds: string[]) {
     await this.findOne(organizationId, displayId);
 
+    const uniqueTagIds = [...new Set(tagIds)];
+    if (uniqueTagIds.length > 0) {
+      const tags = await this.db.tag.findMany({
+        where: {
+          id: { in: uniqueTagIds },
+          organizationId,
+        },
+        select: { id: true },
+      });
+
+      if (tags.length !== uniqueTagIds.length) {
+        throw new NotFoundException('One or more tags not found');
+      }
+    }
+
     // Create DisplayTag entries for each tag, skipping duplicates
-    const createPromises = tagIds.map((tagId) =>
+    const createPromises = uniqueTagIds.map((tagId) =>
       this.db.displayTag.upsert({
         where: {
           displayId_tagId: { displayId, tagId },

--- a/middleware/src/modules/displays/pairing.service.spec.ts
+++ b/middleware/src/modules/displays/pairing.service.spec.ts
@@ -662,7 +662,7 @@ describe('PairingService', () => {
       expect(result).toEqual([]);
     });
 
-    it('should return active pairings', async () => {
+    it('should not return brand-new unclaimed pairing requests to org dashboards', async () => {
       mockDatabaseService.display.findUnique.mockResolvedValue(null);
       mockDatabaseService.display.findMany.mockResolvedValue([]);
 
@@ -680,13 +680,7 @@ describe('PairingService', () => {
 
       const result = await service.getActivePairings('org-123');
 
-      expect(result).toHaveLength(2);
-      result.forEach((pairing: any) => {
-        expect(pairing).toHaveProperty('code');
-        expect(pairing).toHaveProperty('nickname');
-        expect(pairing).toHaveProperty('createdAt');
-        expect(pairing).toHaveProperty('expiresAt');
-      });
+      expect(result).toEqual([]);
     });
 
     it('should not return expired pairings', async () => {
@@ -707,7 +701,7 @@ describe('PairingService', () => {
       expect(result).toHaveLength(0);
     });
 
-    it('should batch Redis reads and display ownership lookup for active pairings', async () => {
+    it('should batch Redis reads and only show unclaimed active pairings for displays owned by the org', async () => {
       const orgId = 'org-123';
       mockDatabaseService.display.findUnique.mockResolvedValue(null);
       mockDatabaseService.display.findMany.mockResolvedValue([
@@ -752,16 +746,18 @@ describe('PairingService', () => {
         select: { deviceIdentifier: true, organizationId: true },
       });
       expect(mockDatabaseService.display.findUnique).not.toHaveBeenCalled();
-      expect(result).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ nickname: 'Owned Display' }),
-          expect.objectContaining({ nickname: 'Brand New Display' }),
-        ]),
-      );
-      expect(result).toHaveLength(2);
+      expect(result).toEqual([
+        expect.objectContaining({
+          nickname: 'Owned Display',
+          code: expect.any(String),
+          createdAt: expect.any(String),
+          expiresAt: expect.any(String),
+        }),
+      ]);
       expect(result).not.toEqual(
         expect.arrayContaining([
           expect.objectContaining({ nickname: 'Other Org Display' }),
+          expect.objectContaining({ nickname: 'Brand New Display' }),
         ]),
       );
     });

--- a/middleware/src/modules/displays/pairing.service.ts
+++ b/middleware/src/modules/displays/pairing.service.ts
@@ -433,8 +433,10 @@ export class PairingService implements OnModuleDestroy {
     for (const request of unclaimedRequests) {
       const displayOrganizationId = displayOrganizationsByDevice.get(request.deviceIdentifier);
 
-      // Show if device belongs to this org, or is brand new (no org yet)
-      if (!displayOrganizationId || displayOrganizationId === organizationId) {
+      // Show unclaimed requests only when the device is already owned by
+      // this org. Brand-new unclaimed requests are visible only to the
+      // physical display polling its own code, not to every tenant dashboard.
+      if (displayOrganizationId === organizationId) {
         activePairings.push({
           code: request.code,
           nickname: request.nickname,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,78 @@
 # Vizora - Task Tracker
 
-## Active: Analytics Truthfulness Pass 31 (2026-06-01)
+## Active: Middleware Guardrail + Sanitize Fast Path Pass 32 (2026-06-01)
+
+**Branch:** `feat/customer-experience-pass-32`
+
+**Why now:** PR #161/#162 are merged with green CI, while production deploy
+remains blocked by dirty/diverged prod-local state. A remaining middleware
+performance hot path is the global `SanitizeInterceptor`, which recursively
+passes every ordinary response string through `sanitize-html` even when the
+string contains no HTML/entity trigger characters. A synthetic 20k-row safe
+payload benchmark of the current call pattern took about 190 ms locally.
+Parallel security review also found two bounded tenant guardrail gaps worth
+fixing in the same middleware pass: brand-new unclaimed pairing codes were
+visible in every tenant dashboard's active pairing list, and display tag
+assignment could write cross-org tag join rows. Diff review then identified the
+read-side residual: existing polluted display-tag rows also needed org-scoped
+filters on display tag reads.
+
+**New primitives introduced:** none. This pass only tightens existing
+middleware service/interceptor behavior and tests. No route, module, middleware
+order, schema, response envelope, realtime path, notification path, MCP tool,
+Hermes skill, provider spend path, or production process changes.
+
+**Hermes-first analysis:** not applicable. This pass does not add or modify
+business agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
+
+**Plan/design:**
+`docs/plans/2026-06-01-sanitize-fast-path-performance-pass-32.md`
+
+**Plan**
+- [x] Start fresh branch from `origin/main`.
+- [x] Dispatch customer UX/trust, performance, and security/tenant reviewers.
+- [x] Drift-check sanitizer behavior and existing tests.
+- [x] Add failing sanitizer tests for safe-string fast path.
+- [x] Implement conservative sanitizer trigger check.
+- [x] Add failing pairing/tag tenant-boundary tests.
+- [x] Implement bounded pairing visibility and display tag ownership fixes.
+- [x] Add and fix display-tag read-side tenant filters for historical polluted
+  rows.
+- [x] Run multi-subagent review before broader verification.
+- [x] Run focused and broader verification.
+- [ ] PR, CI, merge if green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Evidence so far:**
+- Sanitizer TDD red: focused interceptor spec failed because safe plain strings
+  still called `sanitize-html` 9 times.
+- Sanitizer focused green: `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/common/interceptors/sanitize.interceptor.spec.ts`
+  passed 52/52 after the fast path.
+- Synthetic sanitizer benchmark: old safe-string call pattern ~190 ms for
+  20,000 safe rows locally; new helper path ~28.6 ms locally. Independent
+  performance reviewer measured old avg 134.2 ms vs new avg 13.1 ms.
+- Tenant TDD red: focused display/pairing suite failed on brand-new unclaimed
+  pairing visibility and cross-org display tag assignment behavior.
+- Tenant focused green: `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/displays/pairing.service.spec.ts src/modules/displays/displays.service.spec.ts src/modules/displays/displays.service.tag-events.spec.ts`
+  passed 80/80 after the guardrail fixes.
+- Review finding fixed: display list/detail/update/create selects and `getTags`
+  now scope tag relation reads by tag organization, so existing polluted
+  display-tag rows are filtered before response serialization.
+- Multi-vector diff review: security/tenant reviewer found the display-tag
+  read-side residual above; follow-up reviewer returned CLEAN after the scoped
+  select builders and `getTags` filter. Compatibility/performance reviewer
+  returned CLEAN, with residual note that pairing Redis scan scalability remains
+  a separate backlog item.
+- Verification: focused sanitizer tests passed 52/52; focused display/pairing
+  tests passed 81/81; TypeScript `tsc --noEmit` passed; changed-file ESLint
+  passed with only the repo's existing ESLintRC deprecation warning; JWT secret
+  scan passed; `git diff --check` passed; full middleware Jest passed 146/146
+  suites and 2935/2935 tests; `npx nx build @vizora/middleware --skip-nx-cache`
+  succeeded with existing webpack dependency warnings.
+
+---
+
+## Completed: Analytics Truthfulness Pass 31 (2026-06-01)
 
 **Branch:** `feat/analytics-truthfulness-pass-31`
 


### PR DESCRIPTION
﻿## Summary
- add a sanitizer safe-string fast path that skips `sanitize-html` only when trimmed strings contain no `<`, `>`, or `&`
- hide brand-new unclaimed pairing codes from tenant dashboard active-pairing lists while preserving completed and already-owned display pairing visibility
- enforce display tag tenant boundaries on writes and reads, including scoped display tag relation selects for historical polluted rows

## Review
- security/tenant reviewer found a display-tag read-side residual after the initial write guard
- fixed with org-scoped select builders and `getTags()` relation filters
- follow-up security re-review: CLEAN
- compatibility/performance review: CLEAN

## Verification
- `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/common/interceptors/sanitize.interceptor.spec.ts` (52/52)
- `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/displays/pairing.service.spec.ts src/modules/displays/displays.service.spec.ts src/modules/displays/displays.service.tag-events.spec.ts` (81/81)
- `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
- changed-file ESLint via `pnpm exec eslint ...` (repo ESLintRC deprecation warning only)
- `pnpm security:no-hardcoded-jwts`
- `git diff --check`
- `pnpm --filter @vizora/middleware test -- --runInBand` (146 suites, 2935 tests)
- `npx nx build @vizora/middleware --skip-nx-cache` (succeeded; existing webpack dependency warnings)

## Residual Risks
- existing polluted `DisplayTag` rows are filtered from display response paths but not deleted from the database in this pass
- active pairing still scans Redis keys; this pass fixes visibility, not pairing-list scalability
- production deploy gate previously blocked by dirty/diverged prod-local checkout and still requires re-check after merge
