### PR TITLE
fix: close customer hot-path followups

### DIFF
--- a/display/src/renderer/app.ts
+++ b/display/src/renderer/app.ts
@@ -1,5 +1,10 @@
 // Renderer process code
 import { getEntityId } from './ids';
+import {
+  shouldDownloadOnCacheMiss,
+  shouldReadCachedContent,
+  shouldPreloadContentType,
+} from './preload-policy';
 
 declare global {
   interface Window {
@@ -430,8 +435,9 @@ class DisplayApp {
     // Support both 'source' and 'url' field names for compatibility
     let contentSource = currentItem.content?.source || currentItem.content?.url;
 
-    // Check cache for image/video content
-    if (currentItem.content?.type === 'image' || currentItem.content?.type === 'video') {
+    // Read cached image/video content, but only images are downloaded on a miss.
+    // Videos should rely on native range streaming unless already cached.
+    if (shouldReadCachedContent(currentItem.content?.type)) {
       try {
         const contentId = getEntityId(currentItem.content);
         if (contentId && contentSource) {
@@ -439,9 +445,9 @@ class DisplayApp {
           if (cached.path) {
             contentSource = cached.path;
             console.log('[App] Using cached content:', cached.path);
-          } else {
+          } else if (shouldDownloadOnCacheMiss(currentItem.content?.type)) {
             // Background download for future use
-            const mimeType = currentItem.content.mimeType || (currentItem.content.type === 'video' ? 'video/mp4' : 'image/jpeg');
+            const mimeType = currentItem.content.mimeType || 'image/jpeg';
             window.electronAPI.cacheDownload(contentId, contentSource, mimeType)
               .catch(err => console.warn('[App] Background cache failed:', err));
           }
@@ -787,11 +793,11 @@ class DisplayApp {
     for (const item of items) {
       if (!item.content) continue;
       const type = item.content.type;
-      if (type !== 'image' && type !== 'video') continue;
+      if (!shouldPreloadContentType(type)) continue;
 
       const contentUrl = item.content.source || item.content.url;
       const contentId = getEntityId(item.content);
-      const mimeType = item.content.mimeType || (type === 'video' ? 'video/mp4' : 'image/jpeg');
+      const mimeType = item.content.mimeType || 'image/jpeg';
 
       try {
         if (!contentId || !contentUrl) {

--- a/display/src/renderer/preload-policy.spec.ts
+++ b/display/src/renderer/preload-policy.spec.ts
@@ -1,0 +1,32 @@
+import {
+  shouldDownloadOnCacheMiss,
+  shouldReadCachedContent,
+  shouldPreloadContentType,
+} from './preload-policy';
+
+describe('shouldPreloadContentType', () => {
+  it('allows image preloads', () => {
+    expect(shouldPreloadContentType('image')).toBe(true);
+  });
+
+  it('blocks video preloads so playback can use native range streaming', () => {
+    expect(shouldPreloadContentType('video')).toBe(false);
+  });
+
+  it('blocks non-media and missing content types', () => {
+    expect(shouldPreloadContentType('html')).toBe(false);
+    expect(shouldPreloadContentType(undefined)).toBe(false);
+  });
+});
+
+describe('playback cache policy', () => {
+  it('allows video cache reads without allowing video cache-miss downloads', () => {
+    expect(shouldReadCachedContent('video')).toBe(true);
+    expect(shouldDownloadOnCacheMiss('video')).toBe(false);
+  });
+
+  it('allows image cache reads and cache-miss downloads', () => {
+    expect(shouldReadCachedContent('image')).toBe(true);
+    expect(shouldDownloadOnCacheMiss('image')).toBe(true);
+  });
+});

--- a/display/src/renderer/preload-policy.ts
+++ b/display/src/renderer/preload-policy.ts
@@ -1,0 +1,11 @@
+export function shouldPreloadContentType(type: unknown): boolean {
+  return type === 'image';
+}
+
+export function shouldReadCachedContent(type: unknown): boolean {
+  return type === 'image' || type === 'video';
+}
+
+export function shouldDownloadOnCacheMiss(type: unknown): boolean {
+  return type === 'image';
+}

--- a/docs/plans/2026-06-02-customer-hotpath-followup-pass-42.md
+++ b/docs/plans/2026-06-02-customer-hotpath-followup-pass-42.md
@@ -1,0 +1,75 @@
+# Customer Hot-Path Follow-up Pass 42
+
+Date: 2026-06-02
+Branch: `feat/customer-hotpath-followup-pass-42`
+
+## Goal
+
+Close adjacent customer-readiness gaps left after Pass 41:
+
+- Electron display clients should not prefetch full video assets before playback.
+- Public readiness should not leak dependency internals.
+- Missing object-storage wiring should fail readiness because content upload and
+  playback depend on storage.
+- Device media stream failures after headers are sent should log enough request
+  context to debug customer playback incidents.
+
+## New primitives introduced
+
+One Electron renderer preload-policy helper with three small predicates:
+`shouldPreloadContentType`, `shouldReadCachedContent`, and
+`shouldDownloadOnCacheMiss`.
+
+No schema, env var, runtime process, notification path, realtime substrate, MCP
+tool, Hermes skill, provider spend path, or parallel infrastructure.
+
+## Hermes-first analysis
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Electron display preload policy | none found | build in existing display renderer |
+| Public readiness response shaping | none found | build in existing NestJS health controller |
+| Object-storage readiness requirement | none found | build in existing HealthService |
+| Device media stream error context | none found | build in existing DeviceContentController |
+
+Awesome-hermes-agent ecosystem check: no applicable runtime/library primitive
+for Electron media preload policy, NestJS readiness shaping, or HTTP stream
+error logging; proceed with Vizora-native code.
+
+## Drift Check
+
+Pass 41 already changed the web display client to preload image content only.
+Electron still preloaded both image and video content in
+`display/src/renderer/app.ts`, so the residual gap is specific to the packaged
+display client.
+
+Pass 41 removed `self_test_failures` from public `/health/ready`, but the
+endpoint still returned the full dependency `checks` object. The residual gap
+is public response shaping, not the internal health probe.
+
+Pass 41 made MinIO unhealthy fail readiness, but a missing `StorageService`
+dependency still reported degraded. For production readiness, missing storage
+configuration is not optional.
+
+Device-content streaming already destroys the response on post-header stream
+errors, but the log line only included the stream error message. The residual
+gap is incident-debug context.
+
+## Implementation Plan
+
+1. Add a small preload-policy helper in the display renderer and use it from
+   `DisplayApp.preloadContent` plus playback cache-miss handling.
+2. Return a minimal public readiness response with status, timestamp, uptime,
+   version, and self-test status. Keep detailed dependency checks inside
+   internal health paths.
+3. Mark missing storage service as unhealthy in `HealthService`.
+4. Pass request context into the device-content streaming helper and log
+   request id, content id, path, and response status on stream failure.
+5. Verify with focused display, health, and device-content tests, then broader
+   builds/hygiene.
+6. Send to orthogonal reviewers before PR/CI/merge.
+
+## Deployment
+
+Do not deploy unless production checkout is reconciled and safe. Current prod
+state is dirty/diverged and therefore blocks automated deploys.

--- a/middleware/src/modules/content/device-content.controller.spec.ts
+++ b/middleware/src/modules/content/device-content.controller.spec.ts
@@ -116,6 +116,7 @@ describe('DeviceContentController', () => {
       const req: any = {
         headers: {},
         query: {},
+        originalUrl: `/api/v1/device-content/${contentId}/file`,
       };
       if (token) {
         req.headers.authorization = `Bearer ${token}`;
@@ -143,10 +144,16 @@ describe('DeviceContentController', () => {
           callback();
         },
       });
+      res.statusCode = 200;
       res.set = jest.fn().mockReturnValue(res);
-      res.status = jest.fn().mockReturnValue(res);
+      res.status = jest.fn((statusCode: number) => {
+        res.statusCode = statusCode;
+        return res;
+      });
       res.redirect = jest.fn();
       res.removeHeader = jest.fn();
+      const destroy = res.destroy.bind(res);
+      res.destroy = jest.fn((error?: Error) => destroy(error));
       res.getBody = () => Buffer.concat(chunks);
       return res;
     };
@@ -1171,6 +1178,43 @@ describe('DeviceContentController', () => {
       expect(res.removeHeader).toHaveBeenCalledWith('ETag');
       expect(res.removeHeader).toHaveBeenCalledWith('Last-Modified');
       expect(res.removeHeader).toHaveBeenCalledWith('Cross-Origin-Resource-Policy');
+    });
+
+    it('should log request context when streaming fails after media headers are sent', async () => {
+      const req = createMockRequest('valid-device-token') as any;
+      req.requestId = 'req-stream-123';
+      const res = createMockResponse();
+      Object.defineProperty(res, 'headersSent', {
+        configurable: true,
+        get: () => true,
+      });
+      const loggerErrorSpy = jest
+        .spyOn((controller as any).logger, 'error')
+        .mockImplementation();
+
+      const failingStream = new Readable({
+        read() {
+          this.destroy(new Error('post-header stream failed'));
+        },
+      });
+
+      mockContentService.findByIdForDevice.mockResolvedValue(mockContent as any);
+      mockJwtService.verify.mockReturnValue(validDevicePayload);
+      mockStorageService.getFileMetadata.mockResolvedValue({
+        size: 12,
+        lastModified: new Date('2026-05-31T00:00:00.000Z'),
+        contentType: 'image/jpeg',
+      });
+      mockStorageService.getObject.mockResolvedValue(failingStream);
+
+      await controller.serveFile(contentId, req, res);
+
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '[req-stream-123] Failed to stream device content content-789 at /api/v1/device-content/content-789/file: post-header stream failed',
+        ),
+      );
+      expect(res.destroy).toHaveBeenCalledWith(expect.any(Error));
     });
 
     it('should not set media headers when full-object stream acquisition fails', async () => {

--- a/middleware/src/modules/content/device-content.controller.spec.ts
+++ b/middleware/src/modules/content/device-content.controller.spec.ts
@@ -138,13 +138,16 @@ describe('DeviceContentController', () => {
 
     const createMockResponse = () => {
       const chunks: Buffer[] = [];
-      const res: any = new Writable({
+      let res: any;
+      res = new Writable({
         write(chunk, _encoding, callback) {
+          res.headersSent = true;
           chunks.push(Buffer.from(chunk));
           callback();
         },
       });
       res.statusCode = 200;
+      res.headersSent = false;
       res.set = jest.fn().mockReturnValue(res);
       res.status = jest.fn((statusCode: number) => {
         res.statusCode = statusCode;
@@ -1184,19 +1187,14 @@ describe('DeviceContentController', () => {
       const req = createMockRequest('valid-device-token') as any;
       req.requestId = 'req-stream-123';
       const res = createMockResponse();
-      Object.defineProperty(res, 'headersSent', {
-        configurable: true,
-        get: () => true,
-      });
       const loggerErrorSpy = jest
         .spyOn((controller as any).logger, 'error')
         .mockImplementation();
 
-      const failingStream = new Readable({
-        read() {
-          this.destroy(new Error('post-header stream failed'));
-        },
-      });
+      const failingStream = Readable.from((async function* () {
+        yield Buffer.from('partial');
+        throw new Error('post-header stream failed');
+      })());
 
       mockContentService.findByIdForDevice.mockResolvedValue(mockContent as any);
       mockJwtService.verify.mockReturnValue(validDevicePayload);
@@ -1209,9 +1207,11 @@ describe('DeviceContentController', () => {
 
       await controller.serveFile(contentId, req, res);
 
+      expect(res.getBody().toString()).toBe('partial');
+      expect(res.headersSent).toBe(true);
       expect(loggerErrorSpy).toHaveBeenCalledWith(
         expect.stringContaining(
-          '[req-stream-123] Failed to stream device content content-789 at /api/v1/device-content/content-789/file: post-header stream failed',
+          '[req-stream-123] Failed to stream device content content-789 at /api/v1/device-content/content-789/file: post-header stream failed (status=200)',
         ),
       );
       expect(res.destroy).toHaveBeenCalledWith(expect.any(Error));

--- a/middleware/src/modules/content/device-content.controller.ts
+++ b/middleware/src/modules/content/device-content.controller.ts
@@ -57,6 +57,10 @@ interface CachedDeviceAuth {
   tokenHash: string;
 }
 
+interface DeviceContentRequest extends Request {
+  requestId?: string;
+}
+
 interface CachedLookup<T> {
   value: T;
   cacheHit: boolean;
@@ -518,8 +522,10 @@ export class DeviceContentController {
   }
 
   private async writeResolvedContent(
+    contentId: string,
     resolved: ResolvedDeviceContent,
     stream: NodeJS.ReadableStream | null,
+    req: DeviceContentRequest,
     res: Response,
   ): Promise<void> {
     if (resolved.kind === 'redirect') {
@@ -557,7 +563,11 @@ export class DeviceContentController {
         'Last-Modified': validators.lastModified,
         'Cross-Origin-Resource-Policy': 'cross-origin',
       });
-      await this.streamToResponse(stream, res);
+      await this.streamToResponse(stream, res, {
+        contentId,
+        path: this.getRequestPath(req),
+        requestId: req.requestId,
+      });
       return;
     }
 
@@ -571,7 +581,11 @@ export class DeviceContentController {
       'Last-Modified': validators.lastModified,
       'Cross-Origin-Resource-Policy': 'cross-origin',
     });
-    await this.streamToResponse(stream, res);
+    await this.streamToResponse(stream, res, {
+      contentId,
+      path: this.getRequestPath(req),
+      requestId: req.requestId,
+    });
   }
 
   private getMediaValidators(resolved: ResolvedMinioContent): {
@@ -733,12 +747,24 @@ export class DeviceContentController {
     res.end();
   }
 
-  private async streamToResponse(stream: NodeJS.ReadableStream, res: Response): Promise<void> {
+  private getRequestPath(req: Request): string {
+    const url = req.originalUrl || req.url || '';
+    return url.split('?')[0] || 'unknown-path';
+  }
+
+  private async streamToResponse(
+    stream: NodeJS.ReadableStream,
+    res: Response,
+    context: { contentId: string; path: string; requestId?: string },
+  ): Promise<void> {
     try {
       await pipeline(stream, res);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'unknown stream error';
-      this.logger.error(`Failed to stream device content: ${message}`);
+      const requestId = context.requestId ?? 'no-request-id';
+      this.logger.error(
+        `[${requestId}] Failed to stream device content ${context.contentId} at ${context.path}: ${message} (status=${res.statusCode})`,
+      );
 
       if (!res.headersSent) {
         res.removeHeader('Content-Type');
@@ -767,7 +793,7 @@ export class DeviceContentController {
   @SkipOutputSanitize()
   async serveFile(
     @Param('id', ParseIdPipe) id: string,
-    @Req() req: Request,
+    @Req() req: DeviceContentRequest,
     @Res() res: Response,
   ): Promise<void> {
     // Device JWT is mandatory — throws UnauthorizedException if missing/invalid.
@@ -806,6 +832,6 @@ export class DeviceContentController {
       stream = opened.stream;
     }
 
-    await this.writeResolvedContent(resolved, stream, res);
+    await this.writeResolvedContent(id, resolved, stream, req, res);
   }
 }

--- a/middleware/src/modules/health/health.controller.spec.ts
+++ b/middleware/src/modules/health/health.controller.spec.ts
@@ -117,9 +117,12 @@ describe('HealthController', () => {
 
       const result = await controller.ready();
 
-      expect(result).toMatchObject(mockHealthyResponse);
       expect(result.status).toBe('ok');
       expect(result).toHaveProperty('self_test', 'pending');
+      expect(result).toHaveProperty('timestamp', mockHealthyResponse.timestamp);
+      expect(result).toHaveProperty('uptime', mockHealthyResponse.uptime);
+      expect(result).toHaveProperty('version', mockHealthyResponse.version);
+      expect(result).not.toHaveProperty('checks');
     });
 
     it('should return health response when degraded', async () => {
@@ -127,8 +130,8 @@ describe('HealthController', () => {
 
       const result = await controller.ready();
 
-      expect(result).toMatchObject(mockDegradedResponse);
       expect(result.status).toBe('degraded');
+      expect(result).not.toHaveProperty('checks');
     });
 
     it('should throw SERVICE_UNAVAILABLE when unhealthy', async () => {
@@ -141,19 +144,25 @@ describe('HealthController', () => {
       } catch (error) {
         expect(error).toBeInstanceOf(HttpException);
         expect((error as HttpException).getStatus()).toBe(HttpStatus.SERVICE_UNAVAILABLE);
-        expect((error as HttpException).getResponse()).toMatchObject(mockUnhealthyResponse);
+        expect((error as HttpException).getResponse()).toEqual({
+          status: 'unhealthy',
+          timestamp: mockUnhealthyResponse.timestamp,
+          uptime: mockUnhealthyResponse.uptime,
+          version: mockUnhealthyResponse.version,
+          self_test: 'pending',
+        });
       }
     });
 
-    it('should include all checks in response', async () => {
+    it('should not expose dependency details on the public readiness endpoint', async () => {
       healthService.check.mockResolvedValue(mockHealthyResponse);
 
       const result = await controller.ready();
 
-      expect(result.checks).toBeDefined();
-      expect(result.checks.database).toBeDefined();
-      expect(result.checks.redis).toBeDefined();
-      expect(result.checks.memory).toBeDefined();
+      expect(result).not.toHaveProperty('checks');
+      expect(JSON.stringify(result)).not.toContain('heapUsedMB');
+      expect(JSON.stringify(result)).not.toContain('bucket');
+      expect(JSON.stringify(result)).not.toContain('Connection refused');
     });
 
     it('should include uptime and version', async () => {

--- a/middleware/src/modules/health/health.controller.ts
+++ b/middleware/src/modules/health/health.controller.ts
@@ -8,6 +8,14 @@ import { Public } from '../auth/decorators/public.decorator';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { SuperAdminGuard } from '../admin/guards/super-admin.guard';
 
+interface PublicReadinessResponse {
+  status: 'ok' | 'degraded' | 'unhealthy';
+  timestamp: string;
+  uptime: number;
+  version: string;
+  self_test: 'running' | 'passed' | 'failed' | 'pending';
+}
+
 @Controller('health')
 @SkipThrottle() // Health checks should not be rate limited
 export class HealthController {
@@ -45,16 +53,19 @@ export class HealthController {
           : 'failed'
         : 'pending';
 
-    const enriched = {
-      ...result,
+    const readiness: PublicReadinessResponse = {
+      status: result.status,
+      timestamp: result.timestamp,
+      uptime: result.uptime,
+      version: result.version,
       self_test: selfTestStatus,
     };
 
     if (result.status === 'unhealthy') {
-      throw new HttpException(enriched, HttpStatus.SERVICE_UNAVAILABLE);
+      throw new HttpException(readiness, HttpStatus.SERVICE_UNAVAILABLE);
     }
 
-    return enriched;
+    return readiness;
   }
 
   /**

--- a/middleware/src/modules/health/health.service.spec.ts
+++ b/middleware/src/modules/health/health.service.spec.ts
@@ -178,6 +178,30 @@ describe('HealthService', () => {
       });
     });
 
+    describe('when storage service is not available', () => {
+      beforeEach(() => {
+        mockDatabaseService.$queryRaw.mockResolvedValue([{ '?column?': 1 }]);
+        mockRedisService.healthCheck.mockResolvedValue({
+          healthy: true,
+          responseTime: 5,
+        });
+        service = new HealthService(
+          mockDatabaseService as DatabaseService,
+          undefined,
+          mockRedisService as RedisService,
+          undefined,
+        );
+      });
+
+      it('should return unhealthy status because object storage is required for readiness', async () => {
+        const result = await service.check();
+
+        expect(result.status).toBe('unhealthy');
+        expect(result.checks.minio.status).toBe('unhealthy');
+        expect(result.checks.minio.error).toContain('not configured');
+      });
+    });
+
     describe('when redis service throws an error', () => {
       beforeEach(() => {
         mockDatabaseService.$queryRaw.mockResolvedValue([{ '?column?': 1 }]);
@@ -196,7 +220,12 @@ describe('HealthService', () => {
       beforeEach(() => {
         mockDatabaseService.$queryRaw.mockResolvedValue([{ '?column?': 1 }]);
         // Create service without redis
-        service = new HealthService(mockDatabaseService as DatabaseService, undefined);
+        service = new HealthService(
+          mockDatabaseService as DatabaseService,
+          undefined,
+          undefined,
+          mockStorageService as StorageService,
+        );
       });
 
       it('should return degraded status for redis', async () => {

--- a/middleware/src/modules/health/health.service.ts
+++ b/middleware/src/modules/health/health.service.ts
@@ -207,7 +207,7 @@ export class HealthService {
 
     if (!this.storage) {
       return {
-        status: 'degraded',
+        status: 'unhealthy',
         responseTime: 0,
         error: 'Storage service not configured',
         details: { configured: false },

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,8 +1,110 @@
 # Vizora - Task Tracker
 
-## Active: Customer Readiness Hot-Path Pass 41 (2026-06-02)
+## Active: Customer Hot-Path Follow-up Pass 42 (2026-06-02)
+
+**Branch:** `feat/customer-hotpath-followup-pass-42`
+
+**Why now:** The Pass 41 merge hardened the web display client and public
+readiness basics. The next coherent follow-up closes adjacent repo-side gaps:
+Electron display clients should use the same no-video-preload policy, public
+readiness should not expose dependency internals, missing object-storage wiring
+should fail readiness, and post-header media stream failures need actionable
+request context in logs.
+
+**New primitives introduced:** one tiny Electron renderer preload-policy helper.
+No schema, env var, runtime process, notification path, realtime substrate, MCP
+tool, Hermes skill, provider spend path, or parallel infrastructure.
+
+**Hermes-first analysis:** checked per project convention. These are in-repo
+display/runtime-health/logging mechanics; no Hermes runtime skill is applicable.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Electron display preload policy | none found | build in existing display renderer |
+| Public readiness response shaping | none found | build in existing NestJS health controller |
+| Object-storage readiness requirement | none found | build in existing HealthService |
+| Device media stream error context | none found | build in existing DeviceContentController |
+
+Awesome-hermes-agent ecosystem check: no applicable runtime/library primitive
+for Electron media preload policy, NestJS readiness shaping, or HTTP stream
+error logging; proceed with Vizora-native code.
+
+**Plan/design:**
+`docs/plans/2026-06-02-customer-hotpath-followup-pass-42.md`
+
+**Plan**
+- [x] Preserve carried dirty work on a fresh branch from merged `origin/main`.
+- [x] Document scope and Hermes-first analysis.
+- [x] Run focused verification for display, health, and device-content changes.
+- [x] Run build/hygiene verification.
+- [x] Run multi-vector subagent re-review.
+- [ ] PR, CI, merge if green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Scoped fixes**
+- Electron display: centralize preload eligibility and skip video preloads so
+  native playback/range streaming controls large files. Existing cached video
+  paths are still usable, but video cache misses do not trigger background full
+  downloads.
+- Readiness: return a minimal public `/health/ready` payload instead of full
+  dependency checks and mark missing storage wiring unhealthy.
+- Device media streaming: include request id, content id, path, and response
+  status when a stream fails after headers are sent.
+
+**Evidence so far**
+- Pass 41 merged as PR #177. Production deploy remains blocked because
+  `/opt/vizora/app` is dirty/diverged and behind `origin/main`.
+- Red verification:
+  - `pnpm --filter @vizora/display test -- --runInBand src/renderer/preload-policy.spec.ts`
+    initially failed because the preload-policy helper did not exist, then
+    failed again on missing playback cache policy predicates before the video
+    cache-miss download guard was added.
+  - `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/content/device-content.controller.spec.ts --testNamePattern="log request context"`
+    failed as expected because post-header stream errors only logged the stream
+    error message.
+  - `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/health/health.controller.spec.ts middleware/src/modules/health/health.service.spec.ts`
+    failed as expected because public readiness exposed `checks` and missing
+    storage wiring returned degraded.
+- Focused verification:
+  - `pnpm --filter @vizora/web test -- DisplayClient.test.tsx` passed 1 suite
+    / 3 tests.
+  - `pnpm --filter @vizora/display test -- --runInBand src/renderer/ids.spec.ts src/renderer/preload-policy.spec.ts`
+    passed 2 suites / 8 tests.
+  - `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/common/interceptors/logging.interceptor.spec.ts middleware/src/modules/content/device-content.controller.spec.ts middleware/src/modules/health/health.controller.spec.ts middleware/src/modules/health/health.service.spec.ts middleware/src/modules/playlists/playlists.service.spec.ts`
+    passed 5 suites / 128 tests.
+- Broader local verification:
+  - `pnpm --filter @vizora/display test -- --runInBand` passed 7 suites / 131
+    tests, with existing console noise from older Electron tests.
+  - `pnpm --filter @vizora/display typecheck` passed.
+  - `pnpm --filter @vizora/display build` passed.
+  - `npx nx build @vizora/middleware --skip-nx-cache` passed with existing
+    webpack warnings and Nx flaky-task note for `@vizora/database:build`.
+  - `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` passed.
+  - `git diff --check` passed with Windows CRLF line-ending warnings only.
+  - `pnpm security:no-hardcoded-jwts` passed.
+- Subagent re-review:
+  - Readiness/tenant reviewer CLEAN after public readiness sanitization and
+    missing-storage readiness fixes.
+  - Media reviewer first found Electron `preloadContent()` still allowed video
+    downloads; fixed with image-only preload policy.
+  - Final media reviewer then found playback cache-miss still background
+    downloaded videos; fixed with separate read-vs-download cache policy.
+  - Final narrow media re-review CLEAN after the second Electron cache fix.
+
+## Completed: Customer Readiness Hot-Path Pass 41 (2026-06-02)
 
 **Branch:** `feat/customer-dashboard-performance-pass-41`
+
+**PR:** #177
+
+**Commit:** `fbc2ae0`
+
+**Merge SHA:** `4db861dd1124a68dbed52bc0a0b059086b490e2f`
+
+**CI:** Green - audit, build, e2e, lint, security, and test.
+
+**Deploy:** Not deployed. Production checkout is dirty/diverged and unsafe for
+automation.
 
 **Why now:** The customer/performance analysis lanes found several repo-side
 production-readiness issues. The first buildable slice should harden the
@@ -43,8 +145,8 @@ playlist fanout; proceed with Vizora-native code.
 - [x] Run focused verification.
 - [x] Run broader verification.
 - [x] Run multi-vector subagent re-review.
-- [ ] PR, CI, merge if green.
-- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+- [x] PR, CI, merge if green.
+- [x] Re-check deployment gate; deploy only if prod checkout is safe.
 
 **Scoped fixes**
 - Display playback: preload image content only; do not full-fetch/cache video
@@ -117,6 +219,15 @@ playlist fanout; proceed with Vizora-native code.
 - Final subagent re-review: performance/regression reviewer CLEAN; security,
   architecture, readiness, and process reviewer CLEAN. No tenant/auth/readiness
   envelope or realtime-substrate drift found.
+- PR/CI/merge: PR #177 merged at
+  `4db861dd1124a68dbed52bc0a0b059086b490e2f`; audit, build, e2e, lint,
+  security, and test passed.
+- Deployment gate after merge: production remains on
+  `bb76aa1838740bff5b58623dfef7a906d44f46a6` while remote main is
+  `4db861dd1124a68dbed52bc0a0b059086b490e2f`; prod status is
+  `ahead 17, behind 123` with tracked and untracked files. Middleware/web are
+  online; public realtime `/health` probe returned no HTTP response. No deploy
+  or restart attempted.
 
 ## Completed: Content MinIO Tenant Boundary Pass 40 (2026-06-02)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -72,6 +72,12 @@ error logging; proceed with Vizora-native code.
     passed 2 suites / 8 tests.
   - `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/common/interceptors/logging.interceptor.spec.ts middleware/src/modules/content/device-content.controller.spec.ts middleware/src/modules/health/health.controller.spec.ts middleware/src/modules/health/health.service.spec.ts middleware/src/modules/playlists/playlists.service.spec.ts`
     passed 5 suites / 128 tests.
+  - Reviewer-fix rerun:
+    `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/content/device-content.controller.spec.ts`
+    passed 1 suite / 41 tests, and
+    `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/common/interceptors/logging.interceptor.spec.ts`
+    passed 1 suite / 22 tests after the post-write stream-failure test was
+    tightened.
 - Broader local verification:
   - `pnpm --filter @vizora/display test -- --runInBand` passed 7 suites / 131
     tests, with existing console noise from older Electron tests.
@@ -90,6 +96,11 @@ error logging; proceed with Vizora-native code.
   - Final media reviewer then found playback cache-miss still background
     downloaded videos; fixed with separate read-vs-download cache policy.
   - Final narrow media re-review CLEAN after the second Electron cache fix.
+  - Stream-logging reviewer found the post-header stream failure regression
+    test was artificially forcing `headersSent=true`; fixed by making the mock
+    response mark headers sent on an actual write, writing a partial chunk
+    before stream failure, and asserting the `(status=200)` log suffix. Final
+    re-review CLEAN.
 
 ## Completed: Customer Readiness Hot-Path Pass 41 (2026-06-02)
 


### PR DESCRIPTION
## Summary
- align packaged Electron display cache policy with web display: images can preload/download on cache miss, videos only read existing cache and otherwise rely on native playback/range streaming
- make public `/health/ready` return a minimal readiness payload without dependency internals, while missing/unhealthy object storage fails readiness
- add request id, content id, path, and response status to device-content stream failure logs

## Tests
- `pnpm --filter @vizora/display test -- --runInBand src/renderer/preload-policy.spec.ts` (red/green; final 1 suite / 5 tests)
- `pnpm --filter @vizora/display test -- --runInBand` (pass: 7 suites / 131 tests)
- `pnpm --filter @vizora/display typecheck` (pass)
- `pnpm --filter @vizora/display build` (pass)
- `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/content/device-content.controller.spec.ts middleware/src/modules/health/health.controller.spec.ts middleware/src/modules/health/health.service.spec.ts` (pass: 3 suites / 74 tests)
- `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/content/device-content.controller.spec.ts` (reviewer-fix rerun: pass, 41 tests)
- `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/common/interceptors/logging.interceptor.spec.ts` (reviewer-fix rerun: pass, 22 tests)
- `npx nx build @vizora/middleware --skip-nx-cache` (pass with existing webpack warnings)
- `git diff --check` (pass; Windows CRLF warnings only)
- `pnpm security:no-hardcoded-jwts` (pass)

## Review
- Electron display playback/performance reviewer: CLEAN
- Public readiness/security/ops reviewer: CLEAN
- Device-content stream logging reviewer: initial test-strength finding fixed; final re-review CLEAN

## Deployment
- Not deployed by this PR. Production checkout remains dirty/diverged and unsafe for automated deploy until reconciled.