### PR TITLE
fix(web): align template actions with backend permissions

### DIFF
--- a/docs/plans/2026-06-01-template-action-truthfulness-pass-36.md
+++ b/docs/plans/2026-06-01-template-action-truthfulness-pass-36.md
@@ -1,0 +1,41 @@
+# Template Action Truthfulness Pass 36
+
+## Goal
+
+Make the template dashboard show only actions a customer admin can complete, and
+make the AI Designer entry points honest while the backend feature remains
+disabled.
+
+## New primitives introduced
+
+None. This pass only aligns existing frontend affordances with existing backend
+guards and the existing `ai-generate` unavailable response. No route, module,
+schema, middleware, response envelope, realtime path, notification path, MCP
+tool, Hermes skill, provider spend path, env var, or production process changes.
+
+## Hermes-first analysis
+
+Not applicable. This pass does not add or modify business agents, MCP tools,
+Hermes skills, AI/provider calls, or spend paths.
+
+## Drift check
+
+- `middleware/src/modules/template-library/template-library.controller.ts`
+  protects create/update/delete with `SuperAdminGuard`.
+- `middleware/src/modules/template-library/template-library.service.ts`
+  returns `{ available: false }` from AI generation.
+- The dashboard currently keys several authoring actions off `role === 'admin'`
+  and the AI modal simulates generation before showing the disabled response.
+
+## Plan
+
+- [x] Extend frontend auth user shape to preserve optional `isSuperAdmin`.
+- [x] Gate template library create/edit/delete actions on `isSuperAdmin === true`
+  rather than org admin role.
+- [x] Route customer customization through clone/publish flows instead of
+  update-template-only editors.
+- [x] Replace AI Designer generation simulation with an honest coming-soon modal
+  and copy across hero/sidebar/mobile/empty states.
+- [x] Add focused web tests for ordinary org admin behavior.
+- [x] Run multi-vector review, focused tests, typecheck/lint/security, and web
+  unit/build verification.

--- a/middleware/src/modules/auth/strategies/jwt.strategy.spec.ts
+++ b/middleware/src/modules/auth/strategies/jwt.strategy.spec.ts
@@ -202,6 +202,44 @@ describe('JwtStrategy', () => {
           storageQuotaBytes: 2000,
         });
       });
+
+      it('should preserve isSuperAdmin from the database path for /auth/me consumers', async () => {
+        mockDatabaseService.user.findUnique.mockResolvedValue({
+          ...mockUser,
+          isSuperAdmin: true,
+        } as any);
+
+        const result = await strategy.validate(userPayload);
+
+        expect(result.isSuperAdmin).toBe(true);
+        const cachedPayload = JSON.parse(mockRedisService.set.mock.calls[0][1] as string);
+        expect(cachedPayload.isSuperAdmin).toBe(true);
+      });
+
+      it('should preserve isSuperAdmin from the Redis cache path for /auth/me consumers', async () => {
+        mockRedisService.get.mockResolvedValue(JSON.stringify({
+          id: mockUser.id,
+          email: mockUser.email,
+          firstName: mockUser.firstName,
+          lastName: mockUser.lastName,
+          avatar: null,
+          organizationId: mockUser.organizationId,
+          role: mockUser.role,
+          isActive: true,
+          isSuperAdmin: true,
+          organization: {
+            id: 'org-123',
+            name: 'Test Organization',
+            storageUsedBytes: 0,
+            storageQuotaBytes: 1073741824,
+          },
+        }));
+
+        const result = await strategy.validate(userPayload);
+
+        expect(result.isSuperAdmin).toBe(true);
+        expect(mockDatabaseService.user.findUnique).not.toHaveBeenCalled();
+      });
     });
 
     describe('token revocation', () => {

--- a/middleware/src/modules/auth/strategies/jwt.strategy.ts
+++ b/middleware/src/modules/auth/strategies/jwt.strategy.ts
@@ -1,6 +1,6 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
-import { ExtractJwt, Strategy } from 'passport-jwt';
+import { Strategy } from 'passport-jwt';
 import { Request } from 'express';
 import { DatabaseService } from '../../database/database.service';
 import { RedisService } from '../../redis/redis.service';
@@ -137,6 +137,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
           avatar: userData.avatar || null,
           organizationId: userData.organizationId,
           role: userData.role,
+          ...(userData.isSuperAdmin === true ? { isSuperAdmin: true } : {}),
           organization: userData.organization,
         };
       } catch (e) {
@@ -173,6 +174,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       organizationId: user.organizationId,
       role: user.role,
       isActive: user.isActive,
+      ...(user.isSuperAdmin === true ? { isSuperAdmin: true } : {}),
       organization: safeOrganization,
     };
     await this.redisService.set(cacheKey, JSON.stringify(userDataToCache), JwtStrategy.USER_CACHE_TTL);
@@ -185,6 +187,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       avatar: user.avatar,
       organizationId: user.organizationId,
       role: user.role,
+      ...(user.isSuperAdmin === true ? { isSuperAdmin: true } : {}),
       organization: safeOrganization,
     };
   }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,86 @@
 # Vizora - Task Tracker
 
-## Active: Bounded Playlist Fan-out Pass 35 (2026-06-01)
+## Active: Template Action Truthfulness Pass 36 (2026-06-01)
+
+**Branch:** `feat/customer-experience-pass-36`
+
+**Why now:** PR #166 is merged with green PR and post-merge main CI, but
+production deploy remains blocked by dirty/diverged prod-local state. The next
+customer trust issue from the dashboard audit is template authoring: the UI
+shows AI Designer and template editing affordances that ordinary customer admins
+cannot complete because the backend intentionally keeps AI generation disabled
+and template create/update/delete behind `SuperAdminGuard`.
+
+**New primitives introduced:** none. This pass only aligns existing frontend
+affordances with existing backend guards and unavailable AI response. No route,
+module, middleware, schema, response envelope, realtime path, notification path,
+MCP tool, Hermes skill, provider spend path, env var, or production process
+changes.
+
+**Hermes-first analysis:** not applicable. This pass does not add or modify
+business agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
+
+**Plan/design:**
+`docs/plans/2026-06-01-template-action-truthfulness-pass-36.md`
+
+**Plan**
+- [x] Start fresh branch from updated `origin/main`.
+- [x] Drift-check template frontend actions against backend guards.
+- [x] Document pass 36 design and test plan.
+- [x] Add failing ordinary-admin template action tests.
+- [x] Gate super-admin-only actions and make AI Designer unavailable state honest.
+- [x] Run multi-subagent review before broader verification.
+- [x] Run focused and broader verification.
+- [ ] PR, CI, merge if green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Evidence so far:**
+- PR #166 / pass 35 integration: merged at
+  `7728ea03dfa0a108f957d0225727f9613915f776`; PR CI and post-merge main CI run
+  `26779421101` completed with build, lint, test, security, and e2e all
+  successful.
+- Production gate after PR #166: blocked. `/opt/vizora/app` is still dirty and
+  diverged (`main...origin/main [ahead 17, behind 123]`, `HEAD bb76aa...`,
+  `origin/main 7728ea0...`) with many modified template/landing/Hermes files and
+  untracked production files. Core API health is OK, but most ops/agent PM2
+  entries remain stopped. No deploy attempted.
+- Open PR check after PR #166: no open pull requests.
+- Drift-check: `template-library.controller.ts` uses `SuperAdminGuard` on
+  create/update/delete, while `template-library.service.ts` returns
+  `available: false` for AI generation. The dashboard currently keys some
+  create/edit actions from `role === 'admin'` and simulates AI generation before
+  showing the unavailable state.
+- Implementation: `/auth/me` now preserves optional `isSuperAdmin`, global
+  template authoring is gated on `isSuperAdmin === true`, org-owned template
+  editing stays available to admin/manager roles through the existing
+  `/template-library/:id/save` route, and clone/use actions are hidden for
+  viewers and org-owned templates because backend clone accepts global templates
+  only.
+- Implementation: AI Designer entry points now show an honest coming-soon modal
+  and no longer simulate or call disabled generation.
+- Multi-vector review: authorization/architecture reviewer CLEAN; customer-flow
+  and backend-contract reviewer CLEAN after follow-up tests hid clone/use actions
+  on org-owned templates.
+- Focused verification:
+  `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/dashboard/templates/__tests__/templates-page.test.tsx src/components/templates/__tests__/AIDesignerModal.test.tsx src/components/templates/__tests__/TemplateDetailModal.test.tsx src/lib/api/__tests__/templates.test.ts 'src/app/dashboard/templates/[id]/__tests__/template-detail-page.test.tsx' 'src/app/dashboard/templates/[id]/edit/__tests__/page-client.test.tsx'`
+  passed 6 suites / 26 tests. `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/auth/strategies/jwt.strategy.spec.ts`
+  passed 34 tests.
+- Broader verification: `pnpm --filter @vizora/web test -- --runInBand` passed
+  101 suites / 1065 tests; `pnpm --filter @vizora/middleware test -- --runInBand`
+  passed 146 suites / 2942 tests. Existing warning noise remains from React
+  `act(...)`, jsdom navigation, MinIO/storage logs, and expected health/circuit
+  breaker logs.
+- Type/build/security: web and middleware `tsc --noEmit --pretty false` passed;
+  changed-file ESLint passed with warnings only from existing `any` debt;
+  `npx nx build @vizora/web --skip-nx-cache`, `npx nx build @vizora/middleware --skip-nx-cache`,
+  and `npx nx build @vizora/realtime --skip-nx-cache` passed. The first
+  concurrent middleware build hit a Windows Prisma generated-client copy lock;
+  serial retry passed. `git diff --check` and `pnpm security:no-hardcoded-jwts`
+  passed.
+
+---
+
+## Completed: Bounded Playlist Fan-out Pass 35 (2026-06-01)
 
 **Branch:** `feat/customer-experience-pass-35`
 
@@ -32,8 +112,12 @@ business agents, MCP tools, Hermes skills, AI/provider calls, or spend paths.
 - [x] Implement bounded notification dispatch with existing circuit breaker path.
 - [x] Run multi-subagent review before broader verification.
 - [x] Run focused and broader verification.
-- [ ] PR, CI, merge if green.
-- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+- [x] PR, CI, merge if green. PR #166 merged to `origin/main` at
+  `7728ea03dfa0a108f957d0225727f9613915f776`; PR CI and post-merge main CI
+  green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe. Rechecked
+  after PR #166: blocked because `/opt/vizora/app` is dirty and diverged
+  (`main...origin/main [ahead 17, behind 123]`) despite healthy core API.
 
 **Evidence so far:**
 - Drift-check: `middleware/src/modules/playlists/playlists.service.ts`

--- a/web/src/app/dashboard/templates/[id]/__tests__/template-detail-page.test.tsx
+++ b/web/src/app/dashboard/templates/[id]/__tests__/template-detail-page.test.tsx
@@ -1,0 +1,121 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import TemplateDetailPage from '../page';
+
+const mockGetTemplateDetail = jest.fn();
+const mockGetTemplatePreview = jest.fn();
+const mockUpdateTemplate = jest.fn();
+const mockUpdateLibraryTemplate = jest.fn();
+const mockCloneTemplate = jest.fn();
+const mockPush = jest.fn();
+let mockUser: { role: string; isSuperAdmin?: boolean } | null = { role: 'admin' };
+let mockEditMode = true;
+
+jest.mock('next/navigation', () => ({
+  useParams: () => ({ id: 'template-1' }),
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => ({ get: (key: string) => (key === 'edit' && mockEditMode ? 'true' : null) }),
+}));
+
+jest.mock('@/lib/hooks/useAuth', () => ({
+  useAuth: () => ({ user: mockUser, loading: false }),
+}));
+
+jest.mock('@/lib/api', () => ({
+  apiClient: {
+    getTemplateDetail: (...args: any[]) => mockGetTemplateDetail(...args),
+    getTemplatePreview: (...args: any[]) => mockGetTemplatePreview(...args),
+    updateTemplate: (...args: any[]) => mockUpdateTemplate(...args),
+    updateLibraryTemplate: (...args: any[]) => mockUpdateLibraryTemplate(...args),
+    cloneTemplate: (...args: any[]) => mockCloneTemplate(...args),
+  },
+}));
+
+jest.mock('@/components/TemplateEditor', () => function MockTemplateEditor() {
+  return <div data-testid="template-editor" />;
+});
+
+jest.mock('@/components/LoadingSpinner', () => function MockLoadingSpinner() {
+  return <div data-testid="loading-spinner" />;
+});
+
+const template = (isLibraryTemplate: boolean) => ({
+  id: 'template-1',
+  name: 'Restaurant Menu',
+  description: 'Menu board template',
+  category: 'restaurant',
+  difficulty: 'beginner',
+  orientation: 'landscape',
+  templateHtml: '<div>Template</div>',
+  sampleData: {},
+  metadata: { isLibraryTemplate },
+});
+
+describe('TemplateDetailPage route selection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUser = { role: 'admin' };
+    mockEditMode = true;
+    mockGetTemplatePreview.mockResolvedValue({ html: '<div>Preview</div>' });
+    mockUpdateTemplate.mockResolvedValue({});
+    mockUpdateLibraryTemplate.mockResolvedValue({});
+    mockCloneTemplate.mockResolvedValue({ id: 'content-1' });
+  });
+
+  it('saves global library template edits through the super-admin update route', async () => {
+    mockUser = { role: 'admin', isSuperAdmin: true };
+    mockGetTemplateDetail.mockResolvedValue(template(true));
+
+    render(<TemplateDetailPage />);
+
+    const save = await screen.findByRole('button', { name: /save changes/i });
+    fireEvent.click(save);
+
+    await waitFor(() => expect(mockUpdateLibraryTemplate).toHaveBeenCalledWith(
+      'template-1',
+      expect.objectContaining({ templateHtml: '<div>Template</div>' }),
+    ));
+    expect(mockUpdateTemplate).not.toHaveBeenCalled();
+  });
+
+  it('saves organization-owned template edits through the scoped save route', async () => {
+    mockUser = { role: 'manager', isSuperAdmin: false };
+    mockGetTemplateDetail.mockResolvedValue(template(false));
+
+    render(<TemplateDetailPage />);
+
+    const save = await screen.findByRole('button', { name: /save changes/i });
+    fireEvent.click(save);
+
+    await waitFor(() => expect(mockUpdateTemplate).toHaveBeenCalledWith(
+      'template-1',
+      expect.objectContaining({ templateHtml: '<div>Template</div>' }),
+    ));
+    expect(mockUpdateLibraryTemplate).not.toHaveBeenCalled();
+  });
+
+  it('does not show clone or edit actions to viewers', async () => {
+    mockUser = { role: 'viewer', isSuperAdmin: false };
+    mockEditMode = false;
+    mockGetTemplateDetail.mockResolvedValue(template(true));
+
+    render(<TemplateDetailPage />);
+
+    expect(await screen.findByText('Restaurant Menu')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /edit visually/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /clone to my content/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^clone template$/i })).not.toBeInTheDocument();
+  });
+
+  it('does not show clone actions for organization-owned templates', async () => {
+    mockUser = { role: 'manager', isSuperAdmin: false };
+    mockEditMode = false;
+    mockGetTemplateDetail.mockResolvedValue(template(false));
+
+    render(<TemplateDetailPage />);
+
+    expect(await screen.findByText('Restaurant Menu')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /edit visually/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /clone to my content/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^clone template$/i })).not.toBeInTheDocument();
+  });
+});

--- a/web/src/app/dashboard/templates/[id]/edit/__tests__/page-client.test.tsx
+++ b/web/src/app/dashboard/templates/[id]/edit/__tests__/page-client.test.tsx
@@ -1,0 +1,141 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import EditPageClient from '../page-client';
+
+const mockGetTemplateDetail = jest.fn();
+const mockGetTemplatePreview = jest.fn();
+const mockUpdateTemplate = jest.fn();
+const mockUpdateLibraryTemplate = jest.fn();
+const mockSerialize = jest.fn();
+const mockPush = jest.fn();
+const mockToastError = jest.fn();
+const mockToastSuccess = jest.fn();
+let mockUser: { role: string; isSuperAdmin?: boolean } | null = { role: 'admin' };
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush, back: jest.fn() }),
+}));
+
+jest.mock('@/lib/hooks/useAuth', () => ({
+  useAuth: () => ({ user: mockUser, loading: false }),
+}));
+
+jest.mock('@/lib/hooks/useToast', () => ({
+  useToast: () => ({
+    error: mockToastError,
+    success: mockToastSuccess,
+  }),
+}));
+
+jest.mock('@/lib/api', () => ({
+  apiClient: {
+    getTemplateDetail: (...args: any[]) => mockGetTemplateDetail(...args),
+    getTemplatePreview: (...args: any[]) => mockGetTemplatePreview(...args),
+    updateTemplate: (...args: any[]) => mockUpdateTemplate(...args),
+    updateLibraryTemplate: (...args: any[]) => mockUpdateLibraryTemplate(...args),
+  },
+}));
+
+jest.mock('@/components/template-editor/TemplateEditorCanvas', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  return React.forwardRef(function MockTemplateEditorCanvas(props: any, ref: any) {
+    React.useImperativeHandle(ref, () => ({
+      serialize: mockSerialize,
+      sendUpdate: jest.fn(),
+    }));
+    React.useEffect(() => {
+      props.onReady?.();
+    }, [props]);
+    return <div data-testid="template-editor-canvas" />;
+  });
+});
+
+jest.mock('@/components/template-editor/PropertyPanel', () => function MockPropertyPanel() {
+  return <div data-testid="property-panel" />;
+});
+
+jest.mock('@/components/template-editor/DisplayPickerModal', () => function MockDisplayPickerModal() {
+  return <div data-testid="display-picker" />;
+});
+
+jest.mock('@/components/template-editor/FloatingToolbar', () => function MockFloatingToolbar() {
+  return <div data-testid="floating-toolbar" />;
+});
+
+jest.mock('@/components/template-editor/useEditorHistory', () => ({
+  useEditorHistory: () => ({
+    pushChange: jest.fn(),
+    canUndo: false,
+    canRedo: false,
+    undo: jest.fn(),
+    redo: jest.fn(),
+  }),
+}));
+
+jest.mock('@/components/template-editor/useCanvasZoom', () => ({
+  useCanvasZoom: () => ({
+    containerRef: { current: null },
+    zoomPreset: 'fit',
+    setZoomPreset: jest.fn(),
+    scale: 1,
+    isScrollable: false,
+  }),
+}));
+
+const template = (isLibraryTemplate: boolean) => ({
+  id: 'template-1',
+  name: 'Restaurant Menu',
+  metadata: { isLibraryTemplate },
+});
+
+describe('EditPageClient route selection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUser = { role: 'admin' };
+    mockGetTemplatePreview.mockResolvedValue({ html: '<div>Preview</div>' });
+    mockUpdateTemplate.mockResolvedValue({});
+    mockUpdateLibraryTemplate.mockResolvedValue({});
+    mockSerialize.mockResolvedValue('<div>Edited</div>');
+  });
+
+  it('saves global library template drafts through the super-admin update route', async () => {
+    mockUser = { role: 'admin', isSuperAdmin: true };
+    mockGetTemplateDetail.mockResolvedValue(template(true));
+
+    render(<EditPageClient templateId="template-1" />);
+
+    const save = await screen.findByRole('button', { name: /save as draft/i });
+    await waitFor(() => expect(save).not.toBeDisabled());
+    fireEvent.click(save);
+
+    await waitFor(() => expect(mockUpdateLibraryTemplate).toHaveBeenCalledWith('template-1', {
+      templateHtml: '<div>Edited</div>',
+    }));
+    expect(mockUpdateTemplate).not.toHaveBeenCalled();
+  });
+
+  it('saves organization-owned template drafts through the scoped save route', async () => {
+    mockUser = { role: 'manager', isSuperAdmin: false };
+    mockGetTemplateDetail.mockResolvedValue(template(false));
+
+    render(<EditPageClient templateId="template-1" />);
+
+    const save = await screen.findByRole('button', { name: /save as draft/i });
+    await waitFor(() => expect(save).not.toBeDisabled());
+    fireEvent.click(save);
+
+    await waitFor(() => expect(mockUpdateTemplate).toHaveBeenCalledWith('template-1', {
+      templateHtml: '<div>Edited</div>',
+    }));
+    expect(mockUpdateLibraryTemplate).not.toHaveBeenCalled();
+  });
+
+  it('keeps viewers out of the visual editor even for organization-owned templates', async () => {
+    mockUser = { role: 'viewer', isSuperAdmin: false };
+    mockGetTemplateDetail.mockResolvedValue(template(false));
+
+    render(<EditPageClient templateId="template-1" />);
+
+    expect(await screen.findByText(/template editing is not available/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /save as draft/i })).not.toBeInTheDocument();
+  });
+});

--- a/web/src/app/dashboard/templates/[id]/edit/page-client.tsx
+++ b/web/src/app/dashboard/templates/[id]/edit/page-client.tsx
@@ -12,6 +12,7 @@ import { useEditorHistory } from '@/components/template-editor/useEditorHistory'
 import { useCanvasZoom } from '@/components/template-editor/useCanvasZoom';
 import type { ZoomPreset } from '@/components/template-editor/useCanvasZoom';
 import { apiClient } from '@/lib/api';
+import { useAuth } from '@/lib/hooks/useAuth';
 import { useToast } from '@/lib/hooks/useToast';
 
 interface EditPageClientProps {
@@ -21,9 +22,15 @@ interface EditPageClientProps {
 export default function EditPageClient({ templateId }: EditPageClientProps) {
   const router = useRouter();
   const toast = useToast();
+  const { user, loading: authLoading } = useAuth();
+  const canManageLibraryTemplates = user?.isSuperAdmin === true;
+  const canUseTemplates = user?.role === 'admin' || user?.role === 'manager';
+  const routerRef = useRef(router);
+  const toastRef = useRef(toast);
 
   // ── State ────────────────────────────────────────────────────────────
   const [templateName, setTemplateName] = useState('');
+  const [isOrgTemplate, setIsOrgTemplate] = useState(false);
   const [previewHtml, setPreviewHtml] = useState('');
   const [loading, setLoading] = useState(true);
   const [editorReady, setEditorReady] = useState(false);
@@ -31,6 +38,9 @@ export default function EditPageClient({ templateId }: EditPageClientProps) {
   const [showDisplayPicker, setShowDisplayPicker] = useState(false);
   const [publishing, setPublishing] = useState(false);
   const [saving, setSaving] = useState(false);
+  const canEditTemplate =
+    canManageLibraryTemplates ||
+    (isOrgTemplate && canUseTemplates);
 
   // ── Refs ──────────────────────────────────────────────────────────────
   const canvasRef = useRef<CanvasHandle>(null);
@@ -41,6 +51,11 @@ export default function EditPageClient({ templateId }: EditPageClientProps) {
 
   // ── Editor History (undo/redo) ────────────────────────────────────────
   const history = useEditorHistory(iframeRef);
+
+  useEffect(() => {
+    routerRef.current = router;
+    toastRef.current = toast;
+  }, [router, toast]);
 
   // Populate iframeRef by finding the iframe inside the canvas container
   // after the editor is ready.
@@ -68,11 +83,12 @@ export default function EditPageClient({ templateId }: EditPageClientProps) {
         if (cancelled) return;
 
         setTemplateName(detail.name || 'Untitled Template');
+        setIsOrgTemplate(detail.metadata?.isLibraryTemplate === false);
         setPreviewHtml(preview.html || '');
       } catch (err: any) {
         if (cancelled) return;
-        toast.error(err.message || 'Failed to load template');
-        router.push('/dashboard/templates');
+        toastRef.current.error(err.message || 'Failed to load template');
+        routerRef.current.push('/dashboard/templates');
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -82,7 +98,7 @@ export default function EditPageClient({ templateId }: EditPageClientProps) {
     return () => {
       cancelled = true;
     };
-  }, [templateId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [templateId]);
 
   // ── Handlers ─────────────────────────────────────────────────────────
 
@@ -113,14 +129,16 @@ export default function EditPageClient({ templateId }: EditPageClientProps) {
   }, []);
 
   const handleSaveDraft = useCallback(async () => {
-    if (!canvasRef.current) return;
+    if (!canvasRef.current || !canEditTemplate) return;
 
     setSaving(true);
     try {
       const renderedHtml = await canvasRef.current.serialize();
+      const update = canManageLibraryTemplates && !isOrgTemplate
+        ? apiClient.updateLibraryTemplate
+        : apiClient.updateTemplate;
 
-      // Save the edited HTML back to the template
-      await apiClient.updateTemplate(templateId, {
+      await update.call(apiClient, templateId, {
         templateHtml: renderedHtml,
       });
 
@@ -130,11 +148,11 @@ export default function EditPageClient({ templateId }: EditPageClientProps) {
     } finally {
       setSaving(false);
     }
-  }, [templateId, toast]);
+  }, [canEditTemplate, canManageLibraryTemplates, isOrgTemplate, templateId, toast]);
 
   const handlePublish = useCallback(
     async (displayIds: string[]) => {
-      if (!canvasRef.current) return;
+      if (!canvasRef.current || !canEditTemplate) return;
 
       setPublishing(true);
       try {
@@ -163,12 +181,12 @@ export default function EditPageClient({ templateId }: EditPageClientProps) {
         setPublishing(false);
       }
     },
-    [templateId, templateName, toast, router],
+    [canEditTemplate, templateId, templateName, toast, router],
   );
 
   // ── Loading state ────────────────────────────────────────────────────
 
-  if (loading) {
+  if (authLoading || loading) {
     return (
       <div className="flex h-screen items-center justify-center bg-gray-950">
         <div className="flex flex-col items-center gap-3">
@@ -193,6 +211,25 @@ export default function EditPageClient({ templateId }: EditPageClientProps) {
             />
           </svg>
           <span className="text-sm text-gray-400">Loading template...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (!canEditTemplate) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-gray-950">
+        <div className="max-w-sm text-center">
+          <p className="text-sm font-semibold text-gray-200">Template editing is not available</p>
+          <p className="mt-2 text-sm text-gray-400">
+            Clone this template into your organization before editing it, or use a platform super-admin account for global library templates.
+          </p>
+          <button
+            onClick={() => router.push('/dashboard/templates')}
+            className="mt-5 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-emerald-500"
+          >
+            Back to Templates
+          </button>
         </div>
       </div>
     );

--- a/web/src/app/dashboard/templates/[id]/page.tsx
+++ b/web/src/app/dashboard/templates/[id]/page.tsx
@@ -33,6 +33,7 @@ interface TemplateDetail {
   previewUrl?: string | null;
   createdAt?: string;
   updatedAt?: string;
+  metadata?: Record<string, unknown>;
 }
 
 export default function TemplateDetailPage() {
@@ -42,7 +43,8 @@ export default function TemplateDetailPage() {
   const templateId = params.id as string;
 
   const { user } = useAuth();
-  const isAdmin = user?.role === 'admin';
+  const canManageLibraryTemplates = user?.isSuperAdmin === true;
+  const canUseTemplates = user?.role === 'admin' || user?.role === 'manager';
   const startInEditMode = searchParams.get('edit') === 'true';
 
   const [template, setTemplate] = useState<TemplateDetail | null>(null);
@@ -74,6 +76,12 @@ export default function TemplateDetailPage() {
   const [saveError, setSaveError] = useState<string | null>(null);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const isOrgTemplate = template?.metadata?.isLibraryTemplate === false;
+  const canEditTemplate =
+    canManageLibraryTemplates ||
+    (isOrgTemplate && canUseTemplates);
+  const canDeleteTemplate = canManageLibraryTemplates && !isOrgTemplate;
+  const canCloneTemplate = canUseTemplates && template?.metadata?.isLibraryTemplate !== false;
 
   useEffect(() => {
     if (templateId) {
@@ -112,7 +120,7 @@ export default function TemplateDetailPage() {
   };
 
   const enterEditMode = () => {
-    if (!template) return;
+    if (!template || !canEditTemplate) return;
     setEditName(template.name || '');
     setEditDescription(template.description || '');
     setEditCategory(template.category || 'general');
@@ -127,16 +135,19 @@ export default function TemplateDetailPage() {
 
   // Auto-enter edit mode from URL param
   useEffect(() => {
-    if (startInEditMode && template && !editMode) {
+    if (startInEditMode && template && canEditTemplate && !editMode) {
       enterEditMode();
     }
-  }, [template, startInEditMode]);
+  }, [template, startInEditMode, canEditTemplate, editMode]);
 
   const handleSave = async () => {
     try {
       setSaving(true);
       setSaveError(null);
-      await apiClient.updateTemplate(templateId, {
+      const update = canManageLibraryTemplates && !isOrgTemplate
+        ? apiClient.updateLibraryTemplate
+        : apiClient.updateTemplate;
+      await update.call(apiClient, templateId, {
         name: editName.trim() || undefined,
         description: editDescription.trim() || undefined,
         templateHtml: editHtml || undefined,
@@ -186,6 +197,7 @@ export default function TemplateDetailPage() {
   };
 
   const handleClone = async () => {
+    if (!canCloneTemplate) return;
     try {
       setCloning(true);
       setCloneError(null);
@@ -316,7 +328,7 @@ export default function TemplateDetailPage() {
 
         {/* Action Buttons */}
         <div className="flex items-center gap-3 flex-shrink-0">
-          {isAdmin && !editMode && (
+          {canEditTemplate && !editMode && (
             <button
               onClick={enterEditMode}
               className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium bg-[var(--surface)] border border-[var(--border)] rounded-lg hover:bg-[var(--surface-hover)] transition text-[var(--foreground)]"
@@ -328,12 +340,14 @@ export default function TemplateDetailPage() {
 
           {editMode ? (
             <div className="flex items-center gap-3">
-              <button
-                onClick={() => setShowDeleteModal(true)}
-                className="px-4 py-2 text-sm font-medium text-error-600 dark:text-error-400 bg-[var(--surface)] border border-error-500/20 rounded-lg hover:bg-error-500/10 transition"
-              >
-                Delete
-              </button>
+              {canDeleteTemplate && (
+                <button
+                  onClick={() => setShowDeleteModal(true)}
+                  className="px-4 py-2 text-sm font-medium text-error-600 dark:text-error-400 bg-[var(--surface)] border border-error-500/20 rounded-lg hover:bg-error-500/10 transition"
+                >
+                  Delete
+                </button>
+              )}
               <button
                 onClick={() => setEditMode(false)}
                 className="px-4 py-2 text-sm font-medium text-[var(--foreground-secondary)] bg-[var(--surface)] border border-[var(--border)] rounded-lg hover:bg-[var(--surface-hover)] transition"
@@ -350,20 +364,24 @@ export default function TemplateDetailPage() {
             </div>
           ) : (
             <>
-              <Link
-                href={`/dashboard/templates/${templateId}/edit`}
-                className="px-4 py-2 rounded-lg bg-emerald-600 text-white hover:bg-emerald-500 text-sm font-medium inline-flex items-center gap-2"
-              >
-                <Icon name="edit" size="sm" />
-                Edit Visually
-              </Link>
-              <button
-                onClick={() => setShowCloneModal(true)}
-                className="px-6 py-3 bg-[#00E5A0] text-[#061A21] rounded-lg hover:bg-[#00CC8E] transition font-semibold shadow-md hover:shadow-lg flex items-center gap-2"
-              >
-                <Icon name="copy" size="md" />
-                Clone to My Content
-              </button>
+              {canEditTemplate && (
+                <Link
+                  href={`/dashboard/templates/${templateId}/edit`}
+                  className="px-4 py-2 rounded-lg bg-emerald-600 text-white hover:bg-emerald-500 text-sm font-medium inline-flex items-center gap-2"
+                >
+                  <Icon name="edit" size="sm" />
+                  Edit Visually
+                </Link>
+              )}
+              {canCloneTemplate && (
+                <button
+                  onClick={() => setShowCloneModal(true)}
+                  className="px-6 py-3 bg-[#00E5A0] text-[#061A21] rounded-lg hover:bg-[#00CC8E] transition font-semibold shadow-md hover:shadow-lg flex items-center gap-2"
+                >
+                  <Icon name="copy" size="md" />
+                  Clone to My Content
+                </button>
+              )}
             </>
           )}
         </div>
@@ -596,28 +614,30 @@ export default function TemplateDetailPage() {
               )}
 
               {/* Clone CTA (repeated for visibility) */}
-              <div className="bg-gradient-to-br from-[#00E5A0]/10 to-[#00B4D8]/10 rounded-lg p-5 border border-[#00E5A0]/20">
-                <h3 className="text-sm font-semibold text-[var(--foreground)] mb-2">
-                  Use this template
-                </h3>
-                <p className="text-xs text-[var(--foreground-secondary)] mb-4">
-                  Clone this template to your content library and customize it with your own data.
-                </p>
-                <button
-                  onClick={() => setShowCloneModal(true)}
-                  className="w-full px-4 py-2.5 bg-[#00E5A0] text-[#061A21] rounded-lg hover:bg-[#00CC8E] transition font-semibold text-sm flex items-center justify-center gap-2"
-                >
-                  <Icon name="copy" size="sm" />
-                  Clone Template
-                </button>
-              </div>
+              {canCloneTemplate && (
+                <div className="bg-gradient-to-br from-[#00E5A0]/10 to-[#00B4D8]/10 rounded-lg p-5 border border-[#00E5A0]/20">
+                  <h3 className="text-sm font-semibold text-[var(--foreground)] mb-2">
+                    Use this template
+                  </h3>
+                  <p className="text-xs text-[var(--foreground-secondary)] mb-4">
+                    Clone this template to your content library and customize it with your own data.
+                  </p>
+                  <button
+                    onClick={() => setShowCloneModal(true)}
+                    className="w-full px-4 py-2.5 bg-[#00E5A0] text-[#061A21] rounded-lg hover:bg-[#00CC8E] transition font-semibold text-sm flex items-center justify-center gap-2"
+                  >
+                    <Icon name="copy" size="sm" />
+                    Clone Template
+                  </button>
+                </div>
+              )}
             </>
           )}
         </div>
       </div>
 
       {/* Clone Modal */}
-      {showCloneModal && (
+      {showCloneModal && canCloneTemplate && (
         <div className="fixed inset-0 z-50 flex items-center justify-center">
           {/* Overlay */}
           <div

--- a/web/src/app/dashboard/templates/__tests__/templates-page.test.tsx
+++ b/web/src/app/dashboard/templates/__tests__/templates-page.test.tsx
@@ -1,16 +1,23 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import TemplateLibraryPage from '../page';
 
 const mockGetTemplateCategories = jest.fn();
 const mockGetFeaturedTemplates = jest.fn();
+const mockGetPopularTemplates = jest.fn();
 const mockSearchTemplates = jest.fn();
+const mockGetUserTemplates = jest.fn();
+const mockGetCurrentUser = jest.fn();
+const mockAiGenerateTemplate = jest.fn();
 
 jest.mock('@/lib/api', () => ({
   apiClient: {
     getTemplateCategories: (...args: any[]) => mockGetTemplateCategories(...args),
     getFeaturedTemplates: (...args: any[]) => mockGetFeaturedTemplates(...args),
+    getPopularTemplates: (...args: any[]) => mockGetPopularTemplates(...args),
     searchTemplates: (...args: any[]) => mockSearchTemplates(...args),
-    getCurrentUser: jest.fn().mockResolvedValue({ id: '1', email: 'test@test.com', firstName: 'Test', lastName: 'User', organizationId: 'org-1', role: 'admin' }),
+    getUserTemplates: (...args: any[]) => mockGetUserTemplates(...args),
+    getCurrentUser: (...args: any[]) => mockGetCurrentUser(...args),
+    aiGenerateTemplate: (...args: any[]) => mockAiGenerateTemplate(...args),
     setAuthenticated: jest.fn(),
     getQuotaUsage: jest.fn().mockResolvedValue({ storageUsedBytes: 0, storageQuotaBytes: 1073741824, screenCount: 0, screenQuota: 5 }),
   },
@@ -83,9 +90,21 @@ const sampleTemplates = [
 describe('TemplateLibraryPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetCurrentUser.mockResolvedValue({
+      id: '1',
+      email: 'test@test.com',
+      firstName: 'Test',
+      lastName: 'User',
+      organizationId: 'org-1',
+      role: 'admin',
+      isSuperAdmin: false,
+    });
     mockGetTemplateCategories.mockResolvedValue(sampleCategories);
     mockGetFeaturedTemplates.mockResolvedValue({ data: sampleTemplates.filter(t => t.isFeatured) });
+    mockGetPopularTemplates.mockResolvedValue([]);
     mockSearchTemplates.mockResolvedValue({ data: sampleTemplates, meta: { total: 3 } });
+    mockGetUserTemplates.mockResolvedValue({ data: [], meta: { total: 0 } });
+    mockAiGenerateTemplate.mockResolvedValue({ available: false, message: 'AI Designer is launching soon.' });
   });
 
   it('renders loading spinner initially', () => {
@@ -165,5 +184,61 @@ describe('TemplateLibraryPage', () => {
     await waitFor(() => {
       expect(mockSearchTemplates).toHaveBeenCalled();
     });
+  });
+
+  it('does not expose platform template authoring actions to organization admins', async () => {
+    render(<TemplateLibraryPage />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('button', { name: /new design/i })).not.toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /ai designer coming soon/i }).length).toBeGreaterThan(0);
+  });
+
+  it('shows platform template authoring actions to super admins', async () => {
+    mockGetCurrentUser.mockResolvedValueOnce({
+      id: 'super-1',
+      email: 'super@test.com',
+      firstName: 'Super',
+      lastName: 'Admin',
+      organizationId: 'org-1',
+      role: 'admin',
+      isSuperAdmin: true,
+    });
+
+    render(<TemplateLibraryPage />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', { name: /new design/i })).toBeInTheDocument();
+  });
+
+  it('does not expose clone/use actions on organization-owned templates', async () => {
+    mockGetUserTemplates.mockResolvedValueOnce({
+      data: [{
+        id: 'owned-1',
+        name: 'My Menu Clone',
+        description: 'Org-owned template',
+        category: 'Restaurant',
+        orientation: 'landscape',
+        difficulty: 'beginner',
+        metadata: { isLibraryTemplate: false },
+      }],
+      meta: { total: 1 },
+    });
+
+    render(<TemplateLibraryPage />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: /your templates/i })[0]);
+
+    expect(await screen.findByText('My Menu Clone')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^use template$/i })).not.toBeInTheDocument();
   });
 });

--- a/web/src/app/dashboard/templates/new/page.tsx
+++ b/web/src/app/dashboard/templates/new/page.tsx
@@ -66,7 +66,7 @@ export default function CreateTemplatePage() {
   }
 
   // Auth gate: access denied
-  if (user?.role !== 'admin') {
+  if (user?.isSuperAdmin !== true) {
     return (
       <div className="flex flex-col items-center justify-center min-h-[60vh] text-center">
         <Icon name="shield" size="3xl" className="text-red-500 mb-4" />
@@ -74,7 +74,7 @@ export default function CreateTemplatePage() {
           Access Denied
         </h2>
         <p className="text-[var(--foreground-secondary)] mb-6">
-          You do not have permission to create templates. Admin access is required.
+          Platform super-admin access is required to create global library templates.
         </p>
         <Link
           href="/dashboard/templates"

--- a/web/src/app/dashboard/templates/page.tsx
+++ b/web/src/app/dashboard/templates/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
 import { apiClient } from '@/lib/api';
 import { useAuth } from '@/lib/hooks/useAuth';
 import TemplateHeroSearch from '@/components/templates/TemplateHeroSearch';
@@ -40,7 +39,8 @@ type ViewMode = 'home' | 'your-templates';
 export default function TemplateLibraryPage() {
   const router = useRouter();
   const { user } = useAuth();
-  const isAdmin = user?.role === 'admin';
+  const canManageLibraryTemplates = user?.isSuperAdmin === true;
+  const canUseTemplates = user?.role === 'admin' || user?.role === 'manager';
 
   // Data
   const [templates, setTemplates] = useState<TemplateItem[]>([]);
@@ -215,8 +215,9 @@ export default function TemplateLibraryPage() {
   }, []);
 
   const handleUseTemplate = useCallback(async (id: string) => {
+    if (!canUseTemplates) return;
     setCloneModalId(id);
-  }, []);
+  }, [canUseTemplates]);
 
   const handleCloneConfirm = async () => {
     if (!cloneModalId) return;
@@ -295,6 +296,11 @@ export default function TemplateLibraryPage() {
     tags: t.libraryTags || t.tags,
   });
 
+  const canManageLibraryTemplate = (template: TemplateItem) =>
+    canManageLibraryTemplates && template.metadata?.isLibraryTemplate !== false;
+  const canCloneLibraryTemplate = (template: TemplateItem) =>
+    canUseTemplates && template.metadata?.isLibraryTemplate !== false;
+
   return (
     <div className="space-y-6 -mx-2 sm:-mx-4 lg:-mx-6">
       {/* Hero Search */}
@@ -321,7 +327,7 @@ export default function TemplateLibraryPage() {
           onViewModeChange={(m) => { setViewMode(m); setPage(1); setSearchQuery(''); }}
           onNewDesignClick={() => router.push('/dashboard/templates/new')}
           onAIDesignerClick={() => setShowAIDesigner(true)}
-          isAdmin={isAdmin}
+          isAdmin={canManageLibraryTemplates}
           totalCount={totalCount}
         />
 
@@ -350,7 +356,7 @@ export default function TemplateLibraryPage() {
                 onClick={() => setShowAIDesigner(true)}
                 className="flex-shrink-0 px-3 py-1.5 rounded-lg text-xs font-medium text-[#00E5A0] border border-[#00E5A0]/20 hover:bg-[#00E5A0]/5 transition-all"
               >
-                AI Designer
+                AI Designer coming soon
               </button>
               {viewMode === 'home' && (
                 <>
@@ -436,16 +442,18 @@ export default function TemplateLibraryPage() {
                   <div ref={featuredRef} className="flex gap-4 overflow-x-auto pb-2 scrollbar-thin" style={{ scrollbarWidth: 'thin' }}>
                     {featuredTemplates.map((t) => {
                       const mapped = mapForCard(t);
+                      const canManageThisTemplate = canManageLibraryTemplate(t);
+                      const canCloneThisTemplate = canCloneLibraryTemplate(t);
                       return (
                         <TemplateCard
                           key={t.id}
                           {...mapped}
                           variant="featured"
                           onClick={(id) => setDetailModalId(id)}
-                          onUseTemplate={handleUseTemplate}
-                          isAdmin={isAdmin}
-                          onEdit={isAdmin ? (id) => router.push(`/dashboard/templates/${id}?edit=true`) : undefined}
-                          onDelete={isAdmin ? (id) => setDeleteModalId(id) : undefined}
+                          onUseTemplate={canCloneThisTemplate ? handleUseTemplate : undefined}
+                          isAdmin={canManageThisTemplate}
+                          onEdit={canManageThisTemplate ? (id) => router.push(`/dashboard/templates/${id}?edit=true`) : undefined}
+                          onDelete={canManageThisTemplate ? (id) => setDeleteModalId(id) : undefined}
                         />
                       );
                     })}
@@ -465,15 +473,17 @@ export default function TemplateLibraryPage() {
                   <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
                     {popularTemplates.map((t) => {
                       const mapped = mapForCard(t);
+                      const canManageThisTemplate = canManageLibraryTemplate(t);
+                      const canCloneThisTemplate = canCloneLibraryTemplate(t);
                       return (
                         <TemplateCard
                           key={t.id}
                           {...mapped}
                           onClick={(id) => setDetailModalId(id)}
-                          onUseTemplate={handleUseTemplate}
-                          isAdmin={isAdmin}
-                          onEdit={isAdmin ? (id) => router.push(`/dashboard/templates/${id}?edit=true`) : undefined}
-                          onDelete={isAdmin ? (id) => setDeleteModalId(id) : undefined}
+                          onUseTemplate={canCloneThisTemplate ? handleUseTemplate : undefined}
+                          isAdmin={canManageThisTemplate}
+                          onEdit={canManageThisTemplate ? (id) => router.push(`/dashboard/templates/${id}?edit=true`) : undefined}
+                          onDelete={canManageThisTemplate ? (id) => setDeleteModalId(id) : undefined}
                         />
                       );
                     })}
@@ -543,7 +553,7 @@ export default function TemplateLibraryPage() {
                   <>
                     <h3 className="font-semibold text-[var(--foreground)] mb-1">No templates yet</h3>
                     <p className="text-sm text-[var(--foreground-secondary)] mb-4">
-                      Browse the library and clone templates to get started, or try the AI Designer.
+                      Browse the library and clone templates to get started. AI Designer is coming soon.
                     </p>
                     <div className="flex gap-2 justify-center">
                       <button
@@ -556,7 +566,7 @@ export default function TemplateLibraryPage() {
                         onClick={() => setShowAIDesigner(true)}
                         className="px-4 py-2 rounded-lg border border-[#00E5A0]/20 text-[#00E5A0] font-medium text-sm hover:bg-[#00E5A0]/5 transition-all"
                       >
-                        Try AI Designer
+                        AI Designer coming soon
                       </button>
                     </div>
                   </>
@@ -580,15 +590,17 @@ export default function TemplateLibraryPage() {
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
                   {currentTemplates.map((t) => {
                     const mapped = mapForCard(t);
+                    const canManageThisTemplate = canManageLibraryTemplate(t);
+                    const canCloneThisTemplate = canCloneLibraryTemplate(t);
                     return (
                       <TemplateCard
                         key={t.id}
                         {...mapped}
                         onClick={(id) => setDetailModalId(id)}
-                        onUseTemplate={handleUseTemplate}
-                        isAdmin={isAdmin}
-                        onEdit={isAdmin ? (id) => router.push(`/dashboard/templates/${id}?edit=true`) : undefined}
-                        onDelete={isAdmin ? (id) => setDeleteModalId(id) : undefined}
+                        onUseTemplate={canCloneThisTemplate ? handleUseTemplate : undefined}
+                        isAdmin={canManageThisTemplate}
+                        onEdit={canManageThisTemplate ? (id) => router.push(`/dashboard/templates/${id}?edit=true`) : undefined}
+                        onDelete={canManageThisTemplate ? (id) => setDeleteModalId(id) : undefined}
                       />
                     );
                   })}
@@ -650,7 +662,10 @@ export default function TemplateLibraryPage() {
         <TemplateDetailModal
           templateId={detailModalId}
           onClose={() => setDetailModalId(null)}
-          onUseTemplate={handleUseTemplate}
+          onUseTemplate={canUseTemplates ? handleUseTemplate : undefined}
+          canManageLibraryTemplates={canManageLibraryTemplates}
+          canEditOrgTemplates={canUseTemplates}
+          canUseTemplates={canUseTemplates}
           onCustomize={(id) => {
             setDetailModalId(null);
             router.push(`/dashboard/templates/${id}?edit=true`);
@@ -662,11 +677,6 @@ export default function TemplateLibraryPage() {
       {showAIDesigner && (
         <AIDesignerModal
           onClose={() => setShowAIDesigner(false)}
-          onTemplateGenerated={(id) => {
-            setShowAIDesigner(false);
-            setViewMode('your-templates');
-            loadUserTemplates();
-          }}
         />
       )}
 

--- a/web/src/components/templates/AIDesignerModal.tsx
+++ b/web/src/components/templates/AIDesignerModal.tsx
@@ -1,305 +1,60 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { apiClient } from '@/lib/api';
+import { useEffect } from 'react';
 
 interface AIDesignerModalProps {
   onClose: () => void;
-  onTemplateGenerated?: (templateId: string) => void;
 }
 
-type Step = 'prompt' | 'generating' | 'result' | 'coming-soon';
-
-const STYLE_OPTIONS = ['Modern', 'Classic', 'Bold', 'Minimal', 'Playful', 'Elegant'];
-const INDUSTRY_OPTIONS = [
-  { value: '', label: 'Any Industry' },
-  { value: 'retail', label: 'Retail' },
-  { value: 'restaurant', label: 'Restaurant' },
-  { value: 'corporate', label: 'Corporate' },
-  { value: 'education', label: 'Education' },
-  { value: 'healthcare', label: 'Healthcare' },
-  { value: 'events', label: 'Events' },
-];
-
-const GENERATION_STEPS = [
-  'Understanding your vision...',
-  'Choosing color palette...',
-  'Designing layout...',
-  'Adding typography...',
-  'Applying finishing touches...',
-];
-
-export default function AIDesignerModal({ onClose, onTemplateGenerated }: AIDesignerModalProps) {
-  const [step, setStep] = useState<Step>('prompt');
-  const [prompt, setPrompt] = useState('');
-  const [selectedIndustry, setSelectedIndustry] = useState('');
-  const [selectedOrientation, setSelectedOrientation] = useState<'landscape' | 'portrait'>('landscape');
-  const [selectedStyle, setSelectedStyle] = useState('');
-  const [generationStep, setGenerationStep] = useState(0);
-  const [error, setError] = useState<string | null>(null);
-
-  // Close on Escape key
+export default function AIDesignerModal({ onClose }: AIDesignerModalProps) {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && step !== 'generating') onClose();
+      if (e.key === 'Escape') onClose();
     };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [onClose, step]);
-
-  const handleGenerate = async () => {
-    if (!prompt.trim()) return;
-
-    setStep('generating');
-    setGenerationStep(0);
-
-    // Simulate generation steps for visual effect
-    const stepInterval = setInterval(() => {
-      setGenerationStep((prev) => {
-        if (prev >= GENERATION_STEPS.length - 1) {
-          clearInterval(stepInterval);
-          return prev;
-        }
-        return prev + 1;
-      });
-    }, 800);
-
-    try {
-      const response = await apiClient.aiGenerateTemplate({
-        prompt: prompt.trim(),
-        category: selectedIndustry || undefined,
-        orientation: selectedOrientation,
-        style: selectedStyle || undefined,
-      });
-
-      clearInterval(stepInterval);
-
-      if (response.available && response.template) {
-        setStep('result');
-        onTemplateGenerated?.(response.template.id);
-      } else {
-        setStep('coming-soon');
-      }
-    } catch {
-      clearInterval(stepInterval);
-      setStep('coming-soon');
-    }
-  };
+  }, [onClose]);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
-      {/* Backdrop with mesh gradient */}
       <div className="fixed inset-0 bg-black/70 backdrop-blur-md" onClick={onClose} />
 
-      {/* Modal */}
-      <div className="relative bg-[var(--surface)] rounded-2xl border border-[var(--border)] w-full max-w-2xl mx-4 shadow-2xl overflow-hidden animate-[fadeIn_0.2s_ease-out]">
-        {/* Top gradient bar */}
+      <div className="relative bg-[var(--surface)] rounded-2xl border border-[var(--border)] w-full max-w-lg mx-4 shadow-2xl overflow-hidden animate-[fadeIn_0.2s_ease-out]">
         <div className="h-1 bg-gradient-to-r from-[#00E5A0] via-[#00B4D8] to-[#00E5A0]" />
 
-        {/* Close button */}
         <button
           onClick={onClose}
           className="absolute top-4 right-4 z-10 p-2 rounded-lg text-[var(--foreground-tertiary)] hover:text-[var(--foreground)] hover:bg-[var(--surface-hover)] transition-all"
+          aria-label="Close AI Designer status"
         >
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
         </button>
 
-        {/* Step: Prompt input */}
-        {step === 'prompt' && (
-          <div className="p-6 sm:p-8">
-            {/* Header */}
-            <div className="flex items-center gap-3 mb-6">
-              <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-[#00E5A0]/20 to-[#00B4D8]/20 border border-[#00E5A0]/20 flex items-center justify-center">
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" className="text-[#00E5A0]">
-                  <path d="M12 2L14.09 8.26L20 9.27L15.55 13.97L16.91 20L12 16.9L7.09 20L8.45 13.97L4 9.27L9.91 8.26L12 2Z" fill="currentColor" />
-                </svg>
-              </div>
-              <div>
-                <h2 className="font-[var(--font-sora)] text-lg font-bold text-[var(--foreground)]">
-                  AI Template Designer
-                </h2>
-                <p className="text-sm text-[var(--foreground-tertiary)]">
-                  Describe what you want and AI will design it
-                </p>
-              </div>
-            </div>
-
-            {/* Prompt textarea */}
-            <div className="mb-5">
-              <textarea
-                value={prompt}
-                onChange={(e) => setPrompt(e.target.value)}
-                placeholder="Describe your ideal display template...&#10;&#10;e.g., A modern coffee shop menu board with warm earth tones, featuring daily specials and prices in a clean grid layout"
-                className="w-full h-32 px-4 py-3 rounded-xl bg-[var(--background)] border border-[var(--border)] text-[var(--foreground)] placeholder-[var(--foreground-tertiary)] text-sm focus:outline-none focus:ring-2 focus:ring-[#00E5A0]/30 focus:border-[#00E5A0]/30 resize-none transition-all"
-              />
-            </div>
-
-            {/* Options row */}
-            <div className="grid grid-cols-2 gap-3 mb-5">
-              <div>
-                <label className="block text-[10px] font-bold uppercase tracking-[0.12em] text-[var(--foreground-tertiary)] mb-1.5">
-                  Industry
-                </label>
-                <select
-                  value={selectedIndustry}
-                  onChange={(e) => setSelectedIndustry(e.target.value)}
-                  className="w-full px-3 py-2 rounded-lg bg-[var(--background)] border border-[var(--border)] text-[var(--foreground)] text-sm focus:outline-none focus:ring-2 focus:ring-[#00E5A0]/30"
-                >
-                  {INDUSTRY_OPTIONS.map((opt) => (
-                    <option key={opt.value} value={opt.value}>{opt.label}</option>
-                  ))}
-                </select>
-              </div>
-              <div>
-                <label className="block text-[10px] font-bold uppercase tracking-[0.12em] text-[var(--foreground-tertiary)] mb-1.5">
-                  Orientation
-                </label>
-                <div className="flex gap-1.5">
-                  <button
-                    onClick={() => setSelectedOrientation('landscape')}
-                    className={`flex-1 flex items-center justify-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium transition-all border ${
-                      selectedOrientation === 'landscape'
-                        ? 'bg-[#00E5A0]/10 text-[#00E5A0] border-[#00E5A0]/20'
-                        : 'bg-[var(--background)] text-[var(--foreground-tertiary)] border-[var(--border)] hover:text-[var(--foreground-secondary)]'
-                    }`}
-                  >
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><rect x="2" y="5" width="20" height="14" rx="2" /></svg>
-                    Landscape
-                  </button>
-                  <button
-                    onClick={() => setSelectedOrientation('portrait')}
-                    className={`flex-1 flex items-center justify-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium transition-all border ${
-                      selectedOrientation === 'portrait'
-                        ? 'bg-[#00E5A0]/10 text-[#00E5A0] border-[#00E5A0]/20'
-                        : 'bg-[var(--background)] text-[var(--foreground-tertiary)] border-[var(--border)] hover:text-[var(--foreground-secondary)]'
-                    }`}
-                  >
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><rect x="5" y="2" width="14" height="20" rx="2" /></svg>
-                    Portrait
-                  </button>
-                </div>
-              </div>
-            </div>
-
-            {/* Style chips */}
-            <div className="mb-6">
-              <label className="block text-[10px] font-bold uppercase tracking-[0.12em] text-[var(--foreground-tertiary)] mb-1.5">
-                Style Preference
-              </label>
-              <div className="flex flex-wrap gap-1.5">
-                {STYLE_OPTIONS.map((style) => (
-                  <button
-                    key={style}
-                    onClick={() => setSelectedStyle(selectedStyle === style ? '' : style)}
-                    className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-all border ${
-                      selectedStyle === style
-                        ? 'bg-[#00E5A0]/10 text-[#00E5A0] border-[#00E5A0]/20'
-                        : 'text-[var(--foreground-tertiary)] border-[var(--border)] hover:text-[var(--foreground-secondary)] hover:border-[var(--border-dark)]'
-                    }`}
-                  >
-                    {style}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            {/* Generate button */}
-            <button
-              onClick={handleGenerate}
-              disabled={!prompt.trim()}
-              className="w-full py-3 rounded-xl bg-gradient-to-r from-[#00E5A0] to-[#00CC8E] text-[#061A21] font-bold text-sm hover:shadow-[0_0_30px_rgba(0,229,160,0.3)] transition-all disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:shadow-none flex items-center justify-center gap-2"
-            >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" className="text-[#061A21]">
-                <path d="M12 2L14.09 8.26L20 9.27L15.55 13.97L16.91 20L12 16.9L7.09 20L8.45 13.97L4 9.27L9.91 8.26L12 2Z" fill="currentColor" />
-              </svg>
-              Generate Template
-            </button>
-
-            {error && (
-              <p className="mt-3 text-xs text-red-400 text-center">{error}</p>
-            )}
+        <div className="p-8 sm:p-10 flex flex-col items-center justify-center min-h-[360px] text-center">
+          <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-[#00E5A0]/10 to-[#00B4D8]/10 border border-[#00E5A0]/15 flex items-center justify-center mb-6">
+            <svg width="30" height="30" viewBox="0 0 24 24" fill="none" className="text-[#00E5A0]">
+              <path d="M12 2L14.09 8.26L20 9.27L15.55 13.97L16.91 20L12 16.9L7.09 20L8.45 13.97L4 9.27L9.91 8.26L12 2Z" fill="currentColor" opacity="0.85" />
+              <path d="M19 2L19.5 3.5L21 4L19.5 4.5L19 6L18.5 4.5L17 4L18.5 3.5L19 2Z" fill="currentColor" opacity="0.5" />
+            </svg>
           </div>
-        )}
 
-        {/* Step: Generating */}
-        {step === 'generating' && (
-          <div className="p-8 sm:p-12 flex flex-col items-center justify-center min-h-[400px]">
-            {/* Animated gradient orb */}
-            <div className="relative w-24 h-24 mb-8">
-              <div className="absolute inset-0 rounded-full bg-gradient-to-br from-[#00E5A0] to-[#00B4D8] opacity-20 animate-ping" />
-              <div className="absolute inset-2 rounded-full bg-gradient-to-br from-[#00E5A0] to-[#00B4D8] opacity-30 animate-pulse" />
-              <div className="absolute inset-4 rounded-full bg-gradient-to-br from-[#00E5A0]/60 to-[#00B4D8]/60 flex items-center justify-center">
-                <svg width="28" height="28" viewBox="0 0 24 24" fill="none" className="text-white animate-spin" style={{ animationDuration: '3s' }}>
-                  <path d="M12 2L14.09 8.26L20 9.27L15.55 13.97L16.91 20L12 16.9L7.09 20L8.45 13.97L4 9.27L9.91 8.26L12 2Z" fill="currentColor" />
-                </svg>
-              </div>
-            </div>
+          <h3 className="font-[var(--font-sora)] text-xl font-bold text-[var(--foreground)] mb-3">
+            AI Designer is Launching Soon
+          </h3>
+          <p className="text-[var(--foreground-secondary)] text-sm max-w-sm mb-8">
+            AI template generation is not enabled yet. Use the template library today; we will enable AI Designer once production cost controls and rollout gates are in place.
+          </p>
 
-            <h3 className="font-[var(--font-sora)] text-lg font-bold text-[var(--foreground)] mb-3">
-              AI is designing your template
-            </h3>
-
-            {/* Progress steps */}
-            <div className="space-y-2 w-full max-w-xs">
-              {GENERATION_STEPS.map((stepText, i) => (
-                <div
-                  key={i}
-                  className={`flex items-center gap-2 text-sm transition-all duration-500 ${
-                    i <= generationStep ? 'opacity-100' : 'opacity-0 translate-y-2'
-                  }`}
-                >
-                  {i < generationStep ? (
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#00E5A0" strokeWidth="2.5"><polyline points="20 6 9 17 4 12" /></svg>
-                  ) : i === generationStep ? (
-                    <div className="w-3.5 h-3.5 border-2 border-[#00E5A0]/30 border-t-[#00E5A0] rounded-full animate-spin" />
-                  ) : (
-                    <div className="w-3.5 h-3.5 rounded-full border border-[var(--border)]" />
-                  )}
-                  <span className={i <= generationStep ? 'text-[var(--foreground)]' : 'text-[var(--foreground-tertiary)]'}>
-                    {stepText}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* Step: Coming Soon */}
-        {step === 'coming-soon' && (
-          <div className="p-8 sm:p-12 flex flex-col items-center justify-center min-h-[400px] text-center">
-            {/* Gradient icon */}
-            <div className="w-20 h-20 rounded-2xl bg-gradient-to-br from-[#00E5A0]/10 to-[#00B4D8]/10 border border-[#00E5A0]/15 flex items-center justify-center mb-6">
-              <svg width="36" height="36" viewBox="0 0 24 24" fill="none" className="text-[#00E5A0]">
-                <path d="M12 2L14.09 8.26L20 9.27L15.55 13.97L16.91 20L12 16.9L7.09 20L8.45 13.97L4 9.27L9.91 8.26L12 2Z" fill="currentColor" opacity="0.8" />
-                <path d="M19 2L19.5 3.5L21 4L19.5 4.5L19 6L18.5 4.5L17 4L18.5 3.5L19 2Z" fill="currentColor" opacity="0.5" />
-                <path d="M5 18L5.5 19.5L7 20L5.5 20.5L5 22L4.5 20.5L3 20L4.5 19.5L5 18Z" fill="currentColor" opacity="0.5" />
-              </svg>
-            </div>
-
-            <h3 className="font-[var(--font-sora)] text-xl font-bold text-[var(--foreground)] mb-2">
-              AI Designer is Launching Soon
-            </h3>
-            <p className="text-[var(--foreground-secondary)] text-sm max-w-sm mb-8">
-              We&apos;re training our AI to create stunning display templates.
-              Be among the first to experience AI-powered design.
-            </p>
-
-            <div className="flex gap-3">
-              <button
-                onClick={onClose}
-                className="px-5 py-2.5 rounded-lg bg-[#00E5A0] text-[#061A21] font-semibold text-sm hover:bg-[#00CC8E] transition-all"
-              >
-                Browse Templates
-              </button>
-              <button
-                onClick={() => setStep('prompt')}
-                className="px-5 py-2.5 rounded-lg border border-[var(--border)] text-[var(--foreground-secondary)] font-medium text-sm hover:bg-[var(--surface-hover)] transition-all"
-              >
-                Try Again
-              </button>
-            </div>
-          </div>
-        )}
+          <button
+            onClick={onClose}
+            className="px-5 py-2.5 rounded-lg bg-[#00E5A0] text-[#061A21] font-semibold text-sm hover:bg-[#00CC8E] transition-all"
+          >
+            Browse Templates
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/web/src/components/templates/TemplateCard.tsx
+++ b/web/src/components/templates/TemplateCard.tsx
@@ -53,7 +53,6 @@ export default function TemplateCard({
   renderedHtml,
   isFeatured,
   useCount,
-  tags,
   onClick,
   onUseTemplate,
   isAdmin,
@@ -117,18 +116,19 @@ export default function TemplateCard({
           </div>
         )}
 
-        {/* Hover overlay */}
-        <div className="absolute inset-0 bg-black/0 group-hover:bg-black/40 transition-all duration-300 flex items-center justify-center">
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onUseTemplate?.(id);
-            }}
-            className="opacity-0 group-hover:opacity-100 translate-y-2 group-hover:translate-y-0 transition-all duration-300 px-5 py-2 rounded-lg bg-[#00E5A0] text-[#061A21] font-semibold text-sm hover:bg-[#00CC8E] shadow-lg"
-          >
-            Use Template
-          </button>
-        </div>
+        {onUseTemplate && (
+          <div className="absolute inset-0 bg-black/0 group-hover:bg-black/40 transition-all duration-300 flex items-center justify-center">
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onUseTemplate(id);
+              }}
+              className="opacity-0 group-hover:opacity-100 translate-y-2 group-hover:translate-y-0 transition-all duration-300 px-5 py-2 rounded-lg bg-[#00E5A0] text-[#061A21] font-semibold text-sm hover:bg-[#00CC8E] shadow-lg"
+            >
+              Use Template
+            </button>
+          </div>
+        )}
 
         {/* Badges */}
         <div className="absolute top-2.5 left-2.5 flex gap-1.5">

--- a/web/src/components/templates/TemplateDetailModal.tsx
+++ b/web/src/components/templates/TemplateDetailModal.tsx
@@ -7,8 +7,11 @@ import { apiClient } from '@/lib/api';
 interface TemplateDetailModalProps {
   templateId: string;
   onClose: () => void;
-  onUseTemplate: (id: string) => void;
+  onUseTemplate?: (id: string) => void;
   onCustomize: (id: string) => void;
+  canManageLibraryTemplates?: boolean;
+  canEditOrgTemplates?: boolean;
+  canUseTemplates?: boolean;
 }
 
 interface TemplateData {
@@ -30,12 +33,20 @@ export default function TemplateDetailModal({
   onClose,
   onUseTemplate,
   onCustomize,
+  canManageLibraryTemplates = false,
+  canEditOrgTemplates = false,
+  canUseTemplates = false,
 }: TemplateDetailModalProps) {
   const router = useRouter();
   const [template, setTemplate] = useState<TemplateData | null>(null);
   const [previewHtml, setPreviewHtml] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [similar, setSimilar] = useState<TemplateData[]>([]);
+  const canEditTemplate =
+    canManageLibraryTemplates ||
+    (canEditOrgTemplates && template?.metadata?.isLibraryTemplate === false);
+  const canCloneTemplate =
+    canUseTemplates && template?.metadata?.isLibraryTemplate !== false;
 
   useEffect(() => {
     loadTemplate();
@@ -127,27 +138,33 @@ export default function TemplateDetailModal({
 
                 {/* Action buttons */}
                 <div className="flex gap-2 flex-shrink-0">
-                  <button
-                    onClick={() => {
-                      onClose();
-                      router.push(`/dashboard/templates/${template.id}/edit`);
-                    }}
-                    className="px-5 py-2.5 rounded-lg bg-[#00E5A0] text-[#061A21] font-semibold text-sm hover:bg-[#00CC8E] transition-all hover:shadow-[0_0_20px_rgba(0,229,160,0.3)]"
-                  >
-                    Edit Visually
-                  </button>
-                  <button
-                    onClick={() => onUseTemplate(template.id)}
-                    className="px-5 py-2.5 rounded-lg border border-[var(--border)] text-[var(--foreground-secondary)] font-medium text-sm hover:bg-[var(--surface-hover)] hover:text-[var(--foreground)] transition-all"
-                  >
-                    Use This Template
-                  </button>
-                  <button
-                    onClick={() => onCustomize(template.id)}
-                    className="px-5 py-2.5 rounded-lg border border-[var(--border)] text-[var(--foreground-secondary)] font-medium text-sm hover:bg-[var(--surface-hover)] hover:text-[var(--foreground)] transition-all"
-                  >
-                    Customize
-                  </button>
+                  {canEditTemplate && (
+                    <button
+                      onClick={() => {
+                        onClose();
+                        router.push(`/dashboard/templates/${template.id}/edit`);
+                      }}
+                      className="px-5 py-2.5 rounded-lg bg-[#00E5A0] text-[#061A21] font-semibold text-sm hover:bg-[#00CC8E] transition-all hover:shadow-[0_0_20px_rgba(0,229,160,0.3)]"
+                    >
+                      Edit Visually
+                    </button>
+                  )}
+                  {canCloneTemplate && onUseTemplate && (
+                    <button
+                      onClick={() => onUseTemplate(template.id)}
+                      className="px-5 py-2.5 rounded-lg border border-[var(--border)] text-[var(--foreground-secondary)] font-medium text-sm hover:bg-[var(--surface-hover)] hover:text-[var(--foreground)] transition-all"
+                    >
+                      Use This Template
+                    </button>
+                  )}
+                  {canEditTemplate && (
+                    <button
+                      onClick={() => onCustomize(template.id)}
+                      className="px-5 py-2.5 rounded-lg border border-[var(--border)] text-[var(--foreground-secondary)] font-medium text-sm hover:bg-[var(--surface-hover)] hover:text-[var(--foreground)] transition-all"
+                    >
+                      Customize
+                    </button>
+                  )}
                 </div>
               </div>
 

--- a/web/src/components/templates/TemplateHeroSearch.tsx
+++ b/web/src/components/templates/TemplateHeroSearch.tsx
@@ -77,7 +77,7 @@ export default function TemplateHeroSearch({
             mounted ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
           }`}
         >
-          Browse professionally designed templates or let AI create one for you
+          Browse professionally designed templates and clone one to customize for your screens
         </p>
 
         {/* Search bar */}
@@ -147,8 +147,8 @@ export default function TemplateHeroSearch({
             <path d="M19 2L19.5 3.5L21 4L19.5 4.5L19 6L18.5 4.5L17 4L18.5 3.5L19 2Z" fill="currentColor" opacity="0.6" />
             <path d="M5 18L5.5 19.5L7 20L5.5 20.5L5 22L4.5 20.5L3 20L4.5 19.5L5 18Z" fill="currentColor" opacity="0.6" />
           </svg>
-          Try AI Designer
-          <span className="text-[#00E5A0]/60 text-xs font-normal">New</span>
+          AI Designer coming soon
+          <span className="text-[#00E5A0]/60 text-xs font-normal">Soon</span>
         </button>
       </div>
     </div>

--- a/web/src/components/templates/TemplateSidebar.tsx
+++ b/web/src/components/templates/TemplateSidebar.tsx
@@ -124,8 +124,8 @@ export default function TemplateSidebar({
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M12 2L14.09 8.26L20 9.27L15.55 13.97L16.91 20L12 16.9L7.09 20L8.45 13.97L4 9.27L9.91 8.26L12 2Z" />
               </svg>
-              AI Designer
-              <span className="ml-auto text-[10px] font-semibold bg-[#00E5A0]/15 text-[#00E5A0] px-1.5 py-0.5 rounded-full">NEW</span>
+              AI Designer coming soon
+              <span className="ml-auto text-[10px] font-semibold bg-[#00E5A0]/15 text-[#00E5A0] px-1.5 py-0.5 rounded-full">Soon</span>
             </button>
           </nav>
         </div>

--- a/web/src/components/templates/__tests__/AIDesignerModal.test.tsx
+++ b/web/src/components/templates/__tests__/AIDesignerModal.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import AIDesignerModal from '../AIDesignerModal';
+
+const mockAiGenerateTemplate = jest.fn();
+
+jest.mock('@/lib/api', () => ({
+  apiClient: {
+    aiGenerateTemplate: (...args: any[]) => mockAiGenerateTemplate(...args),
+  },
+}));
+
+describe('AIDesignerModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('opens in an honest unavailable state instead of a fake generation form', () => {
+    render(<AIDesignerModal onClose={jest.fn()} />);
+
+    expect(screen.getByRole('heading', { name: /ai designer is launching soon/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /generate template/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/ai is designing your template/i)).not.toBeInTheDocument();
+    expect(mockAiGenerateTemplate).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/templates/__tests__/TemplateDetailModal.test.tsx
+++ b/web/src/components/templates/__tests__/TemplateDetailModal.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from '@testing-library/react';
+import TemplateDetailModal from '../TemplateDetailModal';
+
+const mockGetTemplateDetail = jest.fn();
+const mockGetTemplatePreview = jest.fn();
+const mockSearchTemplates = jest.fn();
+const mockPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('@/lib/api', () => ({
+  apiClient: {
+    getTemplateDetail: (...args: any[]) => mockGetTemplateDetail(...args),
+    getTemplatePreview: (...args: any[]) => mockGetTemplatePreview(...args),
+    searchTemplates: (...args: any[]) => mockSearchTemplates(...args),
+  },
+}));
+
+describe('TemplateDetailModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetTemplateDetail.mockResolvedValue({
+      id: 'template-1',
+      name: 'Restaurant Menu',
+      description: 'Menu board template',
+      category: 'restaurant',
+      difficulty: 'beginner',
+      templateOrientation: 'landscape',
+      libraryTags: ['menu'],
+      isFeatured: false,
+      useCount: 0,
+      createdAt: '2026-01-01T00:00:00Z',
+      metadata: { isLibraryTemplate: true },
+    });
+    mockGetTemplatePreview.mockResolvedValue({ html: '<div>Preview</div>' });
+    mockSearchTemplates.mockResolvedValue({ data: [] });
+  });
+
+  it('keeps customer users on clone/use actions instead of platform edit routes', async () => {
+    render(
+      <TemplateDetailModal
+        templateId="template-1"
+        onClose={jest.fn()}
+        onUseTemplate={jest.fn()}
+        onCustomize={jest.fn()}
+        canUseTemplates
+      />,
+    );
+
+    expect(await screen.findByText('Restaurant Menu')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /use this template/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /edit visually/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /customize/i })).not.toBeInTheDocument();
+  });
+
+  it('keeps visual editing available for organization-owned template clones', async () => {
+    mockGetTemplateDetail.mockResolvedValueOnce({
+      id: 'template-1',
+      name: 'Restaurant Menu',
+      description: 'Menu board template',
+      category: 'restaurant',
+      difficulty: 'beginner',
+      templateOrientation: 'landscape',
+      libraryTags: ['menu'],
+      isFeatured: false,
+      useCount: 0,
+      createdAt: '2026-01-01T00:00:00Z',
+      metadata: { isLibraryTemplate: false },
+    });
+
+    render(
+      <TemplateDetailModal
+        templateId="template-1"
+        onClose={jest.fn()}
+        onUseTemplate={jest.fn()}
+        onCustomize={jest.fn()}
+        canEditOrgTemplates
+        canUseTemplates
+      />,
+    );
+
+    expect(await screen.findByText('Restaurant Menu')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /edit visually/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /customize/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /use this template/i })).not.toBeInTheDocument();
+  });
+
+  it('keeps viewers on read-only org-owned template details', async () => {
+    mockGetTemplateDetail.mockResolvedValueOnce({
+      id: 'template-1',
+      name: 'Restaurant Menu',
+      description: 'Menu board template',
+      category: 'restaurant',
+      difficulty: 'beginner',
+      templateOrientation: 'landscape',
+      libraryTags: ['menu'],
+      isFeatured: false,
+      useCount: 0,
+      createdAt: '2026-01-01T00:00:00Z',
+      metadata: { isLibraryTemplate: false },
+    });
+
+    render(
+      <TemplateDetailModal
+        templateId="template-1"
+        onClose={jest.fn()}
+        onUseTemplate={jest.fn()}
+        onCustomize={jest.fn()}
+      />,
+    );
+
+    expect(await screen.findByText('Restaurant Menu')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /use this template/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /edit visually/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /customize/i })).not.toBeInTheDocument();
+  });
+});

--- a/web/src/lib/api/__tests__/templates.test.ts
+++ b/web/src/lib/api/__tests__/templates.test.ts
@@ -1,0 +1,28 @@
+import { ApiClient } from '../client';
+import '../templates';
+
+describe('template api methods', () => {
+  it('saves organization-owned templates through the scoped save route', async () => {
+    const client = new ApiClient('/api/v1');
+    const requestSpy = jest.spyOn(client, 'request').mockResolvedValue({ id: 'template-1' } as any);
+
+    await client.updateTemplate('template-1', { templateHtml: '<div>Org draft</div>' });
+
+    expect(requestSpy).toHaveBeenCalledWith(
+      '/template-library/template-1/save',
+      expect.objectContaining({ method: 'PATCH' }),
+    );
+  });
+
+  it('updates global library templates through the super-admin route', async () => {
+    const client = new ApiClient('/api/v1');
+    const requestSpy = jest.spyOn(client, 'request').mockResolvedValue({ id: 'template-1' } as any);
+
+    await client.updateLibraryTemplate('template-1', { templateHtml: '<div>Library draft</div>' });
+
+    expect(requestSpy).toHaveBeenCalledWith(
+      '/template-library/template-1',
+      expect.objectContaining({ method: 'PATCH' }),
+    );
+  });
+});

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -32,6 +32,7 @@ export interface AuthUser {
   firstName: string;
   lastName: string;
   role: string;
+  isSuperAdmin?: boolean;
   avatarUrl?: string | null;
   organizationId: string;
   organization?: {

--- a/web/src/lib/api/templates.ts
+++ b/web/src/lib/api/templates.ts
@@ -21,6 +21,7 @@ declare module './client' {
     // Template Admin
     createTemplate(data: { name: string; description?: string; templateHtml: string; category: string; difficulty?: string; orientation?: string; tags?: string[]; sampleData?: Record<string, any>; thumbnailUrl?: string; duration?: number }): Promise<any>;
     updateTemplate(id: string, data: { name?: string; description?: string; templateHtml?: string; category?: string; difficulty?: string; orientation?: string; tags?: string[]; sampleData?: Record<string, any>; thumbnailUrl?: string; duration?: number }): Promise<any>;
+    updateLibraryTemplate(id: string, data: { name?: string; description?: string; templateHtml?: string; category?: string; difficulty?: string; orientation?: string; tags?: string[]; sampleData?: Record<string, any>; thumbnailUrl?: string; duration?: number }): Promise<any>;
     deleteTemplate(id: string): Promise<void>;
     publishTemplate(templateId: string, data: { renderedHtml: string; displayIds: string[]; name: string; duration?: number }): Promise<{ contentId: string; displayCount: number }>;
   }
@@ -135,6 +136,24 @@ ApiClient.prototype.updateTemplate = async function (id: string, data: {
   duration?: number;
 }): Promise<any> {
   return this.request<any>(`/template-library/${id}/save`, {
+    method: 'PATCH',
+    body: JSON.stringify(data),
+  });
+};
+
+ApiClient.prototype.updateLibraryTemplate = async function (id: string, data: {
+  name?: string;
+  description?: string;
+  templateHtml?: string;
+  category?: string;
+  difficulty?: string;
+  orientation?: string;
+  tags?: string[];
+  sampleData?: Record<string, any>;
+  thumbnailUrl?: string;
+  duration?: number;
+}): Promise<any> {
+  return this.request<any>(`/template-library/${id}`, {
     method: 'PATCH',
     body: JSON.stringify(data),
   });

--- a/web/src/lib/hooks/useAuth.ts
+++ b/web/src/lib/hooks/useAuth.ts
@@ -9,6 +9,7 @@ interface User {
   avatarUrl?: string | null;
   organizationId: string;
   role: string;
+  isSuperAdmin?: boolean;
   organization?: {
     name: string;
     subscriptionTier: string;


### PR DESCRIPTION
## Summary
- expose `isSuperAdmin` through `/auth/me` so the dashboard can distinguish platform library authors from org admins
- gate global template create/edit/delete on super-admin while keeping org-owned template editing available to admin/manager roles through the existing save route
- hide clone/use actions for viewers and org-owned templates, and replace the fake AI Designer generation flow with an honest coming-soon state

## Verification
- `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/dashboard/templates/__tests__/templates-page.test.tsx src/components/templates/__tests__/AIDesignerModal.test.tsx src/components/templates/__tests__/TemplateDetailModal.test.tsx src/lib/api/__tests__/templates.test.ts 'src/app/dashboard/templates/[id]/__tests__/template-detail-page.test.tsx' 'src/app/dashboard/templates/[id]/edit/__tests__/page-client.test.tsx'`
- `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/auth/strategies/jwt.strategy.spec.ts`
- `pnpm --filter @vizora/web test -- --runInBand`
- `pnpm --filter @vizora/middleware test -- --runInBand`
- `pnpm --filter @vizora/web exec tsc --noEmit --pretty false`
- `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
- changed-file ESLint, warnings only from existing `any` debt
- `npx nx build @vizora/web --skip-nx-cache`
- `npx nx build @vizora/middleware --skip-nx-cache`
- `npx nx build @vizora/realtime --skip-nx-cache`
- `git diff --check`
- `pnpm security:no-hardcoded-jwts`

## Review
- Authorization/architecture subagent review: CLEAN
- Customer-flow/backend-contract subagent review: CLEAN after adding org-owned clone/use hiding coverage

## Deploy note
Production deploy remains gated separately: last prod check showed `/opt/vizora/app` dirty and diverged, so this PR should merge only after CI; deploy should not proceed until that checkout is reconciled or an explicit operator deploy path is approved.