### PR TITLE
fix(middleware): bound playlist update fanout

### DIFF
--- a/docs/plans/2026-06-01-playlist-fanout-performance-pass-35.md
+++ b/docs/plans/2026-06-01-playlist-fanout-performance-pass-35.md
@@ -1,0 +1,76 @@
+# Bounded Playlist Fan-out Pass 35
+
+## Goal
+
+Reduce middleware/realtime pressure when a playlist assigned to many displays is
+updated by bounding the number of simultaneous realtime push requests.
+
+## New primitives introduced
+
+None. This pass only adds a small private concurrency helper inside the existing
+`PlaylistsService` notification path. No schema, route, module, queue, env var,
+response envelope, realtime gateway contract, notification substrate, MCP tool,
+Hermes skill, provider spend path, or production process changes.
+
+## Hermes-first analysis
+
+Not applicable. This pass does not add or modify business agents, MCP tools,
+Hermes skills, AI/provider calls, or spend paths.
+
+## Drift check
+
+Evidence before scope:
+
+- `middleware/src/modules/playlists/playlists.service.ts` already has the native
+  update path and circuit-breaker wrapped realtime POST in
+  `notifyDisplaysOfPlaylistUpdate()`.
+- That method currently calls `Promise.allSettled(displays.map(...))`, so a
+  playlist assigned to hundreds of displays can enqueue hundreds of simultaneous
+  HTTP requests.
+- Existing tests in `middleware/src/modules/playlists/playlists.service.spec.ts`
+  cover dispatch count, no-display skip, missing secret skip, and fallback
+  behavior, but not fan-out concurrency.
+
+## Plan
+
+- [x] Add a focused Jest test that makes the existing unbounded fan-out fail by
+  holding notifier promises open and asserting active circuit-breaker calls never
+  exceed the configured limit.
+- [x] Implement a private bounded runner in `PlaylistsService` and route display
+  notifications through it.
+- [x] Keep the existing fire-and-forget behavior: playlist updates must still
+  return without surfacing realtime delivery failures to the caller.
+- [x] Preserve the existing circuit-breaker call, internal auth header, and
+  realtime `/api/push/playlist` payload shape.
+- [x] Run multi-vector subagent review before broader verification.
+- [x] Run focused middleware playlist tests, middleware typecheck, changed-file
+  lint, security scan, and broader middleware verification.
+- [ ] Open PR, wait for CI, merge only if green, then re-check the production
+  deploy gate without modifying prod state.
+
+## Test Strategy
+
+Focused red/green:
+
+```powershell
+pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/playlists/playlists.service.spec.ts
+```
+
+Broader verification:
+
+```powershell
+pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false
+$env:ESLINT_USE_FLAT_CONFIG='false'; npx eslint middleware/src/modules/playlists/playlists.service.ts middleware/src/modules/playlists/playlists.service.spec.ts
+pnpm security:no-hardcoded-jwts
+git diff --check
+pnpm --filter @vizora/middleware test -- --runInBand
+npx nx build @vizora/middleware --skip-nx-cache
+```
+
+## Review Vectors
+
+- Performance/correctness: concurrency limit is real, all displays are attempted,
+  and failures do not stall later displays.
+- Architecture/security: uses the existing internal realtime route,
+  circuit-breaker path, auth secret, and tenant-neutral display query behavior
+  without adding parallel infrastructure.

--- a/middleware/src/modules/playlists/playlists.service.spec.ts
+++ b/middleware/src/modules/playlists/playlists.service.spec.ts
@@ -680,5 +680,79 @@ describe('PlaylistsService', () => {
       expect(result).toEqual(updatedPlaylist);
       expect(mockCircuitBreaker.executeWithFallback).toHaveBeenCalledTimes(1);
     });
+
+    it('should limit concurrent realtime notifications for large display fan-out', async () => {
+      const displays = Array.from({ length: 45 }, (_, index) => ({ id: `display-${index + 1}` }));
+      const concurrencyLimit = 20;
+      const releases: Array<() => void> = [];
+      let activeCalls = 0;
+      let maxActiveCalls = 0;
+      let completed = false;
+
+      mockDatabaseService.display.findMany.mockResolvedValue(displays);
+      mockCircuitBreaker.executeWithFallback.mockImplementation(async () => {
+        activeCalls += 1;
+        maxActiveCalls = Math.max(maxActiveCalls, activeCalls);
+        await new Promise<void>((resolve) => releases.push(resolve));
+        activeCalls -= 1;
+      });
+
+      const waitFor = async (predicate: () => boolean) => {
+        const startedAt = Date.now();
+        while (!predicate()) {
+          if (Date.now() - startedAt > 1000) {
+            throw new Error('Timed out waiting for playlist notification fan-out');
+          }
+          await new Promise((resolve) => setTimeout(resolve, 5));
+        }
+      };
+
+      const notifyPromise = (service as any)
+        .notifyDisplaysOfPlaylistUpdate('playlist-123', updatedPlaylist)
+        .finally(() => {
+          completed = true;
+        });
+
+      await waitFor(() => mockCircuitBreaker.executeWithFallback.mock.calls.length >= concurrencyLimit);
+
+      let concurrencyError: unknown;
+      try {
+        expect(maxActiveCalls).toBeLessThanOrEqual(concurrencyLimit);
+      } catch (error) {
+        concurrencyError = error;
+      }
+
+      while (!completed) {
+        await waitFor(() => releases.length > 0 || completed);
+        while (releases.length > 0) {
+          releases.shift()?.();
+        }
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      await notifyPromise;
+
+      expect(maxActiveCalls).toBeLessThanOrEqual(concurrencyLimit);
+      expect(mockCircuitBreaker.executeWithFallback).toHaveBeenCalledTimes(displays.length);
+      expect(activeCalls).toBe(0);
+
+      if (concurrencyError) {
+        throw concurrencyError;
+      }
+    });
+
+    it('should continue notifying later displays when earlier notifications reject', async () => {
+      const displays = Array.from({ length: 45 }, (_, index) => ({ id: `display-${index + 1}` }));
+      mockDatabaseService.display.findMany.mockResolvedValue(displays);
+      mockCircuitBreaker.executeWithFallback.mockImplementation(async () => {
+        const currentCallNumber = mockCircuitBreaker.executeWithFallback.mock.calls.length;
+        if (currentCallNumber <= 20) {
+          throw new Error('realtime unavailable');
+        }
+      });
+
+      await (service as any).notifyDisplaysOfPlaylistUpdate('playlist-123', updatedPlaylist);
+
+      expect(mockCircuitBreaker.executeWithFallback).toHaveBeenCalledTimes(displays.length);
+    });
   });
 });

--- a/middleware/src/modules/playlists/playlists.service.ts
+++ b/middleware/src/modules/playlists/playlists.service.ts
@@ -15,6 +15,7 @@ const REALTIME_CIRCUIT_CONFIG = {
   successThreshold: 2,
   failureWindow: 60000, // 1 minute
 };
+const PLAYLIST_UPDATE_NOTIFY_CONCURRENCY = 20;
 
 @Injectable()
 export class PlaylistsService {
@@ -538,8 +539,10 @@ export class PlaylistsService {
 
     const url = `${this.realtimeUrl}/api/push/playlist`;
 
-    await Promise.allSettled(
-      displays.map(async (display) => {
+    await this.runBounded(
+      displays,
+      PLAYLIST_UPDATE_NOTIFY_CONCURRENCY,
+      async (display) => {
         await this.circuitBreaker.executeWithFallback(
           'realtime-service',
           async () => {
@@ -564,6 +567,31 @@ export class PlaylistsService {
           },
           REALTIME_CIRCUIT_CONFIG,
         );
+      },
+    );
+  }
+
+  private async runBounded<T>(
+    items: readonly T[],
+    concurrency: number,
+    task: (item: T) => Promise<void>,
+  ): Promise<void> {
+    if (items.length === 0) return;
+
+    const workerCount = Math.min(Math.max(1, concurrency), items.length);
+    let nextIndex = 0;
+
+    await Promise.all(
+      Array.from({ length: workerCount }, async () => {
+        while (nextIndex < items.length) {
+          const item = items[nextIndex];
+          nextIndex += 1;
+          try {
+            await task(item);
+          } catch {
+            // Preserve the previous Promise.allSettled behavior: attempt every display.
+          }
+        }
       }),
     );
   }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,78 @@
 # Vizora - Task Tracker
 
-## Active: Display Cache Streaming Pass 34 (2026-06-01)
+## Active: Bounded Playlist Fan-out Pass 35 (2026-06-01)
+
+**Branch:** `feat/customer-experience-pass-35`
+
+**Why now:** PR #165 is merged with green PR and post-merge main CI, but
+production deploy remains blocked by dirty/diverged prod-local state. The next
+highest performance issue from the audit is playlist update fan-out:
+`notifyDisplaysOfPlaylistUpdate()` currently sends one realtime HTTP request per
+assigned display through `Promise.allSettled(displays.map(...))`. For larger
+fleets this can create an avoidable burst against middleware, realtime, and the
+internal command path.
+
+**New primitives introduced:** none. This pass only adds a small private
+bounded-concurrency helper in the existing playlist service notification path.
+No route, module, middleware, schema, response envelope, realtime gateway
+contract, notification substrate, MCP tool, Hermes skill, provider spend path,
+env var, or production process changes.
+
+**Hermes-first analysis:** not applicable. This pass does not add or modify
+business agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
+
+**Plan/design:**
+`docs/plans/2026-06-01-playlist-fanout-performance-pass-35.md`
+
+**Plan**
+- [x] Start fresh branch from updated `origin/main`.
+- [x] Drift-check playlist update notification path and tests.
+- [x] Document pass 35 design and test plan.
+- [x] Add failing bounded fan-out tests.
+- [x] Implement bounded notification dispatch with existing circuit breaker path.
+- [x] Run multi-subagent review before broader verification.
+- [x] Run focused and broader verification.
+- [ ] PR, CI, merge if green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Evidence so far:**
+- Drift-check: `middleware/src/modules/playlists/playlists.service.ts`
+  `notifyDisplaysOfPlaylistUpdate()` loads displays by `currentPlaylistId` and
+  currently uses unbounded `Promise.allSettled(displays.map(...))` around the
+  existing `this.circuitBreaker.executeWithFallback('realtime-service', ...)`
+  realtime POST. Existing focused tests cover dispatch count, no-display skip,
+  missing-secret skip, and fallback behavior, but not concurrency.
+- PR #165 / pass 34 integration: merged at
+  `4827344cab9c538461e8b7a6bd368a084e33b694`; post-merge main CI run
+  `26777703887` completed with build, lint, test, security, and e2e all
+  successful.
+- Production gate after PR #165: blocked. `/opt/vizora/app` is still dirty and
+  diverged (`main...origin/main [ahead 17, behind 121]`, `HEAD bb76aa...`,
+  `origin/main 4827344...`) with many modified template/landing/Hermes files and
+  untracked production files. Core services are healthy, but most ops/agent PM2
+  entries remain stopped. No deploy attempted.
+- Red TDD: focused playlist service suite failed on the new fan-out test because
+  the existing `Promise.allSettled(displays.map(...))` path reached 45 active
+  realtime notifications with 45 displays, exceeding the 20-request cap.
+- Focused green: after adding the bounded runner, the focused playlist service
+  suite passed 31/31. Review follow-up hardened the test set with a final
+  post-drain peak assertion and an explicit "earlier rejects do not stop later
+  displays" regression; the focused suite then passed 32/32.
+- Multi-vector review: performance/correctness reviewer CLEAN with low notes to
+  add explicit reject-continuation coverage and update docs; architecture,
+  security, and runtime/deploy-safety reviewer CLEAN with a low note to reassert
+  peak concurrency after all batches drain. Both low notes were addressed.
+- Verification: focused playlist service suite passed 32/32; middleware
+  `tsc --noEmit` passed; changed-file ESLint passed with 0 errors and only the
+  existing ESLintRC deprecation warning; hardcoded JWT scan passed; `git diff
+  --check` passed with CRLF warnings only; full middleware Jest passed 146/146
+  suites and 2940/2940 tests; `npx nx build @vizora/middleware
+  --skip-nx-cache` passed with existing webpack dependency warnings and the
+  existing Nx flaky-task note for `@vizora/database:build`.
+
+---
+
+## Completed: Display Cache Streaming Pass 34 (2026-06-01)
 
 **Branch:** `feat/customer-experience-pass-34`
 
@@ -32,8 +104,12 @@ business agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
 - [x] Wire existing `getCachedUrl()` through playback components.
 - [x] Run multi-subagent review before broader verification.
 - [x] Run focused and broader verification.
-- [ ] PR, CI, merge if green.
-- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+- [x] PR, CI, merge if green. PR #165 merged to `origin/main` at
+  `4827344cab9c538461e8b7a6bd368a084e33b694`; PR CI and post-merge main CI
+  green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe. Rechecked
+  after PR #165: blocked because `/opt/vizora/app` is dirty and diverged
+  (`main...origin/main [ahead 17, behind 121]`) despite healthy core services.
 
 **Evidence so far:**
 - Red TDD: `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/display/components/__tests__/ContentRenderer.test.tsx`
@@ -58,6 +134,8 @@ business agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
   JWT scan passed; `git diff --check` passed with CRLF warnings only; production
   `pnpm --filter @vizora/web build` passed with existing Next middleware/proxy
   and TypeScript project-reference warnings.
+- PR/CI: PR #165 merged; post-merge main CI run `26777703887` succeeded for
+  build, lint, test, security, and e2e.
 
 ---
 


### PR DESCRIPTION
﻿## Summary
- Bound playlist update realtime fan-out to 20 concurrent display notifications.
- Preserve the existing circuit-breaker/internal realtime POST path and fire-and-forget playlist update behavior.
- Add regression coverage for peak concurrency and continuing after early notification rejections.

## Test Plan
- pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/playlists/playlists.service.spec.ts
- pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false
- ESLINT_USE_FLAT_CONFIG=false npx eslint middleware/src/modules/playlists/playlists.service.ts middleware/src/modules/playlists/playlists.service.spec.ts
- pnpm security:no-hardcoded-jwts
- git diff --check
- pnpm --filter @vizora/middleware test -- --runInBand
- npx nx build @vizora/middleware --skip-nx-cache

## Review
- Performance/correctness subagent: CLEAN, low notes addressed.
- Architecture/security/runtime subagent: CLEAN, low note addressed.

## Deploy
- Not deployed. Production checkout remains dirty/diverged and operator-gated; no prod state was modified.
