### PR TITLE
test(middleware): gate customer critical path e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,13 +163,15 @@ jobs:
       - name: Setup test database
         run: pnpm --filter @vizora/database exec prisma db push --skip-generate
 
-      # Only the agents e2e suite is gated in CI right now.
+      # Only a narrow middleware E2E set is gated in CI right now.
       # The other middleware e2e specs (content/displays/playlists/auth/rate-limit)
       # have pre-existing failures that predate this pipeline — they never ran
       # in CI before (the old `middleware-e2e` Nx project didn't exist), so they
-      # drifted. Tracked separately; unblocking the agent-system PR here.
-      - name: Run middleware E2E tests (agents suite)
-        run: pnpm --filter @vizora/middleware exec jest --config=jest.e2e.config.js --runInBand --testPathPattern=agents
+      # drifted. The customer-critical-path suite is intentionally included so
+      # CI proves register -> pair -> content -> playlist -> schedule -> device
+      # active-schedule delivery through the production /api/v1 route shape.
+      - name: Run middleware E2E tests (gated suites)
+        run: pnpm --filter @vizora/middleware exec jest --config=jest.e2e.config.js --runInBand --testPathPattern="(agents|customer-critical-path)"
 
       # Realtime e2e (device-gateway.e2e-spec.ts) has a known pre-existing
        # failure in CI — it requires Prisma generate state + a MongoDB service

--- a/docs/plans/2026-06-01-customer-critical-path-e2e-pass-37.md
+++ b/docs/plans/2026-06-01-customer-critical-path-e2e-pass-37.md
@@ -1,0 +1,56 @@
+## Customer Critical Path E2E Gate Pass 37
+
+**Goal:** Add a CI-gated middleware E2E test that proves the customer-critical
+API path from account creation to paired-display schedule delivery works through
+the production `/api/v1` routing shape.
+
+**New primitives introduced:** none. This pass adds test coverage and CI wiring
+only. It reuses the existing NestJS app module, auth, Redis pairing flow,
+content, playlists, schedules, device JWT verification, Prisma persistence,
+response envelope, and `/api/v1` route prefix.
+
+**Hermes-first analysis:** not applicable. This task is not a business-agent,
+MCP, Hermes, AI/provider, or spend-path change.
+
+## Drift Check
+
+- `scripts/smoke/api-critical-path.sh` already covers the integrated runtime
+  path: register/login, pairing request and complete, device token retrieval,
+  content creation, multipart upload, device-content range streaming, playlist
+  creation, active schedule creation, and device active-schedule read.
+- `.github/workflows/ci.yml` still gates only
+  `--testPathPattern=agents` in the middleware E2E job.
+- Existing middleware E2E specs are older and use `app.setGlobalPrefix('api')`;
+  the new customer-critical-path spec should use `api/v1` to match production.
+
+## Scope
+
+1. Add `middleware/test/customer-critical-path.e2e-spec.ts`.
+2. The spec registers a disposable org/user, completes device pairing, creates
+   URL content, creates a playlist with that content, creates an always-active
+   display schedule, and verifies the paired device token can read that schedule
+   with playlist item content.
+3. The spec also asserts device-boundary and tenant-boundary failures: no token,
+   user JWT, and a second org's device JWT cannot read the first display's
+   active schedule; a second org cannot add first-org content to a playlist or
+   schedule its own playlist onto the first org's display.
+4. Update GitHub Actions E2E command to run this spec alongside the existing
+   agents E2E suite.
+5. Leave production code untouched unless the E2E exposes a real regression.
+
+## Test Plan
+
+- Focused local E2E:
+  `pnpm --filter @vizora/middleware exec jest --config=jest.e2e.config.js --runInBand --testPathPattern=customer-critical-path`
+- CI-shaped local E2E:
+  `pnpm --filter @vizora/middleware exec jest --config=jest.e2e.config.js --runInBand --testPathPattern="(agents|customer-critical-path)"`
+- Focused unit safety if production code changes become necessary.
+- `git diff --check`.
+
+## Risks
+
+- Local E2E requires PostgreSQL and Redis on the configured test URLs. If local
+  infrastructure is unavailable, CI is the authoritative verification for this
+  pass.
+- This does not replace the operator-gated production smoke or real hardware
+  walkthrough; it only prevents obvious integrated API regressions from merging.

--- a/middleware/test/agents.e2e-spec.ts
+++ b/middleware/test/agents.e2e-spec.ts
@@ -59,14 +59,14 @@ describe('Agents onboarding pipeline (e2e)', () => {
   });
 
   afterAll(async () => {
+    if (userId) {
+      await db.user.delete({ where: { id: userId } }).catch(() => {});
+    }
     if (organizationId) {
       // Onboarding row cascade-deletes with the org (onDelete: Cascade).
       await db.organization
         .delete({ where: { id: organizationId } })
         .catch(() => {});
-    }
-    if (userId) {
-      await db.user.delete({ where: { id: userId } }).catch(() => {});
     }
     await db.$disconnect();
     await app.close();

--- a/middleware/test/customer-critical-path.e2e-spec.ts
+++ b/middleware/test/customer-critical-path.e2e-spec.ts
@@ -1,0 +1,340 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import request from 'supertest';
+import helmet from 'helmet';
+import { AppModule } from '../src/app/app.module';
+import { DatabaseService } from '../src/modules/database/database.service';
+import { RedisService } from '../src/modules/redis/redis.service';
+import { SanitizeInterceptor } from '../src/modules/common/interceptors/sanitize.interceptor';
+import { ResponseEnvelopeInterceptor } from '../src/modules/common/interceptors/response-envelope.interceptor';
+
+type RegisterData = {
+  access_token: string;
+  user: {
+    id: string;
+    organizationId: string;
+  };
+};
+
+type PairingRequestData = {
+  code: string;
+};
+
+type PairingCompleteBody = {
+  success: boolean;
+  display: {
+    id: string;
+    deviceIdentifier: string;
+    status: string;
+  };
+};
+
+type PairingStatusData = {
+  status: string;
+  deviceToken: string;
+  deviceId: string;
+  organizationId: string;
+};
+
+type ContentData = {
+  id: string;
+  name: string;
+  type: string;
+  url: string;
+};
+
+type PlaylistData = {
+  id: string;
+  items: Array<{
+    contentId: string;
+    duration: number | null;
+    content: {
+      id: string;
+      name: string;
+      type: string;
+      url: string;
+    };
+  }>;
+};
+
+type ScheduleData = {
+  id: string;
+  displayId: string;
+  playlistId: string;
+  playlist?: PlaylistData;
+};
+
+type Envelope<T> = {
+  success: boolean;
+  data: T;
+};
+
+const dataOf = <T>(body: Envelope<T>): T => {
+  expect(body.success).toBe(true);
+  return body.data;
+};
+
+describe('Customer critical path (e2e)', () => {
+  let app: INestApplication;
+  let db: DatabaseService;
+  let redis: RedisService;
+  const userIds: string[] = [];
+  const organizationIds: string[] = [];
+  const pairingCodes: string[] = [];
+
+  const timestamp = Date.now();
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.use(
+      helmet({
+        contentSecurityPolicy: false,
+        crossOriginEmbedderPolicy: false,
+      }),
+    );
+    app.setGlobalPrefix('api/v1');
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+      }),
+    );
+
+    const reflector = app.get(Reflector);
+    app.useGlobalInterceptors(
+      new SanitizeInterceptor(reflector),
+      new ResponseEnvelopeInterceptor(reflector),
+    );
+
+    await app.init();
+    db = moduleFixture.get<DatabaseService>(DatabaseService);
+    redis = moduleFixture.get<RedisService>(RedisService);
+  });
+
+  afterAll(async () => {
+    for (const code of pairingCodes) {
+      await redis.del(`pairing:${code}`).catch(() => {});
+    }
+
+    for (const id of userIds) {
+      await db.user.delete({ where: { id } }).catch(() => {});
+    }
+    for (const id of organizationIds) {
+      await db.organization.delete({ where: { id } }).catch(() => {});
+    }
+    await db.$disconnect();
+    await app.close();
+  }, 60000);
+
+  const registerAccount = async (suffix: string) => {
+    const email = `customer-path-${suffix}-${timestamp}@example.com`;
+    const password = 'SecureP@ssw0rd!';
+    const registerRes = await request(app.getHttpServer())
+      .post('/api/v1/auth/register')
+      .send({
+        email,
+        password,
+        firstName: 'Customer',
+        lastName: 'Path',
+        organizationName: `Customer Path ${suffix} E2E Org`,
+        organizationSlug: `customer-path-${suffix}-${timestamp}`,
+      })
+      .expect(201);
+    const registerData = dataOf<RegisterData>(registerRes.body);
+    userIds.push(registerData.user.id);
+    organizationIds.push(registerData.user.organizationId);
+
+    const loginRes = await request(app.getHttpServer())
+      .post('/api/v1/auth/login')
+      .send({ email, password })
+      .expect(201);
+    const loginData = dataOf<RegisterData>(loginRes.body);
+    expect(loginData.user.id).toBe(registerData.user.id);
+    expect(loginData.user.organizationId).toBe(registerData.user.organizationId);
+
+    return {
+      authToken: loginData.access_token,
+      userId: registerData.user.id,
+      organizationId: registerData.user.organizationId,
+    };
+  };
+
+  const pairDisplay = async (authToken: string, suffix: string) => {
+    const deviceIdentifier = `customer-path-${suffix}-display-${timestamp}`;
+    const pairingRequestRes = await request(app.getHttpServer())
+      .post('/api/v1/devices/pairing/request')
+      .send({
+        deviceIdentifier,
+        nickname: `Customer Path ${suffix} Display`,
+        metadata: { platform: 'e2e' },
+      })
+      .expect(201);
+    const pairingRequest = dataOf<PairingRequestData>(pairingRequestRes.body);
+    expect(pairingRequest.code).toMatch(/^[A-Z0-9]{6}$/);
+    pairingCodes.push(pairingRequest.code);
+
+    const pairingCompleteRes = await request(app.getHttpServer())
+      .post('/api/v1/devices/pairing/complete')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        code: pairingRequest.code,
+        nickname: `Customer Path ${suffix} Display`,
+        location: 'Customer Test Lab',
+      })
+      .expect(201);
+    const pairingComplete = pairingCompleteRes.body as PairingCompleteBody;
+    expect(pairingComplete.success).toBe(true);
+    expect(pairingComplete.display.deviceIdentifier).toBe(deviceIdentifier);
+
+    const pairingStatusRes = await request(app.getHttpServer())
+      .get(`/api/v1/devices/pairing/status/${pairingRequest.code}`)
+      .expect(200);
+    const pairingStatus = dataOf<PairingStatusData>(pairingStatusRes.body);
+    expect(pairingStatus.status).toBe('paired');
+    expect(pairingStatus.deviceId).toBe(pairingComplete.display.id);
+    expect(pairingStatus.deviceToken).toBeTruthy();
+
+    return {
+      displayId: pairingComplete.display.id,
+      deviceIdentifier,
+      deviceToken: pairingStatus.deviceToken,
+      organizationId: pairingStatus.organizationId,
+    };
+  };
+
+  it('delivers scheduled playlist content to a newly paired display', async () => {
+    const primaryAccount = await registerAccount('primary');
+    const primaryDisplay = await pairDisplay(primaryAccount.authToken, 'primary');
+    expect(primaryDisplay.organizationId).toBe(primaryAccount.organizationId);
+
+    const contentRes = await request(app.getHttpServer())
+      .post('/api/v1/content')
+      .set('Authorization', `Bearer ${primaryAccount.authToken}`)
+      .send({
+        name: 'Customer Path Menu',
+        type: 'url',
+        url: `https://example.com/vizora-customer-path-${timestamp}`,
+        duration: 10,
+      })
+      .expect(201);
+    const content = dataOf<ContentData>(contentRes.body);
+    expect(content.type).toBe('url');
+
+    const playlistRes = await request(app.getHttpServer())
+      .post('/api/v1/playlists')
+      .set('Authorization', `Bearer ${primaryAccount.authToken}`)
+      .send({
+        name: 'Customer Path Playlist',
+        loop: true,
+        items: [{ contentId: content.id, duration: 10 }],
+      })
+      .expect(201);
+    const playlist = dataOf<PlaylistData>(playlistRes.body);
+    expect(playlist.items).toHaveLength(1);
+    expect(playlist.items[0].contentId).toBe(content.id);
+
+    const now = new Date();
+    const startDate = new Date(now.getTime() - 60_000).toISOString();
+    const allDays = [0, 1, 2, 3, 4, 5, 6];
+    const scheduleRes = await request(app.getHttpServer())
+      .post('/api/v1/schedules')
+      .set('Authorization', `Bearer ${primaryAccount.authToken}`)
+      .send({
+        name: 'Customer Path Schedule',
+        startDate,
+        daysOfWeek: allDays,
+        isActive: true,
+        priority: 100,
+        playlistId: playlist.id,
+        displayId: primaryDisplay.displayId,
+      })
+      .expect(201);
+    const schedule = dataOf<ScheduleData>(scheduleRes.body);
+    expect(schedule.displayId).toBe(primaryDisplay.displayId);
+    expect(schedule.playlistId).toBe(playlist.id);
+
+    const activeRes = await request(app.getHttpServer())
+      .get(`/api/v1/schedules/active/${primaryDisplay.displayId}`)
+      .set('Authorization', `Bearer ${primaryDisplay.deviceToken}`)
+      .expect(200);
+    const activeSchedules = dataOf<ScheduleData[]>(activeRes.body);
+    const activeSchedule = activeSchedules.find((item) => item.id === schedule.id);
+
+    expect(activeSchedule).toBeDefined();
+    expect(activeSchedule?.playlistId).toBe(playlist.id);
+    expect(activeSchedule?.playlist?.items).toHaveLength(1);
+    expect(activeSchedule?.playlist?.items[0].content.id).toBe(content.id);
+    expect(activeSchedule?.playlist?.items[0].content.name).toBe('Customer Path Menu');
+
+    await request(app.getHttpServer())
+      .get(`/api/v1/schedules/active/${primaryDisplay.displayId}`)
+      .expect(401);
+
+    await request(app.getHttpServer())
+      .get(`/api/v1/schedules/active/${primaryDisplay.displayId}`)
+      .set('Authorization', `Bearer ${primaryAccount.authToken}`)
+      .expect(401);
+
+    const otherAccount = await registerAccount('other');
+    const otherDisplay = await pairDisplay(otherAccount.authToken, 'other');
+    expect(otherDisplay.organizationId).toBe(otherAccount.organizationId);
+
+    await request(app.getHttpServer())
+      .get(`/api/v1/schedules/active/${primaryDisplay.displayId}`)
+      .set('Authorization', `Bearer ${otherDisplay.deviceToken}`)
+      .expect(401);
+
+    await request(app.getHttpServer())
+      .post('/api/v1/playlists')
+      .set('Authorization', `Bearer ${otherAccount.authToken}`)
+      .send({
+        name: 'Cross Org Playlist',
+        loop: true,
+        items: [{ contentId: content.id, duration: 10 }],
+      })
+      .expect(404);
+
+    const otherContentRes = await request(app.getHttpServer())
+      .post('/api/v1/content')
+      .set('Authorization', `Bearer ${otherAccount.authToken}`)
+      .send({
+        name: 'Other Org Menu',
+        type: 'url',
+        url: `https://example.com/vizora-other-org-${timestamp}`,
+        duration: 10,
+      })
+      .expect(201);
+    const otherContent = dataOf<ContentData>(otherContentRes.body);
+
+    const otherPlaylistRes = await request(app.getHttpServer())
+      .post('/api/v1/playlists')
+      .set('Authorization', `Bearer ${otherAccount.authToken}`)
+      .send({
+        name: 'Other Org Playlist',
+        loop: true,
+        items: [{ contentId: otherContent.id, duration: 10 }],
+      })
+      .expect(201);
+    const otherPlaylist = dataOf<PlaylistData>(otherPlaylistRes.body);
+
+    await request(app.getHttpServer())
+      .post('/api/v1/schedules')
+      .set('Authorization', `Bearer ${otherAccount.authToken}`)
+      .send({
+        name: 'Cross Org Schedule',
+        startDate,
+        daysOfWeek: allDays,
+        isActive: true,
+        playlistId: otherPlaylist.id,
+        displayId: primaryDisplay.displayId,
+      })
+      .expect(404);
+  });
+});

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,86 @@
 # Vizora - Task Tracker
 
+## Active: Customer Critical Path E2E Gate Pass 37 (2026-06-01)
+
+**Branch:** `feat/customer-experience-pass-37`
+
+**Why now:** Recent smoke-script work now exercises the customer path from
+register/login through pairing, content, playlist, schedule, uploaded-content
+streaming, and device active-schedule reads. CI still only gates the agents E2E
+suite, so this customer-critical path can regress without blocking a merge.
+
+**New primitives introduced:** none. This pass adds automated E2E coverage and
+CI wiring only. It reuses existing NestJS modules/controllers/services/DTOs,
+Prisma models, Redis pairing flow, device JWT verification, response envelope,
+and `/api/v1` routing. No route, schema, runtime process, env var, realtime
+substrate, notification substrate, MCP tool, Hermes skill, or provider spend
+path changes.
+
+**Hermes-first analysis:** not applicable. This is a repo-local middleware E2E
+gate for existing customer-critical API paths, not a business-agent, MCP,
+Hermes, or AI/provider workflow.
+
+**Plan/design:**
+`docs/plans/2026-06-01-customer-critical-path-e2e-pass-37.md`
+
+**Plan**
+- [x] Start fresh isolated branch from updated `origin/main`.
+- [x] Drift-check smoke, runbook, and CI coverage against current repo truth.
+- [x] Document pass 37 design and verification plan.
+- [x] Add middleware E2E coverage for register/login, pairing, content,
+  playlist, schedule, and device active-schedule read through `/api/v1`.
+- [x] Wire GitHub Actions E2E job to run the customer-critical-path spec
+  alongside the existing agents suite.
+- [x] Run multi-vector subagent review before broader verification.
+- [x] Run focused and broader verification.
+- [ ] PR, CI, merge if green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Evidence so far:**
+- Drift-check: `scripts/smoke/api-critical-path.sh` already covers full pairing
+  completion, URL content, multipart PDF upload, authenticated device-content
+  range streaming, playlist creation, schedule creation, and device
+  `/schedules/active/:displayId` reads. The current CI E2E job still runs only
+  `--testPathPattern=agents`.
+- Customer UX reviewer findings queued for follow-up after this gate:
+  dashboard server fetch cookie mismatch, 401/403 client handling, viewer action
+  gating, misleading playlist Publish, multi-device schedule mismatch, bulk
+  delete safeguards, content/template performance hotspots, mobile fit, and trust
+  copy drift.
+- Performance reviewer findings queued for follow-up after this gate: device
+  media buffering, memory-backed uploads/replacements, thumbnail generation
+  stampede, playlist realtime fan-out, playlist list overfetch, missing list
+  sort indexes, first-page-only dashboard assumptions, global response sanitize
+  overhead, proof-of-play write path, reorder scaling, and pairing Redis scans.
+- Implementation: added `customer-critical-path.e2e-spec.ts` covering
+  register + login, public pairing request/status, authenticated pairing
+  completion, URL content creation, playlist creation, active schedule creation,
+  device-token active schedule read, no-token rejection, user-JWT rejection,
+  foreign-device-token rejection, cross-org playlist-content rejection, and
+  cross-org display-schedule rejection. The schedule uses all seven days to
+  avoid midnight flakes and cleanup deletes any leftover `pairing:{code}` Redis
+  keys.
+- CI wiring: GitHub Actions middleware E2E job now runs
+  `--testPathPattern="(agents|customer-critical-path)"`.
+- Test cleanup: `agents.e2e-spec.ts` now deletes its user before deleting the
+  org so the gated suite does not emit a Prisma not-found cleanup error.
+- Review: CI/release-safety reviewer CLEAN. API/security reviewer initially
+  found missing negative device-token and tenant-isolation assertions; after
+  follow-up assertions, re-review CLEAN.
+- Verification:
+  `pnpm --filter @vizora/middleware exec jest --config=jest.e2e.config.js --runInBand --testPathPattern=customer-critical-path --detectOpenHandles`
+  passed 1 suite / 1 test. `pnpm --filter @vizora/middleware exec jest --config=jest.e2e.config.js --runInBand --testPathPattern="(agents|customer-critical-path)"`
+  passed 2 suites / 2 tests. `pnpm --filter @vizora/middleware test -- --runInBand`
+  passed 146 suites / 2942 tests. `npx nx build @vizora/middleware --skip-nx-cache`
+  passed with existing webpack warnings. `git diff --check` passed with only
+  Windows CRLF conversion warnings. `pnpm security:no-hardcoded-jwts` passed.
+  Direct `tsc --project tsconfig.spec.json` is not a valid
+  repo check because the spec tsconfig has a pre-existing
+  `moduleResolution: NodeNext` / `module` mismatch; Jest/ts-jest is the E2E
+  compile path and passed.
+
+---
+
 ## Completed: Template Action Truthfulness Pass 36 (2026-06-01)
 
 **Branch:** `feat/customer-experience-pass-36`


### PR DESCRIPTION
## Summary
- add a CI-gated middleware E2E spec for the customer-critical path: register/login -> pairing -> content -> playlist -> schedule -> device active schedule
- assert device-token and tenant-boundary failures in the same path
- run the new spec alongside the existing agents E2E suite in GitHub Actions
- fix agents E2E cleanup ordering so the gated suite does not emit a Prisma not-found cleanup error

## Verification
- `pnpm --filter @vizora/middleware exec jest --config=jest.e2e.config.js --runInBand --testPathPattern=customer-critical-path --detectOpenHandles` passed 1 suite / 1 test
- `pnpm --filter @vizora/middleware exec jest --config=jest.e2e.config.js --runInBand --testPathPattern=(agents|customer-critical-path)` passed 2 suites / 2 tests
- `pnpm --filter @vizora/middleware test -- --runInBand` passed 146 suites / 2942 tests
- `npx nx build @vizora/middleware --skip-nx-cache` passed with existing webpack warnings
- `git diff --check` passed with only Windows CRLF conversion warnings
- `pnpm security:no-hardcoded-jwts` passed

## Review
- CI/release-safety subagent review: CLEAN
- API/security subagent review: CLEAN after adding negative device-token and tenant-isolation assertions

## Deployment
- No production deploy in this PR. Deployment gate will be checked after merge.