### PR TITLE
fix: harden customer hot paths

### DIFF
--- a/docs/plans/2026-06-02-customer-readiness-hotpath-pass-41.md
+++ b/docs/plans/2026-06-02-customer-readiness-hotpath-pass-41.md
@@ -1,0 +1,79 @@
+# Customer Readiness Hot-Path Pass 41
+
+**Branch:** `feat/customer-dashboard-performance-pass-41`
+
+**Why now:** Customer and performance review lanes found multiple repo-side
+production-readiness issues. This pass targets the highest-impact hot-path
+items that are small, testable, and safe to merge independently.
+
+**New primitives introduced:** one logging skip metadata decorator on the
+existing LoggingInterceptor. No schema, env var, runtime process, notification
+path, realtime substrate, MCP tool, Hermes skill, provider spend path, or
+parallel infrastructure.
+
+**Hermes-first analysis:** checked per project convention. The Hermes Agent
+Skills Hub currently reports no listed skills, and the awesome-hermes-agent
+community index is an informational catalog rather than a runtime primitive for
+these in-repo hot-path fixes.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Display playback cache policy | none found | build in Vizora display client; this is browser media behavior |
+| Middleware health/readiness | none found | build in existing NestJS health module |
+| HTTP media-stream logging | none found | build in existing LoggingInterceptor |
+| Playlist realtime fanout tenant scope | none found | build in existing playlist/realtime path |
+
+Awesome-hermes-agent ecosystem check: no applicable runtime/library primitive
+for display media caching, NestJS readiness, HTTP logging, or tenant-scoped
+playlist fanout; proceed with Vizora-native code.
+
+## Scope
+
+1. Display playback should not prefetch/cache videos before playback. The
+   display client may still preload images, but videos should rely on normal
+   `<video>` range streaming.
+2. Successful device media streaming requests should not emit normal HTTP logs
+   or slow-request warnings. Errors must still be logged, and request IDs must
+   still be attached for tracing.
+3. Public readiness should fail closed when storage/MinIO is unhealthy, because
+   content upload, download, and playback are customer-visible core paths.
+   Public readiness should expose only self-test status, not detailed
+   self-test failure messages.
+4. Playlist update fanout should only notify displays in the playlist's
+   organization.
+
+## Out Of Scope
+
+- Dashboard role-truth fixes for schedules, pairing CTAs, landing quick
+  actions, team/API key settings, and settings email. These are queued as the
+  next customer-dashboard pass.
+- Large API-shape changes for dashboard all-page overfetch and playlist
+  summary/detail split.
+- Database indexing migrations for content search.
+- Operator-only prod deploy or checkout cleanup.
+
+## Verification Plan
+
+- Red/green focused tests:
+  - `web/src/app/display/__tests__/DisplayClient.test.tsx`
+  - `middleware/src/modules/common/interceptors/logging.interceptor.spec.ts`
+  - `middleware/src/modules/health/health.controller.spec.ts`
+  - `middleware/src/modules/health/health.service.spec.ts`
+  - `middleware/src/modules/playlists/playlists.service.spec.ts`
+- Broader tests:
+  - `pnpm --filter @vizora/web test -- DisplayClient.test.tsx`
+  - `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/common/interceptors/logging.interceptor.spec.ts middleware/src/modules/health/health.controller.spec.ts middleware/src/modules/health/health.service.spec.ts middleware/src/modules/playlists/playlists.service.spec.ts`
+  - relevant builds and CI after PR.
+
+## Customer Improvement Backlog Captured
+
+- Viewer schedule create/edit/delete controls.
+- Support chat failed-message visibility and retry.
+- Viewer pairing CTAs and pair-page access.
+- Dashboard quick actions that ignore role permissions.
+- Settings admin email field that looks editable but is not saved.
+- Team/API key admin-only controls shown to lower roles.
+- Offline-device push semantics.
+- Strict browser upload/pairing/playlist/schedule/support/fleet smoke gaps.
+- Dashboard overfetch, playlist payload bloat, output sanitization cost, content
+  search indexes, and pairing Redis scan performance follow-ups.

--- a/middleware/src/main.ts
+++ b/middleware/src/main.ts
@@ -140,7 +140,7 @@ async function bootstrap() {
   // Order matters: logging first, then Sentry error tracking, then sanitization, then envelope
   const reflector = app.get(Reflector);
   app.useGlobalInterceptors(
-    new LoggingInterceptor(),
+    new LoggingInterceptor(reflector),
     new SentryInterceptor(),
     new SanitizeInterceptor(reflector),
     new ResponseEnvelopeInterceptor(reflector),

--- a/middleware/src/modules/common/interceptors/logging.interceptor.spec.ts
+++ b/middleware/src/modules/common/interceptors/logging.interceptor.spec.ts
@@ -1,6 +1,6 @@
 import { LoggingInterceptor } from './logging.interceptor';
 import { ExecutionContext, CallHandler, Logger } from '@nestjs/common';
-import { of, throwError } from 'rxjs';
+import { firstValueFrom, of, throwError } from 'rxjs';
 
 describe('LoggingInterceptor', () => {
   let interceptor: LoggingInterceptor;
@@ -180,6 +180,57 @@ describe('LoggingInterceptor', () => {
           done();
         },
       });
+    });
+  });
+
+  describe('device media stream logging', () => {
+    it('suppresses normal and slow logs for successful device-content file streams', async () => {
+      mockRequest.url = '/api/v1/device-content/content-1/file?token=secret-token';
+      const startTime = Date.now();
+      let callCount = 0;
+      jest.spyOn(Date, 'now').mockImplementation(() => {
+        callCount += 1;
+        return callCount > 1 ? startTime + 2500 : startTime;
+      });
+
+      await firstValueFrom(interceptor.intercept(mockExecutionContext, mockCallHandler));
+
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('Slow request detected'),
+        'Performance',
+      );
+    });
+
+    it('still logs device-content file stream errors', (done) => {
+      mockRequest.url = '/api/v1/device-content/content-1/file?token=secret-token';
+      const error = { status: 500, message: 'stream failed' };
+      mockCallHandler.handle = jest.fn().mockReturnValue(throwError(() => error));
+
+      const result$ = interceptor.intercept(mockExecutionContext, mockCallHandler);
+
+      result$.subscribe({
+        error: () => {
+          expect(errorSpy).toHaveBeenCalledWith(
+            expect.stringContaining('stream failed'),
+            undefined,
+            expect.any(String),
+          );
+          done();
+        },
+      });
+    });
+
+    it('still logs completed 4xx device-content file responses', async () => {
+      mockRequest.url = '/api/v1/device-content/content-1/file?token=secret-token';
+      mockResponse.statusCode = 416;
+
+      await firstValueFrom(interceptor.intercept(mockExecutionContext, mockCallHandler));
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('GET /api/v1/device-content/content-1/file?token=REDACTED 416'),
+        expect.any(String),
+      );
     });
   });
 

--- a/middleware/src/modules/common/interceptors/logging.interceptor.ts
+++ b/middleware/src/modules/common/interceptors/logging.interceptor.ts
@@ -4,11 +4,16 @@ import {
   ExecutionContext,
   CallHandler,
   Logger,
+  SetMetadata,
 } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { Request, Response } from 'express';
 import * as crypto from 'crypto';
+
+export const SKIP_HTTP_LOGGING_KEY = 'skipHttpLogging';
+export const SkipHttpLogging = () => SetMetadata(SKIP_HTTP_LOGGING_KEY, true);
 
 interface AuthenticatedRequest extends Request {
   user?: {
@@ -34,9 +39,12 @@ interface LogMetadata {
 export class LoggingInterceptor implements NestInterceptor {
   private readonly logger = new Logger('HTTP');
 
+  constructor(private readonly reflector?: Reflector) {}
+
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
     const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
     const response = context.switchToHttp().getResponse<Response>();
+    const skipSuccessfulLogging = this.shouldSkipSuccessfulLogging(context, request);
 
     // Use incoming X-Request-ID if valid (alphanumeric/dashes, max 128 chars), else generate
     const incomingId = request.headers['x-request-id'] as string;
@@ -61,7 +69,7 @@ export class LoggingInterceptor implements NestInterceptor {
     };
 
     // Log incoming request (debug level in production)
-    if (process.env.NODE_ENV !== 'production') {
+    if (process.env.NODE_ENV !== 'production' && !skipSuccessfulLogging) {
       this.logger.debug(`[${requestId}] --> ${metadata.method} ${metadata.url}`, 'Request');
     }
 
@@ -72,7 +80,9 @@ export class LoggingInterceptor implements NestInterceptor {
           metadata.statusCode = response.statusCode;
           metadata.duration = duration;
 
-          this.logRequest(metadata);
+          if (!skipSuccessfulLogging || response.statusCode >= 400) {
+            this.logRequest(metadata);
+          }
         },
         error: (error) => {
           const duration = Date.now() - startTime;
@@ -117,6 +127,18 @@ export class LoggingInterceptor implements NestInterceptor {
     }
   }
 
+  private shouldSkipSuccessfulLogging(
+    context: ExecutionContext,
+    request: AuthenticatedRequest,
+  ): boolean {
+    const skipFromMetadata = this.reflector?.getAllAndOverride<boolean>(
+      SKIP_HTTP_LOGGING_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    return Boolean(skipFromMetadata) || LoggingInterceptor.isDeviceContentFileUrl(request.url);
+  }
+
   private generateRequestId(): string {
     return crypto.randomUUID();
   }
@@ -158,5 +180,10 @@ export class LoggingInterceptor implements NestInterceptor {
       })
       .join('&');
     return `${path}?${redacted}`;
+  }
+
+  static isDeviceContentFileUrl(url: string): boolean {
+    const path = url.split('?')[0];
+    return /^\/(?:api\/v1\/)?device-content\/[^/]+\/file$/.test(path);
   }
 }

--- a/middleware/src/modules/content/device-content.controller.ts
+++ b/middleware/src/modules/content/device-content.controller.ts
@@ -15,6 +15,7 @@ import { ParseIdPipe } from '../common/pipes/parse-id.pipe';
 import type { Request, Response } from 'express';
 import { JwtService } from '@nestjs/jwt';
 import { Public } from '../auth/decorators/public.decorator';
+import { SkipHttpLogging } from '../common/interceptors/logging.interceptor';
 import { SkipEnvelope } from '../common/interceptors/response-envelope.interceptor';
 import { SkipOutputSanitize } from '../common/interceptors/sanitize.interceptor';
 import { ContentService } from './content.service';
@@ -762,6 +763,7 @@ export class DeviceContentController {
   @Get(':id/file')
   @Public()
   @SkipEnvelope()
+  @SkipHttpLogging()
   @SkipOutputSanitize()
   async serveFile(
     @Param('id', ParseIdPipe) id: string,

--- a/middleware/src/modules/health/health.controller.spec.ts
+++ b/middleware/src/modules/health/health.controller.spec.ts
@@ -11,6 +11,7 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 describe('HealthController', () => {
   let controller: HealthController;
   let healthService: jest.Mocked<HealthService>;
+  let selfTestService: jest.Mocked<StartupSelfTestService>;
 
   const mockHealthyResponse = {
     status: 'ok' as const,
@@ -20,8 +21,8 @@ describe('HealthController', () => {
     checks: {
       database: { status: 'healthy' as const, responseTime: 5 },
       redis: { status: 'healthy' as const, responseTime: 3 },
-      memory: {
-        status: 'healthy' as const,
+        memory: {
+          status: 'healthy' as const,
         responseTime: 0,
         details: {
           heapUsedMB: 50,
@@ -30,6 +31,7 @@ describe('HealthController', () => {
           rssMB: 120,
         },
       },
+      minio: { status: 'healthy' as const, responseTime: 4 },
     },
   };
 
@@ -42,6 +44,7 @@ describe('HealthController', () => {
       database: { status: 'unhealthy' as const, responseTime: 100, error: 'Connection refused' },
       redis: { status: 'healthy' as const, responseTime: 3 },
       memory: { status: 'healthy' as const, responseTime: 0 },
+      minio: { status: 'healthy' as const, responseTime: 4 },
     },
   };
 
@@ -54,6 +57,7 @@ describe('HealthController', () => {
       database: { status: 'healthy' as const, responseTime: 5 },
       redis: { status: 'unhealthy' as const, responseTime: 10, error: 'Connection refused' },
       memory: { status: 'healthy' as const, responseTime: 0 },
+      minio: { status: 'healthy' as const, responseTime: 4 },
     },
   };
 
@@ -89,6 +93,7 @@ describe('HealthController', () => {
 
     controller = module.get<HealthController>(HealthController);
     healthService = module.get(HealthService);
+    selfTestService = module.get(StartupSelfTestService);
   });
 
   describe('health', () => {
@@ -158,6 +163,24 @@ describe('HealthController', () => {
 
       expect(result.uptime).toBe(3600);
       expect(result.version).toBe('1.0.0');
+    });
+
+    it('should not expose detailed self-test failure messages on the public readiness endpoint', async () => {
+      healthService.check.mockResolvedValue(mockHealthyResponse);
+      selfTestService.result = {
+        passed: false,
+        timestamp: '2026-02-01T10:00:00.000Z',
+        duration_ms: 12,
+        results: {
+          smtp: { passed: false, message: 'SMTP_PASS is not configured' },
+          database: { passed: true, message: 'ok' },
+        },
+      } as any;
+
+      const result = await controller.ready();
+
+      expect(result).toHaveProperty('self_test', 'failed');
+      expect(result).not.toHaveProperty('self_test_failures');
     });
   });
 

--- a/middleware/src/modules/health/health.controller.ts
+++ b/middleware/src/modules/health/health.controller.ts
@@ -48,13 +48,6 @@ export class HealthController {
     const enriched = {
       ...result,
       self_test: selfTestStatus,
-      ...(this.selfTest.result && !this.selfTest.result.passed
-        ? {
-            self_test_failures: Object.entries(this.selfTest.result.results)
-              .filter(([, r]) => !r.passed)
-              .map(([name, r]) => `${name}: ${r.message}`),
-          }
-        : {}),
     };
 
     if (result.status === 'unhealthy') {

--- a/middleware/src/modules/health/health.service.spec.ts
+++ b/middleware/src/modules/health/health.service.spec.ts
@@ -155,6 +155,29 @@ describe('HealthService', () => {
       });
     });
 
+    describe('when MinIO is unhealthy', () => {
+      beforeEach(() => {
+        mockDatabaseService.$queryRaw.mockResolvedValue([{ '?column?': 1 }]);
+        mockRedisService.healthCheck.mockResolvedValue({
+          healthy: true,
+          responseTime: 5,
+        });
+        mockStorageService.healthCheck.mockResolvedValue({
+          healthy: false,
+          bucket: 'vizora',
+          error: 'MinIO unavailable',
+        });
+      });
+
+      it('should return unhealthy status because storage is required for customer content paths', async () => {
+        const result = await service.check();
+
+        expect(result.status).toBe('unhealthy');
+        expect(result.checks.minio.status).toBe('unhealthy');
+        expect(result.checks.minio.error).toContain('MinIO unavailable');
+      });
+    });
+
     describe('when redis service throws an error', () => {
       beforeEach(() => {
         mockDatabaseService.$queryRaw.mockResolvedValue([{ '?column?': 1 }]);

--- a/middleware/src/modules/health/health.service.ts
+++ b/middleware/src/modules/health/health.service.ts
@@ -61,9 +61,9 @@ export class HealthService {
 
     let status: 'ok' | 'degraded' | 'unhealthy';
     if (hasUnhealthy) {
-      // Database unhealthy = overall unhealthy
+      // Database and object storage are required for customer-facing readiness.
       // Redis unhealthy = degraded (it's optional for basic functionality)
-      if (database.status === 'unhealthy') {
+      if (database.status === 'unhealthy' || minio.status === 'unhealthy') {
         status = 'unhealthy';
       } else {
         status = 'degraded';

--- a/middleware/src/modules/playlists/playlists.service.spec.ts
+++ b/middleware/src/modules/playlists/playlists.service.spec.ts
@@ -633,7 +633,7 @@ describe('PlaylistsService', () => {
       await new Promise((r) => setTimeout(r, 50));
 
       expect(mockDatabaseService.display.findMany).toHaveBeenCalledWith({
-        where: { currentPlaylistId: 'playlist-123' },
+        where: { currentPlaylistId: 'playlist-123', organizationId: 'org-123' },
         select: { id: true },
       });
       expect(mockCircuitBreaker.executeWithFallback).toHaveBeenCalledTimes(2);
@@ -708,7 +708,7 @@ describe('PlaylistsService', () => {
       };
 
       const notifyPromise = (service as any)
-        .notifyDisplaysOfPlaylistUpdate('playlist-123', updatedPlaylist)
+        .notifyDisplaysOfPlaylistUpdate('org-123', 'playlist-123', updatedPlaylist)
         .finally(() => {
           completed = true;
         });
@@ -750,7 +750,7 @@ describe('PlaylistsService', () => {
         }
       });
 
-      await (service as any).notifyDisplaysOfPlaylistUpdate('playlist-123', updatedPlaylist);
+      await (service as any).notifyDisplaysOfPlaylistUpdate('org-123', 'playlist-123', updatedPlaylist);
 
       expect(mockCircuitBreaker.executeWithFallback).toHaveBeenCalledTimes(displays.length);
     });

--- a/middleware/src/modules/playlists/playlists.service.ts
+++ b/middleware/src/modules/playlists/playlists.service.ts
@@ -281,7 +281,7 @@ export class PlaylistsService {
     this.eventEmitter.emit('playlist.updated', { entityId: id, organizationId });
 
     // Notify all displays using this playlist
-    this.notifyDisplaysOfPlaylistUpdate(id, updatedPlaylist).catch(error => {
+    this.notifyDisplaysOfPlaylistUpdate(organizationId, id, updatedPlaylist).catch(error => {
       this.logger.error(`Failed to notify displays of playlist update: ${error.message}`);
     });
 
@@ -318,7 +318,7 @@ export class PlaylistsService {
     });
 
     // Notify displays about the playlist change
-    this.notifyPlaylistChangeAfterItemUpdate(playlistId);
+    this.notifyPlaylistChangeAfterItemUpdate(organizationId, playlistId);
 
     return newItem;
   }
@@ -340,7 +340,7 @@ export class PlaylistsService {
       include: { content: true },
     });
 
-    this.notifyPlaylistChangeAfterItemUpdate(playlistId);
+    this.notifyPlaylistChangeAfterItemUpdate(organizationId, playlistId);
 
     return updatedItem;
   }
@@ -360,7 +360,7 @@ export class PlaylistsService {
     const deletedItem = { id: itemId, playlistId };
 
     // Notify displays about the playlist change
-    this.notifyPlaylistChangeAfterItemUpdate(playlistId);
+    this.notifyPlaylistChangeAfterItemUpdate(organizationId, playlistId);
 
     return deletedItem;
   }
@@ -368,7 +368,10 @@ export class PlaylistsService {
   /**
    * Helper to notify displays after adding/removing playlist items
    */
-  private async notifyPlaylistChangeAfterItemUpdate(playlistId: string): Promise<void> {
+  private async notifyPlaylistChangeAfterItemUpdate(
+    organizationId: string,
+    playlistId: string,
+  ): Promise<void> {
     // Fetch the full playlist with items
     const playlist = await this.db.playlist.findUnique({
       where: { id: playlistId },
@@ -381,7 +384,7 @@ export class PlaylistsService {
     });
 
     if (playlist) {
-      this.notifyDisplaysOfPlaylistUpdate(playlistId, playlist).catch(error => {
+      this.notifyDisplaysOfPlaylistUpdate(organizationId, playlistId, playlist).catch(error => {
         this.logger.error(`Failed to notify displays after item update: ${error.message}`);
       });
     }
@@ -425,7 +428,7 @@ export class PlaylistsService {
     const updatedPlaylist = await this.findOne(organizationId, playlistId);
 
     // Notify displays
-    this.notifyDisplaysOfPlaylistUpdate(playlistId, updatedPlaylist).catch(error => {
+    this.notifyDisplaysOfPlaylistUpdate(organizationId, playlistId, updatedPlaylist).catch(error => {
       this.logger.error(`Failed to notify displays of playlist reorder: ${error.message}`);
     });
 
@@ -508,7 +511,7 @@ export class PlaylistsService {
         );
         return;
       }
-      await this.notifyDisplaysOfPlaylistUpdate(payload.entityId, playlist);
+      await this.notifyDisplaysOfPlaylistUpdate(payload.organizationId, payload.entityId, playlist);
     } catch (err) {
       this.logger.error(
         `Failed to notify displays of expired-content playlist refresh for ${payload.entityId}: ${
@@ -521,13 +524,17 @@ export class PlaylistsService {
   /**
    * Notify all displays using a playlist about the update
    */
-  private async notifyDisplaysOfPlaylistUpdate(playlistId: string, playlist: unknown): Promise<void> {
+  private async notifyDisplaysOfPlaylistUpdate(
+    organizationId: string,
+    playlistId: string,
+    playlist: unknown,
+  ): Promise<void> {
     const headers = this.getInternalApiHeaders();
     if (!headers) return;
 
     // Find all displays currently using this playlist
     const displays = await this.db.display.findMany({
-      where: { currentPlaylistId: playlistId },
+      where: { currentPlaylistId: playlistId, organizationId },
       select: { id: true },
     });
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,123 @@
 # Vizora - Task Tracker
 
+## Active: Customer Readiness Hot-Path Pass 41 (2026-06-02)
+
+**Branch:** `feat/customer-dashboard-performance-pass-41`
+
+**Why now:** The customer/performance analysis lanes found several repo-side
+production-readiness issues. The first buildable slice should harden the
+customer-1 hot paths that are small enough to verify in one PR: display media
+prefetching, streaming-route logging, readiness semantics, and playlist
+tenant-boundary fanout.
+
+**New primitives introduced:** one logging skip metadata decorator on the
+existing LoggingInterceptor. No schema, env var, runtime process, notification
+path, realtime substrate, MCP tool, Hermes skill, provider spend path, or
+parallel infrastructure.
+
+**Hermes-first analysis:** checked per project convention. The Hermes Agent
+Skills Hub currently reports no listed skills, and the awesome-hermes-agent
+community index is informational rather than a runtime primitive for these
+in-repo hot-path fixes.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Display playback cache policy | none found | build in Vizora display client |
+| Middleware health/readiness | none found | build in existing NestJS health module |
+| HTTP media-stream logging | none found | build in existing LoggingInterceptor |
+| Playlist realtime fanout tenant scope | none found | build in existing playlist/realtime path |
+
+Awesome-hermes-agent ecosystem check: no applicable runtime/library primitive
+for display media caching, NestJS readiness, HTTP logging, or tenant-scoped
+playlist fanout; proceed with Vizora-native code.
+
+**Plan/design:**
+`docs/plans/2026-06-02-customer-readiness-hotpath-pass-41.md`
+
+**Plan**
+- [x] Start fresh branch from merged `origin/main`.
+- [x] Run multi-vector analysis lanes: customer UX, performance, backend
+  security/readiness, and customer-critical tests.
+- [x] Add red tests for scoped hot-path fixes.
+- [x] Implement display/media/readiness/playlist fanout fixes.
+- [x] Run focused verification.
+- [x] Run broader verification.
+- [x] Run multi-vector subagent re-review.
+- [ ] PR, CI, merge if green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Scoped fixes**
+- Display playback: preload image content only; do not full-fetch/cache video
+  files before playback.
+- Middleware logging: suppress normal and slow-request logs for successful
+  device-content media streaming while preserving request IDs and error logs.
+- Readiness: make public `/health/ready` fail when MinIO/storage is unhealthy
+  and stop exposing detailed self-test failure messages on the public endpoint.
+- Playlist fanout: scope display lookup for playlist-update push by
+  `organizationId` so polluted display rows cannot receive cross-tenant
+  playlist payloads.
+
+**Backlog/customer-improvement findings to carry forward**
+- P1 schedule role truth: viewers can currently open create/edit/delete
+  schedule workflows.
+- P1 support chat failure state: failed sends can disappear without a visible
+  retry/error state.
+- P2 device pairing role truth: viewer users see pairing entry points.
+- P2 dashboard landing role truth: quick actions advertise write workflows to
+  all roles.
+- P2 settings email truth: editable admin email is not persisted by the save
+  path.
+- P2 team/API key admin gates: sensitive controls are visible to non-admins.
+- P3 content push semantics: offline devices can be selected with unclear
+  delivery expectations.
+- Test gaps: strict browser upload, pairing, playlist/schedule, support, and
+  fleet-command critical paths still need stronger Playwright/API smoke
+  coverage.
+- Performance backlog: dashboard all-page overfetch, playlist list payload
+  bloat, output sanitization cost on large list responses, search indexes, and
+  pairing Redis scan remain for follow-up passes.
+
+**Evidence so far**
+- PR #175 and #176 merged; no open PRs at the start of this pass.
+- Production deploy remains blocked from prior probe: `/opt/vizora/app` is
+  dirty/diverged and behind `origin/main`. No deploy will be attempted unless
+  the checkout becomes safe.
+- Red verification:
+  - `pnpm --filter @vizora/web test -- DisplayClient.test.tsx` failed as
+    expected because video device-content URLs were included in `preloadItems`.
+  - `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/common/interceptors/logging.interceptor.spec.ts middleware/src/modules/health/health.controller.spec.ts middleware/src/modules/health/health.service.spec.ts middleware/src/modules/playlists/playlists.service.spec.ts`
+    failed as expected because successful media streams were logged, MinIO
+    outage was degraded, public readiness exposed `self_test_failures`, and
+    playlist fanout queried displays without `organizationId`.
+- Focused green verification:
+  - `pnpm --filter @vizora/web test -- DisplayClient.test.tsx` passed 1 suite
+    / 3 tests.
+  - `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/common/interceptors/logging.interceptor.spec.ts middleware/src/modules/health/health.controller.spec.ts middleware/src/modules/health/health.service.spec.ts middleware/src/modules/playlists/playlists.service.spec.ts`
+    passed 4 suites / 85 tests.
+- Subagent re-review follow-up: reviewers found that media-stream logging also
+  suppressed completed 4xx responses such as 416, and that the plan needed the
+  mandatory Hermes-first table. Added a red test for completed 4xx media
+  responses before narrowing the logging skip to 2xx/3xx successes.
+- Reviewer-fix focused green:
+  `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/common/interceptors/logging.interceptor.spec.ts`
+  passed 1 suite / 22 tests.
+- Broader affected verification:
+  - `pnpm --filter @vizora/web test -- src/app/display` passed 6 suites / 25
+    tests.
+  - `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/content/device-content.controller.spec.ts middleware/src/modules/common/interceptors/logging.interceptor.spec.ts middleware/src/modules/health/health.controller.spec.ts middleware/src/modules/health/health.service.spec.ts middleware/src/modules/playlists/playlists.service.spec.ts`
+    passed 5 suites / 126 tests.
+- Build and hygiene verification:
+  - `npx nx build @vizora/middleware --skip-nx-cache` passed with existing
+    webpack warnings and Nx flaky-task note for `@vizora/database:build`.
+  - `NEXT_PUBLIC_API_URL=http://localhost:3000 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NODE_OPTIONS=--max-old-space-size=4096 npx nx build @vizora/web --skip-nx-cache`
+    passed with existing Next middleware/proxy and TypeScript project-reference
+    warnings.
+  - `git diff --check` passed with Windows CRLF line-ending warnings only.
+  - `pnpm security:no-hardcoded-jwts` passed.
+- Final subagent re-review: performance/regression reviewer CLEAN; security,
+  architecture, readiness, and process reviewer CLEAN. No tenant/auth/readiness
+  envelope or realtime-substrate drift found.
+
 ## Completed: Content MinIO Tenant Boundary Pass 40 (2026-06-02)
 
 **Branch:** `feat/customer-performance-readiness`

--- a/web/src/app/display/DisplayClient.tsx
+++ b/web/src/app/display/DisplayClient.tsx
@@ -76,10 +76,11 @@ export function DisplayClient() {
     player.updatePlaylist(playlist);
     setState('PLAYING');
 
-    // Preload first 5 media items
+    // Preload image items only. Videos should rely on native range streaming;
+    // Cache API preloads would fetch the full file before playback.
     const urls = playlist.items
       .slice(0, 5)
-      .filter((item) => item.content && (item.content.type === 'image' || item.content.type === 'video'))
+      .filter((item) => item.content?.type === 'image')
       .map((item) => authenticateDisplayContentUrl(item.content!.url, credentials?.deviceToken))
       .filter(Boolean);
     if (urls.length > 0) preloadItems(urls);

--- a/web/src/app/display/__tests__/DisplayClient.test.tsx
+++ b/web/src/app/display/__tests__/DisplayClient.test.tsx
@@ -91,7 +91,37 @@ describe('DisplayClient', () => {
     });
   });
 
-  it('preloads authenticated device-content URLs after playlist updates', async () => {
+  it('preloads authenticated image device-content URLs after playlist updates', async () => {
+    render(<DisplayClient />);
+
+    await waitFor(() => expect(capturedPlaylistUpdate).toBeDefined());
+
+    capturedPlaylistUpdate?.({
+      id: 'playlist-1',
+      name: 'Main',
+      items: [
+        {
+          id: 'item-1',
+          contentId: 'content-1',
+          duration: 10,
+          order: 0,
+          content: {
+            id: 'content-1',
+            name: 'Image',
+            type: 'image',
+            url: '/api/v1/device-content/content-1/file',
+          },
+        },
+      ],
+    });
+
+    expect(updatePlaylist).toHaveBeenCalled();
+    expect(mockPreloadItems).toHaveBeenCalledWith([
+      '/api/v1/device-content/content-1/file?token=device-token-123',
+    ]);
+  });
+
+  it('does not preload video files before playback', async () => {
     render(<DisplayClient />);
 
     await waitFor(() => expect(capturedPlaylistUpdate).toBeDefined());
@@ -112,12 +142,24 @@ describe('DisplayClient', () => {
             url: '/api/v1/device-content/content-1/file',
           },
         },
+        {
+          id: 'item-2',
+          contentId: 'content-2',
+          duration: 10,
+          order: 1,
+          content: {
+            id: 'content-2',
+            name: 'Image',
+            type: 'image',
+            url: '/api/v1/device-content/content-2/file',
+          },
+        },
       ],
     });
 
     expect(updatePlaylist).toHaveBeenCalled();
     expect(mockPreloadItems).toHaveBeenCalledWith([
-      '/api/v1/device-content/content-1/file?token=device-token-123',
+      '/api/v1/device-content/content-2/file?token=device-token-123',
     ]);
   });
 


### PR DESCRIPTION
## Summary
- stop display clients from Cache API preloading video device-content URLs before playback; images still preload with display-token URL auth
- suppress normal/slow HTTP logs for successful device-content media streams while preserving 4xx/5xx and thrown-error logging
- make readiness fail on MinIO/storage outage and stop exposing detailed self-test failure messages from public `/health/ready`
- tenant-scope playlist update fanout display lookup by `organizationId`

## Tests
- `pnpm --filter @vizora/web test -- DisplayClient.test.tsx` (red before implementation, then pass: 1 suite / 3 tests)
- `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/common/interceptors/logging.interceptor.spec.ts middleware/src/modules/health/health.controller.spec.ts middleware/src/modules/health/health.service.spec.ts middleware/src/modules/playlists/playlists.service.spec.ts` (red before implementation, then pass: 4 suites / 85 tests)
- reviewer-fix red/green: `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/common/interceptors/logging.interceptor.spec.ts` (pass: 1 suite / 22 tests)
- `pnpm --filter @vizora/web test -- src/app/display` (pass: 6 suites / 25 tests)
- `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/content/device-content.controller.spec.ts middleware/src/modules/common/interceptors/logging.interceptor.spec.ts middleware/src/modules/health/health.controller.spec.ts middleware/src/modules/health/health.service.spec.ts middleware/src/modules/playlists/playlists.service.spec.ts` (pass: 5 suites / 126 tests)
- `npx nx build @vizora/middleware --skip-nx-cache` (pass with existing webpack warnings)
- `NEXT_PUBLIC_API_URL=http://localhost:3000 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NODE_OPTIONS=--max-old-space-size=4096 npx nx build @vizora/web --skip-nx-cache` (pass with existing Next warnings)
- `git diff --check` (pass; Windows CRLF warnings only)
- `pnpm security:no-hardcoded-jwts` (pass)

## Review
- Performance/regression re-review: CLEAN
- Security/architecture/readiness/process re-review: CLEAN

## Deployment
- Not deployed by this PR. Production checkout remains dirty/diverged and unsafe for automated deploy until reconciled.