### PR TITLE
fix(web): align dashboard actions with roles

### DIFF
--- a/docs/plans/2026-06-01-dashboard-action-truth-pass-39.md
+++ b/docs/plans/2026-06-01-dashboard-action-truth-pass-39.md
@@ -1,0 +1,55 @@
+# Dashboard Action Truth Pass 39
+
+**Goal:** Prevent customer dashboard users from seeing controls that their role
+cannot execute, and make primary list-load failures explicit instead of falling
+through to empty states.
+
+**New primitives introduced:** one small frontend permission helper. No backend
+route, schema, env var, realtime substrate, notification path, MCP tool, Hermes
+skill, provider spend path, or runtime process changes.
+
+**Hermes-first analysis:** not applicable. This is dashboard UI state and tests,
+not a business-agent, MCP, Hermes, AI/provider, or spend-path change.
+
+## Drift Check
+
+- Schedules already has a persistent `loadError` panel and suppresses its empty
+  state while schedule data failed to load.
+- Content, devices, and playlists still rely on toast-only primary list-load
+  failures, so failed loads can look like truthful empty lists.
+- Backend role contracts are already explicit with `@Roles`: content, devices,
+  and playlists allow most create/update/assignment actions for admin/manager,
+  but deletes are admin-only. Viewers are read-only on these list pages except
+  content moderation/approval proposal affordances already exposed by backend.
+
+## Scope
+
+1. Add a shared web permission helper that mirrors the relevant backend role
+   contracts for content, devices, playlists, and emergency override actions.
+2. Gate content list actions: upload/folders/move/edit/push/add-to-playlist for
+   admin/manager, delete for admin only, review for admin/manager, flag remains
+   available where backend permits it.
+3. Gate devices list actions: pair/edit/assign/group for admin/manager, delete
+   and emergency override for admin only, fleet commands for admin/manager, and
+   make inline playlist assignment read-only for viewers.
+4. Gate playlist list actions: create/edit/assign/duplicate for admin/manager,
+   playlist delete and playlist-item remove for admin only.
+5. Add persistent primary load-error panels with Retry on content, devices, and
+   playlists, and suppress misleading empty states while those errors are active.
+
+## Test Plan
+
+- Permission helper unit tests for admin, manager, viewer, and missing user.
+- Focused React tests for viewer/manager/admin action visibility on content,
+  devices, and playlists.
+- Focused React tests proving primary list-load errors render an inline alert and
+  do not render an empty-state message.
+- Focused page suites, full web Jest suite, web build, diff check, and
+  hardcoded-JWT scan before PR.
+
+## Risks
+
+- These pages are large. Keep changes localized to role booleans and existing
+  render branches.
+- Hiding controls improves truthfulness but backend authorization remains the
+  source of enforcement.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,84 @@
 # Vizora - Task Tracker
 
+## Active: Dashboard Action Truth Pass 39 (2026-06-01)
+
+**Branch:** `feat/dashboard-action-truth-pass-39`
+
+**Why now:** Pass 38 fixed a destructive confirmation gap. The next customer
+trust issue is dashboard action truthfulness: viewers and managers can still see
+some controls that backend roles reject, and failed primary list loads can still
+look like real empty accounts.
+
+**New primitives introduced:** one frontend permission helper. No backend route,
+schema, env var, realtime substrate, notification path, MCP tool, Hermes skill,
+provider spend path, or runtime process changes.
+
+**Hermes-first analysis:** not applicable. This is dashboard UI state and tests,
+not a business-agent, MCP, Hermes, AI/provider, or spend-path change.
+
+**Plan/design:**
+`docs/plans/2026-06-01-dashboard-action-truth-pass-39.md`
+
+**Plan**
+- [x] Start fresh isolated branch from updated `origin/main`.
+- [x] Drift-check backend role contracts and existing list-error patterns.
+- [x] Document pass 39 design and scope.
+- [x] Add failing tests for permission helper, role-gated controls, and primary
+  load-error panels.
+- [x] Implement minimal permission helper, UI gates, read-only playlist select,
+  and list-error panels.
+- [x] Run multi-vector subagent review before broader verification.
+- [x] Run focused and broader verification.
+- [ ] PR, CI, merge if green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Evidence so far:**
+- Drift-check: schedules already has `loadError` with an inline panel and
+  suppresses empty state while failed.
+- Drift-check: content/devices/playlists primary loads still toast on failure
+  and can render empty states.
+- Drift-check: backend `@Roles` contracts show admin/manager can create/update
+  content/devices/playlists; admin-only deletes apply to content, devices,
+  playlists, and playlist item removal. Emergency override is admin-only by
+  fleet service guard.
+- Implementation: added `web/src/lib/permissions.ts` and focused tests for
+  admin/manager/viewer/missing-user permissions.
+- Implementation: content, devices, and playlists now suppress unauthorized
+  mutation controls and modal submit surfaces; devices keep Pair New Device
+  visible because backend `/devices/pairing/complete` has no role decorator.
+- Implementation: content, devices, and playlists now render persistent
+  `DashboardSectionError` panels on primary load failure and suppress misleading
+  empty states while errors are active.
+- Implementation: device playlist quick-select is disabled for viewers;
+  emergency override create/clear is admin-only; screenshot read remains
+  available in preview but screenshot capture request controls are hidden unless
+  the user can manage devices.
+- Review: UX/test reviewer found a medium false affordance where viewers could
+  still re-flag already-flagged content; fixed by excluding `flagged` from the
+  viewer flag branch and adding a regression test.
+- Review: RBAC/security reviewer found a medium false affordance where viewers
+  could request a screenshot capture from the device preview modal; fixed by
+  passing `canRequestScreenshot` into `DevicePreviewModal` and adding page +
+  component regression tests.
+- Review: final RBAC/security reviewer found a medium direct-route gap where
+  `/dashboard/playlists/:id` still exposed viewer/manager backend-rejected
+  mutations; fixed by applying the same permission helper to the builder route
+  and shared playlist panels. Re-review returned CLEAN.
+- Review: UX/test/release re-review returned CLEAN after the flagged-content
+  and screenshot-capture fixes.
+- Focused verification:
+  `pnpm --filter @vizora/web test -- --runInBand web/src/lib/__tests__/permissions.test.ts web/src/app/dashboard/content/__tests__/content-page.test.tsx web/src/app/dashboard/devices/__tests__/devices-page.test.tsx web/src/app/dashboard/playlists/__tests__/playlists-page.test.tsx web/src/components/__tests__/DevicePreviewModal.test.tsx web/src/components/__tests__/PlaylistBuilder.test.tsx`
+  passed 6 suites / 144 tests. The existing playlist-builder tests emitted
+  React `act(...)` warnings but exited 0.
+- Broader verification:
+  `pnpm --filter @vizora/web test -- --runInBand` passed 102 suites / 1080
+  tests with existing React `act(...)` warnings in several suites;
+  `npx nx build @vizora/web --skip-nx-cache` passed with production env
+  placeholders; `pnpm security:no-hardcoded-jwts` passed; `git diff --check`
+  passed with Windows CRLF warnings only.
+
+---
+
 ## Completed: Dashboard Safety and Truth Pass 38 (2026-06-01)
 
 **Branch:** `feat/customer-dashboard-pass-38`

--- a/web/src/app/dashboard/content/__tests__/content-page.test.tsx
+++ b/web/src/app/dashboard/content/__tests__/content-page.test.tsx
@@ -50,6 +50,26 @@ jest.mock('@/lib/hooks/useToast', () => ({
   useToast: () => ({ ...mockToast }),
 }));
 
+let mockUser: any = {
+  id: 'u1',
+  email: 'admin@test.com',
+  firstName: 'Admin',
+  lastName: 'User',
+  organizationId: 'org-1',
+  role: 'admin',
+};
+
+jest.mock('@/lib/hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: mockUser,
+    loading: false,
+    error: null,
+    isAuthenticated: !!mockUser,
+    logout: jest.fn(),
+    reload: jest.fn(),
+  }),
+}));
+
 jest.mock('@/lib/hooks/useDebounce', () => ({
   useDebounce: (val: any) => val,
 }));
@@ -247,6 +267,14 @@ const createDeferred = <T,>() => {
 describe('ContentClient', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUser = {
+      id: 'u1',
+      email: 'admin@test.com',
+      firstName: 'Admin',
+      lastName: 'User',
+      organizationId: 'org-1',
+      role: 'admin',
+    };
     mockGetContent.mockResolvedValue({ data: [], meta: { page: 1, limit: 50, total: 0, totalPages: 0 } });
     mockGetContentItem.mockResolvedValue(sampleContent[0]);
     mockGetContentTags.mockResolvedValue([
@@ -847,12 +875,75 @@ describe('ContentClient', () => {
   });
 
   it('shows error toast on fetch failure', async () => {
-    mockGetContent.mockRejectedValue(new Error('Network error'));
+    mockGetContent
+      .mockRejectedValueOnce(new Error('Network error'))
+      .mockResolvedValueOnce({ data: sampleContent, meta: { total: 3 } });
     render(<ContentClient />);
     await waitFor(() => {
       expect(mockToast.showToast).toHaveBeenCalledWith('Network error', 'error');
     });
+    expect(screen.getByRole('alert')).toHaveTextContent('Content Library Error');
+    fireEvent.click(screen.getByRole('button', { name: 'Try Again' }));
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('No content yet')).not.toBeInTheDocument();
     await waitForAuxiliaryRequestsToSettle();
+  });
+
+  it('keeps viewers on read-only content actions while preserving flagging', async () => {
+    mockUser = { ...mockUser, role: 'viewer' };
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+
+    render(<ContentClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    expect(screen.queryByText('Upload Content')).not.toBeInTheDocument();
+    expect(screen.queryByText('Push')).not.toBeInTheDocument();
+    expect(screen.queryByText('Playlist')).not.toBeInTheDocument();
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument();
+    expect(screen.queryAllByText('Delete')).toHaveLength(0);
+    expect(screen.getAllByText('Flag').length).toBeGreaterThan(0);
+  });
+
+  it('does not offer viewers a duplicate flag action for already flagged content', async () => {
+    mockUser = { ...mockUser, role: 'viewer' };
+    mockGetContent.mockResolvedValue({
+      data: [{ ...sampleContent[0], status: 'flagged' }],
+      meta: { total: 1 },
+    });
+
+    render(<ContentClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    expect(screen.queryByText('Review')).not.toBeInTheDocument();
+    expect(screen.queryByText('Flag')).not.toBeInTheDocument();
+  });
+
+  it('allows managers to manage content but not delete it', async () => {
+    mockUser = { ...mockUser, role: 'manager' };
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+
+    render(<ContentClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    expect(screen.getByText('Upload Content')).toBeInTheDocument();
+    expect(screen.getAllByText('Push').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Playlist').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Edit').length).toBeGreaterThan(0);
+    expect(screen.queryAllByText('Delete')).toHaveLength(0);
   });
 
   it('renders content page header', async () => {

--- a/web/src/app/dashboard/content/page-client.tsx
+++ b/web/src/app/dashboard/content/page-client.tsx
@@ -15,11 +15,14 @@ import LoadingSpinner from '@/components/LoadingSpinner';
 import EmptyState from '@/components/EmptyState';
 import SearchFilter from '@/components/SearchFilter';
 import ContentTagger, { ContentTag } from '@/components/ContentTagger';
+import DashboardSectionError from '@/components/DashboardSectionError';
 import { ViewToggle, getInitialView } from '@/components/ViewToggle';
 import { useToast } from '@/lib/hooks/useToast';
+import { useAuth } from '@/lib/hooks/useAuth';
 import { useDebounce } from '@/lib/hooks/useDebounce';
 import { useRealtimeEvents, useOptimisticState, useErrorRecovery } from '@/lib/hooks';
 import { contentUploadSchema, validateForm } from '@/lib/validation';
+import { getDashboardPermissions } from '@/lib/permissions';
 import { Icon } from '@/theme/icons';
 import type { IconName } from '@/theme/icons';
 
@@ -95,10 +98,14 @@ const getUploadButtonLabel = (queue: UploadQueueItem[]): string => {
 export default function ContentClient() {
  const toast = useToast();
  const { showToast } = toast;
+ const { user } = useAuth();
+ const permissions = getDashboardPermissions(user);
+ const canSelectContent = permissions.canManageContent || permissions.canDeleteContent;
  const [content, setContent] = useState<Content[]>([]);
  const [contentMeta, setContentMeta] = useState<ContentPageMeta>(EMPTY_CONTENT_META);
  const [contentPage, setContentPage] = useState(1);
  const [loading, setLoading] = useState(true);
+ const [contentLoadError, setContentLoadError] = useState<Error | null>(null);
  const [selectedContent, setSelectedContent] = useState<Content | null>(null);
  const [contentDetailLoadingId, setContentDetailLoadingId] = useState<string | null>(null);
  const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
@@ -252,6 +259,7 @@ export default function ContentClient() {
  const folderId = selectedFolderId;
  try {
  setLoading(true);
+ setContentLoadError(null);
  const params = buildContentListParams();
  const response = folderId
  ? await apiClient.getFolderContent(folderId, params)
@@ -274,6 +282,7 @@ export default function ContentClient() {
  }
  setContent(items);
  setContentMeta(meta);
+ setContentLoadError(null);
  setSelectedItems(previous => {
  const visibleIds = new Set(items.map(item => item.id));
  return new Set(Array.from(previous).filter(id => visibleIds.has(id)));
@@ -282,7 +291,9 @@ export default function ContentClient() {
  if (requestId !== loadContentRequestRef.current) {
  return;
  }
-  showToast(error.message || 'Failed to load content', 'error');
+ const message = error.message || 'Failed to load content';
+ setContentLoadError(error instanceof Error ? error : new Error(message));
+  showToast(message, 'error');
   } finally {
  if (requestId === loadContentRequestRef.current) {
  setLoading(false);
@@ -1135,7 +1146,7 @@ export default function ContentClient() {
  setSelectedItems(new Set());
  setContentPage(1);
  }}
- onCreateFolder={() => setIsCreateFolderModalOpen(true)}
+ onCreateFolder={permissions.canManageContent ? () => setIsCreateFolderModalOpen(true) : undefined}
  />
  </div>
 
@@ -1170,6 +1181,7 @@ export default function ContentClient() {
  )}
  </p>
  </div>
+ {permissions.canManageContent && (
  <button
  onClick={() => setIsUploadModalOpen(true)}
  className="eh-btn-neon px-6 py-3 rounded-xl flex items-center gap-2"
@@ -1177,6 +1189,7 @@ export default function ContentClient() {
  <Icon name="add" size="lg" className="text-[#061A21]" />
  <span>Upload Content</span>
  </button>
+ )}
  </div>
 
  {/* Unified Toolbar */}
@@ -1365,7 +1378,7 @@ export default function ContentClient() {
  />
 
  {/* Bulk Actions Toolbar */}
- {selectedItems.size > 0 && (
+ {selectedItems.size > 0 && canSelectContent && (
  <div className="eh-bulk-bar">
  <div className="flex items-center gap-4">
  <span className="text-sm font-medium">
@@ -1379,6 +1392,7 @@ export default function ContentClient() {
  </button>
  </div>
  <div className="flex items-center gap-2">
+ {permissions.canManageContent && (
  <button
  onClick={() => setIsMoveToFolderModalOpen(true)}
  disabled={actionLoading}
@@ -1387,6 +1401,8 @@ export default function ContentClient() {
  <Icon name="folder" size="md" />
  Move to Folder
  </button>
+ )}
+ {permissions.canDeleteContent && (
  <button
  onClick={handleBulkDelete}
  disabled={actionLoading}
@@ -1396,6 +1412,7 @@ export default function ContentClient() {
  <Icon name="delete" size="md" />
  Delete Selected
  </button>
+ )}
  </div>
  </div>
  )}
@@ -1436,21 +1453,30 @@ export default function ContentClient() {
  <div className="eh-dash-card p-12">
  <LoadingSpinner size="lg" />
  </div>
+ ) : contentLoadError ? (
+ <DashboardSectionError
+ section="Content Library"
+ error={contentLoadError}
+ reset={() => {
+ void loadContent();
+ }}
+ />
  ) : filteredContent.length === 0 ? (
  <EmptyState
  icon="folder"
  title={hasActiveFilters ? 'No matching content' : 'No content yet'}
  description={hasActiveFilters ? 'Try changing or clearing your filters' : 'Start by uploading your first media file'}
- action={{
+ action={permissions.canManageContent ? {
  label: 'Upload Content',
  onClick: () => setIsUploadModalOpen(true),
- }}
+ } : undefined}
  />
  ) : viewMode === 'list' ? (
  <div className="eh-dash-card overflow-hidden">
  <table className="min-w-full divide-y divide-[var(--border)]">
  <thead>
  <tr>
+ {canSelectContent && (
  <th className="eh-th">
  <input
  type="checkbox"
@@ -1460,6 +1486,7 @@ export default function ContentClient() {
  className="rounded border-[var(--border)] text-[var(--primary)] focus:ring-[var(--primary)]"
  />
  </th>
+ )}
  <th className="eh-th">Content</th>
  <th className="eh-th">Type</th>
  <th className="eh-th">Status</th>
@@ -1470,6 +1497,7 @@ export default function ContentClient() {
  <tbody className="divide-y divide-[var(--border)]">
  {filteredContent.map((item) => (
  <tr key={item.id} className="eh-tr-hover">
+ {canSelectContent && (
  <td className="eh-td">
  <input
  type="checkbox"
@@ -1480,6 +1508,7 @@ export default function ContentClient() {
  onClick={(e) => e.stopPropagation()}
  />
  </td>
+ )}
  <td className="eh-td">
  <div
  role="button"
@@ -1528,7 +1557,7 @@ export default function ContentClient() {
  </td>
  <td className="eh-td text-right text-sm font-medium">
  <div className="flex justify-end gap-2">
- {item.status === 'flagged' ? (
+ {item.status === 'flagged' && permissions.canReviewContent ? (
  <button
  onClick={() => handleReview(item)}
  disabled={isContentDetailLoading(item.id)}
@@ -1537,7 +1566,7 @@ export default function ContentClient() {
  >
  <Icon name="shield" size="md" />
  </button>
- ) : item.status !== 'archived' && item.status !== 'rejected' ? (
+ ) : item.status !== 'flagged' && item.status !== 'archived' && item.status !== 'rejected' ? (
  <button
  onClick={() => handleFlag(item)}
  className="eh-icon-btn"
@@ -1546,6 +1575,7 @@ export default function ContentClient() {
  <Icon name="warning" size="md" />
  </button>
  ) : null}
+ {permissions.canManageContent && (
  <button
  onClick={() => handlePushToDevice(item)}
  className="eh-icon-btn"
@@ -1553,6 +1583,8 @@ export default function ContentClient() {
  >
  <Icon name="push" size="md" />
  </button>
+ )}
+ {permissions.canManageContent && (
  <button
  onClick={() => handleAddToPlaylist(item)}
  className="eh-icon-btn"
@@ -1560,6 +1592,8 @@ export default function ContentClient() {
  >
  <Icon name="add" size="md" />
  </button>
+ )}
+ {permissions.canManageContent && (
  <button
  onClick={() => handleEdit(item)}
  disabled={isContentDetailLoading(item.id)}
@@ -1568,6 +1602,8 @@ export default function ContentClient() {
  >
  <Icon name="edit" size="md" />
  </button>
+ )}
+ {permissions.canDeleteContent && (
  <button
  onClick={() => handleDelete(item)}
  className="eh-icon-btn-danger"
@@ -1575,6 +1611,7 @@ export default function ContentClient() {
  >
  <Icon name="delete" size="md" />
  </button>
+ )}
  </div>
  </td>
  </tr>
@@ -1609,6 +1646,7 @@ export default function ContentClient() {
  />
  ) : null}
  <Icon name={getTypeIcon(item.type)} size="6xl" className={`text-white ${item.thumbnailUrl ? 'hidden' : ''}`} />
+ {canSelectContent && (
  <div className="absolute top-3 left-3">
  <input
  type="checkbox"
@@ -1618,6 +1656,7 @@ export default function ContentClient() {
  className="w-5 h-5 rounded border-[var(--border)] text-[var(--primary)] focus:ring-[var(--primary)] bg-[var(--surface)] shadow-sm"
  />
  </div>
+ )}
  <span
  className={`absolute top-3 right-3 px-3 py-1 text-xs rounded-full font-semibold ${getStatusColor(
  item.status
@@ -1640,7 +1679,7 @@ export default function ContentClient() {
  </div>
  )}
  <div className="grid grid-cols-2 gap-3">
- {item.status === 'flagged' ? (
+ {item.status === 'flagged' && permissions.canReviewContent ? (
  <button
  onClick={() => handleReview(item)}
  disabled={isContentDetailLoading(item.id)}
@@ -1649,7 +1688,7 @@ export default function ContentClient() {
  <Icon name="shield" size="sm" />
  Review
  </button>
- ) : item.status !== 'archived' && item.status !== 'rejected' ? (
+ ) : item.status !== 'flagged' && item.status !== 'archived' && item.status !== 'rejected' ? (
  <button
  onClick={() => handleFlag(item)}
  className="eh-icon-btn text-sm py-2 rounded-lg font-medium flex items-center justify-center gap-1"
@@ -1660,6 +1699,7 @@ export default function ContentClient() {
  ) : (
  <div />
  )}
+ {permissions.canManageContent && (
  <button
  onClick={() => handlePushToDevice(item)}
  className="eh-icon-btn text-sm py-2 rounded-lg font-medium flex items-center justify-center gap-1"
@@ -1667,6 +1707,8 @@ export default function ContentClient() {
  <Icon name="push" size="sm" />
  Push
  </button>
+ )}
+ {permissions.canManageContent && (
  <button
  onClick={() => handleAddToPlaylist(item)}
  className="eh-icon-btn text-sm py-2 rounded-lg font-medium flex items-center justify-center gap-1"
@@ -1674,6 +1716,8 @@ export default function ContentClient() {
  <Icon name="add" size="sm" />
  Playlist
  </button>
+ )}
+ {permissions.canManageContent && (
  <button
  onClick={() => handleEdit(item)}
  disabled={isContentDetailLoading(item.id)}
@@ -1682,6 +1726,8 @@ export default function ContentClient() {
  <Icon name="edit" size="sm" />
  Edit
  </button>
+ )}
+ {permissions.canDeleteContent && (
  <button
  onClick={() => handleDelete(item)}
  className="eh-icon-btn-danger text-sm py-2 rounded-lg font-medium flex items-center justify-center gap-1"
@@ -1689,6 +1735,7 @@ export default function ContentClient() {
  <Icon name="delete" size="sm" />
  Delete
  </button>
+ )}
  </div>
  </div>
  </div>
@@ -1698,7 +1745,7 @@ export default function ContentClient() {
 
  {/* Upload Modal */}
  <Modal
- isOpen={isUploadModalOpen}
+ isOpen={isUploadModalOpen && permissions.canManageContent}
  onClose={() => {
  if (actionLoading) return;
  if (uploadForm.url.startsWith('blob:')) {
@@ -1982,7 +2029,7 @@ export default function ContentClient() {
 
  {/* Edit Content Modal */}
  <Modal
- isOpen={isEditModalOpen}
+ isOpen={isEditModalOpen && permissions.canManageContent}
  onClose={() => {
  setIsEditModalOpen(false);
  setFormErrors({});
@@ -2053,7 +2100,7 @@ export default function ContentClient() {
 
  {/* Push to Device Modal */}
  <Modal
- isOpen={isPushModalOpen}
+ isOpen={isPushModalOpen && permissions.canManageContent}
  onClose={() => setIsPushModalOpen(false)}
  title="Push Content to Devices"
  >
@@ -2181,7 +2228,7 @@ export default function ContentClient() {
 
  {/* Add to Playlist Modal */}
  <Modal
- isOpen={isAddToPlaylistModalOpen}
+ isOpen={isAddToPlaylistModalOpen && permissions.canManageContent}
  onClose={() => setIsAddToPlaylistModalOpen(false)}
  title="Add to Playlist"
  >
@@ -2247,7 +2294,7 @@ export default function ContentClient() {
 
  {/* Delete Confirmation */}
  <ConfirmDialog
- isOpen={isDeleteModalOpen}
+ isOpen={isDeleteModalOpen && permissions.canDeleteContent}
  onClose={() => setIsDeleteModalOpen(false)}
  onConfirm={confirmDelete}
  title="Delete Content"
@@ -2257,7 +2304,7 @@ export default function ContentClient() {
  />
 
  <ConfirmDialog
- isOpen={isBulkDeleteModalOpen}
+ isOpen={isBulkDeleteModalOpen && permissions.canDeleteContent}
  onClose={() => {
  if (!actionLoading) setIsBulkDeleteModalOpen(false);
  }}
@@ -2270,7 +2317,7 @@ export default function ContentClient() {
 
  {/* Create Folder Modal */}
  <Modal
- isOpen={isCreateFolderModalOpen}
+ isOpen={isCreateFolderModalOpen && permissions.canManageContent}
  onClose={() => {
  setIsCreateFolderModalOpen(false);
  setNewFolderName('');
@@ -2383,7 +2430,7 @@ export default function ContentClient() {
 
  {/* Review Flagged Content Modal */}
  <Modal
- isOpen={isReviewModalOpen}
+ isOpen={isReviewModalOpen && permissions.canReviewContent}
  onClose={() => {
  setIsReviewModalOpen(false);
  setReviewReason('');
@@ -2455,7 +2502,7 @@ export default function ContentClient() {
 
  {/* Move to Folder Modal */}
  <Modal
- isOpen={isMoveToFolderModalOpen}
+ isOpen={isMoveToFolderModalOpen && permissions.canManageContent}
  onClose={() => {
  setIsMoveToFolderModalOpen(false);
  setTargetFolderId(null);

--- a/web/src/app/dashboard/devices/__tests__/devices-page.test.tsx
+++ b/web/src/app/dashboard/devices/__tests__/devices-page.test.tsx
@@ -12,6 +12,15 @@ const mockBulkDeleteDisplays = jest.fn();
 const mockBulkAssignPlaylist = jest.fn();
 const mockBulkAssignGroup = jest.fn();
 
+let mockUser: any = {
+  id: 'u1',
+  email: 'test@test.com',
+  firstName: 'Test',
+  lastName: 'User',
+  organizationId: 'org-1',
+  role: 'admin',
+};
+
 jest.mock('next/navigation', () => ({
   useRouter: () => ({
     push: mockPush,
@@ -45,10 +54,10 @@ jest.mock('@/lib/api', () => ({
 
 jest.mock('@/lib/hooks/useAuth', () => ({
   useAuth: () => ({
-    user: { id: 'u1', email: 'test@test.com', firstName: 'Test', lastName: 'User', organizationId: 'org-1', role: 'admin' },
+    user: mockUser,
     loading: false,
     error: null,
-    isAuthenticated: true,
+    isAuthenticated: !!mockUser,
     logout: jest.fn(),
     reload: jest.fn(),
   }),
@@ -158,11 +167,23 @@ jest.mock('@/components/DeviceGroupSelector', () => {
 });
 
 jest.mock('@/components/DevicePreviewModal', () => {
-  return function MockDevicePreview() { return null; };
+  return function MockDevicePreview({ isOpen, canRequestScreenshot }: any) {
+    return isOpen ? (
+      <div data-testid="device-preview-modal">
+        {canRequestScreenshot && <button>Refresh Screenshot</button>}
+      </div>
+    ) : null;
+  };
 });
 
 jest.mock('@/components/PlaylistQuickSelect', () => {
-  return function MockPlaylistSelect() { return null; };
+  return function MockPlaylistSelect({ device, disabled }: any) {
+    return (
+      <select data-testid={`playlist-select-${device.id}`} disabled={disabled}>
+        <option>No playlist</option>
+      </select>
+    );
+  };
 });
 
 jest.mock('@/components/fleet', () => ({
@@ -214,6 +235,14 @@ const samplePlaylists = [
 describe('DevicesClient', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUser = {
+      id: 'u1',
+      email: 'test@test.com',
+      firstName: 'Test',
+      lastName: 'User',
+      organizationId: 'org-1',
+      role: 'admin',
+    };
     mockGetDisplays.mockResolvedValue({ data: [], meta: { total: 0 } });
     mockGetPlaylists.mockResolvedValue({ data: [] });
     mockGetDisplayGroups.mockResolvedValue({ data: [] });
@@ -323,6 +352,64 @@ describe('DevicesClient', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
     }, { timeout: 3000 });
+    expect(screen.getByRole('alert')).toHaveTextContent('Devices Error');
+    expect(screen.getByRole('button', { name: 'Try Again' })).toBeInTheDocument();
+    expect(screen.queryByText('No devices yet')).not.toBeInTheDocument();
+  });
+
+  it('keeps viewers on read-only device actions', async () => {
+    mockUser = { ...mockUser, role: 'viewer' };
+
+    render(
+      <DevicesClient
+        initialDevices={sampleDevices as any}
+        initialPlaylists={samplePlaylists as any}
+        initialDevicesComplete
+        initialPlaylistsComplete
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Lobby Display')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId('fleet-dropdown')).not.toBeInTheDocument();
+    expect(screen.queryByText('Emergency Override')).not.toBeInTheDocument();
+    expect(screen.getByText('Pair New Device')).toBeInTheDocument();
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument();
+    expect(screen.queryByText('Pair')).not.toBeInTheDocument();
+    expect(screen.queryByText('Delete')).not.toBeInTheDocument();
+    expect(screen.getAllByText('Preview').length).toBeGreaterThan(0);
+    expect(screen.getAllByTestId(/playlist-select-/).every((select) => select.hasAttribute('disabled'))).toBe(true);
+
+    fireEvent.click(screen.getAllByText('Preview')[0]);
+
+    expect(screen.getByTestId('device-preview-modal')).toBeInTheDocument();
+    expect(screen.queryByText('Refresh Screenshot')).not.toBeInTheDocument();
+  });
+
+  it('allows managers to pair and assign devices without exposing admin-only deletes or emergency override', async () => {
+    mockUser = { ...mockUser, role: 'manager' };
+
+    render(
+      <DevicesClient
+        initialDevices={sampleDevices as any}
+        initialPlaylists={samplePlaylists as any}
+        initialDevicesComplete
+        initialPlaylistsComplete
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Lobby Display')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('fleet-dropdown')).toBeInTheDocument();
+    expect(screen.getByText('Pair New Device')).toBeInTheDocument();
+    expect(screen.getAllByText('Edit').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Pair').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Emergency Override')).not.toBeInTheDocument();
+    expect(screen.queryByText('Delete')).not.toBeInTheDocument();
   });
 
   it('renders device page header', async () => {

--- a/web/src/app/dashboard/devices/page-client.tsx
+++ b/web/src/app/dashboard/devices/page-client.tsx
@@ -14,12 +14,14 @@ import DeviceStatusIndicator from '@/components/DeviceStatusIndicator';
 import DeviceGroupSelector from '@/components/DeviceGroupSelector';
 import DevicePreviewModal from '@/components/DevicePreviewModal';
 import PlaylistQuickSelect from '@/components/PlaylistQuickSelect';
+import DashboardSectionError from '@/components/DashboardSectionError';
 import { useToast } from '@/lib/hooks/useToast';
 import { useDebounce } from '@/lib/hooks/useDebounce';
 import { useRealtimeEvents, useOptimisticState, useErrorRecovery } from '@/lib/hooks';
 import { Icon } from '@/theme/icons';
 import { FleetCommandDropdown, EmergencyOverrideModal, ActiveOverrideBanner } from '@/components/fleet';
 import { useAuth } from '@/lib/hooks/useAuth';
+import { getDashboardPermissions } from '@/lib/permissions';
 
 interface DevicesClientProps {
  initialDevices: Display[];
@@ -37,12 +39,15 @@ export default function DevicesClient({
  const router = useRouter();
  const toast = useToast();
  const { user } = useAuth();
+ const permissions = getDashboardPermissions(user);
+ const canSelectDevices = permissions.canManageDevices || permissions.canDeleteDevices;
  const [isOverrideModalOpen, setIsOverrideModalOpen] = useState(false);
  const [devices, setDevices] = useState<Display[]>(initialDevices);
  const [playlists, setPlaylists] = useState<PlaylistSummary[]>(initialPlaylists);
  const [deviceGroups, setDeviceGroups] = useState<any[]>([]);
  const [selectedGroups, setSelectedGroups] = useState<string[]>([]);
  const [loading, setLoading] = useState(!initialDevices.length && initialDevices.length === 0 ? false : false);
+ const [devicesLoadError, setDevicesLoadError] = useState<Error | null>(null);
  const [selectedDevice, setSelectedDevice] = useState<Display | null>(null);
  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
@@ -138,11 +143,13 @@ export default function DevicesClient({
  const loadDevices = async (showLoading = true) => {
  try {
  if (showLoading) setLoading(true);
+ setDevicesLoadError(null);
  await retry(
  'loadDevices',
  async () => {
  const devicesList = await fetchAllPaginated((params) => apiClient.getDisplays(params));
  setDevices(devicesList);
+ setDevicesLoadError(null);
  clearError('loadDevices');
  return devicesList;
  },
@@ -153,6 +160,8 @@ export default function DevicesClient({
  );
  } catch (error: any) {
  recordError('loadDevices', error, 'warning');
+ const message = error?.message || 'Failed to load devices';
+ setDevicesLoadError(error instanceof Error ? error : new Error(message));
  } finally {
  if (showLoading) setLoading(false);
  }
@@ -455,9 +464,10 @@ export default function DevicesClient({
  </p>
  </div>
  <div className="flex items-center gap-3">
- {user?.organizationId && (
+ {permissions.canUseFleetCommands && user?.organizationId && (
  <FleetCommandDropdown organizationId={user.organizationId} />
  )}
+ {permissions.canUseEmergencyOverride && (
  <button
  onClick={() => setIsOverrideModalOpen(true)}
  className="eh-btn-danger rounded-xl px-4 py-3 flex items-center gap-2 text-sm font-medium"
@@ -465,6 +475,7 @@ export default function DevicesClient({
  <Icon name="warning" size="lg" className="text-white" />
  <span>Emergency Override</span>
  </button>
+ )}
  <button
  onClick={() => router.push('/dashboard/devices/pair')}
  className="eh-btn-neon rounded-xl px-6 py-3 flex items-center gap-2"
@@ -475,7 +486,9 @@ export default function DevicesClient({
  </div>
  </div>
 
- <ActiveOverrideBanner />
+ {permissions.canUseFleetCommands && (
+ <ActiveOverrideBanner canClearOverride={permissions.canUseEmergencyOverride} />
+ )}
 
  <SearchFilter
  value={searchQuery}
@@ -499,7 +512,7 @@ export default function DevicesClient({
  groups={deviceGroups}
  selectedGroupIds={selectedGroups}
  onChange={setSelectedGroups}
- showCreate={true}
+ showCreate={permissions.canManageDevices}
  onCreateGroup={async (name, description) => {
  try {
  await apiClient.createDisplayGroup({ name, description });
@@ -518,6 +531,14 @@ export default function DevicesClient({
  <div className="eh-dash-card p-12">
  <LoadingSpinner size="lg" />
  </div>
+ ) : devicesLoadError ? (
+ <DashboardSectionError
+ section="Devices"
+ error={devicesLoadError}
+ reset={() => {
+ void loadDevices(true);
+ }}
+ />
  ) : devices.length === 0 ? (
  <EmptyState
  icon="devices"
@@ -538,15 +559,15 @@ export default function DevicesClient({
  </p>
  </div>
  )}
- {selectedDeviceIds.size > 0 && (
+ {selectedDeviceIds.size > 0 && canSelectDevices && (
  <div className="eh-bulk-bar flex items-center justify-between">
  <span className="text-sm font-medium text-[#00E5A0] dark:text-[#00E5A0]">
  {selectedDeviceIds.size} device{selectedDeviceIds.size !== 1 ? 's' : ''} selected
  </span>
  <div className="flex gap-4 items-center">
- <button onClick={() => setIsBulkPlaylistModalOpen(true)} className="eh-btn-neon rounded-xl px-4 py-2 text-sm font-medium">Assign Playlist</button>
- <button onClick={() => setIsBulkGroupModalOpen(true)} className="px-4 py-2 text-sm bg-green-600 text-white rounded-lg hover:bg-green-700 transition font-medium">Add to Group</button>
- <button onClick={() => setIsBulkDeleteModalOpen(true)} disabled={actionLoading} className="px-4 py-2 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 transition font-medium disabled:opacity-50">Delete Selected</button>
+ {permissions.canManageDevices && <button onClick={() => setIsBulkPlaylistModalOpen(true)} className="eh-btn-neon rounded-xl px-4 py-2 text-sm font-medium">Assign Playlist</button>}
+ {permissions.canManageDevices && <button onClick={() => setIsBulkGroupModalOpen(true)} className="px-4 py-2 text-sm bg-green-600 text-white rounded-lg hover:bg-green-700 transition font-medium">Add to Group</button>}
+ {permissions.canDeleteDevices && <button onClick={() => setIsBulkDeleteModalOpen(true)} disabled={actionLoading} className="px-4 py-2 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 transition font-medium disabled:opacity-50">Delete Selected</button>}
  <button onClick={() => setSelectedDeviceIds(new Set())} className="px-4 py-2 text-sm text-[var(--foreground-secondary)] hover:text-[var(--foreground)] transition">Clear</button>
  </div>
  </div>
@@ -555,9 +576,11 @@ export default function DevicesClient({
  <table className="min-w-full divide-y divide-[var(--border)]">
  <thead className="bg-[var(--background)]">
  <tr>
+ {canSelectDevices && (
  <th className="px-4 py-3 text-left">
  <input type="checkbox" checked={selectedDeviceIds.size === displayDevices.length && displayDevices.length > 0} onChange={toggleSelectAll} className="rounded border-[var(--border)] text-[#00E5A0] focus:ring-[#00E5A0]" />
  </th>
+ )}
  <th className="eh-th cursor-pointer hover:bg-[var(--surface-hover)] select-none" onClick={() => handleSort('nickname')}>Device{getSortIcon('nickname')}</th>
  <th className="eh-th cursor-pointer hover:bg-[var(--surface-hover)] select-none" onClick={() => handleSort('status')}>Status{getSortIcon('status')}</th>
  <th className="eh-th cursor-pointer hover:bg-[var(--surface-hover)] select-none" onClick={() => handleSort('location')}>Location{getSortIcon('location')}</th>
@@ -569,7 +592,7 @@ export default function DevicesClient({
  <tbody className="bg-[var(--surface)] divide-y divide-[var(--border)]">
  {displayDevices.map((device) => (
  <tr key={device.id} className="eh-tr-hover">
- <td className="eh-td"><input type="checkbox" checked={selectedDeviceIds.has(device.id)} onChange={() => toggleDeviceSelection(device.id)} className="rounded border-[var(--border)] text-[#00E5A0] focus:ring-[#00E5A0]" /></td>
+ {canSelectDevices && <td className="eh-td"><input type="checkbox" checked={selectedDeviceIds.has(device.id)} onChange={() => toggleDeviceSelection(device.id)} className="rounded border-[var(--border)] text-[#00E5A0] focus:ring-[#00E5A0]" /></td>}
  <td className="eh-td">
  <div className="flex items-center">
  <Icon name="devices" size="xl" className="mr-3 text-[var(--foreground-secondary)]" />
@@ -582,15 +605,28 @@ export default function DevicesClient({
  <td className="eh-td"><DeviceStatusIndicator deviceId={device.id} showLabel showTime /></td>
  <td className="eh-td text-sm text-[var(--foreground-secondary)]">{device.location || '\u2014'}</td>
  <td className="eh-td text-sm">
- <PlaylistQuickSelect device={device} playlists={playlists} onSuccess={() => toast.success('Playlist updated')} onError={(err) => toast.error(err.message || 'Failed to update playlist')} onUpdate={() => { loadDevices(); }} />
+ <PlaylistQuickSelect
+ device={device}
+ playlists={playlists}
+ disabled={!permissions.canManageDevices}
+ onSuccess={() => toast.success('Playlist updated')}
+ onError={(err) => toast.error(err.message || 'Failed to update playlist')}
+ onUpdate={() => { loadDevices(); }}
+ />
  </td>
  <td className="eh-td text-sm text-[var(--foreground-tertiary)]">{(device.lastSeen || device.lastHeartbeat) ? new Date(String(device.lastSeen || device.lastHeartbeat)).toLocaleString() : 'Never'}</td>
  <td className="eh-td text-right text-sm font-medium">
  <div className="flex justify-end gap-2">
  <button onClick={() => handlePreview(device)} className="eh-icon-btn" title="Preview device screen">Preview</button>
+ {permissions.canManageDevices && (
  <button onClick={() => handleEdit(device)} className="eh-icon-btn">Edit</button>
+ )}
+ {permissions.canManageDevices && (
  <button onClick={() => handleGeneratePairingCode(device)} className="eh-icon-btn">Pair</button>
+ )}
+ {permissions.canDeleteDevices && (
  <button onClick={() => handleDelete(device)} className="eh-icon-btn eh-icon-btn-danger">Delete</button>
+ )}
  </div>
  </td>
  </tr>
@@ -637,7 +673,7 @@ export default function DevicesClient({
  </>
  )}
 
- <Modal isOpen={isEditModalOpen} onClose={() => setIsEditModalOpen(false)} title="Edit Device">
+ <Modal isOpen={isEditModalOpen && permissions.canManageDevices} onClose={() => setIsEditModalOpen(false)} title="Edit Device">
  <div className="space-y-5">
  <div>
  <label className="block text-sm font-medium text-[var(--foreground-secondary)] mb-2">Device Nickname</label>
@@ -654,7 +690,7 @@ export default function DevicesClient({
  </div>
  </Modal>
 
- <Modal isOpen={isPairingModalOpen} onClose={() => setIsPairingModalOpen(false)} title="Pairing Token">
+ <Modal isOpen={isPairingModalOpen && permissions.canManageDevices} onClose={() => setIsPairingModalOpen(false)} title="Pairing Token">
  <div className="text-center space-y-5">
  <p className="text-[var(--foreground-secondary)]">Use this token on your display device to pair it:</p>
  <div className="bg-[var(--background-secondary)] rounded-lg p-6">
@@ -665,10 +701,10 @@ export default function DevicesClient({
  </div>
  </Modal>
 
- <ConfirmDialog isOpen={isDeleteModalOpen} onClose={() => setIsDeleteModalOpen(false)} onConfirm={confirmDelete} title="Delete Device" message={`Are you sure you want to delete "${selectedDevice?.nickname}"? This action cannot be undone.`} confirmText="Delete" type="danger" />
+ <ConfirmDialog isOpen={isDeleteModalOpen && permissions.canDeleteDevices} onClose={() => setIsDeleteModalOpen(false)} onConfirm={confirmDelete} title="Delete Device" message={`Are you sure you want to delete "${selectedDevice?.nickname}"? This action cannot be undone.`} confirmText="Delete" type="danger" />
 
  <ConfirmDialog
- isOpen={isBulkDeleteModalOpen}
+ isOpen={isBulkDeleteModalOpen && permissions.canDeleteDevices}
  onClose={() => setIsBulkDeleteModalOpen(false)}
  onConfirm={handleBulkDelete}
  title="Delete Selected Devices"
@@ -677,7 +713,7 @@ export default function DevicesClient({
  type="danger"
  />
 
- <Modal isOpen={isBulkPlaylistModalOpen} onClose={() => { setIsBulkPlaylistModalOpen(false); setBulkPlaylistId(''); }} title="Assign Playlist to Selected Devices">
+ <Modal isOpen={isBulkPlaylistModalOpen && permissions.canManageDevices} onClose={() => { setIsBulkPlaylistModalOpen(false); setBulkPlaylistId(''); }} title="Assign Playlist to Selected Devices">
  <div className="space-y-5">
  <p className="text-sm text-[var(--foreground-secondary)]">Assign a playlist to {selectedDeviceIds.size} selected device{selectedDeviceIds.size !== 1 ? 's' : ''}.</p>
  <select value={bulkPlaylistId} onChange={(e) => setBulkPlaylistId(e.target.value)} className="w-full px-4 py-2 border border-[var(--border)] rounded-lg bg-[var(--surface)] text-[var(--foreground)]">
@@ -691,7 +727,7 @@ export default function DevicesClient({
  </div>
  </Modal>
 
- <Modal isOpen={isBulkGroupModalOpen} onClose={() => { setIsBulkGroupModalOpen(false); setBulkGroupId(''); }} title="Add Selected Devices to Group">
+ <Modal isOpen={isBulkGroupModalOpen && permissions.canManageDevices} onClose={() => { setIsBulkGroupModalOpen(false); setBulkGroupId(''); }} title="Add Selected Devices to Group">
  <div className="space-y-5">
  <p className="text-sm text-[var(--foreground-secondary)]">Add {selectedDeviceIds.size} selected device{selectedDeviceIds.size !== 1 ? 's' : ''} to a group.</p>
  <select value={bulkGroupId} onChange={(e) => setBulkGroupId(e.target.value)} className="w-full px-4 py-2 border border-[var(--border)] rounded-lg bg-[var(--surface)] text-[var(--foreground)]">
@@ -706,12 +742,17 @@ export default function DevicesClient({
  </Modal>
 
  {selectedDevice && (
- <DevicePreviewModal device={selectedDevice} isOpen={isPreviewModalOpen} onClose={() => setIsPreviewModalOpen(false)} />
+ <DevicePreviewModal
+ device={selectedDevice}
+ isOpen={isPreviewModalOpen}
+ onClose={() => setIsPreviewModalOpen(false)}
+ canRequestScreenshot={permissions.canManageDevices}
+ />
  )}
 
- {user?.organizationId && (
+ {permissions.canUseEmergencyOverride && user?.organizationId && (
  <EmergencyOverrideModal
- isOpen={isOverrideModalOpen}
+ isOpen={isOverrideModalOpen && permissions.canUseEmergencyOverride}
  onClose={() => setIsOverrideModalOpen(false)}
  organizationId={user.organizationId}
  />

--- a/web/src/app/dashboard/playlists/[id]/page.tsx
+++ b/web/src/app/dashboard/playlists/[id]/page.tsx
@@ -6,7 +6,9 @@ import { apiClient } from '@/lib/api';
 import { Playlist, PlaylistItem, Content } from '@/lib/types';
 import { Icon } from '@/theme/icons';
 import { useToast } from '@/lib/hooks/useToast';
+import { useAuth } from '@/lib/hooks/useAuth';
 import { usePlaylistHistory } from '@/lib/hooks/usePlaylistHistory';
+import { getDashboardPermissions } from '@/lib/permissions';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import ContentLibraryPanel from '@/components/playlist/ContentLibraryPanel';
 import PlaylistEditorPanel from '@/components/playlist/PlaylistEditorPanel';
@@ -33,6 +35,10 @@ export default function PlaylistBuilderPage() {
  const params = useParams();
  const playlistId = params.id as string;
  const toast = useToast();
+ const { user } = useAuth();
+ const permissions = getDashboardPermissions(user);
+ const canManagePlaylist = permissions.canManagePlaylists;
+ const canRemovePlaylistItems = permissions.canRemovePlaylistItems;
 
  const [playlist, setPlaylist] = useState<Playlist | null>(null);
  const [loading, setLoading] = useState(true);
@@ -71,19 +77,19 @@ export default function PlaylistBuilderPage() {
 
  // Wrapped undo handler that shows toast feedback
  const handleUndo = useCallback(() => {
- if (canUndo) {
+ if (canManagePlaylist && canUndo) {
  undo();
  toast.info('Undo');
  }
- }, [canUndo, undo, toast]);
+ }, [canManagePlaylist, canUndo, undo, toast]);
 
  // Wrapped redo handler that shows toast feedback
  const handleRedo = useCallback(() => {
- if (canRedo) {
+ if (canManagePlaylist && canRedo) {
  redo();
  toast.info('Redo');
  }
- }, [canRedo, redo, toast]);
+ }, [canManagePlaylist, canRedo, redo, toast]);
 
  // Keyboard shortcuts for undo/redo
  useEffect(() => {
@@ -93,7 +99,7 @@ export default function PlaylistBuilderPage() {
  return;
  }
 
- if ((e.metaKey || e.ctrlKey) && e.key === 'z') {
+ if (canManagePlaylist && (e.metaKey || e.ctrlKey) && e.key === 'z') {
  if (e.shiftKey) {
  handleRedo();
  } else {
@@ -105,7 +111,7 @@ export default function PlaylistBuilderPage() {
 
  window.addEventListener('keydown', handleKeyDown);
  return () => window.removeEventListener('keydown', handleKeyDown);
- }, [handleUndo, handleRedo]);
+ }, [canManagePlaylist, handleUndo, handleRedo]);
 
  const loadPlaylist = async (resetUndoHistory = true) => {
  try {
@@ -125,6 +131,7 @@ export default function PlaylistBuilderPage() {
  };
 
  const handleDragStart = (event: DragStartEvent) => {
+ if (!canManagePlaylist) return;
  const { active } = event;
  if (active.data.current?.content) {
  setActiveContent(active.data.current.content);
@@ -135,6 +142,7 @@ export default function PlaylistBuilderPage() {
  const { active, over } = event;
  setActiveContent(null);
 
+ if (!canManagePlaylist) return;
  if (!over || !playlist) return;
 
  // Check if dragging from content library to playlist
@@ -188,6 +196,7 @@ export default function PlaylistBuilderPage() {
  };
 
  const handleRemoveItem = async (itemId: string) => {
+ if (!canRemovePlaylistItems) return;
  if (!playlist) return;
 
  // Optimistically update UI
@@ -207,6 +216,7 @@ export default function PlaylistBuilderPage() {
  };
 
  const handleUpdateDuration = async (itemId: string, duration: number) => {
+ if (!canManagePlaylist) return;
  if (!playlist) return;
 
  // Optimistically update UI
@@ -228,6 +238,7 @@ export default function PlaylistBuilderPage() {
  };
 
  const handleReorder = async (itemIds: string[]) => {
+ if (!canManagePlaylist) return;
  if (!playlist) return;
 
  // Create reordered items array based on new order
@@ -252,6 +263,7 @@ export default function PlaylistBuilderPage() {
  };
 
  const handleSave = async () => {
+ if (!canManagePlaylist) return;
  if (!playlist) return;
 
  try {
@@ -302,6 +314,7 @@ export default function PlaylistBuilderPage() {
  {playlist.description && (
  <p className="text-sm text-[var(--foreground-secondary)]">{playlist.description}</p>
  )}
+ {canManagePlaylist && (
  <label className="flex items-center gap-2 cursor-pointer select-none">
  <button
    role="switch"
@@ -329,11 +342,13 @@ export default function PlaylistBuilderPage() {
  </button>
  <span className="text-xs text-[var(--foreground-tertiary)]">Loop</span>
  </label>
+ )}
  </div>
  </div>
  </div>
  <div className="flex items-center gap-3">
  {/* Undo/Redo buttons */}
+ {canManagePlaylist && (
  <div className="flex items-center gap-1 mr-2">
  <button
  onClick={handleUndo}
@@ -352,6 +367,8 @@ export default function PlaylistBuilderPage() {
  <Icon name="redo" size="md" className="text-[var(--foreground-secondary)]" />
  </button>
  </div>
+ )}
+ {canManagePlaylist && (
  <button
  onClick={handleSave}
  disabled={saving}
@@ -361,6 +378,7 @@ export default function PlaylistBuilderPage() {
  <Icon name="check" size="sm" className="text-white" />
  Save
  </button>
+ )}
  </div>
  </div>
 
@@ -374,7 +392,7 @@ export default function PlaylistBuilderPage() {
  >
  {/* Left Panel - Content Library */}
  <div className="w-80 flex-shrink-0">
- <ContentLibraryPanel organizationId={playlist.id} />
+ <ContentLibraryPanel organizationId={playlist.id} canDragContent={canManagePlaylist} />
  </div>
 
  {/* Center Panel - Playlist Editor */}
@@ -384,6 +402,9 @@ export default function PlaylistBuilderPage() {
  onRemoveItem={handleRemoveItem}
  onUpdateDuration={handleUpdateDuration}
  onReorder={handleReorder}
+ canReorder={canManagePlaylist}
+ canUpdateDuration={canManagePlaylist}
+ canRemoveItems={canRemovePlaylistItems}
  />
  </div>
 

--- a/web/src/app/dashboard/playlists/__tests__/playlists-page.test.tsx
+++ b/web/src/app/dashboard/playlists/__tests__/playlists-page.test.tsx
@@ -4,6 +4,15 @@ import '@testing-library/jest-dom';
 
 const mockPush = jest.fn();
 
+let mockUser: any = {
+  id: 'u1',
+  email: 'admin@test.com',
+  firstName: 'Admin',
+  lastName: 'User',
+  organizationId: 'org-1',
+  role: 'admin',
+};
+
 jest.mock('next/navigation', () => ({
   useRouter: () => ({
     push: mockPush,
@@ -35,6 +44,17 @@ const mockToast = {
 };
 jest.mock('@/lib/hooks/useToast', () => ({
   useToast: () => mockToast,
+}));
+
+jest.mock('@/lib/hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: mockUser,
+    loading: false,
+    error: null,
+    isAuthenticated: !!mockUser,
+    logout: jest.fn(),
+    reload: jest.fn(),
+  }),
 }));
 
 jest.mock('@/lib/hooks/useDebounce', () => ({
@@ -183,6 +203,14 @@ const mockDevices = [
 describe('PlaylistsClient', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUser = {
+      id: 'u1',
+      email: 'admin@test.com',
+      firstName: 'Admin',
+      lastName: 'User',
+      organizationId: 'org-1',
+      role: 'admin',
+    };
     (apiClient.getPlaylists as jest.Mock).mockResolvedValue({ data: mockPlaylists });
     (apiClient.getContent as jest.Mock).mockResolvedValue({ data: [] });
     (apiClient.getDisplays as jest.Mock).mockResolvedValue({ data: [] });
@@ -441,6 +469,39 @@ describe('PlaylistsClient', () => {
     });
   });
 
+  it('keeps viewers on read-only playlist actions', async () => {
+    mockUser = { ...mockUser, role: 'viewer' };
+
+    render(<PlaylistsClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Morning Promo')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Create Playlist')).not.toBeInTheDocument();
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument();
+    expect(screen.queryByText('Assign')).not.toBeInTheDocument();
+    expect(screen.queryByText('Duplicate')).not.toBeInTheDocument();
+    expect(screen.queryAllByText('Delete')).toHaveLength(0);
+    expect(screen.getAllByText('Preview').length).toBeGreaterThan(0);
+  });
+
+  it('allows managers to manage playlists without exposing admin-only deletes', async () => {
+    mockUser = { ...mockUser, role: 'manager' };
+
+    render(<PlaylistsClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Morning Promo')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Create Playlist')).toBeInTheDocument();
+    expect(screen.getAllByText('Edit').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Assign').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Duplicate').length).toBeGreaterThan(0);
+    expect(screen.queryAllByText('Delete')).toHaveLength(0);
+  });
+
   it('opens create modal when Create Playlist is clicked', async () => {
     render(<PlaylistsClient />);
 
@@ -477,6 +538,9 @@ describe('PlaylistsClient', () => {
     await waitFor(() => {
       expect(mockToast.error).toHaveBeenCalledWith('Network error');
     });
+    expect(screen.getByRole('alert')).toHaveTextContent('Playlists Error');
+    expect(screen.getByRole('button', { name: 'Try Again' })).toBeInTheDocument();
+    expect(screen.queryByText('No playlists yet')).not.toBeInTheDocument();
   });
 
   it('opens delete confirmation when Delete is clicked', async () => {

--- a/web/src/app/dashboard/playlists/page-client.tsx
+++ b/web/src/app/dashboard/playlists/page-client.tsx
@@ -10,9 +10,12 @@ import ConfirmDialog from '@/components/ConfirmDialog';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import EmptyState from '@/components/EmptyState';
 import SearchFilter from '@/components/SearchFilter';
+import DashboardSectionError from '@/components/DashboardSectionError';
 import { useToast } from '@/lib/hooks/useToast';
 import { useDebounce } from '@/lib/hooks/useDebounce';
+import { useAuth } from '@/lib/hooks/useAuth';
 import { useRealtimeEvents } from '@/lib/hooks';
+import { getDashboardPermissions } from '@/lib/permissions';
 import {
  DndContext,
  closestCenter,
@@ -34,11 +37,12 @@ import { Icon } from '@/theme/icons';
 import PlaylistPreview from '@/components/PlaylistPreview';
 
 // Sortable playlist item component
-function SortablePlaylistItem({ item, idx, onRemove, onDurationChange }: {
+function SortablePlaylistItem({ item, idx, onRemove, onDurationChange, canRemove }: {
  item: any;
  idx: number;
  onRemove: () => void;
  onDurationChange: (newDuration: number) => void;
+ canRemove: boolean;
 }) {
  const {
  attributes,
@@ -94,12 +98,14 @@ function SortablePlaylistItem({ item, idx, onRemove, onDurationChange }: {
  </div>
  </div>
  </div>
+ {canRemove && (
  <button
  onClick={onRemove}
  className="text-red-600 hover:text-red-800 text-sm"
  >
  <Icon name="delete" size="md" className="text-red-600 dark:text-red-400" />
  </button>
+ )}
  </div>
  );
 }
@@ -107,12 +113,15 @@ function SortablePlaylistItem({ item, idx, onRemove, onDurationChange }: {
 export default function PlaylistsClient() {
  const router = useRouter();
  const toast = useToast();
+ const { user } = useAuth();
+ const permissions = getDashboardPermissions(user);
  const [playlists, setPlaylists] = useState<PlaylistSummary[]>([]);
  const [content, setContent] = useState<Content[]>([]);
  const [devices, setDevices] = useState<Display[]>([]);
  const [devicesLoading, setDevicesLoading] = useState(true);
  const [devicesLoadFailed, setDevicesLoadFailed] = useState(false);
  const [loading, setLoading] = useState(true);
+ const [playlistsLoadError, setPlaylistsLoadError] = useState<Error | null>(null);
  const [selectedPlaylist, setSelectedPlaylist] = useState<PlaylistSummary | null>(null);
  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
@@ -201,10 +210,14 @@ export default function PlaylistsClient() {
  const loadPlaylists = async () => {
  try {
  setLoading(true);
+ setPlaylistsLoadError(null);
  const playlistList = await fetchAllPaginated((params) => apiClient.getPlaylists(params));
  setPlaylists(playlistList);
+ setPlaylistsLoadError(null);
  } catch (error: any) {
- toast.error(error.message || 'Failed to load playlists');
+ const message = error.message || 'Failed to load playlists';
+ setPlaylistsLoadError(error instanceof Error ? error : new Error(message));
+ toast.error(message);
  } finally {
  setLoading(false);
  }
@@ -433,6 +446,7 @@ export default function PlaylistsClient() {
  Create and manage content playlists ({playlists.length} total)
  </p>
  </div>
+ {permissions.canManagePlaylists && (
  <button
  onClick={() => setIsCreateModalOpen(true)}
  className="eh-btn-neon rounded-xl px-6 py-3 transition font-semibold shadow-md hover:shadow-lg flex items-center gap-2"
@@ -440,6 +454,7 @@ export default function PlaylistsClient() {
  <span className="text-xl">+</span>
  <span>Create Playlist</span>
  </button>
+ )}
  </div>
 
  {/* Search Filter */}
@@ -454,15 +469,23 @@ export default function PlaylistsClient() {
  <div className="bg-[var(--surface)] rounded-lg shadow p-12">
  <LoadingSpinner size="lg" />
  </div>
+ ) : playlistsLoadError ? (
+ <DashboardSectionError
+ section="Playlists"
+ error={playlistsLoadError}
+ reset={() => {
+ void loadPlaylists();
+ }}
+ />
  ) : playlists.length === 0 ? (
  <EmptyState
  icon="playlists"
  title="No playlists yet"
  description="Create your first playlist to organize content"
- action={{
+ action={permissions.canManagePlaylists ? {
  label: 'Create Playlist',
  onClick: () => setIsCreateModalOpen(true),
- }}
+ } : undefined}
  />
  ) : (
  <>
@@ -584,6 +607,7 @@ export default function PlaylistsClient() {
  <Icon name="preview" size="sm" className="text-[var(--foreground-secondary)]" />
  Preview
  </button>
+ {permissions.canManagePlaylists && (
  <button
  onClick={() => handleEdit(playlist)}
  className="flex-1 px-4 py-2 text-sm bg-[#00E5A0]/5 text-[#00E5A0] rounded-lg hover:bg-[#00E5A0]/10 transition font-medium flex items-center justify-center gap-1"
@@ -591,6 +615,8 @@ export default function PlaylistsClient() {
  <Icon name="edit" size="sm" className="text-[#00E5A0]" />
  Edit
  </button>
+ )}
+ {permissions.canManagePlaylists && (
  <button
  onClick={() => handlePublish(playlist)}
  className="flex-1 px-4 py-2 text-sm bg-green-500/10 text-green-600 dark:text-green-400 rounded-lg hover:bg-green-500/20 transition font-medium flex items-center justify-center gap-1"
@@ -598,6 +624,8 @@ export default function PlaylistsClient() {
  <Icon name="power" size="sm" className="text-green-600 dark:text-green-400" />
  Assign
  </button>
+ )}
+ {permissions.canManagePlaylists && (
  <button
  onClick={async () => {
  try {
@@ -613,6 +641,8 @@ export default function PlaylistsClient() {
  <Icon name="playlists" size="sm" className="text-purple-600 dark:text-purple-400" />
  Duplicate
  </button>
+ )}
+ {permissions.canDeletePlaylists && (
  <button
  onClick={() => handleDelete(playlist)}
  className="flex-1 px-4 py-2 text-sm bg-red-500/10 text-red-600 dark:text-red-400 rounded-lg hover:bg-red-500/20 transition font-medium flex items-center justify-center gap-1"
@@ -620,6 +650,7 @@ export default function PlaylistsClient() {
  <Icon name="delete" size="sm" className="text-red-600 dark:text-red-400" />
  Delete
  </button>
+ )}
  </div>
  </div>
  ))}
@@ -629,7 +660,7 @@ export default function PlaylistsClient() {
 
  {/* Create Modal */}
  <Modal
- isOpen={isCreateModalOpen}
+ isOpen={isCreateModalOpen && permissions.canManagePlaylists}
  onClose={() => setIsCreateModalOpen(false)}
  title="Create New Playlist"
  >
@@ -679,7 +710,7 @@ export default function PlaylistsClient() {
 
  {/* Playlist Builder Modal */}
  <Modal
- isOpen={isBuilderModalOpen}
+ isOpen={isBuilderModalOpen && permissions.canManagePlaylists}
  onClose={() => setIsBuilderModalOpen(false)}
  title={`Edit: ${selectedPlaylist?.name}`}
  size="xl"
@@ -758,6 +789,7 @@ export default function PlaylistsClient() {
  key={item.id}
  item={item}
  idx={idx}
+ canRemove={permissions.canRemovePlaylistItems}
  onRemove={async () => {
  try {
  await apiClient.removePlaylistItem(selectedPlaylist.id, item.id);
@@ -807,7 +839,7 @@ export default function PlaylistsClient() {
 
  {/* Assign Modal */}
  <Modal
- isOpen={!!publishPlaylist}
+ isOpen={!!publishPlaylist && permissions.canManagePlaylists}
  onClose={requestClosePublishModal}
  title={`Assign ${publishPlaylist?.name || 'Playlist'} to Devices`}
  size="lg"
@@ -934,7 +966,7 @@ export default function PlaylistsClient() {
 
  {/* Delete Confirmation */}
  <ConfirmDialog
- isOpen={isDeleteModalOpen}
+ isOpen={isDeleteModalOpen && permissions.canDeletePlaylists}
  onClose={() => setIsDeleteModalOpen(false)}
  onConfirm={confirmDelete}
  title="Delete Playlist"

--- a/web/src/components/DevicePreviewModal.tsx
+++ b/web/src/components/DevicePreviewModal.tsx
@@ -13,9 +13,15 @@ interface DevicePreviewModalProps {
   device: Display;
   isOpen: boolean;
   onClose: () => void;
+  canRequestScreenshot?: boolean;
 }
 
-export default function DevicePreviewModal({ device, isOpen, onClose }: DevicePreviewModalProps) {
+export default function DevicePreviewModal({
+  device,
+  isOpen,
+  onClose,
+  canRequestScreenshot = true,
+}: DevicePreviewModalProps) {
   const toast = useToast();
   const [screenshot, setScreenshot] = useState<ScreenshotResponse | null>(null);
   const [loading, setLoading] = useState(false);
@@ -140,6 +146,10 @@ export default function DevicePreviewModal({ device, isOpen, onClose }: DevicePr
   };
 
   const handleRefresh = async () => {
+    if (!canRequestScreenshot) {
+      return;
+    }
+
     if (device.status !== 'online') {
       toast.error('Device must be online to capture a screenshot');
       return;
@@ -234,23 +244,25 @@ export default function DevicePreviewModal({ device, isOpen, onClose }: DevicePr
               </div>
             </div>
           </div>
-          <button
-            onClick={handleRefresh}
-            disabled={refreshing || device.status !== 'online'}
-            className="flex items-center gap-2 px-4 py-2 bg-[#00E5A0] text-[#061A21] rounded-lg hover:bg-[#00CC8E] disabled:opacity-50 disabled:cursor-not-allowed transition font-medium"
-          >
-            {refreshing ? (
-              <>
-                <LoadingSpinner size="sm" />
-                <span>Capturing...</span>
-              </>
-            ) : (
-              <>
-                <Icon name="refresh" size="lg" className="text-[#061A21]" />
-                <span>Refresh Screenshot</span>
-              </>
-            )}
-          </button>
+          {canRequestScreenshot && (
+            <button
+              onClick={handleRefresh}
+              disabled={refreshing || device.status !== 'online'}
+              className="flex items-center gap-2 px-4 py-2 bg-[#00E5A0] text-[#061A21] rounded-lg hover:bg-[#00CC8E] disabled:opacity-50 disabled:cursor-not-allowed transition font-medium"
+            >
+              {refreshing ? (
+                <>
+                  <LoadingSpinner size="sm" />
+                  <span>Capturing...</span>
+                </>
+              ) : (
+                <>
+                  <Icon name="refresh" size="lg" className="text-[#061A21]" />
+                  <span>Refresh Screenshot</span>
+                </>
+              )}
+            </button>
+          )}
         </div>
 
         {/* Screenshot Display Area */}
@@ -298,19 +310,21 @@ export default function DevicePreviewModal({ device, isOpen, onClose }: DevicePr
               <p className="text-[var(--foreground-secondary)] mb-2">
                 No screenshot available yet
               </p>
-              <button
-                onClick={handleRefresh}
-                disabled={device.status !== 'online'}
-                className="text-[#00E5A0] hover:text-[#00CC8E] text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {device.status === 'online' ? 'Capture Screenshot' : 'Device is offline'}
-              </button>
+              {canRequestScreenshot && (
+                <button
+                  onClick={handleRefresh}
+                  disabled={device.status !== 'online'}
+                  className="text-[#00E5A0] hover:text-[#00CC8E] text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {device.status === 'online' ? 'Capture Screenshot' : 'Device is offline'}
+                </button>
+              )}
             </div>
           )}
         </div>
 
         {/* Info Message */}
-        {device.status !== 'online' && (
+        {canRequestScreenshot && device.status !== 'online' && (
           <div className="bg-warning-50 dark:bg-warning-900 border border-warning-200 dark:border-warning-700 rounded-lg p-3">
             <p className="text-sm text-warning-800 dark:text-warning-200 flex items-center gap-2">
               <Icon name="warning" size="lg" className="text-warning-600 dark:text-warning-400" />

--- a/web/src/components/PlaylistQuickSelect.tsx
+++ b/web/src/components/PlaylistQuickSelect.tsx
@@ -11,6 +11,7 @@ interface PlaylistQuickSelectProps {
   onUpdate?: () => void;
   onError?: (error: Error) => void;
   onSuccess?: () => void;
+  disabled?: boolean;
 }
 
 export default function PlaylistQuickSelect({
@@ -19,10 +20,12 @@ export default function PlaylistQuickSelect({
   onUpdate,
   onError,
   onSuccess,
+  disabled = false,
 }: PlaylistQuickSelectProps) {
   const [loading, setLoading] = useState(false);
 
   const handleChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
+    if (disabled) return;
     const playlistId = e.target.value || null;
     setLoading(true);
     try {
@@ -43,12 +46,13 @@ export default function PlaylistQuickSelect({
       <select
         value={device.currentPlaylistId || ''}
         onChange={handleChange}
-        disabled={loading}
+        disabled={loading || disabled}
         className={`text-sm border border-[var(--border)] rounded-lg px-2 py-1.5 bg-[var(--surface)] text-[var(--foreground)] focus:ring-2 focus:ring-[#00E5A0] focus:border-transparent min-w-[140px] ${
-          loading ? 'opacity-50 cursor-wait' : ''
+          loading ? 'opacity-50 cursor-wait' : disabled ? 'opacity-70 cursor-not-allowed' : ''
         }`}
         data-testid={`playlist-select-${device.id}`}
         aria-label={`Select playlist for ${device.nickname}`}
+        title={disabled ? 'Playlist assignment requires manager or admin access' : undefined}
       >
         <option value="">No playlist</option>
         {playlists.map((p) => (

--- a/web/src/components/__tests__/DevicePreviewModal.test.tsx
+++ b/web/src/components/__tests__/DevicePreviewModal.test.tsx
@@ -197,6 +197,25 @@ describe('DevicePreviewModal', () => {
     expect(mockToast.info).toHaveBeenCalledWith('Screenshot request sent to device...');
   });
 
+  it('hides screenshot capture controls when request access is not allowed', async () => {
+    (apiClient.getDeviceScreenshot as jest.Mock).mockResolvedValue(null);
+
+    render(
+      <DevicePreviewModal
+        device={mockDevice}
+        isOpen={true}
+        onClose={jest.fn()}
+        canRequestScreenshot={false}
+      />
+    );
+
+    await waitForInitialScreenshotLoad();
+
+    expect(screen.queryByRole('button', { name: /refresh screenshot/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /capture screenshot/i })).not.toBeInTheDocument();
+    expect(apiClient.requestDeviceScreenshot).not.toHaveBeenCalled();
+  });
+
   it('shows a timeout error if screenshot capture never returns', async () => {
     jest.useFakeTimers();
 

--- a/web/src/components/__tests__/PlaylistBuilder.test.tsx
+++ b/web/src/components/__tests__/PlaylistBuilder.test.tsx
@@ -11,6 +11,14 @@ import { Content, Playlist, PlaylistItem } from '@/lib/types';
 // Mock dependencies
 const mockPush = jest.fn();
 const mockBack = jest.fn();
+let mockUser: any = {
+  id: 'u1',
+  email: 'admin@test.com',
+  firstName: 'Admin',
+  lastName: 'User',
+  organizationId: 'org-1',
+  role: 'admin',
+};
 
 jest.mock('next/navigation', () => {
   const actual = jest.requireActual('next/navigation');
@@ -34,8 +42,20 @@ jest.mock('@/lib/api', () => ({
     addPlaylistItem: jest.fn(),
     removePlaylistItem: jest.fn(),
     updatePlaylistItem: jest.fn(),
+    updatePlaylist: jest.fn(),
     reorderPlaylistItems: jest.fn(),
   },
+}));
+
+jest.mock('@/lib/hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: mockUser,
+    loading: false,
+    error: null,
+    isAuthenticated: !!mockUser,
+    logout: jest.fn(),
+    reload: jest.fn(),
+  }),
 }));
 
 jest.mock('@/lib/hooks/useToast', () => ({
@@ -149,6 +169,14 @@ function createDeferred<T>() {
 describe('PlaylistBuilder Components', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUser = {
+      id: 'u1',
+      email: 'admin@test.com',
+      firstName: 'Admin',
+      lastName: 'User',
+      organizationId: 'org-1',
+      role: 'admin',
+    };
   });
 
   describe('DraggableContentItem', () => {
@@ -628,6 +656,36 @@ describe('PlaylistBuilder Components', () => {
       await waitFor(() => {
         expect(screen.getByText('Save')).toBeInTheDocument();
       });
+    });
+
+    it('renders direct playlist route as read-only for viewers', async () => {
+      mockUser = { ...mockUser, role: 'viewer' };
+
+      render(<PlaylistBuilderPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Test Playlist')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText('Save')).not.toBeInTheDocument();
+      expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+      expect(screen.getByRole('spinbutton')).toBeDisabled();
+      expect(screen.queryByLabelText('Remove playlist item')).not.toBeInTheDocument();
+    });
+
+    it('lets managers edit playlist items without exposing admin-only item removal', async () => {
+      mockUser = { ...mockUser, role: 'manager' };
+
+      render(<PlaylistBuilderPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Test Playlist')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Save')).toBeInTheDocument();
+      expect(screen.getByRole('switch')).toBeInTheDocument();
+      expect(screen.getByRole('spinbutton')).not.toBeDisabled();
+      expect(screen.queryByLabelText('Remove playlist item')).not.toBeInTheDocument();
     });
 
     it('shows loading spinner initially', () => {

--- a/web/src/components/fleet/ActiveOverrideBanner.tsx
+++ b/web/src/components/fleet/ActiveOverrideBanner.tsx
@@ -34,7 +34,11 @@ function getTimeRemaining(expiresAt: string): string {
   return `${seconds}s remaining`;
 }
 
-export default function ActiveOverrideBanner() {
+interface ActiveOverrideBannerProps {
+  canClearOverride?: boolean;
+}
+
+export default function ActiveOverrideBanner({ canClearOverride = true }: ActiveOverrideBannerProps) {
   const toast = useToast();
   const [overrides, setOverrides] = useState<Override[]>([]);
   const [, setTick] = useState(0); // force re-render for countdown
@@ -91,12 +95,14 @@ export default function ActiveOverrideBanner() {
               </p>
             </div>
           </div>
-          <button
-            onClick={() => handleClear(override.commandId)}
-            className="px-4 py-2 bg-white/20 hover:bg-white/30 text-white text-sm font-medium rounded-lg transition flex-shrink-0"
-          >
-            Clear Override
-          </button>
+          {canClearOverride && (
+            <button
+              onClick={() => handleClear(override.commandId)}
+              className="px-4 py-2 bg-white/20 hover:bg-white/30 text-white text-sm font-medium rounded-lg transition flex-shrink-0"
+            >
+              Clear Override
+            </button>
+          )}
         </div>
       ))}
     </div>

--- a/web/src/components/playlist/ContentLibraryPanel.tsx
+++ b/web/src/components/playlist/ContentLibraryPanel.tsx
@@ -11,9 +11,13 @@ import DraggableContentItem from './DraggableContentItem';
 
 interface ContentLibraryPanelProps {
   organizationId: string;
+  canDragContent?: boolean;
 }
 
-export default function ContentLibraryPanel({ organizationId: _organizationId }: ContentLibraryPanelProps) {
+export default function ContentLibraryPanel({
+  organizationId: _organizationId,
+  canDragContent = true,
+}: ContentLibraryPanelProps) {
   const [content, setContent] = useState<Content[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
@@ -149,7 +153,7 @@ export default function ContentLibraryPanel({ organizationId: _organizationId }:
         ) : (
           <>
             {content.map((item) => (
-              <DraggableContentItem key={item.id} content={item} />
+              <DraggableContentItem key={item.id} content={item} disabled={!canDragContent} />
             ))}
           </>
         )}

--- a/web/src/components/playlist/DraggableContentItem.tsx
+++ b/web/src/components/playlist/DraggableContentItem.tsx
@@ -7,12 +7,14 @@ import { useDraggable } from '@dnd-kit/core';
 interface DraggableContentItemProps {
   content: Content;
   isDragging?: boolean;
+  disabled?: boolean;
 }
 
-export default function DraggableContentItem({ content, isDragging }: DraggableContentItemProps) {
+export default function DraggableContentItem({ content, isDragging, disabled = false }: DraggableContentItemProps) {
   const { attributes, listeners, setNodeRef, transform } = useDraggable({
     id: `content-${content.id}`,
     data: { content },
+    disabled,
   });
 
   const style = transform
@@ -48,11 +50,12 @@ export default function DraggableContentItem({ content, isDragging }: DraggableC
     <div
       ref={setNodeRef}
       style={style}
-      {...listeners}
-      {...attributes}
+      {...(disabled ? {} : listeners)}
+      {...(disabled ? {} : attributes)}
       className={`
-        p-3 bg-[var(--surface)] border border-[var(--border)] rounded-lg cursor-grab active:cursor-grabbing
+        p-3 bg-[var(--surface)] border border-[var(--border)] rounded-lg
         hover:shadow-md transition-all
+        ${disabled ? 'cursor-default' : 'cursor-grab active:cursor-grabbing'}
         ${isDragging ? 'opacity-50 shadow-lg' : ''}
       `}
     >
@@ -89,10 +92,11 @@ export default function DraggableContentItem({ content, isDragging }: DraggableC
           </div>
         </div>
 
-        {/* Drag Indicator */}
-        <div className="flex-shrink-0 text-[var(--foreground-tertiary)]">
-          <Icon name="list" size="sm" className="text-[var(--foreground-tertiary)]" />
-        </div>
+        {!disabled && (
+          <div className="flex-shrink-0 text-[var(--foreground-tertiary)]">
+            <Icon name="list" size="sm" className="text-[var(--foreground-tertiary)]" />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/web/src/components/playlist/PlaylistEditorPanel.tsx
+++ b/web/src/components/playlist/PlaylistEditorPanel.tsx
@@ -16,6 +16,9 @@ interface PlaylistEditorPanelProps {
   onRemoveItem: (itemId: string) => void;
   onUpdateDuration: (itemId: string, duration: number) => void;
   onReorder: (itemIds: string[]) => void;
+  canReorder?: boolean;
+  canUpdateDuration?: boolean;
+  canRemoveItems?: boolean;
 }
 
 // Sortable playlist item
@@ -24,11 +27,17 @@ function SortablePlaylistItem({
   index,
   onRemove,
   onDurationChange,
+  canReorder,
+  canUpdateDuration,
+  canRemove,
 }: {
   item: PlaylistItem;
   index: number;
   onRemove: () => void;
   onDurationChange: (duration: number) => void;
+  canReorder: boolean;
+  canUpdateDuration: boolean;
+  canRemove: boolean;
 }) {
   const {
     attributes,
@@ -68,9 +77,13 @@ function SortablePlaylistItem({
     >
       {/* Drag Handle */}
       <button
-        {...attributes}
-        {...listeners}
-        className="cursor-grab active:cursor-grabbing text-[var(--foreground-tertiary)] hover:text-[var(--foreground-secondary)]"
+        {...(canReorder ? attributes : {})}
+        {...(canReorder ? listeners : {})}
+        disabled={!canReorder}
+        className={`text-[var(--foreground-tertiary)] hover:text-[var(--foreground-secondary)] ${
+          canReorder ? 'cursor-grab active:cursor-grabbing' : 'cursor-default opacity-50'
+        }`}
+        aria-label="Reorder playlist item"
       >
         <Icon name="list" size="sm" className="text-[var(--foreground-tertiary)]" />
       </button>
@@ -112,24 +125,29 @@ function SortablePlaylistItem({
           max="300"
           value={item.duration || 30}
           onChange={(e) => {
+            if (!canUpdateDuration) return;
             const val = parseInt(e.target.value);
             if (val > 0 && val <= 300) {
               onDurationChange(val);
             }
           }}
+          disabled={!canUpdateDuration}
           onClick={(e) => e.stopPropagation()}
-          className="w-16 px-2 py-1 text-sm border border-[var(--border)] rounded focus:ring-1 focus:ring-[#00E5A0] focus:border-[#00E5A0]"
+          className="w-16 px-2 py-1 text-sm border border-[var(--border)] rounded focus:ring-1 focus:ring-[#00E5A0] focus:border-[#00E5A0] disabled:opacity-70 disabled:cursor-not-allowed"
         />
         <span className="text-sm text-[var(--foreground-tertiary)]">s</span>
       </div>
 
       {/* Remove Button */}
-      <button
-        onClick={onRemove}
-        className="text-red-600 hover:text-red-800 p-1 hover:bg-red-50 rounded transition"
-      >
-        <Icon name="delete" size="sm" className="text-red-600" />
-      </button>
+      {canRemove && (
+        <button
+          onClick={onRemove}
+          className="text-red-600 hover:text-red-800 p-1 hover:bg-red-50 rounded transition"
+          aria-label="Remove playlist item"
+        >
+          <Icon name="delete" size="sm" className="text-red-600" />
+        </button>
+      )}
     </div>
   );
 }
@@ -139,6 +157,9 @@ export default function PlaylistEditorPanel({
   onRemoveItem,
   onUpdateDuration,
   onReorder,
+  canReorder = true,
+  canUpdateDuration = true,
+  canRemoveItems = true,
 }: PlaylistEditorPanelProps) {
   const { setNodeRef, isOver } = useDroppable({
     id: 'playlist-drop-zone',
@@ -169,7 +190,7 @@ export default function PlaylistEditorPanel({
         ref={setNodeRef}
         className={`
           flex-1 overflow-y-auto p-4 space-y-2
-          ${isOver ? 'bg-[#00E5A0]/5 border-2 border-[#00E5A0] border-dashed' : ''}
+          ${canReorder && isOver ? 'bg-[#00E5A0]/5 border-2 border-[#00E5A0] border-dashed' : ''}
         `}
       >
         {items.length === 0 ? (
@@ -193,6 +214,9 @@ export default function PlaylistEditorPanel({
                 index={index}
                 onRemove={() => onRemoveItem(item.id)}
                 onDurationChange={(duration) => onUpdateDuration(item.id, duration)}
+                canReorder={canReorder}
+                canUpdateDuration={canUpdateDuration}
+                canRemove={canRemoveItems}
               />
             ))}
           </SortableContext>

--- a/web/src/lib/__tests__/permissions.test.ts
+++ b/web/src/lib/__tests__/permissions.test.ts
@@ -1,0 +1,50 @@
+import { getDashboardPermissions } from '../permissions';
+
+describe('getDashboardPermissions', () => {
+  it('allows admins to use all dashboard mutations covered by the helper', () => {
+    expect(getDashboardPermissions({ role: 'admin' })).toEqual({
+      canManageContent: true,
+      canDeleteContent: true,
+      canReviewContent: true,
+      canManageDevices: true,
+      canDeleteDevices: true,
+      canUseFleetCommands: true,
+      canUseEmergencyOverride: true,
+      canManagePlaylists: true,
+      canDeletePlaylists: true,
+      canRemovePlaylistItems: true,
+    });
+  });
+
+  it('allows managers to manage but not delete admin-only records', () => {
+    expect(getDashboardPermissions({ role: 'manager' })).toMatchObject({
+      canManageContent: true,
+      canDeleteContent: false,
+      canReviewContent: true,
+      canManageDevices: true,
+      canDeleteDevices: false,
+      canUseFleetCommands: true,
+      canUseEmergencyOverride: false,
+      canManagePlaylists: true,
+      canDeletePlaylists: false,
+      canRemovePlaylistItems: false,
+    });
+  });
+
+  it('keeps viewers and missing users read-only for these dashboard pages', () => {
+    expect(getDashboardPermissions({ role: 'viewer' })).toMatchObject({
+      canManageContent: false,
+      canDeleteContent: false,
+      canManageDevices: false,
+      canDeleteDevices: false,
+      canManagePlaylists: false,
+      canDeletePlaylists: false,
+    });
+
+    expect(getDashboardPermissions(null)).toMatchObject({
+      canManageContent: false,
+      canManageDevices: false,
+      canManagePlaylists: false,
+    });
+  });
+});

--- a/web/src/lib/permissions.ts
+++ b/web/src/lib/permissions.ts
@@ -1,0 +1,39 @@
+type RoleUser = {
+  role?: string | null;
+} | null | undefined;
+
+export type DashboardPermissions = {
+  canManageContent: boolean;
+  canDeleteContent: boolean;
+  canReviewContent: boolean;
+  canManageDevices: boolean;
+  canDeleteDevices: boolean;
+  canUseFleetCommands: boolean;
+  canUseEmergencyOverride: boolean;
+  canManagePlaylists: boolean;
+  canDeletePlaylists: boolean;
+  canRemovePlaylistItems: boolean;
+};
+
+const isAdmin = (role?: string | null) => role === 'admin';
+const isManager = (role?: string | null) => role === 'manager';
+const isAdminOrManager = (role?: string | null) => isAdmin(role) || isManager(role);
+
+export function getDashboardPermissions(user: RoleUser): DashboardPermissions {
+  const role = user?.role;
+  const admin = isAdmin(role);
+  const adminOrManager = isAdminOrManager(role);
+
+  return {
+    canManageContent: adminOrManager,
+    canDeleteContent: admin,
+    canReviewContent: adminOrManager,
+    canManageDevices: adminOrManager,
+    canDeleteDevices: admin,
+    canUseFleetCommands: adminOrManager,
+    canUseEmergencyOverride: admin,
+    canManagePlaylists: adminOrManager,
+    canDeletePlaylists: admin,
+    canRemovePlaylistItems: admin,
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared dashboard permission helper for role-truthful frontend controls
- gate content, devices, playlists, direct playlist builder, screenshot capture, emergency override, and modal mutation surfaces to match backend role contracts
- add persistent primary list-load error panels with retry for content/devices/playlists

## Reviews
- UX/test/release review found duplicate viewer `Flag` affordance on already flagged content; fixed and regression-tested
- RBAC/security review found viewer screenshot capture affordance; fixed and regression-tested
- RBAC/security final review found direct playlist builder route false affordances; fixed and re-reviewed CLEAN
- UX/test/release re-review CLEAN

## Verification
- `pnpm --filter @vizora/web test -- --runInBand web/src/lib/__tests__/permissions.test.ts web/src/app/dashboard/content/__tests__/content-page.test.tsx web/src/app/dashboard/devices/__tests__/devices-page.test.tsx web/src/app/dashboard/playlists/__tests__/playlists-page.test.tsx web/src/components/__tests__/DevicePreviewModal.test.tsx web/src/components/__tests__/PlaylistBuilder.test.tsx` passed 6 suites / 144 tests
- `pnpm --filter @vizora/web test -- --runInBand` passed 102 suites / 1080 tests; existing React act warnings observed
- `npx nx build @vizora/web --skip-nx-cache` passed with production placeholder env; Nx flaky metadata and existing Next warnings observed
- `pnpm security:no-hardcoded-jwts` passed
- `git diff --check` passed with Windows CRLF warnings only

## Deploy
- Not deployed from this PR. Prod checkout must be rechecked before any deploy.