### PR TITLE
fix(web): confirm bulk content deletion

### DIFF
--- a/docs/plans/2026-06-01-dashboard-safety-truth-pass-38.md
+++ b/docs/plans/2026-06-01-dashboard-safety-truth-pass-38.md
@@ -1,0 +1,62 @@
+# Dashboard Safety and Truth Pass 38
+
+**Goal:** Improve customer trust in the dashboard by fixing small, high-impact
+UI safety/truth gaps that are directly testable.
+
+**New primitives introduced:** none. This pass changes existing React UI state,
+copy, and tests only. It reuses the current dashboard components, API client,
+toast path, confirmation dialog, and Jest/RTL test setup. No route, schema,
+backend module, env var, realtime path, notification path, MCP tool, Hermes
+skill, or runtime process changes.
+
+**Hermes-first analysis:** not applicable. This is not a business-agent, MCP,
+Hermes, AI/provider, or spend-path change.
+
+## Drift Check
+
+- `serverFetch` already reads `vizora_auth_token`, matching the backend auth
+  cookie. The previous cookie-mismatch concern is stale.
+- Device bulk deletion already uses `ConfirmDialog` before the API call.
+- Content bulk deletion still calls `apiClient.deleteContent` immediately from
+  the selected-items toolbar.
+- Dashboard recent-activity subtitles use a Unicode bullet separator; switching
+  to ASCII keeps the dashboard text consistent with repo editing constraints.
+  The first-run guide says "Publish & Schedule" though the native action is
+  assigning playlists and schedules, not a separate publish primitive.
+
+## Broader Customer Improvement List
+
+1. Safer destructive actions: content bulk delete needs a confirmation barrier.
+2. Truthful wording: replace publish language where the product actually assigns
+   playlists/schedules; use ASCII separators in dashboard activity copy.
+3. Permission clarity: keep auditing viewer/admin action visibility across
+   content, playlists, schedules, and templates after pass 36.
+4. Critical-path status clarity: keep dashboard health/storage cards tied to
+   actual API results, not optimistic placeholders.
+5. Performance follow-ups: continue investigating content streaming, upload
+   memory use, pairing scans, playlist/device list pagination, and middleware
+   sanitize overhead.
+
+## Scope
+
+1. Add a bulk-delete confirmation modal to the content page.
+2. Keep the API call deferred until the user confirms.
+3. Clear the modal and selection after success; keep existing error toast path.
+4. Replace dashboard Unicode bullet separators with ASCII separators.
+5. Rename the dashboard first-run step from "Publish & Schedule" to
+   "Assign & Schedule".
+
+## Test Plan
+
+- Focused content page tests for the new bulk-delete confirmation barrier.
+- Focused dashboard tests for clean activity separators and truthful onboarding
+  copy.
+- Relevant web Jest suites for content and dashboard.
+- `git diff --check`.
+
+## Risks
+
+- Content page is a large component; keep the change minimal and avoid unrelated
+  refactors.
+- This pass does not resolve backend performance follow-ups. Those need separate
+  measured work once the read-only performance review returns.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,80 @@
 # Vizora - Task Tracker
 
+## Active: Dashboard Safety and Truth Pass 38 (2026-06-01)
+
+**Branch:** `feat/customer-dashboard-pass-38`
+
+**Why now:** After PR #169/#170, CI now gates the customer-critical API path.
+The next buildable customer-facing gap is dashboard trust: destructive bulk
+content deletion can execute from the toolbar without a confirmation step, and
+dashboard copy includes Unicode separators plus stale "Publish" wording.
+
+**New primitives introduced:** none. This pass changes existing web UI state,
+copy, and tests only. No route, backend module, schema, env var, realtime
+substrate, notification path, MCP tool, Hermes skill, provider spend path, or
+runtime process changes.
+
+**Hermes-first analysis:** not applicable. This is not a business-agent, MCP,
+Hermes, AI/provider, or spend-path change.
+
+**Plan/design:**
+`docs/plans/2026-06-01-dashboard-safety-truth-pass-38.md`
+
+**Plan**
+- [x] Start fresh isolated branch from updated `origin/main`.
+- [x] Drift-check prior customer UX findings against current repo truth.
+- [x] Document pass 38 design and customer-improvement list.
+- [x] Add failing web tests for content bulk-delete confirmation and dashboard
+  copy cleanup.
+- [x] Implement minimal UI state/copy fixes.
+- [x] Run multi-vector subagent review before broader verification.
+- [x] Run focused and broader verification.
+- [ ] PR, CI, merge if green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Evidence so far:**
+- Drift-check: `web/src/lib/server-api.ts` already uses `vizora_auth_token`, so
+  the prior server cookie mismatch concern is stale.
+- Drift-check: `web/src/app/dashboard/devices/page-client.tsx` already wraps
+  device bulk delete in `ConfirmDialog`.
+- Backend/security reviewer findings verified stale in this worktree:
+  `PairingService.getActivePairings` already hides brand-new unclaimed codes
+  from org dashboards and has a test for it; `DisplaysService.bulkAssignGroup`
+  already counts display IDs by `organizationId` before membership inserts and
+  has a mixed-org rejection test; `ApiClient.updateContent` already maps
+  dashboard `title` to backend `name` with a unit test.
+- Residual gap: `web/src/app/dashboard/content/page-client.tsx` calls
+  `apiClient.deleteContent` immediately in `handleBulkDelete` from the selected
+  items toolbar.
+- Residual gap: `web/src/app/dashboard/page-client.tsx` renders Unicode bullet
+  separators in recent activity and says "Publish & Schedule" in the first-run
+  guide.
+- Queued high-value follow-ups from customer UX/security/performance review:
+  frontend role/action matrix, persistent list-load error panels, schedule
+  multi-device/group truthfulness, schedule precedence copy vs backend ordering,
+  offline-device immediate push gating, health dashboard mock metrics, help-copy
+  drift, device-content streaming, thumbnail storm prevention, stream/disk-backed
+  uploads, compact list selects/indexes, active-schedule caching, and pairing
+  active-list scaling.
+- Implementation: content bulk deletion now opens `ConfirmDialog` and defers
+  `apiClient.deleteContent` until confirmation; dashboard recent-activity
+  separators now use ASCII ` - ` and the first-run guide says "Assign &
+  Schedule".
+- Review: replacement frontend reviewer found a real failure-path issue where
+  the bulk-delete confirmation could close after a rejected delete; fixed by
+  rethrowing after the toast and adding a regression test. Release-safety
+  reviewer found a low-risk docs wording issue; fixed before verification.
+- Focused verification:
+  `pnpm --filter @vizora/web test -- --runInBand web/src/app/dashboard/content/__tests__/content-page.test.tsx web/src/app/dashboard/__tests__/dashboard-page.test.tsx`
+  passed 2 suites / 62 tests.
+- Broader verification:
+  `pnpm --filter @vizora/web test -- --runInBand` passed 101 suites / 1067
+  tests; `npx nx build @vizora/web --skip-nx-cache` passed with production env
+  placeholders; `git diff --check` passed with Windows CRLF warnings only;
+  `pnpm security:no-hardcoded-jwts` passed.
+
+---
+
 ## Completed: Customer Critical Path E2E Gate Pass 37 (2026-06-01)
 
 **Branch:** `feat/customer-experience-pass-37`

--- a/web/src/app/dashboard/__tests__/dashboard-page.test.tsx
+++ b/web/src/app/dashboard/__tests__/dashboard-page.test.tsx
@@ -213,6 +213,8 @@ describe('DashboardClient', () => {
   it('shows getting started guide when no devices', async () => {
     await renderDashboardClient();
     expect(screen.getByText('Getting Started')).toBeInTheDocument();
+    expect(screen.getByText('Assign & Schedule')).toBeInTheDocument();
+    expect(screen.queryByText('Publish & Schedule')).not.toBeInTheDocument();
   });
 
   it('does not refetch content and playlists on mount when server summary is present', async () => {
@@ -286,7 +288,9 @@ describe('DashboardClient', () => {
     expect(screen.getByText('7 processing')).toBeInTheDocument();
     expect(screen.getByText('31 ready')).toBeInTheDocument();
     expect(screen.getByText('Fresh Menu')).toBeInTheDocument();
+    expect(screen.getByText('image - ready')).toBeInTheDocument();
     expect(screen.getByText('Lunch Loop')).toBeInTheDocument();
+    expect(screen.queryByText(/â/)).not.toBeInTheDocument();
   });
 
   it('preserves initial overview counts when summary refresh fails', async () => {
@@ -460,7 +464,7 @@ describe('DashboardClient', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Lobby Display')).toBeInTheDocument();
-      expect(screen.getByText(/online.*Front Desk/)).toBeInTheDocument();
+      expect(screen.getByText('online - Front Desk')).toBeInTheDocument();
     });
   });
 });

--- a/web/src/app/dashboard/content/__tests__/content-page.test.tsx
+++ b/web/src/app/dashboard/content/__tests__/content-page.test.tsx
@@ -129,11 +129,20 @@ jest.mock('@/components/PreviewModal', () => {
 });
 
 jest.mock('@/components/ConfirmDialog', () => {
-  return function MockConfirm({ isOpen, onConfirm, title }: any) {
+  return function MockConfirm({ isOpen, onClose, onConfirm, title }: any) {
+    const handleConfirm = async () => {
+      try {
+        await onConfirm();
+        onClose?.();
+      } catch {
+        // Match the real dialog: failed confirmations stay open for retry.
+      }
+    };
+
     return isOpen ? (
       <div data-testid="confirm-dialog">
         <span>{title}</span>
-        <button onClick={onConfirm}>Confirm</button>
+        <button onClick={handleConfirm}>Confirm</button>
       </div>
     ) : null;
   };
@@ -353,6 +362,70 @@ describe('ContentClient', () => {
     await waitForAuxiliaryRequestsToSettle();
     expect(screen.getByText('Promo Video')).toBeInTheDocument();
     expect(screen.getByText('Menu PDF')).toBeInTheDocument();
+  });
+
+  it('requires confirmation before bulk deleting selected content', async () => {
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+    render(<ContentClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    const itemCheckboxes = screen.getAllByRole('checkbox');
+    await act(async () => {
+      fireEvent.click(itemCheckboxes[0]);
+      fireEvent.click(itemCheckboxes[1]);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /delete selected/i }));
+    });
+
+    expect(mockDeleteContent).not.toHaveBeenCalled();
+    expect(screen.getByTestId('confirm-dialog')).toHaveTextContent('Delete Selected Content');
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    });
+
+    await waitFor(() => {
+      expect(mockDeleteContent).toHaveBeenCalledWith('c1');
+      expect(mockDeleteContent).toHaveBeenCalledWith('c2');
+    });
+    expect(mockToast.success).toHaveBeenCalledWith('2 items deleted');
+  });
+
+  it('keeps bulk delete confirmation open when deletion fails', async () => {
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+    mockDeleteContent.mockRejectedValueOnce(new Error('Delete failed'));
+    render(<ContentClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    const itemCheckboxes = screen.getAllByRole('checkbox');
+    await act(async () => {
+      fireEvent.click(itemCheckboxes[0]);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /delete selected/i }));
+    });
+
+    expect(screen.getByTestId('confirm-dialog')).toHaveTextContent('Delete Selected Content');
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    });
+
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith('Delete failed');
+    });
+    expect(screen.getByTestId('confirm-dialog')).toHaveTextContent('Delete Selected Content');
   });
 
   it('renders content list cards from summary payloads without url or metadata', async () => {

--- a/web/src/app/dashboard/content/page-client.tsx
+++ b/web/src/app/dashboard/content/page-client.tsx
@@ -104,6 +104,7 @@ export default function ContentClient() {
  const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+ const [isBulkDeleteModalOpen, setIsBulkDeleteModalOpen] = useState(false);
  const [isPushModalOpen, setIsPushModalOpen] = useState(false);
  const [isAddToPlaylistModalOpen, setIsAddToPlaylistModalOpen] = useState(false);
  const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false);
@@ -944,17 +945,30 @@ export default function ContentClient() {
 
  const handleBulkDelete = async () => {
  if (selectedItems.size === 0) return;
- 
+
+ setIsBulkDeleteModalOpen(true);
+ };
+
+ const confirmBulkDelete = async () => {
+ if (selectedItems.size === 0) {
+ setIsBulkDeleteModalOpen(false);
+ return;
+ }
+
+ const selectedIds = Array.from(selectedItems);
+
  try {
  setActionLoading(true);
  await Promise.all(
- Array.from(selectedItems).map(id => apiClient.deleteContent(id))
+ selectedIds.map(id => apiClient.deleteContent(id))
  );
- toast.success(`${selectedItems.size} items deleted`);
+ toast.success(`${selectedIds.length} items deleted`);
  setSelectedItems(new Set());
- loadContent();
+ setIsBulkDeleteModalOpen(false);
+ void loadContent();
  } catch (error: any) {
  toast.error(error.message || 'Failed to delete some items');
+ throw error;
  } finally {
  setActionLoading(false);
  }
@@ -2239,6 +2253,18 @@ export default function ContentClient() {
  title="Delete Content"
  message={`Are you sure you want to delete "${selectedContent?.title || 'Untitled'}"? This action cannot be undone.`}
  confirmText="Delete"
+ type="danger"
+ />
+
+ <ConfirmDialog
+ isOpen={isBulkDeleteModalOpen}
+ onClose={() => {
+ if (!actionLoading) setIsBulkDeleteModalOpen(false);
+ }}
+ onConfirm={confirmBulkDelete}
+ title="Delete Selected Content"
+ message={`Are you sure you want to delete ${selectedItems.size} selected content item${selectedItems.size === 1 ? '' : 's'}? This action cannot be undone.`}
+ confirmText={`Delete ${selectedItems.size} Item${selectedItems.size === 1 ? '' : 's'}`}
  type="danger"
  />
 

--- a/web/src/app/dashboard/page-client.tsx
+++ b/web/src/app/dashboard/page-client.tsx
@@ -271,7 +271,7 @@ export default function DashboardClient({
  type: 'device',
  iconName: getValidIconName('devices'),
  title: d.metadata?.nickname || 'Unnamed Device',
- subtitle: `${d.status || 'unknown'} • ${d.metadata?.location || 'No location'}`,
+ subtitle: `${d.status || 'unknown'} - ${d.metadata?.location || 'No location'}`,
  time: d.metadata?.lastSeen || new Date().toISOString(),
  })),
  ...content.slice(0, 3).map((c: any) => {
@@ -283,7 +283,7 @@ export default function DashboardClient({
  type: 'content',
  iconName: getValidIconName(iconName),
  title: c.title || 'Untitled',
- subtitle: `${c.type || 'file'} • ${c.status || 'ready'}`,
+ subtitle: `${c.type || 'file'} - ${c.status || 'ready'}`,
  time: c.createdAt || new Date().toISOString(),
  };
  }),
@@ -681,7 +681,7 @@ export default function DashboardClient({
  4
  </div>
  <div>
- <div className="font-semibold mb-1">Publish & Schedule</div>
+ <div className="font-semibold mb-1">Assign & Schedule</div>
  <div className="text-sm text-primary-100">
  Assign playlists to devices and set schedules
  </div>


### PR DESCRIPTION
﻿## Summary
- Add a confirmation barrier before content bulk delete executes API deletes.
- Keep the bulk-delete confirmation open on delete failure so the user can retry or cancel.
- Clean dashboard recent-activity separators to ASCII and rename the first-run step to "Assign & Schedule".
- Record pass-38 drift/review/test evidence in `tasks/todo.md` and the plan doc.

## Review
- Multi-vector reviewers dispatched before broader verification.
- Replacement frontend review found a real failed-delete modal-close issue; fixed and covered with a regression test.
- Release-safety review found a low-risk docs wording issue; fixed before verification.

## Verification
- `pnpm --filter @vizora/web test -- --runInBand web/src/app/dashboard/content/__tests__/content-page.test.tsx web/src/app/dashboard/__tests__/dashboard-page.test.tsx` passed 2 suites / 62 tests.
- `pnpm --filter @vizora/web test -- --runInBand` passed 101 suites / 1067 tests.
- `NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 BACKEND_URL=http://localhost:3000 NODE_OPTIONS=--max-old-space-size=4096 npx nx build @vizora/web --skip-nx-cache` passed.
- `git diff --check` passed with Windows CRLF warnings only.
- `pnpm security:no-hardcoded-jwts` passed.

## Deploy
- No deploy attempted in this PR. Production checkout/deploy gate must be rechecked after merge.
