### PR TITLE
fix(web): use display cache during playback

### DIFF
--- a/docs/plans/2026-06-01-display-cache-streaming-pass-34.md
+++ b/docs/plans/2026-06-01-display-cache-streaming-pass-34.md
@@ -1,0 +1,54 @@
+# Display Cache Streaming Pass 34
+
+## Scope
+
+Use the existing browser display cache during playback. The display client
+already preloads the first media URLs in a playlist into the Cache API, but the
+renderer still fetches protected device-content images as blobs and videos use
+the network URL directly. Preloaded content should be read cache-first so screen
+transitions avoid repeat network fetches and keep working better under spotty
+connectivity.
+
+## New primitives introduced
+
+None. This pass only wires existing display cache hooks into existing renderer
+components and adds focused tests. It adds no schema, route, module, response
+shape, middleware, realtime path, notification path, MCP tool, Hermes skill,
+provider spend path, env var, or production process.
+
+## Hermes-first analysis
+
+Not applicable. This pass does not add or modify business agents, MCP tools,
+Hermes skills, AI/provider calls, or spend paths.
+
+## Drift Check
+
+Existing code evidence:
+
+- `DisplayClient` calls `preloadItems()` for the first five image/video playlist
+  URLs.
+- `useBrowserCache()` exposes `getCachedUrl()`, but no playback component calls
+  it.
+- `ContentRenderer` fetches protected device-content images via `fetch()` every
+  mount and renders videos from the authenticated URL directly.
+
+## Performance Budget
+
+For a preloaded protected device-content media URL, playback should not perform
+an additional network `fetch()` before rendering. Cache misses must preserve
+existing behavior: protected images keep their blob-fetch fallback and videos
+keep direct URL playback.
+
+## Implementation Plan
+
+1. Add failing renderer tests proving cached protected images/videos use cached
+   object URLs and skip network fetches.
+2. Pass `getCachedUrl()` from `DisplayClient` through `ContentScreen`,
+   `ContentRenderer`, and layout zones.
+3. Add a cache-first media object URL hook with proper object URL cleanup.
+4. Run focused display tests, review gate, broader web checks, and build.
+
+## Deployment
+
+No deployment by default. Re-check the production checkout first; deployment
+remains blocked if `/opt/vizora/app` is dirty or diverged.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,66 @@
 # Vizora - Task Tracker
 
+## Active: Display Cache Streaming Pass 34 (2026-06-01)
+
+**Branch:** `feat/customer-experience-pass-34`
+
+**Why now:** PR #164 is merged with green PR and post-merge main CI, but
+production deploy remains blocked by dirty/diverged prod-local state. The next
+highest device/customer performance issue is display media playback: the display
+client preloads protected image/video URLs into the browser Cache API, yet
+`ContentRenderer` does not read from that cache during playback. That makes
+screen transitions pay repeat network fetch cost and weakens offline/poor-link
+behavior.
+
+**New primitives introduced:** none. This pass only wires existing display
+cache helpers into existing display rendering components and tests. No route,
+module, middleware, schema, response envelope, realtime path, notification path,
+MCP tool, Hermes skill, provider spend path, env var, or production process
+changes.
+
+**Hermes-first analysis:** not applicable. This pass does not add or modify
+business agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
+
+**Plan/design:**
+`docs/plans/2026-06-01-display-cache-streaming-pass-34.md`
+
+**Plan**
+- [x] Start fresh branch from updated `origin/main`.
+- [x] Drift-check display preloading/cache/rendering path.
+- [x] Document pass 34 design and test plan.
+- [x] Add failing display renderer cache-first tests.
+- [x] Wire existing `getCachedUrl()` through playback components.
+- [x] Run multi-subagent review before broader verification.
+- [x] Run focused and broader verification.
+- [ ] PR, CI, merge if green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Evidence so far:**
+- Red TDD: `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/display/components/__tests__/ContentRenderer.test.tsx`
+  failed on the new cache-first media tests because protected images still used
+  the old network blob path and videos ignored the browser cache.
+- Focused green: `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/display/components/__tests__/ContentRenderer.test.tsx src/app/display/components/__tests__/ContentScreen.test.tsx src/app/display/__tests__/DisplayClient.test.tsx`
+  passed 3/3 suites and 11/11 tests after threading `getCachedUrl()` through
+  display playback. Web `tsc --noEmit` passed; changed-file ESLint passed with
+  0 errors and only the repo's existing ESLintRC deprecation warning.
+- Review finding fixed: protected videos now wait for cache lookup before
+  mounting a network `src`, and external lookalike `/device-content/.../file`
+  URLs are treated as ordinary external media rather than protected display
+  media. Focused display suite now passes 3/3 suites and 12/12 tests; web
+  `tsc --noEmit` and changed-file ESLint pass.
+- Multi-vector review: first playback/performance reviewer found the video
+  pre-cache network mount and external lookalike URL issues above; follow-up
+  playback reviewer CLEAN after fixes. React lifecycle/browser/security
+  reviewer CLEAN. Reviewers independently ran focused display suites.
+- Verification: full web Jest passed 96/96 suites and 1049/1049 tests, with
+  existing unrelated React `act()`/jsdom navigation console warnings; web
+  `tsc --noEmit` passed; changed-file ESLint passed with 0 errors; hardcoded
+  JWT scan passed; `git diff --check` passed with CRLF warnings only; production
+  `pnpm --filter @vizora/web build` passed with existing Next middleware/proxy
+  and TypeScript project-reference warnings.
+
+---
+
 ## Active: Template Publish Tenant Guardrail Pass 33 (2026-06-01)
 
 **Branch:** `feat/customer-experience-pass-33`
@@ -31,8 +92,12 @@ business agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
 - [x] Implement global-or-own source-template scope and scoped use-count write.
 - [x] Run multi-subagent review before broader verification.
 - [x] Run focused and broader verification.
-- [ ] PR, CI, merge if green.
-- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+- [x] PR, CI, merge if green. PR #164 merged to `origin/main` at
+  `a0e1d915d7034c2c5c9b05f7f8ed0e5187dc8dec`; PR CI and post-merge main CI
+  green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe. Rechecked
+  after PR #164: blocked because `/opt/vizora/app` is dirty and diverged
+  (`main...origin/main [ahead 17, behind 119]`) despite healthy core services.
 
 **Evidence so far:**
 - Red TDD: `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/template-library/template-library.service.spec.ts`

--- a/web/src/app/display/DisplayClient.tsx
+++ b/web/src/app/display/DisplayClient.tsx
@@ -46,7 +46,7 @@ export function DisplayClient() {
   const impressionRef = useRef<((...args: any[]) => void) | null>(null);
 
   const { isFullscreen, toggleFullscreen } = useFullscreen();
-  const { preloadItems, clearCache } = useBrowserCache();
+  const { getCachedUrl, preloadItems, clearCache } = useBrowserCache();
 
   const {
     pairingCode,
@@ -98,7 +98,7 @@ export function DisplayClient() {
         window.location.reload();
         break;
       default:
-        console.log('[Vizora Display] Unknown command:', command.type);
+        console.warn('[Vizora Display] Unknown command:', command.type);
     }
   }, [clearCache]);
 
@@ -228,6 +228,7 @@ export function DisplayClient() {
         onVideoEnded={player.handleVideoEnded}
         onContentError={handleContentError}
         deviceToken={credentials.deviceToken}
+        getCachedUrl={getCachedUrl}
       />
       <StatusBar status={connection.status} />
       <FullscreenButton isFullscreen={isFullscreen} onToggle={toggleFullscreen} />

--- a/web/src/app/display/__tests__/DisplayClient.test.tsx
+++ b/web/src/app/display/__tests__/DisplayClient.test.tsx
@@ -2,9 +2,9 @@ import { render, waitFor } from '@testing-library/react';
 import { DisplayClient } from '../DisplayClient';
 import type { Playlist } from '../lib/types';
 
-var mockPreloadItems = jest.fn();
-var mockClearCache = jest.fn().mockResolvedValue(undefined);
-var mockClearCredentials = jest.fn();
+const mockPreloadItems = jest.fn();
+const mockClearCache = jest.fn().mockResolvedValue(undefined);
+const mockClearCredentials = jest.fn();
 const updatePlaylist = jest.fn();
 let capturedPlaylistUpdate: ((playlist: Playlist) => void) | undefined;
 let capturedCommand: ((command: { type: string }) => void) | undefined;

--- a/web/src/app/display/components/ContentRenderer.tsx
+++ b/web/src/app/display/components/ContentRenderer.tsx
@@ -12,64 +12,185 @@ interface ContentRendererProps {
   name?: string;
   metadata?: LayoutMetadata;
   authenticateUrl?: (url: string) => string;
+  getCachedUrl?: (url: string) => Promise<string | null>;
   onEnded?: () => void;
   onError?: (errorType: string, errorMessage: string) => void;
 }
 
 /**
- * Fetch an image URL via JavaScript and return a blob URL.
- * This bypasses browser caching/header issues with <img src>.
+ * Resolve protected media to an object URL. The browser display cache is
+ * checked first; protected images keep the old network blob fallback.
  */
-function useBlobUrl(url: string, enabled: boolean) {
-  const [blobUrl, setBlobUrl] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+function useMediaObjectUrl(
+  url: string,
+  enabled: boolean,
+  fetchOnCacheMiss: boolean,
+  getCachedUrl?: (url: string) => Promise<string | null>,
+) {
+  const [state, setState] = useState<{
+    url: string;
+    objectUrl: string | null;
+    error: string | null;
+    cacheDone: boolean;
+    fetchPending: boolean;
+  }>({
+    url: '',
+    objectUrl: null,
+    error: null,
+    cacheDone: false,
+    fetchPending: false,
+  });
 
   useEffect(() => {
-    if (!enabled || !url) return;
+    if (!enabled || !url) {
+      setState({
+        url,
+        objectUrl: null,
+        error: null,
+        cacheDone: true,
+        fetchPending: false,
+      });
+      return;
+    }
 
     let revoked = false;
+    let currentObjectUrl: string | null = null;
     const controller = new AbortController();
 
-    fetch(url, { signal: controller.signal })
-      .then((res) => {
+    setState({
+      url,
+      objectUrl: null,
+      error: null,
+      cacheDone: !getCachedUrl,
+      fetchPending: !getCachedUrl && fetchOnCacheMiss,
+    });
+
+    const loadObjectUrl = async () => {
+      const cachedUrl = getCachedUrl
+        ? await Promise.resolve(getCachedUrl(url)).catch(() => null)
+        : null;
+      if (revoked) {
+        if (cachedUrl && typeof URL.revokeObjectURL === 'function') {
+          URL.revokeObjectURL(cachedUrl);
+        }
+        return;
+      }
+      if (cachedUrl) {
+        currentObjectUrl = cachedUrl;
+        setState({
+          url,
+          objectUrl: cachedUrl,
+          error: null,
+          cacheDone: true,
+          fetchPending: false,
+        });
+        return;
+      }
+      if (!fetchOnCacheMiss) {
+        setState({
+          url,
+          objectUrl: null,
+          error: null,
+          cacheDone: true,
+          fetchPending: false,
+        });
+        return;
+      }
+
+      setState({
+        url,
+        objectUrl: null,
+        error: null,
+        cacheDone: true,
+        fetchPending: true,
+      });
+
+      try {
+        const res = await fetch(url, { signal: controller.signal });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        return res.blob();
-      })
-      .then((blob) => {
+        const blob = await res.blob();
         if (revoked) return;
         const objectUrl = URL.createObjectURL(blob);
-        setBlobUrl(objectUrl);
-        setError(null);
-      })
-      .catch((err) => {
+        currentObjectUrl = objectUrl;
+        setState({
+          url,
+          objectUrl,
+          error: null,
+          cacheDone: true,
+          fetchPending: false,
+        });
+      } catch (err) {
         if (revoked) return;
-        setError(err.message || 'fetch failed');
-      });
+        const error = err instanceof Error ? err.message : 'fetch failed';
+        setState({
+          url,
+          objectUrl: null,
+          error,
+          cacheDone: true,
+          fetchPending: false,
+        });
+      }
+    };
+
+    void loadObjectUrl();
 
     return () => {
       revoked = true;
       controller.abort();
-      setBlobUrl((prev) => {
-        if (prev) URL.revokeObjectURL(prev);
-        return null;
-      });
+      if (currentObjectUrl && typeof URL.revokeObjectURL === 'function') {
+        URL.revokeObjectURL(currentObjectUrl);
+      }
     };
-  }, [url, enabled]);
+  }, [url, enabled, fetchOnCacheMiss, getCachedUrl]);
 
-  return { blobUrl, error };
+  const stateMatchesUrl = state.url === url;
+  const cachePending = enabled && Boolean(getCachedUrl) && (!stateMatchesUrl || !state.cacheDone);
+  const fetchPending = enabled && fetchOnCacheMiss && (!stateMatchesUrl || state.fetchPending);
+
+  return {
+    objectUrl: stateMatchesUrl ? state.objectUrl : null,
+    error: stateMatchesUrl ? state.error : null,
+    pending: cachePending || fetchPending,
+  };
 }
 
-function shouldFetchImageAsBlob(url: string): boolean {
-  return url.includes('/device-content/') && url.includes('/file');
+function shouldUseDeviceContentObjectUrl(url: string): boolean {
+  try {
+    const baseOrigin = typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
+    const parsed = new URL(url, baseOrigin);
+    const apiOrigin = process.env.NEXT_PUBLIC_API_URL
+      ? new URL(process.env.NEXT_PUBLIC_API_URL).origin
+      : baseOrigin;
+    const isDeviceContentPath =
+      /^\/(?:api\/v1\/)?device-content\/[^/]+\/file$/.test(parsed.pathname);
+
+    return new Set([baseOrigin, apiOrigin]).has(parsed.origin) && isDeviceContentPath;
+  } catch {
+    return false;
+  }
 }
 
-export function ContentRenderer({ type, url, name, metadata, authenticateUrl, onEnded, onError }: ContentRendererProps) {
+export function ContentRenderer({
+  type,
+  url,
+  name,
+  metadata,
+  authenticateUrl,
+  getCachedUrl,
+  onEnded,
+  onError,
+}: ContentRendererProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const renderedUrl = authenticateUrl ? authenticateUrl(url) : url;
   const safeRenderedUrl = redactSensitiveUrl(renderedUrl);
   const isImage = type === 'image';
-  const shouldFetchBlob = isImage && shouldFetchImageAsBlob(renderedUrl);
-  const { blobUrl, error: fetchError } = useBlobUrl(renderedUrl, shouldFetchBlob);
+  const isVideo = type === 'video';
+  const shouldUseObjectUrl = (isImage || isVideo) && shouldUseDeviceContentObjectUrl(renderedUrl);
+  const {
+    objectUrl: mediaObjectUrl,
+    error: fetchError,
+    pending: mediaPending,
+  } = useMediaObjectUrl(renderedUrl, shouldUseObjectUrl, isImage, getCachedUrl);
 
   // Attempt autoplay when video mounts
   useEffect(() => {
@@ -82,7 +203,7 @@ export function ContentRenderer({ type, url, name, metadata, authenticateUrl, on
         }
       });
     }
-  }, [type, renderedUrl]);
+  }, [type, renderedUrl, mediaObjectUrl]);
 
   // Report fetch errors for images
   useEffect(() => {
@@ -93,7 +214,7 @@ export function ContentRenderer({ type, url, name, metadata, authenticateUrl, on
 
   switch (type) {
     case 'image':
-      if (!shouldFetchBlob) {
+      if (!shouldUseObjectUrl) {
         return (
           <img
             src={renderedUrl}
@@ -113,7 +234,7 @@ export function ContentRenderer({ type, url, name, metadata, authenticateUrl, on
           </div>
         );
       }
-      if (!blobUrl) {
+      if (!mediaObjectUrl || mediaPending) {
         return (
           <div style={{ ...styles.image, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <div style={{ width: '40px', height: '40px', border: '3px solid rgba(0,229,160,0.2)', borderTopColor: '#00E5A0', borderRadius: '50%', animation: 'spin 1s linear infinite' }} />
@@ -122,7 +243,7 @@ export function ContentRenderer({ type, url, name, metadata, authenticateUrl, on
       }
       return (
         <img
-          src={blobUrl}
+          src={mediaObjectUrl}
           alt={name || 'Display content'}
           style={styles.image}
           onError={() => {
@@ -133,10 +254,17 @@ export function ContentRenderer({ type, url, name, metadata, authenticateUrl, on
       );
 
     case 'video':
+      if (shouldUseObjectUrl && getCachedUrl && mediaPending && !mediaObjectUrl) {
+        return (
+          <div style={{ ...styles.video, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <div style={{ width: '40px', height: '40px', border: '3px solid rgba(0,229,160,0.2)', borderTopColor: '#00E5A0', borderRadius: '50%', animation: 'spin 1s linear infinite' }} />
+          </div>
+        );
+      }
       return (
         <video
           ref={videoRef}
-          src={renderedUrl}
+          src={mediaObjectUrl || renderedUrl}
           autoPlay
           muted
           playsInline
@@ -177,7 +305,14 @@ export function ContentRenderer({ type, url, name, metadata, authenticateUrl, on
 
     case 'layout':
       if (metadata) {
-        return <LayoutRenderer metadata={metadata} authenticateUrl={authenticateUrl} onError={onError} />;
+        return (
+          <LayoutRenderer
+            metadata={metadata}
+            authenticateUrl={authenticateUrl}
+            getCachedUrl={getCachedUrl}
+            onError={onError}
+          />
+        );
       }
       return null;
 

--- a/web/src/app/display/components/ContentScreen.tsx
+++ b/web/src/app/display/components/ContentScreen.tsx
@@ -9,6 +9,7 @@ interface ContentScreenProps {
   onVideoEnded: () => void;
   onContentError?: (contentId: string, errorType: string, errorMessage: string) => void;
   deviceToken?: string;
+  getCachedUrl?: (url: string) => Promise<string | null>;
 }
 
 /**
@@ -47,6 +48,7 @@ export function ContentScreen({
   onVideoEnded,
   onContentError,
   deviceToken,
+  getCachedUrl,
 }: ContentScreenProps) {
   // Temporary pushed content takes priority
   if (temporaryContent) {
@@ -57,6 +59,7 @@ export function ContentScreen({
           url={authenticateUrl(temporaryContent.url, deviceToken)}
           name={temporaryContent.name}
           authenticateUrl={(url) => authenticateUrl(url, deviceToken)}
+          getCachedUrl={getCachedUrl}
           onEnded={onVideoEnded}
           onError={(errType, errMsg) => onContentError?.(temporaryContent.id, errType, errMsg)}
         />
@@ -74,6 +77,7 @@ export function ContentScreen({
           name={currentItem.content.name}
           metadata={currentItem.content.metadata}
           authenticateUrl={(url) => authenticateUrl(url, deviceToken)}
+          getCachedUrl={getCachedUrl}
           onEnded={onVideoEnded}
           onError={(errType, errMsg) => onContentError?.(currentItem.content!.id, errType, errMsg)}
         />

--- a/web/src/app/display/components/LayoutRenderer.tsx
+++ b/web/src/app/display/components/LayoutRenderer.tsx
@@ -1,16 +1,17 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback } from 'react';
-import type { LayoutMetadata, LayoutZone, PlaylistItem } from '../lib/types';
+import type { LayoutMetadata, LayoutZone } from '../lib/types';
 import { ContentRenderer } from './ContentRenderer';
 
 interface LayoutRendererProps {
   metadata: LayoutMetadata;
   authenticateUrl?: (url: string) => string;
+  getCachedUrl?: (url: string) => Promise<string | null>;
   onError?: (errorType: string, errorMessage: string) => void;
 }
 
-export function LayoutRenderer({ metadata, authenticateUrl, onError }: LayoutRendererProps) {
+export function LayoutRenderer({ metadata, authenticateUrl, getCachedUrl, onError }: LayoutRendererProps) {
   const gridStyle: React.CSSProperties = {
     width: '100%',
     height: '100%',
@@ -28,7 +29,13 @@ export function LayoutRenderer({ metadata, authenticateUrl, onError }: LayoutRen
   return (
     <div style={gridStyle}>
       {metadata.zones.map((zone) => (
-        <ZonePlayer key={zone.id} zone={zone} authenticateUrl={authenticateUrl} onError={onError} />
+        <ZonePlayer
+          key={zone.id}
+          zone={zone}
+          authenticateUrl={authenticateUrl}
+          getCachedUrl={getCachedUrl}
+          onError={onError}
+        />
       ))}
     </div>
   );
@@ -37,10 +44,12 @@ export function LayoutRenderer({ metadata, authenticateUrl, onError }: LayoutRen
 function ZonePlayer({
   zone,
   authenticateUrl,
+  getCachedUrl,
   onError,
 }: {
   zone: LayoutZone;
   authenticateUrl?: (url: string) => string;
+  getCachedUrl?: (url: string) => Promise<string | null>;
   onError?: (t: string, m: string) => void;
 }) {
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -80,6 +89,7 @@ function ZonePlayer({
           type={zone.resolvedContent.type}
           url={authenticateUrl ? authenticateUrl(zone.resolvedContent.url) : zone.resolvedContent.url}
           name={zone.resolvedContent.name}
+          getCachedUrl={getCachedUrl}
           onError={onError}
         />
       </div>
@@ -98,6 +108,7 @@ function ZonePlayer({
         type={item.content.type}
         url={authenticateUrl ? authenticateUrl(item.content.url) : item.content.url}
         name={item.content.name}
+        getCachedUrl={getCachedUrl}
         onEnded={advance}
         onError={onError}
       />

--- a/web/src/app/display/components/__tests__/ContentRenderer.test.tsx
+++ b/web/src/app/display/components/__tests__/ContentRenderer.test.tsx
@@ -1,16 +1,43 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ContentRenderer } from '../ContentRenderer';
 import { redactSensitiveUrl } from '../../lib/redact-sensitive-url';
 
 describe('ContentRenderer', () => {
   const originalFetch = global.fetch;
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+  const originalPlay = HTMLMediaElement.prototype.play;
 
   beforeEach(() => {
     global.fetch = jest.fn();
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: jest.fn(() => 'blob:rendered-media'),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: jest.fn(),
+    });
+    Object.defineProperty(HTMLMediaElement.prototype, 'play', {
+      configurable: true,
+      value: jest.fn().mockResolvedValue(undefined),
+    });
   });
 
   afterEach(() => {
     global.fetch = originalFetch;
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: originalCreateObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: originalRevokeObjectURL,
+    });
+    Object.defineProperty(HTMLMediaElement.prototype, 'play', {
+      configurable: true,
+      value: originalPlay,
+    });
   });
 
   it('renders external HTTPS images directly instead of fetching them as blobs', () => {
@@ -26,6 +53,25 @@ describe('ContentRenderer', () => {
     expect(screen.getByRole('img', { name: 'Menu' })).toHaveAttribute(
       'src',
       'https://cdn.example.com/menu.png',
+    );
+  });
+
+  it('renders external device-content lookalike images directly instead of treating them as protected media', () => {
+    const getCachedUrl = jest.fn();
+    render(
+      <ContentRenderer
+        type="image"
+        url="https://evil.example/api/v1/device-content/content-1/file"
+        name="Menu"
+        getCachedUrl={getCachedUrl}
+      />,
+    );
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(getCachedUrl).not.toHaveBeenCalled();
+    expect(screen.getByRole('img', { name: 'Menu' })).toHaveAttribute(
+      'src',
+      'https://evil.example/api/v1/device-content/content-1/file',
     );
   });
 
@@ -53,5 +99,90 @@ describe('ContentRenderer', () => {
     expect(redactSensitiveUrl('url: /file?token=abc123&variant=original')).toBe(
       'url: /file?token=[redacted]&variant=original',
     );
+  });
+
+  it('uses cached protected images before falling back to a network blob fetch', async () => {
+    const getCachedUrl = jest.fn().mockResolvedValue('blob:cached-image');
+
+    render(
+      <ContentRenderer
+        type="image"
+        url="/api/v1/device-content/content-1/file?token=device-jwt"
+        name="Menu"
+        getCachedUrl={getCachedUrl}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('img', { name: 'Menu' })).toHaveAttribute(
+        'src',
+        'blob:cached-image',
+      );
+    });
+
+    expect(getCachedUrl).toHaveBeenCalledWith('/api/v1/device-content/content-1/file?token=device-jwt');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('keeps protected image network fallback when the browser cache misses', async () => {
+    const getCachedUrl = jest.fn().mockResolvedValue(null);
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      blob: jest.fn().mockResolvedValue(new Blob(['image'], { type: 'image/png' })),
+    });
+
+    render(
+      <ContentRenderer
+        type="image"
+        url="/api/v1/device-content/content-1/file?token=device-jwt"
+        name="Menu"
+        getCachedUrl={getCachedUrl}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('img', { name: 'Menu' })).toHaveAttribute(
+        'src',
+        'blob:rendered-media',
+      );
+    });
+
+    expect(getCachedUrl).toHaveBeenCalledWith('/api/v1/device-content/content-1/file?token=device-jwt');
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/v1/device-content/content-1/file?token=device-jwt',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it('uses cached protected videos without issuing a duplicate fetch', async () => {
+    let resolveCache!: (url: string) => void;
+    const cachedUrlPromise = new Promise<string>((resolve) => {
+      resolveCache = resolve;
+    });
+    const getCachedUrl = jest.fn(() => cachedUrlPromise);
+    const { container } = render(
+      <ContentRenderer
+        type="video"
+        url="/api/v1/device-content/content-1/file?token=device-jwt"
+        name="Loop"
+        getCachedUrl={getCachedUrl}
+      />,
+    );
+
+    expect(container.querySelector('video')).toBeNull();
+    expect(HTMLMediaElement.prototype.play as jest.Mock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveCache('blob:cached-video');
+      await cachedUrlPromise;
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('video')).toHaveAttribute('src', 'blob:cached-video');
+    });
+
+    expect(getCachedUrl).toHaveBeenCalledWith('/api/v1/device-content/content-1/file?token=device-jwt');
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(HTMLMediaElement.prototype.play as jest.Mock).toHaveBeenCalled();
   });
 });

--- a/web/src/app/display/components/__tests__/ContentScreen.test.tsx
+++ b/web/src/app/display/components/__tests__/ContentScreen.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { ContentScreen } from '../ContentScreen';
 
 jest.mock('../ContentRenderer', () => ({
-  ContentRenderer: ({ url, name, type, metadata, authenticateUrl }: any) => {
+  ContentRenderer: ({ url, name, type, metadata, authenticateUrl, getCachedUrl }: any) => {
     const zoneUrl = metadata?.zones?.[0]?.resolvedContent?.url;
     return (
       <div
@@ -10,6 +10,7 @@ jest.mock('../ContentRenderer', () => ({
         data-url={url}
         data-zone-url={zoneUrl && authenticateUrl ? authenticateUrl(zoneUrl) : zoneUrl}
         data-type={type}
+        data-has-cache-resolver={typeof getCachedUrl === 'function' ? 'true' : 'false'}
       >
         {name}
       </div>
@@ -73,6 +74,7 @@ describe('ContentScreen', () => {
   });
 
   it('passes token authentication through to protected layout zone URLs', () => {
+    const getCachedUrl = jest.fn();
     render(
       <ContentScreen
         currentItem={{
@@ -103,12 +105,17 @@ describe('ContentScreen', () => {
         temporaryContent={null}
         onVideoEnded={jest.fn()}
         deviceToken="device-token"
+        getCachedUrl={getCachedUrl}
       />,
     );
 
     expect(screen.getByTestId('renderer')).toHaveAttribute(
       'data-zone-url',
       '/api/v1/device-content/content-2/file?token=device-token',
+    );
+    expect(screen.getByTestId('renderer')).toHaveAttribute(
+      'data-has-cache-resolver',
+      'true',
     );
   });
 });


### PR DESCRIPTION
## Summary
- Use the existing display Cache API object URLs during protected device-content playback.
- Keep protected image network blob fallback on cache miss while avoiding duplicate fetches on cache hits.
- Ensure protected videos wait for cache lookup before falling back to network playback.
- Keep untrusted external lookalike URLs rendering directly.

## Verification
- `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/display/components/__tests__/ContentRenderer.test.tsx src/app/display/components/__tests__/ContentScreen.test.tsx src/app/display/__tests__/DisplayClient.test.tsx`
- `pnpm --filter @vizora/web exec tsc --noEmit --pretty false`
- `ESLINT_USE_FLAT_CONFIG=false npx eslint ...changed display files...`
- `pnpm --filter @vizora/web test -- --runInBand`
- `pnpm security:no-hardcoded-jwts`
- `git diff --check`
- `NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 BACKEND_URL=http://localhost:3000 pnpm --filter @vizora/web build`

## Reviews
- Playback performance/offline reviewer: found video pre-cache network mount and external lookalike URL issues; follow-up CLEAN after fixes.
- React lifecycle/browser/security reviewer: CLEAN.