### PR TITLE
fix(middleware): enforce MinIO tenant boundaries

### DIFF
--- a/docs/plans/2026-06-02-content-minio-tenant-boundary-pass-40.md
+++ b/docs/plans/2026-06-02-content-minio-tenant-boundary-pass-40.md
@@ -1,0 +1,62 @@
+# Content MinIO Tenant Boundary Pass 40
+
+**Branch:** `feat/customer-performance-readiness`
+
+**Why now:** Multi-vector review found a high-severity tenant-boundary drift:
+device content streaming verifies MinIO object keys are under the device org,
+but dashboard download and delete paths can operate on any `minio://` object key
+persisted on an org-owned content row.
+
+**New primitives introduced:** one storage-module MinIO ownership helper. No
+schema, env var, runtime process, realtime substrate, notification path, MCP
+tool, Hermes skill, provider spend path, or parallel storage path.
+
+**Hermes-first analysis:** not applicable. This is a storage tenant-boundary
+hardening pass inside existing NestJS content/storage services, not a business
+agent, MCP, Hermes, AI/provider, or spend-path change.
+
+## Root Cause
+
+Upload-generated MinIO keys are tenant-prefixed by
+`StorageService.generateObjectKey()`, and `DeviceContentController` already
+rejects keys outside `${organizationId}/`. Other content paths independently
+extract `minio://` object keys without applying that same org-prefix guard.
+This creates a trust-boundary mismatch whenever a polluted content row contains
+`minio://other-org/...`.
+
+## Plan
+
+- [x] Add failing tests for foreign MinIO keys on dashboard download, thumbnail
+  object reads, create/update persistence, single delete, and bulk delete.
+- [x] Add a shared storage helper that extracts a MinIO object key only when it
+  is owned by the current organization.
+- [x] Use the helper in content create/update persistence, download URL
+  generation, manual thumbnail object reads, single delete, and bulk delete.
+- [x] Keep upload/replacement paths working because their generated keys already
+  include the organization prefix.
+- [x] Allow simple replacement to repair legacy polluted rows without deleting
+  the foreign old object; keep backup replacement fail-closed for those rows.
+- [x] Use the cleanup-safe helper in organization deletion and sole-admin
+  account deletion so teardown does not delete foreign content objects or
+  thumbnails from polluted rows.
+- [x] Run focused middleware content tests, broader middleware tests/build, and
+  security scan.
+- [x] Run subagent review before PR/merge.
+
+## Expected Behavior
+
+- `minio://org-123/...` remains valid for org `org-123`.
+- `minio://other-org/...` cannot be persisted through content service
+  create/update as either `url` or `thumbnail`.
+- Dashboard download does not presign foreign object keys.
+- Delete paths do not call storage deletion for foreign object keys.
+- Bulk delete reports the polluted row as failed while allowing safe rows to
+  proceed.
+- Simple replacement can move a polluted row to a current organization-owned
+  object key without touching the foreign old object.
+- Backup replacement rejects polluted old MinIO rows because archiving the
+  previous URL would preserve the tenant-boundary violation.
+- Replacement clears polluted existing MinIO thumbnails instead of preserving
+  them on the active or archived content row.
+- Organization/account teardown deletes only canonical `minio://` objects under
+  the current org prefix and skips foreign or non-canonical persisted URLs.

--- a/middleware/src/modules/auth/auth.service.spec.ts
+++ b/middleware/src/modules/auth/auth.service.spec.ts
@@ -74,6 +74,7 @@ describe('AuthService', () => {
   let mockRedisService: any;
   let mockMailService: any;
   let mockGeoService: any;
+  let mockStorageService: any;
   let mockAlertRulesService: any;
 
   const mockUser = {
@@ -109,6 +110,9 @@ describe('AuthService', () => {
         findUnique: jest.fn(),
         create: jest.fn(),
         update: jest.fn(),
+        count: jest.fn(),
+        findMany: jest.fn(),
+        deleteMany: jest.fn(),
       },
       organization: {
         findUnique: jest.fn(),
@@ -118,10 +122,17 @@ describe('AuthService', () => {
         create: jest.fn().mockResolvedValue({ id: 'audit-current' }),
         findFirst: jest.fn().mockResolvedValue(null),
         findMany: jest.fn().mockResolvedValue([]),
+        deleteMany: jest.fn(),
       },
       passwordResetToken: {
         findUnique: jest.fn(),
         update: jest.fn(),
+        deleteMany: jest.fn(),
+      },
+      content: {
+        findMany: jest.fn(),
+        updateMany: jest.fn(),
+        deleteMany: jest.fn(),
       },
       // Mock $transaction to execute the callback with the same mock database
       $transaction: jest.fn().mockImplementation(async (callback) => {
@@ -158,7 +169,7 @@ describe('AuthService', () => {
       cancelSubscription: jest.fn().mockResolvedValue(undefined),
     };
 
-    const mockStorageService = {
+    mockStorageService = {
       uploadFile: jest.fn().mockResolvedValue(undefined),
       deleteFile: jest.fn().mockResolvedValue(undefined),
       getPresignedUrl: jest.fn().mockResolvedValue('https://minio/avatar.jpg'),
@@ -966,6 +977,91 @@ describe('AuthService', () => {
       await service.logout(mockUser.id);
 
       expect(mockJwtService.decode).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteAccount', () => {
+    function buildAccountDeletionTx() {
+      return {
+        supportMessage: { deleteMany: jest.fn().mockResolvedValue({ count: 0 }) },
+        supportRequest: { deleteMany: jest.fn().mockResolvedValue({ count: 0 }) },
+        notification: { deleteMany: jest.fn().mockResolvedValue({ count: 0 }) },
+        apiKey: { deleteMany: jest.fn().mockResolvedValue({ count: 0 }) },
+        billingTransaction: { deleteMany: jest.fn().mockResolvedValue({ count: 0 }) },
+        contentImpression: { deleteMany: jest.fn().mockResolvedValue({ count: 0 }) },
+        promotionRedemption: { deleteMany: jest.fn().mockResolvedValue({ count: 0 }) },
+        schedule: { deleteMany: jest.fn().mockResolvedValue({ count: 0 }) },
+        displayGroup: {
+          findMany: jest.fn().mockResolvedValue([]),
+          deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+        },
+        displayGroupMember: { deleteMany: jest.fn().mockResolvedValue({ count: 0 }) },
+        display: {
+          findMany: jest.fn().mockResolvedValue([]),
+          deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+        },
+        displayTag: { deleteMany: jest.fn().mockResolvedValue({ count: 0 }) },
+        playlist: {
+          findMany: jest.fn().mockResolvedValue([]),
+          deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+        },
+        playlistItem: { deleteMany: jest.fn().mockResolvedValue({ count: 0 }) },
+        content: {
+          findMany: jest.fn().mockResolvedValue([]),
+          updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+          deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+        },
+        contentTag: { deleteMany: jest.fn().mockResolvedValue({ count: 0 }) },
+        contentFolder: {
+          updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+          deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+        },
+        tag: { deleteMany: jest.fn().mockResolvedValue({ count: 0 }) },
+        auditLog: { deleteMany: jest.fn().mockResolvedValue({ count: 0 }) },
+        passwordResetToken: { deleteMany: jest.fn().mockResolvedValue({ count: 0 }) },
+        user: {
+          findMany: jest.fn().mockResolvedValue([{ id: 'user-123' }]),
+          deleteMany: jest.fn().mockResolvedValue({ count: 1 }),
+        },
+        organization: { delete: jest.fn().mockResolvedValue(mockOrganization) },
+      };
+    }
+
+    it('should delete only same-organization MinIO content and thumbnail objects for sole-admin account deletion', async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue({
+        ...mockUser,
+        organization: mockOrganization,
+      });
+      mockDatabaseService.user.count.mockResolvedValue(1);
+      mockDatabaseService.content.findMany.mockResolvedValue([
+        {
+          url: 'minio://org-123/content/file.png',
+          thumbnail: 'minio://org-123/thumbnails/file.jpg',
+        },
+        {
+          url: 'minio://other-org/content/secret.png',
+          thumbnail: 'minio://other-org/thumbnails/secret.jpg',
+        },
+        {
+          url: 'https://cdn.example.com/vizora-content/other-org/external.png',
+          thumbnail: '/static/thumbnails/local.jpg',
+        },
+      ]);
+      mockDatabaseService.$transaction.mockImplementation(async (callback) => {
+        return callback(buildAccountDeletionTx());
+      });
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+      (bcrypt.hash as jest.Mock).mockResolvedValue('random-disabled-password-hash');
+
+      await service.deleteAccount('user-123', 'correct-password');
+
+      expect(mockStorageService.deleteFile).toHaveBeenCalledTimes(2);
+      expect(mockStorageService.deleteFile).toHaveBeenCalledWith('org-123/content/file.png');
+      expect(mockStorageService.deleteFile).toHaveBeenCalledWith('org-123/thumbnails/file.jpg');
+      expect(mockStorageService.deleteFile).not.toHaveBeenCalledWith('other-org/content/secret.png');
+      expect(mockStorageService.deleteFile).not.toHaveBeenCalledWith('other-org/thumbnails/secret.jpg');
+      expect(mockStorageService.deleteFile).not.toHaveBeenCalledWith('vizora-content/other-org/external.png');
+      expect(mockStorageService.deleteFile).not.toHaveBeenCalledWith('static/thumbnails/local.jpg');
     });
   });
 

--- a/middleware/src/modules/auth/auth.service.ts
+++ b/middleware/src/modules/auth/auth.service.ts
@@ -24,6 +24,7 @@ import { AUTH_CONSTANTS } from './constants/auth.constants';
 import { GeoService } from '../common/services/geo.service';
 import { BillingService } from '../billing/billing.service';
 import { StorageService } from '../storage/storage.service';
+import { getCleanupSafeMinioObjectKey, isMinioUrl } from '../storage/minio-object-key';
 import { AlertRulesService } from '../notifications/alert-rules/alert-rules.service';
 
 // Account lockout constants
@@ -1066,7 +1067,7 @@ export class AuthService {
       });
 
       // 4d. Delete files from MinIO after successful DB transaction (best-effort)
-      await this.deleteStorageFiles(contentWithUrls);
+      await this.deleteStorageFiles(orgId, contentWithUrls);
     } else {
       // 5. Not sole admin — just remove user from org
       await this.databaseService.$transaction(async (tx) => {
@@ -1124,17 +1125,26 @@ export class AuthService {
 
   /**
    * Delete content files from MinIO storage (best-effort, non-blocking).
-   * Extracts MinIO object keys from content URLs and deletes them.
+   * Deletes only canonical minio:// objects owned by this organization.
    */
-  private async deleteStorageFiles(contentRecords: Array<{ url: string; thumbnail: string | null }>): Promise<void> {
+  private async deleteStorageFiles(
+    organizationId: string,
+    contentRecords: Array<{ url: string | null; thumbnail: string | null }>,
+  ): Promise<void> {
     const objectKeys: string[] = [];
     for (const record of contentRecords) {
-      // Extract MinIO object key from URL (format: /content/orgId/filename or full URL)
-      const key = this.extractObjectKey(record.url);
+      const key = getCleanupSafeMinioObjectKey(organizationId, record.url);
       if (key) objectKeys.push(key);
+      else if (isMinioUrl(record.url)) {
+        this.logger.warn('Skipping foreign MinIO content object during account deletion');
+      }
+
       if (record.thumbnail) {
-        const thumbKey = this.extractObjectKey(record.thumbnail);
+        const thumbKey = getCleanupSafeMinioObjectKey(organizationId, record.thumbnail);
         if (thumbKey) objectKeys.push(thumbKey);
+        else if (isMinioUrl(record.thumbnail)) {
+          this.logger.warn('Skipping foreign MinIO thumbnail object during account deletion');
+        }
       }
     }
 
@@ -1149,31 +1159,6 @@ export class AuthService {
     if (objectKeys.length > 0) {
       this.logger.log(`Deleted ${objectKeys.length} storage files for account deletion`);
     }
-  }
-
-  /**
-   * Extract MinIO object key from a content URL.
-   * Handles both relative paths (/content/...) and full URLs (https://minio.../bucket/...).
-   */
-  private extractObjectKey(url: string): string | null {
-    if (!url) return null;
-    // Skip external URLs (not stored in our MinIO)
-    if (url.startsWith('http://') || url.startsWith('https://')) {
-      try {
-        const parsed = new URL(url);
-        // Only process MinIO URLs (contain our bucket name in path)
-        const pathParts = parsed.pathname.split('/').filter(Boolean);
-        // MinIO URLs: /bucket-name/object-key — skip the bucket name
-        if (pathParts.length >= 2) {
-          return pathParts.slice(1).join('/');
-        }
-      } catch {
-        return null;
-      }
-      return null;
-    }
-    // Relative path — use as-is (strip leading slash)
-    return url.startsWith('/') ? url.substring(1) : url;
   }
 
   private generateToken(user: { id: string; email: string; role: string; isSuperAdmin?: boolean }, organization: { id: string }): string {

--- a/middleware/src/modules/content/content.controller.spec.ts
+++ b/middleware/src/modules/content/content.controller.spec.ts
@@ -16,6 +16,7 @@ import { StorageService } from '../storage/storage.service';
 import { StorageQuotaService } from '../storage/storage-quota.service';
 import { SubscriptionActiveGuard } from '../billing/guards/subscription-active.guard';
 import { DatabaseService } from '../database/database.service';
+import { Readable } from 'stream';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -88,6 +89,7 @@ describe('ContentController', () => {
       listObjects: jest.fn(),
       copyFile: jest.fn(),
       getBucket: jest.fn().mockReturnValue('vizora-content'),
+      getObject: jest.fn(),
     } as any;
 
     mockStorageQuotaService = {
@@ -529,6 +531,43 @@ describe('ContentController', () => {
     });
   });
 
+  describe('getDownloadUrl', () => {
+    it('should generate a presigned URL for same-organization MinIO content', async () => {
+      mockContentService.findOne.mockResolvedValue({
+        id: 'content-123',
+        url: 'minio://org-123/uploads/file.jpg',
+      } as any);
+      mockStorageService.isMinioAvailable.mockReturnValue(true);
+      mockStorageService.getPresignedUrl.mockResolvedValue('https://minio.example/signed');
+
+      const result = await controller.getDownloadUrl(organizationId, 'content-123');
+
+      expect(result).toEqual({
+        url: 'https://minio.example/signed',
+        expiresIn: 3600,
+      });
+      expect(mockStorageService.getPresignedUrl).toHaveBeenCalledWith(
+        'org-123/uploads/file.jpg',
+        3600,
+      );
+    });
+
+    it('should reject MinIO content whose object key is outside the organization prefix', async () => {
+      mockContentService.findOne.mockResolvedValue({
+        id: 'content-123',
+        url: 'minio://other-org/uploads/secret.jpg',
+      } as any);
+      mockStorageService.isMinioAvailable.mockReturnValue(true);
+      mockStorageService.getPresignedUrl.mockResolvedValue('https://minio.example/signed');
+
+      await expect(
+        controller.getDownloadUrl(organizationId, 'content-123'),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockStorageService.getPresignedUrl).not.toHaveBeenCalled();
+    });
+  });
+
   describe('generateThumbnail', () => {
     it('should generate thumbnail for image content', async () => {
       const content = { id: 'content-123', type: 'image', url: 'https://example.com/image.jpg' };
@@ -556,6 +595,52 @@ describe('ContentController', () => {
         thumbnail: null,
       });
       expect(mockThumbnailService.generateThumbnailFromUrl).not.toHaveBeenCalled();
+    });
+
+    it('should generate thumbnails from same-organization MinIO content objects', async () => {
+      const content = {
+        id: 'content-123',
+        type: 'image',
+        url: 'minio://org-123/uploads/file.jpg',
+        mimeType: 'image/jpeg',
+      };
+      mockContentService.findOne.mockResolvedValue(content as any);
+      mockStorageService.isMinioAvailable.mockReturnValue(true);
+      mockStorageService.getObject.mockResolvedValue(Readable.from([Buffer.from('image')]) as any);
+      mockThumbnailService.generateThumbnail.mockResolvedValue('/static/thumbnails/minio-thumb.jpg');
+      mockContentService.update.mockResolvedValue({} as any);
+
+      const result = await controller.generateThumbnail(organizationId, 'content-123');
+
+      expect(result).toEqual({ thumbnail: '/static/thumbnails/minio-thumb.jpg' });
+      expect(mockStorageService.getObject).toHaveBeenCalledWith('org-123/uploads/file.jpg');
+      expect(mockThumbnailService.generateThumbnail).toHaveBeenCalledWith(
+        content.id,
+        expect.any(Buffer),
+        content.mimeType,
+      );
+      expect(mockContentService.update).toHaveBeenCalledWith(organizationId, 'content-123', {
+        thumbnail: '/static/thumbnails/minio-thumb.jpg',
+      });
+    });
+
+    it('should reject MinIO thumbnail reads outside the organization prefix', async () => {
+      const content = {
+        id: 'content-123',
+        type: 'image',
+        url: 'minio://other-org/uploads/secret.jpg',
+        mimeType: 'image/jpeg',
+      };
+      mockContentService.findOne.mockResolvedValue(content as any);
+      mockStorageService.isMinioAvailable.mockReturnValue(true);
+      mockStorageService.getObject.mockResolvedValue(Readable.from([Buffer.from('image')]) as any);
+
+      await expect(
+        controller.generateThumbnail(organizationId, 'content-123'),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockStorageService.getObject).not.toHaveBeenCalled();
+      expect(mockThumbnailService.generateThumbnail).not.toHaveBeenCalled();
     });
   });
 

--- a/middleware/src/modules/content/content.controller.ts
+++ b/middleware/src/modules/content/content.controller.ts
@@ -42,13 +42,12 @@ import {
 } from './dto/approval.dto';
 import { ReviewContentDto } from './dto/review-content.dto';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { getOwnedMinioObjectKey, MINIO_URL_PREFIX } from '../storage/minio-object-key';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { randomUUID } from 'crypto';
 
-// Prefix used to identify MinIO-stored content
-const MINIO_URL_PREFIX = 'minio://';
 const MAX_CONTENT_UPLOAD_SIZE = 100 * 1024 * 1024;
 const CONTENT_UPLOAD_TMP_ROOT = path.join(os.tmpdir(), 'vizora-content-uploads');
 
@@ -411,9 +410,8 @@ export class ContentController {
       throw new NotFoundException('Content has no associated file');
     }
 
-    // Check if content is stored in MinIO
-    if (content.url.startsWith(MINIO_URL_PREFIX)) {
-      const objectKey = content.url.substring(MINIO_URL_PREFIX.length);
+    const objectKey = getOwnedMinioObjectKey(organizationId, content.url);
+    if (objectKey) {
       const expiry = Math.min(parseInt(expirySeconds, 10) || 3600, 86400);
 
       if (!this.storageService.isMinioAvailable()) {
@@ -467,8 +465,8 @@ export class ContentController {
 
     // For MinIO-stored content, fetch the object directly via StorageService
     // to avoid SSRF validation blocking internal MinIO URLs
-    if (content.url.startsWith(MINIO_URL_PREFIX)) {
-      const objectKey = content.url.substring(MINIO_URL_PREFIX.length);
+    const objectKey = getOwnedMinioObjectKey(organizationId, content.url);
+    if (objectKey) {
       if (!this.storageService.isMinioAvailable()) {
         throw new BadRequestException('Storage service is currently unavailable');
       }

--- a/middleware/src/modules/content/content.service.spec.ts
+++ b/middleware/src/modules/content/content.service.spec.ts
@@ -173,6 +173,28 @@ describe('ContentService', () => {
         }),
       });
     });
+
+    it('should reject MinIO URLs outside the organization prefix', async () => {
+      await expect(
+        service.create('org-123', {
+          ...createDto,
+          url: 'minio://other-org/uploads/secret.jpg',
+        }),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockDatabaseService.content.create).not.toHaveBeenCalled();
+    });
+
+    it('should reject MinIO thumbnails outside the organization prefix', async () => {
+      await expect(
+        service.create('org-123', {
+          ...createDto,
+          thumbnail: 'minio://other-org/thumbnails/secret.jpg',
+        }),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockDatabaseService.content.create).not.toHaveBeenCalled();
+    });
   });
 
   describe('findAll', () => {
@@ -554,6 +576,30 @@ describe('ContentService', () => {
       });
     });
 
+    it('should reject MinIO URL updates outside the organization prefix', async () => {
+      mockDatabaseService.content.findFirst.mockResolvedValue(mockContent);
+
+      await expect(
+        service.update('org-123', 'content-123', {
+          url: 'minio://other-org/uploads/secret.jpg',
+        }),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockDatabaseService.content.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('should reject MinIO thumbnail updates outside the organization prefix', async () => {
+      mockDatabaseService.content.findFirst.mockResolvedValue(mockContent);
+
+      await expect(
+        service.update('org-123', 'content-123', {
+          thumbnail: 'minio://other-org/thumbnails/secret.jpg',
+        }),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockDatabaseService.content.updateMany).not.toHaveBeenCalled();
+    });
+
     it('should throw NotFoundException if content not found', async () => {
       mockDatabaseService.content.findFirst.mockResolvedValue(null);
 
@@ -592,6 +638,40 @@ describe('ContentService', () => {
         'Content file could not be deleted from storage',
       );
 
+      expect(mockDatabaseService.content.deleteMany).not.toHaveBeenCalled();
+      expect(mockStorageQuotaService.decrementUsage).not.toHaveBeenCalled();
+    });
+
+    it('should delete same-organization MinIO object before removing the DB row', async () => {
+      mockDatabaseService.content.findFirst.mockResolvedValue({
+        ...mockContent,
+        url: 'minio://org-123/uploads/file.jpg',
+        fileSize: 1000,
+      });
+      mockDatabaseService.content.deleteMany.mockResolvedValue({ count: 1 });
+
+      const result = await service.remove('org-123', 'content-123');
+
+      expect(result).toEqual({ count: 1 });
+      expect(mockStorageService.deleteFile).toHaveBeenCalledWith('org-123/uploads/file.jpg');
+      expect(mockDatabaseService.content.deleteMany).toHaveBeenCalledWith({
+        where: { id: 'content-123', organizationId: 'org-123' },
+      });
+      expect(mockStorageQuotaService.decrementUsage).toHaveBeenCalledWith('org-123', 1000);
+    });
+
+    it('should reject MinIO deletes outside the organization prefix without deleting storage or DB row', async () => {
+      mockDatabaseService.content.findFirst.mockResolvedValue({
+        ...mockContent,
+        url: 'minio://other-org/uploads/secret.jpg',
+        fileSize: 1000,
+      });
+
+      await expect(service.remove('org-123', 'content-123')).rejects.toThrow(
+        BadRequestException,
+      );
+
+      expect(mockStorageService.deleteFile).not.toHaveBeenCalled();
       expect(mockDatabaseService.content.deleteMany).not.toHaveBeenCalled();
       expect(mockStorageQuotaService.decrementUsage).not.toHaveBeenCalled();
     });
@@ -1137,6 +1217,63 @@ describe('ContentService', () => {
       expect(mockStorageService.deleteFile).toHaveBeenCalledWith('org-123/uploads/old.jpg');
     });
 
+    it('should repair a polluted old MinIO URL during simple replacement without deleting the foreign object', async () => {
+      mockDatabaseService.content.findFirst.mockResolvedValue({
+        ...existingContent,
+        url: 'minio://other-org/uploads/old.jpg',
+      });
+      mockDatabaseService.content.updateMany.mockResolvedValue({ count: 1 });
+      mockDatabaseService.content.findUnique.mockResolvedValue({
+        ...existingContent,
+        url: 'minio://org-123/uploads/new.jpg',
+        versionNumber: 2,
+      });
+
+      const result = await service.replaceFile(
+        'org-123',
+        'content-123',
+        'minio://org-123/uploads/new.jpg',
+      );
+
+      expect(result.url).toBe('minio://org-123/uploads/new.jpg');
+      expect(mockStorageService.deleteFile).not.toHaveBeenCalled();
+      expect(mockDatabaseService.content.updateMany).toHaveBeenCalledWith({
+        where: { id: 'content-123', organizationId: 'org-123' },
+        data: expect.objectContaining({
+          url: 'minio://org-123/uploads/new.jpg',
+          versionNumber: 2,
+        }),
+      });
+    });
+
+    it('should clear a polluted MinIO thumbnail during simple replacement', async () => {
+      mockDatabaseService.content.findFirst.mockResolvedValue({
+        ...existingContent,
+        thumbnail: 'minio://other-org/thumbnails/old.jpg',
+      });
+      mockDatabaseService.content.updateMany.mockResolvedValue({ count: 1 });
+      mockDatabaseService.content.findUnique.mockResolvedValue({
+        ...existingContent,
+        url: 'minio://org-123/uploads/new.jpg',
+        thumbnail: null,
+        versionNumber: 2,
+      });
+
+      await service.replaceFile(
+        'org-123',
+        'content-123',
+        'minio://org-123/uploads/new.jpg',
+      );
+
+      expect(mockDatabaseService.content.updateMany).toHaveBeenCalledWith({
+        where: { id: 'content-123', organizationId: 'org-123' },
+        data: expect.objectContaining({
+          url: 'minio://org-123/uploads/new.jpg',
+          thumbnail: null,
+        }),
+      });
+    });
+
     it('should account and mark metadata when old MinIO object cleanup fails', async () => {
       mockDatabaseService.content.findFirst.mockResolvedValue({
         ...existingContent,
@@ -1223,6 +1360,66 @@ describe('ContentService', () => {
           versionNumber: existingContent.versionNumber,
         }),
       });
+    });
+
+    it('should not preserve a polluted MinIO thumbnail during backup replacement', async () => {
+      const backupContent = {
+        ...existingContent,
+        id: 'backup-123',
+        thumbnail: null,
+        status: 'archived',
+      };
+      mockDatabaseService.content.findFirst.mockResolvedValue({
+        ...existingContent,
+        thumbnail: 'minio://other-org/thumbnails/old.jpg',
+      });
+      mockDatabaseService.content.create.mockResolvedValue(backupContent);
+      mockDatabaseService.content.update.mockResolvedValue({
+        ...existingContent,
+        url: 'minio://org-123/uploads/new.jpg',
+        thumbnail: null,
+        versionNumber: 2,
+        previousVersionId: 'backup-123',
+      });
+
+      await service.replaceFile(
+        'org-123',
+        'content-123',
+        'minio://org-123/uploads/new.jpg',
+        { keepBackup: true },
+      );
+
+      expect(mockDatabaseService.content.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          thumbnail: null,
+        }),
+      });
+      expect(mockDatabaseService.content.update).toHaveBeenCalledWith({
+        where: { id: 'content-123' },
+        data: expect.objectContaining({
+          thumbnail: null,
+        }),
+      });
+    });
+
+    it('should reject backup replacement when the old MinIO URL is outside the organization prefix', async () => {
+      mockDatabaseService.content.findFirst.mockResolvedValue({
+        ...existingContent,
+        url: 'minio://other-org/uploads/old.jpg',
+      });
+
+      await expect(
+        service.replaceFile(
+          'org-123',
+          'content-123',
+          'minio://org-123/uploads/new.jpg',
+          { keepBackup: true },
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockDatabaseService.content.create).not.toHaveBeenCalled();
+      expect(mockDatabaseService.content.update).not.toHaveBeenCalled();
+      expect(mockStorageService.deleteFile).not.toHaveBeenCalled();
     });
 
     it('should update name when provided', async () => {
@@ -1816,11 +2013,11 @@ describe('ContentService', () => {
       // remained, the DB row was gone — quota counted, no operator
       // visibility. Now only successful-MinIO ids get DB-deleted.
       mockDatabaseService.content.findMany.mockResolvedValue([
-        { id: 'good-1', fileSize: 1000, url: 'minio://o/good-1.png' },
-        { id: 'bad-1', fileSize: 2000, url: 'minio://o/bad-1.png' },
+        { id: 'good-1', fileSize: 1000, url: 'minio://org-123/good-1.png' },
+        { id: 'bad-1', fileSize: 2000, url: 'minio://org-123/bad-1.png' },
       ]);
       mockStorageService.deleteFile.mockImplementation(async (key: string) => {
-        if (key === 'o/bad-1.png') throw new Error('connection refused');
+        if (key === 'org-123/bad-1.png') throw new Error('connection refused');
       });
       mockDatabaseService.content.deleteMany.mockResolvedValue({ count: 1 });
 
@@ -1857,8 +2054,8 @@ describe('ContentService', () => {
 
     it('continues bulk delete and adjusts quota when a DB delete fails after storage cleanup', async () => {
       mockDatabaseService.content.findMany.mockResolvedValue([
-        { id: 'id-1', fileSize: 1000, fileKey: null, url: 'minio://o/id-1.png' },
-        { id: 'id-2', fileSize: 2000, fileKey: null, url: 'minio://o/id-2.png' },
+        { id: 'id-1', fileSize: 1000, fileKey: null, url: 'minio://org-123/id-1.png' },
+        { id: 'id-2', fileSize: 2000, fileKey: null, url: 'minio://org-123/id-2.png' },
       ]);
       mockDatabaseService.content.deleteMany
         .mockRejectedValueOnce(new Error('db temporarily unavailable'))
@@ -1885,6 +2082,33 @@ describe('ContentService', () => {
       });
       expect(mockStorageQuotaService.decrementUsage).toHaveBeenCalledWith('org-123', 1000);
       expect(mockStorageQuotaService.decrementUsage).toHaveBeenCalledWith('org-123', 2000);
+    });
+
+    it('keeps foreign MinIO keys out of storage deletion during bulk delete', async () => {
+      mockDatabaseService.content.findMany.mockResolvedValue([
+        { id: 'good-1', fileSize: 1000, url: 'minio://org-123/good-1.png' },
+        { id: 'foreign-1', fileSize: 2000, url: 'minio://other-org/secret.png' },
+      ]);
+      mockDatabaseService.content.deleteMany.mockResolvedValue({ count: 1 });
+
+      const result = await service.bulkDelete('org-123', { ids: ['good-1', 'foreign-1'] });
+
+      expect(mockStorageService.deleteFile).toHaveBeenCalledTimes(1);
+      expect(mockStorageService.deleteFile).toHaveBeenCalledWith('org-123/good-1.png');
+      expect(mockStorageService.deleteFile).not.toHaveBeenCalledWith('other-org/secret.png');
+      expect(mockDatabaseService.content.deleteMany).toHaveBeenCalledWith({
+        where: { id: 'good-1', organizationId: 'org-123' },
+      });
+      expect(mockDatabaseService.content.deleteMany).not.toHaveBeenCalledWith({
+        where: { id: 'foreign-1', organizationId: 'org-123' },
+      });
+      expect(result).toEqual({
+        deleted: 1,
+        failed: 1,
+        failedIds: ['foreign-1'],
+      });
+      expect(mockStorageQuotaService.decrementUsage).toHaveBeenCalledWith('org-123', 1000);
+      expect(mockStorageQuotaService.decrementUsage).not.toHaveBeenCalledWith('org-123', 2000);
     });
   });
 

--- a/middleware/src/modules/content/content.service.ts
+++ b/middleware/src/modules/content/content.service.ts
@@ -21,6 +21,13 @@ import { StorageService } from '../storage/storage.service';
 import type { WidgetDataSource } from './widget-data-sources';
 import { buildContentListWhere, type ContentListFilters } from './content-list-query';
 import { CONTENT_LIST_SELECT, mapContentListResponse } from './content-list-select';
+import {
+  assertOrgOwnedMinioObjectKey,
+  getCleanupSafeMinioObjectKey,
+  getOwnedMinioObjectKey,
+  isMinioUrl,
+  MINIO_URL_PREFIX,
+} from '../storage/minio-object-key';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -146,6 +153,9 @@ export class ContentService {
   }
 
   async create(organizationId: string, createContentDto: CreateContentDto) {
+    getOwnedMinioObjectKey(organizationId, createContentDto.url);
+    getOwnedMinioObjectKey(organizationId, createContentDto.thumbnail);
+
     const content = await this.db.content.create({
       data: {
         ...createContentDto,
@@ -324,6 +334,8 @@ export class ContentService {
 
   async update(organizationId: string, id: string, updateContentDto: UpdateContentDto) {
     await this.findOne(organizationId, id);
+    getOwnedMinioObjectKey(organizationId, updateContentDto.url);
+    getOwnedMinioObjectKey(organizationId, updateContentDto.thumbnail);
 
     // Defense-in-depth: include organizationId in where clause to prevent TOCTOU races
     const result = await this.db.content.updateMany({
@@ -343,20 +355,22 @@ export class ContentService {
 
     // Delete file from MinIO storage if it exists
     if (content.fileKey) {
+      assertOrgOwnedMinioObjectKey(organizationId, content.fileKey);
       try {
         await this.storageService.deleteFile(content.fileKey);
       } catch (error) {
         this.logger.error(`Failed to delete file ${content.fileKey} from storage: ${error}`);
         throw new ServiceUnavailableException('Content file could not be deleted from storage; DB row retained for retry');
       }
-    } else if (content.url?.startsWith('minio://')) {
-      // Fall back to extracting object key from minio:// URL
-      const objectKey = content.url.substring('minio://'.length);
-      try {
-        await this.storageService.deleteFile(objectKey);
-      } catch (error) {
-        this.logger.error(`Failed to delete file ${objectKey} from storage: ${error}`);
-        throw new ServiceUnavailableException('Content file could not be deleted from storage; DB row retained for retry');
+    } else {
+      const objectKey = getOwnedMinioObjectKey(organizationId, content.url);
+      if (objectKey) {
+        try {
+          await this.storageService.deleteFile(objectKey);
+        } catch (error) {
+          this.logger.error(`Failed to delete file ${objectKey} from storage: ${error}`);
+          throw new ServiceUnavailableException('Content file could not be deleted from storage; DB row retained for retry');
+        }
       }
     }
 
@@ -413,12 +427,23 @@ export class ContentService {
     newUrl: string,
     options: { name?: string; keepBackup?: boolean; thumbnail?: string; fileSize?: number; mimeType?: string } = {},
   ) {
+    getOwnedMinioObjectKey(organizationId, newUrl);
+    getOwnedMinioObjectKey(organizationId, options.thumbnail);
+
     const existingContent = await this.findOne(organizationId, id);
-    const previousObjectKey = existingContent.url?.startsWith('minio://')
-      ? existingContent.url.substring('minio://'.length)
-      : null;
+    const previousObjectKey = getCleanupSafeMinioObjectKey(organizationId, existingContent.url);
+    const backupThumbnail = this.getBackupSafeThumbnail(organizationId, existingContent.thumbnail);
+    const thumbnailUpdate = this.getReplacementThumbnailUpdate(
+      organizationId,
+      existingContent.thumbnail,
+      options.thumbnail,
+    );
 
     if (options.keepBackup) {
+      if (isMinioUrl(existingContent.url) && !previousObjectKey) {
+        throw new BadRequestException('Cannot keep backup for content file outside organization scope');
+      }
+
       // Create backup and update original in a transaction to prevent data loss
       const updatedContent = await this.db.$transaction(async (tx) => {
         const backupContent = await tx.content.create({
@@ -427,7 +452,7 @@ export class ContentService {
             description: existingContent.description,
             type: existingContent.type,
             url: existingContent.url,
-            thumbnail: existingContent.thumbnail,
+            thumbnail: backupThumbnail,
             duration: existingContent.duration,
             fileSize: existingContent.fileSize,
             mimeType: existingContent.mimeType,
@@ -448,7 +473,7 @@ export class ContentService {
           data: {
             url: newUrl,
             name: options.name || existingContent.name,
-            thumbnail: options.thumbnail,
+            ...thumbnailUpdate,
             fileSize: options.fileSize,
             mimeType: options.mimeType,
             versionNumber: existingContent.versionNumber + 1,
@@ -467,7 +492,7 @@ export class ContentService {
       data: {
         url: newUrl,
         name: options.name || existingContent.name,
-        thumbnail: options.thumbnail,
+        ...thumbnailUpdate,
         fileSize: options.fileSize,
         mimeType: options.mimeType,
         versionNumber: existingContent.versionNumber + 1,
@@ -479,7 +504,7 @@ export class ContentService {
     }
     const updatedContent = await this.db.content.findUnique({ where: { id } });
 
-    if (previousObjectKey && newUrl !== `minio://${previousObjectKey}`) {
+    if (previousObjectKey && newUrl !== `${MINIO_URL_PREFIX}${previousObjectKey}`) {
       await this.cleanupPreviousReplacementObject(
         organizationId,
         id,
@@ -490,6 +515,39 @@ export class ContentService {
     }
 
     return this.mapContentResponse(updatedContent);
+  }
+
+  private getBackupSafeThumbnail(
+    organizationId: string,
+    existingThumbnail: unknown,
+  ): string | null | undefined {
+    if (
+      isMinioUrl(existingThumbnail) &&
+      !getCleanupSafeMinioObjectKey(organizationId, existingThumbnail)
+    ) {
+      return null;
+    }
+
+    return existingThumbnail as string | null | undefined;
+  }
+
+  private getReplacementThumbnailUpdate(
+    organizationId: string,
+    existingThumbnail: unknown,
+    replacementThumbnail?: string,
+  ): { thumbnail?: string | null } {
+    if (replacementThumbnail !== undefined) {
+      return { thumbnail: replacementThumbnail };
+    }
+
+    if (
+      isMinioUrl(existingThumbnail) &&
+      !getCleanupSafeMinioObjectKey(organizationId, existingThumbnail)
+    ) {
+      return { thumbnail: null };
+    }
+
+    return {};
   }
 
   private async cleanupPreviousReplacementObject(
@@ -817,9 +875,18 @@ export class ContentService {
     const failedIds: string[] = [];
     await Promise.all(
       items.map(async (item) => {
-        const objectKey = item.url?.startsWith('minio://')
-          ? item.url.substring('minio://'.length)
-          : null;
+        let objectKey: string | null = null;
+        try {
+          objectKey = getOwnedMinioObjectKey(organizationId, item.url);
+        } catch (err) {
+          failedIds.push(item.id);
+          this.logger.warn(
+            `Bulk delete: content ${item.id} points at a MinIO object outside organization scope: ${
+              err instanceof Error ? err.message : err
+            }. DB row retained for operator review.`,
+          );
+          return;
+        }
         if (!objectKey) {
           // No file to delete (e.g., url-type content) — safe to drop DB row.
           deletableIds.push(item.id);

--- a/middleware/src/modules/organizations/organizations.service.spec.ts
+++ b/middleware/src/modules/organizations/organizations.service.spec.ts
@@ -229,6 +229,21 @@ describe('OrganizationsService', () => {
       expect(mockDatabaseService.$transaction).toHaveBeenCalled();
     });
 
+    it('should skip foreign MinIO objects during organization deletion cleanup', async () => {
+      mockDatabaseService.organization.findUnique.mockResolvedValue(mockOrganization);
+      mockDatabaseService.content.findMany.mockResolvedValue([
+        { id: 'c1', url: 'minio://org-123/file.png' },
+        { id: 'c2', url: 'minio://other-org/secret.png' },
+      ]);
+      mockDatabaseService.user.findMany.mockResolvedValue([]);
+
+      await service.remove('org-123', 'admin-user');
+
+      expect(mockStorageService.deleteFile).toHaveBeenCalledTimes(1);
+      expect(mockStorageService.deleteFile).toHaveBeenCalledWith('org-123/file.png');
+      expect(mockStorageService.deleteFile).not.toHaveBeenCalledWith('other-org/secret.png');
+    });
+
     it('should throw NotFoundException if organization not found', async () => {
       mockDatabaseService.organization.findUnique.mockResolvedValue(null);
 

--- a/middleware/src/modules/organizations/organizations.service.ts
+++ b/middleware/src/modules/organizations/organizations.service.ts
@@ -6,6 +6,7 @@ import { UpdateOrganizationDto } from './dto/update-organization.dto';
 import { BrandingConfigDto } from './dto/branding-config.dto';
 import { PaginationDto, PaginatedResponse } from '../common/dto/pagination.dto';
 import { StorageService } from '../storage/storage.service';
+import { getCleanupSafeMinioObjectKey, isMinioUrl } from '../storage/minio-object-key';
 import { RedisService } from '../redis/redis.service';
 
 @Injectable()
@@ -599,13 +600,15 @@ export class OrganizationsService {
     // 3. Clean up MinIO files (after successful DB delete — orphaned files are
     // safer than deleted files with live DB records)
     for (const item of content) {
-      if (item.url?.startsWith('minio://')) {
-        const objectKey = item.url.substring('minio://'.length);
+      const objectKey = getCleanupSafeMinioObjectKey(id, item.url);
+      if (objectKey) {
         try {
           await this.storageService.deleteFile(objectKey);
         } catch (err) {
           this.logger.warn(`Failed to delete MinIO object ${objectKey}: ${err}`);
         }
+      } else if (isMinioUrl(item.url)) {
+        this.logger.warn(`Skipping foreign MinIO object during organization deletion for content ${item.id}`);
       }
     }
 

--- a/middleware/src/modules/storage/minio-object-key.ts
+++ b/middleware/src/modules/storage/minio-object-key.ts
@@ -1,0 +1,41 @@
+import { BadRequestException } from '@nestjs/common';
+
+export const MINIO_URL_PREFIX = 'minio://';
+
+export function isMinioUrl(url: unknown): url is string {
+  return typeof url === 'string' && url.startsWith(MINIO_URL_PREFIX);
+}
+
+export function assertOrgOwnedMinioObjectKey(
+  organizationId: string,
+  objectKey: string,
+): void {
+  if (!objectKey.startsWith(`${organizationId}/`)) {
+    throw new BadRequestException('Content file is not owned by this organization');
+  }
+}
+
+export function getOwnedMinioObjectKey(
+  organizationId: string,
+  url: unknown,
+): string | null {
+  if (!isMinioUrl(url)) {
+    return null;
+  }
+
+  const objectKey = url.substring(MINIO_URL_PREFIX.length);
+  assertOrgOwnedMinioObjectKey(organizationId, objectKey);
+  return objectKey;
+}
+
+export function getCleanupSafeMinioObjectKey(
+  organizationId: string,
+  url: unknown,
+): string | null {
+  if (!isMinioUrl(url)) {
+    return null;
+  }
+
+  const objectKey = url.substring(MINIO_URL_PREFIX.length);
+  return objectKey.startsWith(`${organizationId}/`) ? objectKey : null;
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,119 @@
 # Vizora - Task Tracker
 
+## Active: Content MinIO Tenant Boundary Pass 40 (2026-06-02)
+
+**Branch:** `feat/customer-performance-readiness`
+
+**Why now:** Reviewer lane C found a high-severity storage tenant-boundary gap:
+device content streaming guards MinIO object keys by organization prefix, but
+dashboard download/delete paths can operate on any `minio://` key already
+persisted on an org-owned content row.
+
+**New primitives introduced:** one storage-module MinIO ownership helper. No
+schema, env var, runtime process, realtime substrate, notification path, MCP
+tool, Hermes skill, provider spend path, or parallel storage path.
+
+**Hermes-first analysis:** not applicable. This is storage tenant-boundary
+hardening inside existing NestJS content/storage services, not a business-agent,
+MCP, Hermes, AI/provider, or spend-path change.
+
+**Plan/design:**
+`docs/plans/2026-06-02-content-minio-tenant-boundary-pass-40.md`
+
+**Plan**
+- [x] Start fresh branch from merged `origin/main`.
+- [x] Run multi-vector review lanes for customer dashboard, performance, and
+  architecture/security.
+- [x] Verify the high-severity MinIO object-key finding against repo truth.
+- [x] Add failing tests for foreign MinIO keys on download, thumbnail read,
+  create/update persistence, single delete, and bulk delete.
+- [x] Implement shared org-owned MinIO object-key helper and wire it through
+  create/update/download/delete and org/account teardown cleanup paths.
+- [x] Run focused verification.
+- [x] Run broader verification.
+- [x] Run subagent re-review before PR/merge.
+- [ ] PR, CI, merge if green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Evidence so far:**
+- Current prod deploy gate remains blocked: `/opt/vizora/app` is on `main` at
+  `bb76aa1838740bff5b58623dfef7a906d44f46a6`, remote main is
+  `35dd7397bcab6729f14ead9a8a59ee8539631af1`, and prod is dirty/diverged
+  (`ahead 17, behind 123`) with tracked and untracked template/Hermes/public
+  files. No deploy attempted.
+- Reviewer lane C finding: `DeviceContentController` checks MinIO object keys
+  start with `${organizationId}/`, while `ContentController.getDownloadUrl`,
+  `ContentService.remove`, and `ContentService.bulkDelete` extract keys without
+  that guard.
+- Local verification: `CreateContentDto` allows `minio://...` by regex, while
+  the controller's URL validator rejects non-HTTP(S) on JSON create; update and
+  service-level callers still need a service-side boundary check.
+- Red verification:
+  `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/content/content.service.spec.ts middleware/src/modules/content/content.controller.spec.ts`
+  failed as expected before implementation: foreign MinIO keys were presigned,
+  service create/update/remove did not reject with `BadRequestException`, and
+  bulk delete called storage deletion for `other-org/secret.png`.
+- Implementation: added `middleware/src/modules/storage/minio-object-key.ts`
+  and wired it into content create/update, dashboard download URL generation,
+  manual MinIO thumbnail reads, single delete, replacement cleanup, and bulk
+  delete.
+- Focused verification:
+  `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/content/content.service.spec.ts middleware/src/modules/content/content.controller.spec.ts`
+  passed 2 suites / 163 tests after initial implementation.
+- Diff review follow-up: replacement cleanup originally reused the strict
+  ownership helper for the old URL, which blocked normal replacement of legacy
+  polluted rows. Added a red regression proving
+  `minio://other-org/... -> minio://org-123/...` simple replacement should
+  repair the DB pointer without deleting the foreign object, plus positive
+  same-org download, thumbnail read, and single-delete coverage.
+- Review-fix verification:
+  `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/content/content.service.spec.ts middleware/src/modules/content/content.controller.spec.ts`
+  passed 2 suites / 168 tests. The backup replacement path remains fail-closed
+  for polluted old MinIO URLs so the bad pointer is not preserved in an
+  archived backup row.
+- Subagent re-review found two same-class teardown gaps outside content
+  controller/service paths: organization deletion and sole-admin account
+  deletion could derive storage delete keys from polluted content URLs and
+  thumbnails. Added red tests, then moved the helper to the storage module and
+  applied cleanup-safe org-prefix checks to both teardown paths.
+- Reviewer-fix red verification:
+  `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/organizations/organizations.service.spec.ts middleware/src/modules/auth/auth.service.spec.ts`
+  failed as expected before teardown fixes: organization cleanup deleted
+  `other-org/secret.png`, and account deletion attempted six storage deletes
+  instead of the two same-org MinIO objects.
+- Reviewer-fix green verification:
+  `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/organizations/organizations.service.spec.ts middleware/src/modules/auth/auth.service.spec.ts`
+  passed 2 suites / 90 tests.
+- Post-helper-move content verification:
+  `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=modules/content`
+  passed 19 suites / 567 tests.
+- Final security re-review found one remaining medium thumbnail persistence
+  gap: content create/update/replacement could preserve `thumbnail:
+  minio://other-org/...` even though teardown no longer deletes it. Added red
+  tests for create/update thumbnail rejection and replacement thumbnail cleanup,
+  then validated with
+  `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/content/content.service.spec.ts`
+  passing 1 suite / 121 tests.
+- Final focused affected verification:
+  `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/content/content.service.spec.ts middleware/src/modules/content/content.controller.spec.ts middleware/src/modules/auth/auth.service.spec.ts middleware/src/modules/organizations/organizations.service.spec.ts`
+  passed 4 suites / 262 tests.
+- Broader content verification:
+  `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=modules/content`
+  passed 19 suites / 571 tests.
+- Full middleware verification:
+  `pnpm --filter @vizora/middleware test -- --runInBand` passed 146 suites /
+  2959 tests, 1 snapshot.
+- Build/hygiene verification:
+  `npx nx build @vizora/middleware --skip-nx-cache` exited 0 with the existing
+  webpack warning class; `git diff --check` exited 0 aside from CRLF warnings;
+  `pnpm security:no-hardcoded-jwts` reported no hardcoded JWT-looking tokens.
+- Final subagent re-review: CLEAN. The prior thumbnail finding is resolved;
+  content presign/read/delete, bulk delete, org cleanup, and sole-admin account
+  cleanup now either require org-owned MinIO keys or skip/retain polluted
+  foreign pointers without touching foreign storage objects.
+
+---
+
 ## Completed: Dashboard Action Truth Pass 39 (2026-06-01)
 
 **Branch:** `feat/dashboard-action-truth-pass-39`


### PR DESCRIPTION
## Summary
- Add shared storage helper for org-owned `minio://` object keys.
- Enforce MinIO tenant boundaries for content create/update, dashboard download URLs, manual thumbnail reads, single delete, replacement cleanup, bulk delete, organization deletion cleanup, and sole-admin account deletion cleanup.
- Preserve repair behavior for legacy polluted rows: simple replacement can move a row to an org-owned object without deleting the foreign old object; backup replacement stays fail-closed; polluted existing thumbnails are cleared instead of copied.

## Verification
- `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/content/content.service.spec.ts middleware/src/modules/content/content.controller.spec.ts middleware/src/modules/auth/auth.service.spec.ts middleware/src/modules/organizations/organizations.service.spec.ts` passed 4 suites / 262 tests.
- `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=modules/content` passed 19 suites / 571 tests.
- `pnpm --filter @vizora/middleware test -- --runInBand` passed 146 suites / 2959 tests, 1 snapshot.
- `npx nx build @vizora/middleware --skip-nx-cache` exited 0 with existing webpack warning class.
- `git diff --cached --check` exited 0.
- `pnpm security:no-hardcoded-jwts` reported no hardcoded JWT-looking tokens.

## Reviews
- Security subagent re-review: CLEAN after thumbnail persistence fix.
- Maintainability reviewer: CLEAN after moving helper under `modules/storage`.

## Deploy
- No deployment in this PR. Current prod checkout remains dirty/diverged and must be resolved before deploy.