### PR TITLE
fix(middleware): scope template publishing by tenant

### DIFF
--- a/docs/plans/2026-06-01-template-publish-tenant-pass-33.md
+++ b/docs/plans/2026-06-01-template-publish-tenant-pass-33.md
@@ -1,0 +1,46 @@
+# Template Publish Tenant Guardrail Pass 33
+
+## Scope
+
+Close the residual tenant boundary gap in template publishing: an organization
+must only publish global templates or its own non-global templates, and template
+usage metadata must not be mutated for another organization's private template.
+
+## New primitives introduced
+
+None. This pass only tightens the existing `TemplateLibraryService` query
+boundaries and adds focused regression coverage. It adds no schema, route,
+module, response shape, realtime path, notification path, MCP tool, Hermes
+skill, provider spend path, or production process.
+
+## Hermes-first analysis
+
+Not applicable. This pass does not add or modify business agents, MCP tools,
+Hermes skills, AI/provider calls, or spend paths.
+
+## Drift Check
+
+Existing template reads already use the intended global-or-own rule:
+
+- `TemplateLibraryService.findOne()` scopes templates to global or caller org.
+- `TemplateLibraryService.saveUserTemplate()` scopes non-global template edits
+  to the caller org.
+
+The residual gap is isolated to `TemplateLibraryService.publishTemplate()`,
+which still fetches by template id and type only, then increments metadata by id.
+
+## Implementation Plan
+
+1. Add focused service tests proving cross-org private templates are treated as
+   not found and do not create content or mutate metadata.
+2. Keep global-template publishing and own private-template publishing working.
+3. Move source-template verification into the transaction using the same
+   global-or-own predicate.
+4. Update use-count writes with the same scoped predicate.
+5. Run focused template-library tests, reviewer gate, broader middleware tests,
+   type check, lint, security scan, and build.
+
+## Deployment
+
+No deployment by default. Re-check the production checkout first; deployment
+remains blocked if `/opt/vizora/app` is dirty or diverged.

--- a/middleware/src/modules/template-library/template-library.service.spec.ts
+++ b/middleware/src/modules/template-library/template-library.service.spec.ts
@@ -50,7 +50,21 @@ describe('TemplateLibraryService', () => {
         count: jest.fn().mockResolvedValue(0),
         create: jest.fn(),
         update: jest.fn(),
+        updateMany: jest.fn(),
       },
+      display: {
+        findFirst: jest.fn(),
+        update: jest.fn(),
+      },
+      playlist: {
+        findFirst: jest.fn(),
+        create: jest.fn(),
+      },
+      playlistItem: {
+        findFirst: jest.fn(),
+        create: jest.fn(),
+      },
+      $transaction: jest.fn(async (callback) => callback(mockDb)),
     };
 
     mockTemplateRendering = {
@@ -770,6 +784,98 @@ describe('TemplateLibraryService', () => {
       await expect(
         service.saveUserTemplate('nonexistent', { name: 'Foo' }, 'org-1'),
       ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('publishTemplate', () => {
+    const publishDto = {
+      renderedHtml: '<section>Menu</section>',
+      displayIds: [],
+      name: 'Published Menu',
+      duration: 45,
+    };
+
+    it('rejects a private template from another org without creating content or mutating metadata', async () => {
+      mockDb.content.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.publishTemplate('tmpl-other', publishDto, 'org-1', 'user-1'),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(mockDb.content.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: 'tmpl-other',
+          type: 'template',
+          OR: [{ isGlobal: true }, { organizationId: 'org-1' }],
+        },
+      });
+      expect(mockDb.content.create).not.toHaveBeenCalled();
+      expect(mockDb.content.update).not.toHaveBeenCalled();
+      expect(mockDb.content.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('publishes a global template and increments usage through the scoped template predicate', async () => {
+      mockDb.content.findFirst.mockResolvedValue(
+        makeTemplate({ id: 'tmpl-global', isGlobal: true, organizationId: null, metadata: { useCount: 2 } }),
+      );
+      mockDb.content.create.mockResolvedValue({ id: 'content-1' });
+      mockDb.content.updateMany.mockResolvedValue({ count: 1 });
+
+      const result = await service.publishTemplate('tmpl-global', publishDto, 'org-1', 'user-1');
+
+      expect(result).toEqual({ contentId: 'content-1', displayCount: 0 });
+      expect(mockDb.content.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          name: 'Published Menu',
+          type: 'html',
+          organizationId: 'org-1',
+          isGlobal: false,
+          metadata: expect.objectContaining({
+            htmlContent: '<section>Menu</section>',
+            sourceTemplateId: 'tmpl-global',
+            publishedBy: 'user-1',
+            publishedAt: expect.any(String),
+          }),
+        }),
+      });
+      expect(mockDb.content.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: 'tmpl-global',
+          type: 'template',
+          OR: [{ isGlobal: true }, { organizationId: 'org-1' }],
+        },
+        data: {
+          metadata: expect.objectContaining({ useCount: 3 }),
+        },
+      });
+    });
+
+    it('publishes an org-owned private template through the same global-or-own predicate', async () => {
+      mockDb.content.findFirst.mockResolvedValue(
+        makeTemplate({ id: 'tmpl-owned', isGlobal: false, organizationId: 'org-1', metadata: { useCount: 4 } }),
+      );
+      mockDb.content.create.mockResolvedValue({ id: 'content-2' });
+      mockDb.content.updateMany.mockResolvedValue({ count: 1 });
+
+      await service.publishTemplate('tmpl-owned', publishDto, 'org-1', 'user-1');
+
+      expect(mockDb.content.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: 'tmpl-owned',
+          type: 'template',
+          OR: [{ isGlobal: true }, { organizationId: 'org-1' }],
+        },
+      });
+      expect(mockDb.content.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: 'tmpl-owned',
+          type: 'template',
+          OR: [{ isGlobal: true }, { organizationId: 'org-1' }],
+        },
+        data: {
+          metadata: expect.objectContaining({ useCount: 5 }),
+        },
+      });
     });
   });
 

--- a/middleware/src/modules/template-library/template-library.service.ts
+++ b/middleware/src/modules/template-library/template-library.service.ts
@@ -45,6 +45,14 @@ export class TemplateLibraryService {
     private readonly templateRendering: TemplateRenderingService,
   ) {}
 
+  private accessibleTemplateWhere(templateId: string, organizationId: string): Prisma.ContentWhereInput {
+    return {
+      id: templateId,
+      type: 'template',
+      OR: [{ isGlobal: true }, { organizationId }],
+    };
+  }
+
   /**
    * Search/browse template library with filters
    */
@@ -247,17 +255,16 @@ export class TemplateLibraryService {
     organizationId: string,
     userId: string,
   ) {
-    // 1. Verify the source template exists
-    const template = await this.db.content.findFirst({
-      where: { id: templateId, type: 'template' },
-    });
+    const templateWhere = this.accessibleTemplateWhere(templateId, organizationId);
 
-    if (!template) {
-      throw new NotFoundException('Template not found');
-    }
-
-    // 2. Execute all writes in a transaction for atomicity
+    // Execute all writes in a transaction for atomicity.
     return this.db.$transaction(async (tx) => {
+      const template = await tx.content.findFirst({ where: templateWhere });
+
+      if (!template) {
+        throw new NotFoundException('Template not found');
+      }
+
       // Create the published content record (draft if displayIds is empty)
       const content = await tx.content.create({
         data: {
@@ -340,8 +347,8 @@ export class TemplateLibraryService {
       // 4. Increment useCount on the source template
       const templateMetadata = (template.metadata as Record<string, unknown>) || {};
       const currentUseCount = ((templateMetadata.useCount as number) || 0) + 1;
-      await tx.content.update({
-        where: { id: templateId },
+      const updateResult = await tx.content.updateMany({
+        where: templateWhere,
         data: {
           metadata: {
             ...templateMetadata,
@@ -349,6 +356,10 @@ export class TemplateLibraryService {
           } as Prisma.InputJsonValue,
         },
       });
+
+      if (updateResult.count !== 1) {
+        throw new NotFoundException('Template not found');
+      }
 
       return { contentId: content.id, displayCount };
     });

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,59 @@
 # Vizora - Task Tracker
 
+## Active: Template Publish Tenant Guardrail Pass 33 (2026-06-01)
+
+**Branch:** `feat/customer-experience-pass-33`
+
+**Why now:** The pass 32 security review fixed pairing and display-tag tenant
+guardrails, but it also left one bounded residual in template publishing:
+`publishTemplate()` still resolves a source template by id/type only and updates
+usage metadata by id. That can let a tenant publish another organization's
+private non-global template if they guess the id, and it mutates that private
+template's metadata. Nearby template read/edit paths already use the intended
+global-or-own boundary, so this pass closes the isolated publish gap.
+
+**New primitives introduced:** none. This pass only tightens existing
+`TemplateLibraryService` query predicates and focused tests. No route, module,
+middleware, schema, response envelope, realtime path, notification path, MCP
+tool, Hermes skill, provider spend path, or production process changes.
+
+**Hermes-first analysis:** not applicable. This pass does not add or modify
+business agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
+
+**Plan/design:**
+`docs/plans/2026-06-01-template-publish-tenant-pass-33.md`
+
+**Plan**
+- [x] Start fresh branch from updated `origin/main`.
+- [x] Drift-check existing template read/edit tenant boundaries.
+- [x] Document pass 33 design and test plan.
+- [x] Add failing publish-template tenant-boundary tests.
+- [x] Implement global-or-own source-template scope and scoped use-count write.
+- [x] Run multi-subagent review before broader verification.
+- [x] Run focused and broader verification.
+- [ ] PR, CI, merge if green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Evidence so far:**
+- Red TDD: `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/template-library/template-library.service.spec.ts`
+  failed on the new publish-template tests because source lookup used only
+  `{ id, type }` and use-count writes did not use the scoped predicate.
+- Focused green: the same command passed 52/52 after moving source-template
+  lookup into the transaction with the global-or-own predicate and updating
+  use-count through `updateMany` with that same predicate.
+- Multi-vector review: tenant/security reviewer CLEAN; Prisma/transaction/API
+  compatibility reviewer CLEAN. Both independently reran the focused
+  template-library service suite and saw 52/52 pass.
+- Verification: focused template-library service suite passed 52/52; middleware
+  `tsc --noEmit` passed; changed-file ESLint passed with 0 errors and 2
+  pre-existing warnings in `template-library.service.ts`; hardcoded JWT scan
+  passed; `git diff --check` passed with CRLF warnings only; full middleware
+  Jest passed 146/146 suites and 2938/2938 tests; `npx nx build
+  @vizora/middleware --skip-nx-cache` passed with existing webpack warnings and
+  the existing Nx flaky-task note for `@vizora/database:build`.
+
+---
+
 ## Active: Middleware Guardrail + Sanitize Fast Path Pass 32 (2026-06-01)
 
 **Branch:** `feat/customer-experience-pass-32`
@@ -40,7 +94,8 @@ business agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
   rows.
 - [x] Run multi-subagent review before broader verification.
 - [x] Run focused and broader verification.
-- [ ] PR, CI, merge if green.
+- [x] PR, CI, merge if green. PR #163 merged to `origin/main` at
+  `3249ee22495371d9b3d41f6fd3ba457dcfa6e004`; post-merge main CI green.
 - [ ] Re-check deployment gate; deploy only if prod checkout is safe.
 
 **Evidence so far:**


### PR DESCRIPTION
## Summary
- Scope template publish source-template reads to global-or-caller-owned templates.
- Recheck the same predicate when incrementing template use-count metadata.
- Add regression tests for cross-org private template rejection, global publishing, and org-owned private publishing.

## Verification
- `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/template-library/template-library.service.spec.ts`
- `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
- `ESLINT_USE_FLAT_CONFIG=false npx eslint middleware/src/modules/template-library/template-library.service.ts middleware/src/modules/template-library/template-library.service.spec.ts` (0 errors; 2 existing warnings in service file)
- `pnpm security:no-hardcoded-jwts`
- `git diff --check`
- `pnpm --filter @vizora/middleware test -- --runInBand`
- `npx nx build @vizora/middleware --skip-nx-cache`

## Reviews
- Tenant/security subagent: CLEAN
- Prisma/transaction/API compatibility subagent: CLEAN