### PR TITLE
fix: harden dashboard role and support retry flows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 node_modules
+**/node_modules
 .git
 README.md
 CLAUDE.md

--- a/docker/Dockerfile.realtime
+++ b/docker/Dockerfile.realtime
@@ -22,6 +22,9 @@ COPY packages/database/ ./packages/database/
 COPY tsconfig.base.json ./
 COPY nx.json ./
 
+# Generate Prisma client
+RUN cd packages/database && pnpm prisma generate
+
 # Build the application
 RUN pnpm nx build realtime
 

--- a/docs/plans/2026-06-02-dashboard-role-truth-pass-43.md
+++ b/docs/plans/2026-06-02-dashboard-role-truth-pass-43.md
@@ -1,0 +1,81 @@
+# Dashboard Role Truth Pass 43
+
+Date: 2026-06-02
+Branch: `feat/dashboard-role-truth-pass-43`
+
+## Goal
+
+Fix customer-visible dashboard trust issues that are repo-side and testable:
+
+- Schedules must not advertise create/edit/duplicate/delete workflows to roles
+  the backend rejects.
+- Support chat must not silently remove customer text when a support request or
+  message send fails, and retry must not duplicate durable support records.
+- Realtime Docker builds must carry a generated Prisma client into the runtime
+  image without relying on dev-only Prisma CLI availability there.
+
+## New primitives introduced
+
+One explicit dashboard permission pair: `canManageSchedules` and
+`canDeleteSchedules`.
+
+One support retry idempotency primitive: optional `clientMutationId` on
+`support_requests` and `support_messages`, with scoped unique indexes for
+durable retry deduplication.
+
+No env var, runtime process, notification path, realtime substrate, MCP tool,
+Hermes skill, provider spend path, or parallel infrastructure.
+
+## Hermes-first analysis
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Dashboard role-based action gating | none found | build in existing web permission helper |
+| Support chat failed-message state | none found | build in existing support chat provider/panel |
+| Support retry idempotency | none found | build in existing support API/service with Prisma indexes |
+
+Awesome-hermes-agent ecosystem check: no applicable runtime/library primitive
+for React dashboard role gating or local support-chat failure state; proceed
+with Vizora-native code.
+
+## Drift Check
+
+`web/src/app/dashboard/devices/page-client.tsx` already uses
+`getDashboardPermissions` for pairing and device mutations, so the older device
+pairing finding is stale and is not reopened in this pass.
+
+`middleware/src/modules/schedules/schedules.controller.ts` gates schedule
+create/update/duplicate/conflict-check to admin/manager and delete to admin.
+`web/src/app/dashboard/schedules/page-client.tsx` currently renders schedule
+mutation controls without checking role, so this is the concrete residual gap.
+
+`SupportChatProvider` still removes the optimistic message on failed existing
+conversation sends and clears messages on failed new conversation sends. This
+is the concrete support-chat residual gap.
+
+## Implementation Plan
+
+1. Add red tests for schedule viewer/manager/admin action visibility.
+2. Add red tests for failed support sends preserving visible customer text and
+   retry/error context.
+3. Extend `getDashboardPermissions` with schedule manage/delete permissions.
+4. Gate schedule create/edit/duplicate/calendar-slot actions by
+   `canManageSchedules`, and delete by `canDeleteSchedules`.
+5. Preserve failed support messages as visible retryable/error bubbles instead
+   of deleting them.
+6. Review fix: use the existing backend schedule duplicate endpoint instead of
+   duplicate-as-prefilled-create.
+7. Review fix: prevent manager multi-device create batches that would require
+   admin-only delete rollback.
+8. Review fix: add support client mutation ids so failed-send retry is
+   idempotent across ambiguous POST failures.
+9. Review fix: generate the realtime Prisma client in the Docker builder stage
+   and keep nested local workspace dependencies out of Docker build context.
+10. Run focused web/middleware tests, broader relevant tests,
+   typecheck/build/hygiene.
+11. Dispatch orthogonal reviewers before PR/CI/merge.
+
+## Deployment
+
+Do not deploy unless production checkout is reconciled and safe. Current prod
+state is dirty/diverged and blocks automated deploys.

--- a/middleware/src/modules/support/dto/create-support-message.dto.ts
+++ b/middleware/src/modules/support/dto/create-support-message.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNotEmpty, MaxLength } from 'class-validator';
+import { IsString, IsNotEmpty, IsOptional, MaxLength } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateSupportMessageDto {
@@ -7,4 +7,10 @@ export class CreateSupportMessageDto {
   @IsNotEmpty()
   @MaxLength(5000)
   content: string;
+
+  @ApiProperty({ description: 'Client-generated idempotency key for safe retries', required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(80)
+  clientMutationId?: string;
 }

--- a/middleware/src/modules/support/dto/create-support-request.dto.ts
+++ b/middleware/src/modules/support/dto/create-support-request.dto.ts
@@ -28,4 +28,10 @@ export class CreateSupportRequestDto {
   @ValidateNested()
   @Type(() => SupportContextDto)
   context?: SupportContextDto;
+
+  @ApiProperty({ description: 'Client-generated idempotency key for safe retries', required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(80)
+  clientMutationId?: string;
 }

--- a/middleware/src/modules/support/support.controller.spec.ts
+++ b/middleware/src/modules/support/support.controller.spec.ts
@@ -76,6 +76,24 @@ describe('SupportController', () => {
       expect(result.request).toEqual(mockRequest);
       expect(result.responseText).toBeDefined();
     });
+
+    it('forwards clientMutationId for idempotent request retries', async () => {
+      supportService.createRequest.mockResolvedValue({
+        request: mockRequest as any,
+        responseText: 'We have received your request.',
+        requestNumber: 'REQ-1234',
+      });
+
+      await controller.createRequest('user-123', 'org-123', {
+        message: 'The app keeps crashing',
+        clientMutationId: 'client-mutation-1',
+      } as any);
+
+      expect(supportService.createRequest).toHaveBeenCalledWith('user-123', 'org-123', {
+        message: 'The app keeps crashing',
+        clientMutationId: 'client-mutation-1',
+      });
+    });
   });
 
   describe('GET /support/requests', () => {
@@ -220,8 +238,32 @@ describe('SupportController', () => {
           isSuperAdmin: false,
         },
         'Any update on this?',
+        undefined,
       );
       expect(result.content).toBe('Any update on this?');
+    });
+
+    it('forwards clientMutationId for idempotent message retries', async () => {
+      const dto = { content: 'Any update on this?', clientMutationId: 'client-message-1' };
+
+      supportService.addMessage.mockResolvedValue({
+        id: 'msg-1',
+        requestId: 'req-12345678-abcd',
+        organizationId: 'org-123',
+        userId: 'user-123',
+        role: 'admin',
+        content: 'Any update on this?',
+        createdAt: new Date(),
+      } as any);
+
+      await controller.addMessage('req-12345678-abcd', mockUser, dto as any);
+
+      expect(supportService.addMessage).toHaveBeenCalledWith(
+        'req-12345678-abcd',
+        expect.objectContaining({ id: 'user-123' }),
+        'Any update on this?',
+        'client-message-1',
+      );
     });
   });
 

--- a/middleware/src/modules/support/support.controller.ts
+++ b/middleware/src/modules/support/support.controller.ts
@@ -51,7 +51,8 @@ export class SupportController {
   ) {
     return this.supportService.createRequest(userId, organizationId, {
       message: dto.message,
-      context: dto.context,
+      ...(dto.context ? { context: dto.context } : {}),
+      ...(dto.clientMutationId ? { clientMutationId: dto.clientMutationId } : {}),
     });
   }
 
@@ -140,11 +141,16 @@ export class SupportController {
     @CurrentUser() user: AuthenticatedUser,
     @Body() dto: CreateSupportMessageDto,
   ) {
-    return this.supportService.addMessage(requestId, {
-      id: user.id,
-      organizationId: user.organizationId,
-      role: user.role,
-      isSuperAdmin: user.isSuperAdmin || false,
-    }, dto.content);
+    return this.supportService.addMessage(
+      requestId,
+      {
+        id: user.id,
+        organizationId: user.organizationId,
+        role: user.role,
+        isSuperAdmin: user.isSuperAdmin || false,
+      },
+      dto.content,
+      dto.clientMutationId,
+    );
   }
 }

--- a/middleware/src/modules/support/support.service.spec.ts
+++ b/middleware/src/modules/support/support.service.spec.ts
@@ -57,6 +57,7 @@ describe('SupportService', () => {
       },
       supportMessage: {
         create: jest.fn(),
+        findFirst: jest.fn(),
         findMany: jest.fn(),
       },
       $queryRaw: jest.fn(),
@@ -100,30 +101,32 @@ describe('SupportService', () => {
       db.supportMessage.create.mockResolvedValue(mockMessage);
     });
 
-    it('should create request, user message, and assistant message', async () => {
+    it('should create request with user and assistant messages atomically', async () => {
       const result = await service.createRequest(userId, orgId, {
         message: 'The app keeps crashing when I open settings',
       });
 
       expect(result.request).toEqual(mockRequest);
-      expect(result.requestNumber).toBe(mockRequest.id.substring(0, 8).toUpperCase());
       expect(db.supportRequest.create).toHaveBeenCalledTimes(1);
-      expect(db.supportMessage.create).toHaveBeenCalledTimes(2);
-
-      // First call: user message
-      expect(db.supportMessage.create).toHaveBeenNthCalledWith(1, {
+      expect(db.supportMessage.create).not.toHaveBeenCalled();
+      expect(db.supportRequest.create).toHaveBeenCalledWith({
         data: expect.objectContaining({
-          requestId: mockRequest.id,
-          role: 'user',
-          content: 'The app keeps crashing when I open settings',
-        }),
-      });
-
-      // Second call: assistant message
-      expect(db.supportMessage.create).toHaveBeenNthCalledWith(2, {
-        data: expect.objectContaining({
-          requestId: mockRequest.id,
-          role: 'assistant',
+          id: expect.any(String),
+          organizationId: orgId,
+          userId,
+          description: 'The app keeps crashing when I open settings',
+          messages: {
+            create: [
+              expect.objectContaining({
+                role: 'user',
+                content: 'The app keeps crashing when I open settings',
+              }),
+              expect.objectContaining({
+                role: 'assistant',
+                content: expect.stringContaining("I've logged this as bug report"),
+              }),
+            ],
+          },
         }),
       });
     });
@@ -233,6 +236,76 @@ describe('SupportService', () => {
       });
 
       expect(result.responseText).toBe('To pair a device, go to Devices page...');
+    });
+
+    it('returns an existing request for a repeated client mutation id without writing again', async () => {
+      db.supportRequest.findFirst.mockResolvedValueOnce({
+        ...mockRequest,
+        messages: [
+          mockMessage,
+          {
+            ...mockMessage,
+            id: 'msg-assistant',
+            role: 'assistant',
+            content: 'Existing response',
+          },
+        ],
+      });
+
+      const result = await service.createRequest(userId, orgId, {
+        message: 'The app keeps crashing',
+        clientMutationId: 'client-mutation-1',
+      });
+
+      expect(result.request.id).toBe(mockRequest.id);
+      expect(result.responseText).toBe('Existing response');
+      expect(db.supportRequest.create).not.toHaveBeenCalled();
+      expect(db.supportMessage.create).not.toHaveBeenCalled();
+      expect(classifier.classify).not.toHaveBeenCalled();
+    });
+
+    it('stores the client mutation id on new requests and initial messages', async () => {
+      await service.createRequest(userId, orgId, {
+        message: 'The app keeps crashing',
+        clientMutationId: 'client-mutation-2',
+      });
+
+      const createData = db.supportRequest.create.mock.calls[0][0].data;
+      expect(createData).toEqual(expect.objectContaining({
+        clientMutationId: 'client-mutation-2',
+      }));
+      expect(createData.messages.create[0]).toEqual(expect.objectContaining({
+        role: 'user',
+        clientMutationId: 'client-mutation-2',
+      }));
+    });
+
+    it('returns the raced existing request when concurrent same-key create hits P2002', async () => {
+      db.supportRequest.findFirst
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          ...mockRequest,
+          messages: [
+            mockMessage,
+            {
+              ...mockMessage,
+              id: 'msg-assistant',
+              role: 'assistant',
+              content: 'Raced response',
+            },
+          ],
+        });
+      db.supportRequest.create.mockRejectedValueOnce({ code: 'P2002' });
+
+      const result = await service.createRequest(userId, orgId, {
+        message: 'The app keeps crashing',
+        clientMutationId: 'client-mutation-race',
+      });
+
+      expect(result.request.id).toBe(mockRequest.id);
+      expect(result.responseText).toBe('Raced response');
+      expect(db.supportRequest.findFirst).toHaveBeenCalledTimes(2);
+      expect(db.supportMessage.create).not.toHaveBeenCalled();
     });
   });
 
@@ -690,6 +763,104 @@ describe('SupportService', () => {
       await service.addMessage(mockRequest.id, adminUser, 'This was fixed');
 
       expect(db.supportRequest.update).not.toHaveBeenCalled();
+    });
+
+    it('returns an existing message for a repeated client mutation id without writing again', async () => {
+      db.supportRequest.findUnique.mockResolvedValue(mockRequest);
+      db.supportMessage.findFirst.mockResolvedValueOnce({
+        ...mockMessage,
+        content: 'Retry me safely',
+        clientMutationId: 'client-message-1',
+      });
+
+      const result = await service.addMessage(
+        mockRequest.id,
+        regularUser,
+        'Retry me safely',
+        'client-message-1',
+      );
+
+      expect(result.content).toBe('Retry me safely');
+      expect(db.supportMessage.create).not.toHaveBeenCalled();
+      expect(db.supportRequest.update).not.toHaveBeenCalled();
+    });
+
+    it('reopens resolved requests when returning an existing repeated user message', async () => {
+      db.supportRequest.findUnique.mockResolvedValue({
+        ...mockRequest,
+        status: 'resolved',
+      });
+      db.supportMessage.findFirst.mockResolvedValueOnce({
+        ...mockMessage,
+        content: 'Retry me safely',
+        clientMutationId: 'client-message-1',
+      });
+
+      const result = await service.addMessage(
+        mockRequest.id,
+        regularUser,
+        'Retry me safely',
+        'client-message-1',
+      );
+
+      expect(result.content).toBe('Retry me safely');
+      expect(db.supportMessage.create).not.toHaveBeenCalled();
+      expect(db.supportRequest.update).toHaveBeenCalledWith({
+        where: { id: mockRequest.id },
+        data: { status: 'open' },
+      });
+    });
+
+    it('stores the client mutation id on new support messages', async () => {
+      db.supportRequest.findUnique.mockResolvedValue(mockRequest);
+      db.supportMessage.findFirst.mockResolvedValueOnce(null);
+      db.supportMessage.create.mockResolvedValue({
+        ...mockMessage,
+        content: 'Retry me safely',
+        clientMutationId: 'client-message-2',
+      });
+
+      await service.addMessage(
+        mockRequest.id,
+        regularUser,
+        'Retry me safely',
+        'client-message-2',
+      );
+
+      expect(db.supportMessage.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          clientMutationId: 'client-message-2',
+        }),
+      });
+    });
+
+    it('returns the raced existing message when concurrent same-key create hits P2002', async () => {
+      db.supportRequest.findUnique.mockResolvedValue({
+        ...mockRequest,
+        status: 'resolved',
+      });
+      db.supportMessage.findFirst
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          ...mockMessage,
+          content: 'Retry me safely',
+          clientMutationId: 'client-message-race',
+        });
+      db.supportMessage.create.mockRejectedValueOnce({ code: 'P2002' });
+
+      const result = await service.addMessage(
+        mockRequest.id,
+        regularUser,
+        'Retry me safely',
+        'client-message-race',
+      );
+
+      expect(result.content).toBe('Retry me safely');
+      expect(db.supportMessage.findFirst).toHaveBeenCalledTimes(2);
+      expect(db.supportRequest.update).toHaveBeenCalledWith({
+        where: { id: mockRequest.id },
+        data: { status: 'open' },
+      });
     });
   });
 

--- a/middleware/src/modules/support/support.service.ts
+++ b/middleware/src/modules/support/support.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, NotFoundException, ForbiddenException, Logger } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
 import { Prisma } from '@vizora/database';
 import { DatabaseService } from '../database/database.service';
 import { NotificationsService } from '../notifications/notifications.service';
@@ -7,6 +8,7 @@ import { SupportKnowledgeService } from './support-knowledge.service';
 
 interface CreateRequestInput {
   message: string;
+  clientMutationId?: string;
   context?: {
     pageUrl?: string;
     browserInfo?: string;
@@ -30,6 +32,13 @@ interface UserInfo {
   isSuperAdmin: boolean;
 }
 
+const isUniqueConstraintError = (error: unknown): boolean => {
+  return typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && (error as { code?: string }).code === 'P2002';
+};
+
 @Injectable()
 export class SupportService {
   private readonly logger = new Logger(SupportService.name);
@@ -46,6 +55,33 @@ export class SupportService {
    */
   async createRequest(userId: string, organizationId: string, input: CreateRequestInput) {
     const { message, context } = input;
+    const clientMutationId = input.clientMutationId?.trim() || undefined;
+
+    const findExistingRequest = async () => {
+      if (!clientMutationId) return null;
+      const existing = await this.db.supportRequest.findFirst({
+        where: { organizationId, userId, clientMutationId },
+        include: {
+          messages: { orderBy: { createdAt: 'asc' } },
+        },
+      });
+      return existing;
+    };
+
+    const buildExistingResponse = (existing: NonNullable<Awaited<ReturnType<typeof findExistingRequest>>>) => {
+      const responseText = existing.messages.find((m) => m.role === 'assistant')?.content ?? '';
+      return {
+        request: existing,
+        responseText,
+        response: responseText,
+        requestNumber: existing.id.substring(0, 8).toUpperCase(),
+      };
+    };
+
+    const existing = await findExistingRequest();
+    if (existing) {
+      return buildExistingResponse(existing);
+    }
 
     // Classify the message
     const { category, priority } = this.classifier.classify(message);
@@ -58,49 +94,58 @@ export class SupportService {
     const aiSummary = this.classifier.generateSummary(message, category);
     const aiSuggestedAction = this.classifier.suggestAction(category, priority);
 
-    // Create the support request
-    const request = await this.db.supportRequest.create({
-      data: {
-        organizationId,
-        userId,
-        category,
-        priority,
-        status: 'open',
-        title,
-        description: message,
-        aiSummary,
-        aiSuggestedAction,
-        pageUrl: context?.pageUrl,
-        browserInfo: context?.browserInfo,
-        consoleErrors: context?.consoleErrors,
-      },
-    });
-
-    const requestNumber = request.id.substring(0, 8).toUpperCase();
-
-    // Create the user's initial message
-    await this.db.supportMessage.create({
-      data: {
-        requestId: request.id,
-        organizationId,
-        userId,
-        role: 'user',
-        content: message,
-      },
-    });
+    const requestId = randomUUID();
+    const requestNumber = requestId.substring(0, 8).toUpperCase();
 
     // Generate and save the assistant response
     const responseText = this.generateResponse(category, priority, requestNumber, kbResult?.answer);
 
-    await this.db.supportMessage.create({
-      data: {
-        requestId: request.id,
-        organizationId,
-        userId, // system message attributed to the user's context
-        role: 'assistant',
-        content: responseText,
-      },
-    });
+    let request;
+    try {
+      request = await this.db.supportRequest.create({
+        data: {
+          id: requestId,
+          organizationId,
+          userId,
+          category,
+          priority,
+          status: 'open',
+          title,
+          description: message,
+          aiSummary,
+          aiSuggestedAction,
+          clientMutationId,
+          pageUrl: context?.pageUrl,
+          browserInfo: context?.browserInfo,
+          consoleErrors: context?.consoleErrors,
+          messages: {
+            create: [
+              {
+                organizationId,
+                userId,
+                role: 'user',
+                content: message,
+                clientMutationId,
+              },
+              {
+                organizationId,
+                userId,
+                role: 'assistant',
+                content: responseText,
+              },
+            ],
+          },
+        },
+      });
+    } catch (error) {
+      if (clientMutationId && isUniqueConstraintError(error)) {
+        const racedRequest = await findExistingRequest();
+        if (racedRequest) {
+          return buildExistingResponse(racedRequest);
+        }
+      }
+      throw error;
+    }
 
     // Notify admin if critical or high priority
     if (priority === 'critical' || priority === 'high') {
@@ -122,6 +167,7 @@ export class SupportService {
     return {
       request,
       responseText,
+      response: responseText,
       requestNumber,
     };
   }
@@ -469,6 +515,7 @@ export class SupportService {
     requestId: string,
     user: UserInfo,
     content: string,
+    clientMutationId?: string,
   ) {
     const request = await this.db.supportRequest.findUnique({
       where: { id: requestId },
@@ -490,25 +537,62 @@ export class SupportService {
 
     // Determine role based on user
     const role = (user.role === 'admin' || user.isSuperAdmin) ? 'admin' : 'user';
+    const normalizedClientMutationId = clientMutationId?.trim() || undefined;
 
-    const message = await this.db.supportMessage.create({
-      data: {
-        requestId,
-        organizationId: request.organizationId,
-        userId: user.id,
-        role,
-        content,
-      },
-    });
+    const reopenIfNeeded = async () => {
+      if (role === 'user' && (request.status === 'resolved' || request.status === 'closed')) {
+        await this.db.supportRequest.update({
+          where: { id: requestId },
+          data: { status: 'open' },
+        });
+        this.logger.log(`Reopened support request ${requestId} due to new user message`);
+      }
+    };
+
+    const findExistingMessage = async () => {
+      if (!normalizedClientMutationId) return null;
+      return this.db.supportMessage.findFirst({
+        where: {
+          requestId,
+          userId: user.id,
+          clientMutationId: normalizedClientMutationId,
+        },
+      });
+    };
+
+    if (normalizedClientMutationId) {
+      const existingMessage = await findExistingMessage();
+      if (existingMessage) {
+        await reopenIfNeeded();
+        return existingMessage;
+      }
+    }
+
+    let message;
+    try {
+      message = await this.db.supportMessage.create({
+        data: {
+          requestId,
+          organizationId: request.organizationId,
+          userId: user.id,
+          role,
+          content,
+          clientMutationId: normalizedClientMutationId,
+        },
+      });
+    } catch (error) {
+      if (normalizedClientMutationId && isUniqueConstraintError(error)) {
+        const existingMessage = await findExistingMessage();
+        if (existingMessage) {
+          await reopenIfNeeded();
+          return existingMessage;
+        }
+      }
+      throw error;
+    }
 
     // If the request was resolved/closed and user sends a new message, reopen it
-    if (role === 'user' && (request.status === 'resolved' || request.status === 'closed')) {
-      await this.db.supportRequest.update({
-        where: { id: requestId },
-        data: { status: 'open' },
-      });
-      this.logger.log(`Reopened support request ${requestId} due to new user message`);
-    }
+    await reopenIfNeeded();
 
     this.logger.log(`Added ${role} message to support request ${requestId}`);
 

--- a/packages/database/prisma/migrations/20260602043000_add_support_client_mutation_ids/migration.sql
+++ b/packages/database/prisma/migrations/20260602043000_add_support_client_mutation_ids/migration.sql
@@ -1,0 +1,12 @@
+-- Add client mutation ids so support request/message retries are idempotent.
+ALTER TABLE "support_requests"
+  ADD COLUMN "clientMutationId" VARCHAR(80);
+
+ALTER TABLE "support_messages"
+  ADD COLUMN "clientMutationId" VARCHAR(80);
+
+CREATE UNIQUE INDEX "support_requests_org_user_client_mutation_key"
+  ON "support_requests"("organizationId", "userId", "clientMutationId");
+
+CREATE UNIQUE INDEX "support_messages_request_user_client_mutation_key"
+  ON "support_messages"("requestId", "userId", "clientMutationId");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -766,6 +766,7 @@ model SupportRequest {
   description       String
   aiSummary         String?
   aiSuggestedAction String?
+  clientMutationId  String? @db.VarChar(80)
   aiCategory        String? // TicketCategoryV2 slug — see docs/hermes/ticket-categories-2026-04-24.md
 
   pageUrl       String? @db.VarChar(500)
@@ -790,6 +791,7 @@ model SupportRequest {
   @@index([userId])
   @@index([organizationId, status])
   @@index([organizationId, createdAt])
+  @@unique([organizationId, userId, clientMutationId], map: "support_requests_org_user_client_mutation_key")
   @@map("support_requests")
 }
 
@@ -802,6 +804,7 @@ model SupportMessage {
   role       String // 'user', 'assistant', 'admin' — conversation role
   authorType String @default("user") // 'user' | 'admin' | 'agent' — source (agent = automation)
   content    String
+  clientMutationId String? @db.VarChar(80)
 
   createdAt DateTime @default(now())
 
@@ -811,6 +814,7 @@ model SupportMessage {
   @@index([requestId])
   @@index([organizationId])
   @@index([requestId, authorType])
+  @@unique([requestId, userId, clientMutationId], map: "support_messages_request_user_client_mutation_key")
   @@map("support_messages")
 }
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,122 @@
 # Vizora - Task Tracker
 
+## Active: Dashboard Role Truth Pass 43 (2026-06-02)
+
+**Branch:** `feat/dashboard-role-truth-pass-43`
+
+**Why now:** Customer-dashboard review found high-trust UI gaps where read-only
+users can see write workflows and support messages can disappear after a send
+failure. Drift check shows device pairing is already role-gated; schedules and
+support failed-send state remain concrete repo-side gaps.
+
+**New primitives introduced:** `canManageSchedules` and `canDeleteSchedules`
+on the existing dashboard permission helper; optional `clientMutationId` on
+support requests/messages with scoped unique indexes. No env var, runtime
+process, notification path, realtime substrate, MCP tool, Hermes skill,
+provider spend path, or parallel infrastructure.
+
+**Hermes-first analysis:** checked per project convention. These are local
+dashboard role/state concerns, not agent-runtime tasks.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Dashboard role-based action gating | none found | build in existing web permission helper |
+| Support chat failed-message state | none found | build in existing support chat provider/panel |
+| Support retry idempotency | none found | build in existing support API/service with Prisma indexes |
+
+Awesome-hermes-agent ecosystem check: no applicable runtime/library primitive
+for React dashboard role gating or support-chat failure state; proceed with
+Vizora-native code.
+
+**Plan/design:**
+`docs/plans/2026-06-02-dashboard-role-truth-pass-43.md`
+
+**Plan**
+- [x] Drift-check stale device pairing role finding.
+- [x] Document scope and Hermes-first analysis.
+- [x] Add red tests for schedule role truth and support failed sends.
+- [x] Implement permission/helper and support state fixes.
+- [x] Run focused and broader web verification.
+- [x] Run multi-vector subagent review.
+- [ ] PR, CI, merge if green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Scoped fixes**
+- Schedules: viewers see read-only schedule information; create/edit/duplicate
+  controls are admin/manager-only; delete is admin-only.
+- Support chat: failed existing-message and new-conversation sends keep the
+  customer text visible with an idempotent error/retry state instead of
+  silently removing it.
+- Release hygiene: realtime Docker builds generate Prisma in the builder stage,
+  then copy the generated database package into the runtime image; Docker
+  context ignores nested workspace `node_modules`.
+
+**Evidence so far**
+- Drift check: `web/src/app/dashboard/devices/page-client.tsx` already uses
+  `getDashboardPermissions` and gates pairing/device mutation entry points, so
+  the older viewer-pairing finding is stale.
+- Backend schedule role truth: `SchedulesController` allows
+  create/update/duplicate/conflict-check for admin/manager and delete for
+  admin only.
+- Red verification:
+  `pnpm --filter @vizora/web test -- --runInBand web/src/lib/__tests__/permissions.test.ts web/src/app/dashboard/schedules/__tests__/schedules-page.test.tsx web/src/components/support/__tests__/SupportChat.test.tsx`
+  failed as expected because schedule controls ignored role permissions, the
+  shared dashboard permission helper lacked schedule flags, and failed support
+  sends removed the optimistic customer message.
+- Focused verification:
+  `pnpm --filter @vizora/web test -- --runInBand web/src/lib/__tests__/permissions.test.ts web/src/app/dashboard/schedules/__tests__/schedules-page.test.tsx web/src/components/support/__tests__/SupportChat.test.tsx`
+  passed 3 suites / 42 tests after implementation.
+- Review findings fixed:
+  - Schedule Duplicate now calls the existing backend duplicate endpoint
+    instead of opening a prefilled create form.
+  - Manager individual-device create is single-target, so it cannot need
+    admin-only delete rollback after partial batch failure.
+  - Support retries now carry a durable client mutation id through the web API,
+    DTOs, service, Prisma schema, and migration.
+- Review-fix verification:
+  - `pnpm exec prisma generate --schema prisma/schema.prisma` from
+    `packages/database` passed.
+  - `pnpm --filter @vizora/web test -- --runInBand web/src/app/dashboard/schedules/__tests__/schedules-page.test.tsx web/src/components/support/__tests__/SupportChat.test.tsx`
+    passed 2 suites / 43 tests.
+  - `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/support/support.service.spec.ts middleware/src/modules/support/support.controller.spec.ts`
+    passed 2 suites / 66 tests.
+- Second review findings fixed:
+  - Support request creation now writes the request and initial messages in one
+    nested Prisma create, so a failed assistant-message write cannot leave a
+    partial request.
+  - Support message duplicate/race paths now re-read on `P2002` and reopen
+    resolved/closed user tickets when the duplicate is the durable retry
+    result.
+  - Viewer schedule empty-state copy no longer invites create actions; admin
+    delete and manager update paths have explicit test coverage.
+  - Realtime Dockerfile no longer runs the dev-only Prisma CLI in the runtime
+    stage, and `.dockerignore` excludes nested workspace `node_modules`.
+- Broad local verification:
+  - `pnpm --filter @vizora/web test -- --runInBand` passed 102 suites / 1092
+    tests, with existing React `act()` console warnings in unrelated suites.
+  - `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` passed.
+  - `NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_API_URL=http://localhost:3000 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 npx nx build @vizora/web --skip-nx-cache`
+    passed with existing Next middleware/proxy and Nx flaky-task warnings.
+  - `pnpm --filter @vizora/middleware test -- --runInBand` passed 146 suites /
+    2975 tests.
+  - `pnpm --filter @vizora/realtime test -- --runInBand` passed 12 suites /
+    285 tests.
+  - `git diff --check` passed with Windows CRLF warnings only.
+  - `pnpm security:no-hardcoded-jwts` passed.
+  - `docker build -f docker/Dockerfile.realtime -t vizora-realtime-pass43 .`
+    now gets past Docker context loading but is blocked before project code by
+    local Docker TLS trust (`UNABLE_TO_VERIFY_LEAF_SIGNATURE` fetching pnpm);
+    a minimal `node:22-alpine` package fetch has the same TLS failure. No
+    insecure TLS bypass was added.
+- Final subagent re-review:
+  - Schedule/RBAC reviewer CLEAN after manager update, admin delete, and
+    viewer empty-state tests.
+  - Support idempotency reviewer CLEAN after nested create, `P2002` re-read,
+    scoped unique indexes, and reopen-on-duplicate handling.
+  - Release/Docker reviewer CLEAN after moving Prisma generation to the builder
+    stage only and excluding nested workspace `node_modules` from Docker
+    context.
+
 ## Completed: Customer Hot-Path Follow-up Pass 42 (2026-06-02)
 
 **Branch:** `feat/customer-hotpath-followup-pass-42`

--- a/web/src/app/dashboard/schedules/__tests__/schedules-page.test.tsx
+++ b/web/src/app/dashboard/schedules/__tests__/schedules-page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { act, render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { ApiError } from '@/lib/error-handler';
 import SchedulesClient from '../page-client';
 
@@ -9,7 +9,9 @@ const mockGetDisplayGroups = jest.fn();
 const mockCreateSchedule = jest.fn();
 const mockUpdateSchedule = jest.fn();
 const mockDeleteSchedule = jest.fn();
+const mockDuplicateSchedule = jest.fn();
 const mockCheckScheduleConflicts = jest.fn();
+let mockCurrentUser: { role: string } | null = { role: 'admin' };
 
 jest.mock('@/lib/api', () => ({
   apiClient: {
@@ -20,6 +22,7 @@ jest.mock('@/lib/api', () => ({
     createSchedule: (...args: any[]) => mockCreateSchedule(...args),
     updateSchedule: (...args: any[]) => mockUpdateSchedule(...args),
     deleteSchedule: (...args: any[]) => mockDeleteSchedule(...args),
+    duplicateSchedule: (...args: any[]) => mockDuplicateSchedule(...args),
     checkScheduleConflicts: (...args: any[]) => mockCheckScheduleConflicts(...args),
   },
 }));
@@ -38,6 +41,17 @@ jest.mock('@/lib/hooks/useToast', () => ({
 
 jest.mock('@/lib/hooks', () => ({
   useRealtimeEvents: jest.fn(() => ({ isConnected: false, isOffline: true })),
+}));
+
+jest.mock('@/lib/hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: mockCurrentUser,
+    loading: false,
+    error: null,
+    isAuthenticated: !!mockCurrentUser,
+    logout: jest.fn(),
+    reload: jest.fn(),
+  }),
 }));
 
 jest.mock('@/theme/icons', () => ({
@@ -162,6 +176,7 @@ const sampleGroups = [
 describe('SchedulesClient', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCurrentUser = { role: 'admin' };
     mockGetSchedules.mockResolvedValue({ data: [] });
     mockGetPlaylists.mockResolvedValue({ data: [] });
     mockGetDisplays.mockResolvedValue({ data: [] });
@@ -169,6 +184,12 @@ describe('SchedulesClient', () => {
     mockCreateSchedule.mockResolvedValue({ id: 'new-1' });
     mockUpdateSchedule.mockImplementation((id, payload) => Promise.resolve({ id, ...payload, isActive: true }));
     mockDeleteSchedule.mockResolvedValue({});
+    mockDuplicateSchedule.mockResolvedValue({
+      ...sampleSchedules[0],
+      id: 's1-copy',
+      name: 'Morning Announcements (Copy)',
+      isActive: false,
+    });
     mockCheckScheduleConflicts.mockResolvedValue({ hasConflicts: false, conflicts: [] });
   });
 
@@ -261,6 +282,139 @@ describe('SchedulesClient', () => {
     });
     expect(screen.getAllByText('Active')).toHaveLength(2);
     expect(screen.getByText('Inactive')).toBeInTheDocument();
+  });
+
+  it('renders schedules read-only for viewer users', async () => {
+    mockCurrentUser = { role: 'viewer' };
+    mockGetSchedules.mockResolvedValue({ data: sampleSchedules });
+
+    render(<SchedulesClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Morning Announcements')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Create Schedule')).not.toBeInTheDocument();
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument();
+    expect(screen.queryByText('Duplicate')).not.toBeInTheDocument();
+    expect(screen.queryByText('Delete')).not.toBeInTheDocument();
+  });
+
+  it('allows managers to create and duplicate schedules but not delete them', async () => {
+    mockCurrentUser = { role: 'manager' };
+    mockGetSchedules.mockResolvedValue({ data: sampleSchedules });
+
+    render(<SchedulesClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Morning Announcements')).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText('Create Schedule')).toHaveLength(1);
+    expect(screen.getAllByText('Edit')).toHaveLength(sampleSchedules.length);
+    expect(screen.getAllByText('Duplicate')).toHaveLength(sampleSchedules.length);
+    expect(screen.queryByText('Delete')).not.toBeInTheDocument();
+  });
+
+  it('uses read-only empty-state copy for viewers with no schedules', async () => {
+    mockCurrentUser = { role: 'viewer' };
+    mockGetSchedules.mockResolvedValue({ data: [] });
+
+    render(<SchedulesClient />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText('No schedules are configured for this organization yet')).toBeInTheDocument();
+    expect(screen.queryByText('Create your first schedule to automate content playback on your devices')).not.toBeInTheDocument();
+    expect(screen.queryByText('Create Schedule')).not.toBeInTheDocument();
+  });
+
+  it('duplicates schedules through the backend duplicate endpoint', async () => {
+    mockCurrentUser = { role: 'manager' };
+    mockGetSchedules.mockResolvedValue({ data: sampleSchedules });
+
+    render(<SchedulesClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Morning Announcements')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getAllByText('Duplicate')[0]);
+    });
+
+    await waitFor(() => {
+      expect(mockDuplicateSchedule).toHaveBeenCalledWith('s1');
+    });
+    expect(mockCreateSchedule).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('modal')).not.toBeInTheDocument();
+  });
+
+  it('keeps manager create to one individual device so rollback never needs admin-only delete', async () => {
+    mockCurrentUser = { role: 'manager' };
+    mockGetPlaylists.mockResolvedValue({ data: samplePlaylists });
+    mockGetDisplays.mockResolvedValue({ data: sampleDisplays });
+    mockCreateSchedule.mockResolvedValue({
+      ...sampleSchedules[0],
+      id: 'new-manager-schedule',
+      displayId: 'd2',
+      daysOfWeek: [1, 2, 3, 4, 5],
+      isActive: true,
+    });
+
+    render(<SchedulesClient />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Create Schedule'));
+    fireEvent.change(screen.getByPlaceholderText('e.g., Morning Content, Holiday Special'), {
+      target: { value: 'Manager schedule' },
+    });
+    fireEvent.change(screen.getByDisplayValue('Select a playlist...'), {
+      target: { value: 'p1' },
+    });
+    fireEvent.click(screen.getByLabelText('Lobby Display'));
+    fireEvent.click(screen.getByLabelText('Conference Room'));
+    fireEvent.click(screen.getByText('Create'));
+
+    await waitFor(() => {
+      expect(mockCreateSchedule).toHaveBeenCalledTimes(1);
+    });
+    expect(mockCreateSchedule).toHaveBeenCalledWith(expect.objectContaining({ displayId: 'd2' }));
+    expect(mockDeleteSchedule).not.toHaveBeenCalled();
+  });
+
+  it('allows admins to delete schedules', async () => {
+    mockGetSchedules.mockResolvedValue({ data: sampleSchedules });
+
+    render(<SchedulesClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Morning Announcements')).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText('Delete')).toHaveLength(sampleSchedules.length);
+  });
+
+  it('allows admins to confirm schedule deletion', async () => {
+    mockGetSchedules.mockResolvedValue({ data: sampleSchedules });
+
+    render(<SchedulesClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Morning Announcements')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByText('Delete')[0]);
+    fireEvent.click(screen.getByText('Confirm'));
+
+    await waitFor(() => {
+      expect(mockDeleteSchedule).toHaveBeenCalledWith('s1');
+    });
   });
 
   it('checks candidate schedules for conflicts and displays warnings', async () => {
@@ -389,6 +543,7 @@ describe('SchedulesClient', () => {
   });
 
   it('creates one backend schedule per selected device target', async () => {
+    mockCurrentUser = { role: 'admin' };
     mockGetSchedules.mockResolvedValue({ data: [] });
     mockGetPlaylists.mockResolvedValue({ data: samplePlaylists });
     mockGetDisplays.mockResolvedValue({ data: sampleDisplays });
@@ -423,6 +578,7 @@ describe('SchedulesClient', () => {
   });
 
   it('rolls back already-created device schedules if a later target create fails', async () => {
+    mockCurrentUser = { role: 'admin' };
     mockGetSchedules.mockResolvedValue({ data: [] });
     mockGetPlaylists.mockResolvedValue({ data: samplePlaylists });
     mockGetDisplays.mockResolvedValue({ data: sampleDisplays });
@@ -476,6 +632,7 @@ describe('SchedulesClient', () => {
   });
 
   it('submits null opposite target when editing a group schedule to an individual device', async () => {
+    mockCurrentUser = { role: 'manager' };
     mockGetSchedules.mockResolvedValue({ data: sampleSchedules });
     mockGetPlaylists.mockResolvedValue({ data: samplePlaylists });
     mockGetDisplays.mockResolvedValue({ data: sampleDisplays });
@@ -515,20 +672,13 @@ describe('SchedulesClient', () => {
       expect(screen.getByText('Weekend Specials')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getAllByText('Duplicate')[1]);
-    fireEvent.click(screen.getByText('Create'));
+    await act(async () => {
+      fireEvent.click(screen.getAllByText('Duplicate')[1]);
+    });
 
     await waitFor(() => {
-      expect(mockCreateSchedule).toHaveBeenCalledWith(
-        expect.objectContaining({
-          displayGroupId: 'g1',
-        }),
-      );
+      expect(mockDuplicateSchedule).toHaveBeenCalledWith('s2');
     });
-    expect(mockCreateSchedule).toHaveBeenCalledWith(
-      expect.not.objectContaining({
-        displayId: 'g1',
-      }),
-    );
+    expect(mockCreateSchedule).not.toHaveBeenCalled();
   });
 });

--- a/web/src/app/dashboard/schedules/page-client.tsx
+++ b/web/src/app/dashboard/schedules/page-client.tsx
@@ -14,6 +14,8 @@ import dynamic from 'next/dynamic';
 const ScheduleCalendar = dynamic(() => import('@/components/ScheduleCalendar'), { ssr: false });
 import { useToast } from '@/lib/hooks/useToast';
 import { useRealtimeEvents } from '@/lib/hooks';
+import { useAuth } from '@/lib/hooks/useAuth';
+import { getDashboardPermissions } from '@/lib/permissions';
 import { Icon } from '@/theme/icons';
 import { format } from 'date-fns';
 import { isApiError } from '@/lib/error-handler';
@@ -111,6 +113,9 @@ const formatConflictTimeRange = (conflict: { startTime?: number | string | null;
 
 export default function SchedulesClient() {
  const toast = useToast();
+ const { user } = useAuth();
+ const permissions = getDashboardPermissions(user);
+ const canCreateMultipleDeviceSchedules = permissions.canDeleteSchedules;
  const [schedules, setSchedules] = useState<Schedule[]>([]);
  const [devices, setDevices] = useState<Display[]>([]);
  const [playlists, setPlaylists] = useState<PlaylistSummary[]>([]);
@@ -185,7 +190,7 @@ export default function SchedulesClient() {
  }, []);
 
  useEffect(() => {
- const modalOpen = isCreateModalOpen || isEditModalOpen;
+ const modalOpen = permissions.canManageSchedules && (isCreateModalOpen || isEditModalOpen);
  const daysOfWeek = dayNamesToNumbers(formData.days);
  const targetIds = targetType === 'device' ? formData.deviceIds : formData.deviceIds.slice(0, 1);
 
@@ -286,6 +291,7 @@ export default function SchedulesClient() {
  selectedSchedule?.endDate,
  updateConflictWarnings,
  updateConflictCheckFailed,
+ permissions.canManageSchedules,
  ]);
 
  const loadData = async () => {
@@ -368,6 +374,13 @@ export default function SchedulesClient() {
  if (formData.deviceIds.length === 0) {
  errors.deviceIds = 'Select at least one device';
  }
+ if (
+ targetType === 'device'
+ && !canCreateMultipleDeviceSchedules
+ && formData.deviceIds.length > 1
+ ) {
+ errors.deviceIds = 'Select one device';
+ }
  if (formData.duration < 1 || formData.duration > 1440) {
  errors.duration = 'Duration must be between 1 and 1440 minutes';
  }
@@ -386,6 +399,7 @@ export default function SchedulesClient() {
  };
 
  const handleCreate = async () => {
+ if (!permissions.canManageSchedules) return;
  if (!validateForm()) return;
 
  try {
@@ -417,11 +431,13 @@ export default function SchedulesClient() {
  }
  } catch (error) {
  if (createdSchedules.length > 0) {
+ if (permissions.canDeleteSchedules) {
  await Promise.allSettled(
  createdSchedules
  .filter((schedule) => schedule?.id)
  .map((schedule) => apiClient.deleteSchedule(schedule.id)),
  );
+ }
  await loadData();
  }
  throw error;
@@ -449,6 +465,7 @@ export default function SchedulesClient() {
  };
 
  const handleUpdate = async () => {
+ if (!permissions.canManageSchedules) return;
  if (!validateForm() || !selectedSchedule) return;
 
  try {
@@ -490,6 +507,7 @@ export default function SchedulesClient() {
  };
 
  const handleDelete = async () => {
+ if (!permissions.canDeleteSchedules) return;
  if (!selectedSchedule) return;
 
  try {
@@ -509,6 +527,7 @@ export default function SchedulesClient() {
  };
 
  const openEditModal = (schedule: Schedule) => {
+ if (!permissions.canManageSchedules) return;
  clearConflictCheckCache();
  setSelectedSchedule(schedule);
  setFormData({
@@ -526,6 +545,7 @@ export default function SchedulesClient() {
  };
 
  const openDeleteModal = (schedule: Schedule) => {
+ if (!permissions.canDeleteSchedules) return;
  setSelectedSchedule(schedule);
  setIsDeleteModalOpen(true);
  };
@@ -546,6 +566,34 @@ export default function SchedulesClient() {
  setTargetType('device');
  updateConflictWarnings([]);
  updateConflictCheckFailed(false);
+ };
+
+ const openCreateModal = () => {
+ if (!permissions.canManageSchedules) return;
+ resetForm();
+ setIsCreateModalOpen(true);
+ };
+
+ const handleDuplicate = async (schedule: Schedule) => {
+ if (!permissions.canManageSchedules) return;
+ try {
+ setActionLoading(true);
+ const duplicatedSchedule = await apiClient.duplicateSchedule(schedule.id);
+ const uiSchedule: Schedule = {
+ ...duplicatedSchedule,
+ days: dayNumbersToNames(duplicatedSchedule.daysOfWeek || []),
+ deviceIds: duplicatedSchedule.displayId ? [duplicatedSchedule.displayId] : duplicatedSchedule.displayGroupId ? [duplicatedSchedule.displayGroupId] : [],
+ duration: calculateDuration(duplicatedSchedule.startTime, duplicatedSchedule.endTime),
+ timezone: schedule.timezone || 'UTC',
+ active: duplicatedSchedule.isActive,
+ };
+ setSchedules((prev) => [uiSchedule, ...prev]);
+ toast.success('Schedule duplicated successfully');
+ } catch (error: any) {
+ toast.error(error.message || 'Failed to duplicate schedule');
+ } finally {
+ setActionLoading(false);
+ }
  };
 
  const getPlaylistName = (playlistId: string) => {
@@ -641,16 +689,15 @@ export default function SchedulesClient() {
  </button>
  </div>
  {/* Create button */}
+ {permissions.canManageSchedules && (
  <button
- onClick={() => {
- resetForm();
- setIsCreateModalOpen(true);
- }}
+ onClick={openCreateModal}
  className="eh-btn-neon rounded-xl px-6 py-3 transition font-semibold shadow-md hover:shadow-lg flex items-center gap-2 active:scale-95"
  >
  <Icon name="add" size="lg" className="text-white" />
  <span>Create Schedule</span>
  </button>
+ )}
  </div>
  </div>
 
@@ -672,6 +719,7 @@ export default function SchedulesClient() {
  schedules={schedules}
  onSelectEvent={(schedule) => openEditModal(schedule)}
  onSelectSlot={(slotInfo) => {
+ if (!permissions.canManageSchedules) return;
  resetForm();
  const startTime = format(slotInfo.start, 'HH:mm');
  const endTime = format(slotInfo.end, 'HH:mm');
@@ -688,14 +736,13 @@ export default function SchedulesClient() {
  <EmptyState
  icon="schedules"
  title="No schedules yet"
- description="Create your first schedule to automate content playback on your devices"
- action={{
+ description={permissions.canManageSchedules
+ ? 'Create your first schedule to automate content playback on your devices'
+ : 'No schedules are configured for this organization yet'}
+ action={permissions.canManageSchedules ? {
  label: 'Create Schedule',
- onClick: () => {
- resetForm();
- setIsCreateModalOpen(true);
- },
- }}
+ onClick: openCreateModal,
+ } : undefined}
  />
  ) : (
  /* Schedules List */
@@ -751,6 +798,7 @@ export default function SchedulesClient() {
  </div>
 
  {/* Action Buttons */}
+ {permissions.canManageSchedules && (
  <div className="flex gap-2 mt-4 pt-4 border-t border-[var(--border)]">
  <button
  onClick={() => openEditModal(schedule)}
@@ -759,32 +807,21 @@ export default function SchedulesClient() {
  Edit
  </button>
  <button
- onClick={() => {
- // Don't set selectedSchedule so it's treated as a new schedule
- setSelectedSchedule(null);
- setTargetType((schedule as any).displayGroupId ? 'group' : 'device');
- setFormData({
- name: `${schedule.name} (Copy)`,
- startTime: schedule.startTime != null ? minutesToHHMM(schedule.startTime) : '09:00',
- duration: schedule.duration || 60,
- days: schedule.days || [],
- timezone: schedule.timezone || 'UTC',
- playlistId: schedule.playlistId,
- deviceIds: schedule.deviceIds || [],
- });
- setIsCreateModalOpen(true);
- }}
+ onClick={() => { void handleDuplicate(schedule); }}
  className="px-4 py-2 text-sm bg-[var(--background)] text-[var(--foreground-secondary)] rounded-lg hover:bg-[var(--surface-hover)] transition font-medium active:scale-95"
  >
  Duplicate
  </button>
+ {permissions.canDeleteSchedules && (
  <button
  onClick={() => openDeleteModal(schedule)}
  className="px-4 py-2 text-sm bg-red-50 dark:bg-red-900 text-red-600 dark:text-red-200 rounded-lg hover:bg-red-100 dark:hover:bg-red-800 transition font-medium active:scale-95"
  >
  Delete
  </button>
+ )}
  </div>
+ )}
  </div>
  );
  })}
@@ -808,7 +845,7 @@ export default function SchedulesClient() {
  )}
 
  {/* Create/Edit Schedule Modal */}
- {(isCreateModalOpen || isEditModalOpen) && (
+ {permissions.canManageSchedules && (isCreateModalOpen || isEditModalOpen) && (
  <Modal
  isOpen={isCreateModalOpen || isEditModalOpen}
  onClose={() => {
@@ -1008,7 +1045,9 @@ export default function SchedulesClient() {
  checked={formData.deviceIds.includes(device.id)}
  onChange={e => {
  const newDeviceIds = e.target.checked
+ ? canCreateMultipleDeviceSchedules
  ? [...formData.deviceIds, device.id]
+ : [device.id]
  : formData.deviceIds.filter(id => id !== device.id);
  setFormData({ ...formData, deviceIds: newDeviceIds });
  if (formErrors.deviceIds) setFormErrors({ ...formErrors, deviceIds: '' });
@@ -1086,7 +1125,7 @@ export default function SchedulesClient() {
  )}
 
  {/* Delete Confirmation */}
- {isDeleteModalOpen && selectedSchedule && (
+ {permissions.canDeleteSchedules && isDeleteModalOpen && selectedSchedule && (
  <ConfirmDialog
  isOpen={isDeleteModalOpen}
  onClose={() => {

--- a/web/src/components/support/SupportChatPanel.tsx
+++ b/web/src/components/support/SupportChatPanel.tsx
@@ -43,6 +43,7 @@ export default function SupportChatPanel() {
     setInputText,
     toggleChat,
     sendMessage,
+    retryFailedMessage,
     startNewConversation,
     startComposing,
     selectConversation,
@@ -201,6 +202,9 @@ export default function SupportChatPanel() {
                 role={msg.role}
                 content={msg.content}
                 createdAt={msg.createdAt}
+                deliveryStatus={msg.deliveryStatus}
+                errorMessage={msg.errorMessage}
+                onRetry={msg.deliveryStatus === 'failed' ? () => { void retryFailedMessage(msg.id); } : undefined}
               />
             ))}
             {isLoading && (

--- a/web/src/components/support/SupportChatProvider.tsx
+++ b/web/src/components/support/SupportChatProvider.tsx
@@ -27,7 +27,8 @@ interface SupportChatState {
 // (TS4058).
 export interface SupportChatContextValue extends SupportChatState {
   toggleChat: () => void;
-  sendMessage: (content: string) => Promise<void>;
+  sendMessage: (content: string, clientMutationId?: string) => Promise<void>;
+  retryFailedMessage: (messageId: string) => Promise<void>;
   startNewConversation: () => void;
   startComposing: (prefill?: string) => void;
   selectConversation: (id: string) => Promise<void>;
@@ -40,6 +41,14 @@ export const SupportChatContext = createContext<SupportChatContextValue | null>(
 // Keep last 10 console errors for context capture
 const recentErrors: string[] = [];
 let consoleErrorIntercepted = false;
+const SEND_FAILED_MESSAGE = 'Message not sent';
+
+function createClientMutationId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `support-${Date.now()}-${Math.random().toString(36).slice(2, 12)}`;
+}
 
 function interceptConsoleErrors() {
   if (consoleErrorIntercepted || typeof window === 'undefined') return;
@@ -150,7 +159,7 @@ export function SupportChatProvider({ children }: { children: React.ReactNode })
     }
   }, []);
 
-  const sendMessage = useCallback(async (content: string) => {
+  const sendMessage = useCallback(async (content: string, clientMutationId = createClientMutationId()) => {
     if (!content.trim()) return;
 
     const context = captureContext();
@@ -159,38 +168,47 @@ export function SupportChatProvider({ children }: { children: React.ReactNode })
     if (activeRequestId) {
       // Add to existing conversation
       const optimisticMsg: SupportMessage = {
-        id: `temp-${Date.now()}`,
+        id: `temp-${clientMutationId}`,
         requestId: activeRequestId,
         organizationId: '',
         userId: '',
         role: 'user',
         content: content.trim(),
         createdAt: new Date().toISOString(),
+        clientMutationId,
+        deliveryStatus: 'sending',
       };
       setMessages((prev) => [...prev, optimisticMsg]);
 
       try {
-        const serverMsg = await apiClient.addSupportMessage(activeRequestId, content.trim());
+        const serverMsg = await apiClient.addSupportMessage(activeRequestId, content.trim(), clientMutationId);
         // Replace optimistic message with server response
         setMessages((prev) =>
           prev.map((m) => (m.id === optimisticMsg.id ? serverMsg : m))
         );
       } catch {
-        // Remove optimistic message on error
-        setMessages((prev) => prev.filter((m) => m.id !== optimisticMsg.id));
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === optimisticMsg.id
+              ? { ...optimisticMsg, deliveryStatus: 'failed', errorMessage: SEND_FAILED_MESSAGE }
+              : m
+          )
+        );
       } finally {
         setIsLoading(false);
       }
     } else {
       // Create new conversation
       const optimisticMsg: SupportMessage = {
-        id: `temp-${Date.now()}`,
+        id: `temp-${clientMutationId}`,
         requestId: '',
         organizationId: '',
         userId: '',
         role: 'user',
         content: content.trim(),
         createdAt: new Date().toISOString(),
+        clientMutationId,
+        deliveryStatus: 'sending',
       };
       setMessages([optimisticMsg]);
 
@@ -198,6 +216,7 @@ export function SupportChatProvider({ children }: { children: React.ReactNode })
         const result = await apiClient.createSupportRequest({
           message: content.trim(),
           context,
+          clientMutationId,
         });
         const newRequest = result.request;
         setActiveRequestId(newRequest.id);
@@ -216,14 +235,15 @@ export function SupportChatProvider({ children }: { children: React.ReactNode })
         ];
 
         // Add the assistant response if available
-        if (result.response) {
+        const responseText = result.response ?? result.responseText;
+        if (responseText) {
           newMessages.push({
             id: newRequest.id + '-assistant',
             requestId: newRequest.id,
             organizationId: newRequest.organizationId,
             userId: '',
             role: 'assistant',
-            content: result.response,
+            content: responseText,
             createdAt: new Date().toISOString(),
           });
         }
@@ -241,12 +261,23 @@ export function SupportChatProvider({ children }: { children: React.ReactNode })
           ...prev,
         ]);
       } catch {
-        setMessages([]);
+        setMessages([{ ...optimisticMsg, deliveryStatus: 'failed', errorMessage: SEND_FAILED_MESSAGE }]);
+        setIsComposing(true);
       } finally {
         setIsLoading(false);
       }
     }
   }, [activeRequestId]);
+
+  const retryFailedMessage = useCallback(async (messageId: string) => {
+    const failedMessage = messages.find(
+      (message) => message.id === messageId && message.deliveryStatus === 'failed',
+    );
+    if (!failedMessage) return;
+
+    setMessages((prev) => prev.filter((message) => message.id !== messageId));
+    await sendMessage(failedMessage.content, failedMessage.clientMutationId || undefined);
+  }, [messages, sendMessage]);
 
   const value: SupportChatContextValue = {
     isOpen,
@@ -259,6 +290,7 @@ export function SupportChatProvider({ children }: { children: React.ReactNode })
     inputText,
     toggleChat,
     sendMessage,
+    retryFailedMessage,
     startNewConversation,
     startComposing,
     selectConversation,

--- a/web/src/components/support/SupportMessage.tsx
+++ b/web/src/components/support/SupportMessage.tsx
@@ -1,9 +1,14 @@
 'use client';
 
+import { RefreshCw } from 'lucide-react';
+
 interface SupportMessageProps {
   role: 'user' | 'assistant' | 'admin';
   content: string;
   createdAt: string;
+  deliveryStatus?: 'sending' | 'sent' | 'failed';
+  errorMessage?: string;
+  onRetry?: () => void;
 }
 
 function formatTimeAgo(dateString: string): string {
@@ -101,8 +106,16 @@ function renderMessageContent(text: string): React.ReactNode[] {
   return elements;
 }
 
-export default function SupportMessage({ role, content, createdAt }: SupportMessageProps) {
+export default function SupportMessage({
+  role,
+  content,
+  createdAt,
+  deliveryStatus,
+  errorMessage,
+  onRetry,
+}: SupportMessageProps) {
   const isUser = role === 'user';
+  const failed = deliveryStatus === 'failed';
 
   return (
     <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} mb-3`}>
@@ -131,6 +144,23 @@ export default function SupportMessage({ role, content, createdAt }: SupportMess
         <div className={`mt-1 text-xs text-gray-500 ${isUser ? 'text-right' : 'text-left'}`}>
           {formatTimeAgo(createdAt)}
         </div>
+
+        {failed && (
+          <div className={`mt-1 flex items-center gap-2 text-xs text-red-300 ${isUser ? 'justify-end' : 'justify-start'}`}>
+            <span>{errorMessage || 'Message not sent'}</span>
+            {onRetry && (
+              <button
+                type="button"
+                onClick={onRetry}
+                aria-label="Retry message"
+                className="inline-flex items-center gap-1 rounded-md border border-red-400/30 px-2 py-1 text-red-100 hover:bg-red-500/10 transition"
+              >
+                <RefreshCw className="h-3 w-3" />
+                <span>Retry</span>
+              </button>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/web/src/components/support/__tests__/SupportChat.test.tsx
+++ b/web/src/components/support/__tests__/SupportChat.test.tsx
@@ -263,7 +263,8 @@ describe('SupportChat', () => {
     await waitFor(() => {
       expect(mockApiClient.addSupportMessage).toHaveBeenCalledWith(
         'conv1',
-        'I need help with something'
+        'I need help with something',
+        expect.any(String)
       );
     });
   });
@@ -336,6 +337,207 @@ describe('SupportChat', () => {
 
     // The user message should appear immediately (optimistically)
     expect(screen.getByText('My optimistic message')).toBeInTheDocument();
+  });
+
+  it('keeps failed existing-conversation messages visible with retry affordance', async () => {
+    mockApiClient.getSupportRequests.mockResolvedValue({
+      data: [
+        {
+          id: 'conv1',
+          title: 'Active conversation',
+          status: 'open',
+          description: 'Issue',
+          createdAt: new Date().toISOString(),
+        },
+      ],
+      meta: { total: 1, page: 1, limit: 20, totalPages: 1 },
+    } as any);
+
+    mockApiClient.getSupportRequest.mockResolvedValue({
+      id: 'conv1',
+      title: 'Active conversation',
+      status: 'open',
+      description: 'Issue',
+      messages: [],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    } as any);
+    mockApiClient.addSupportMessage.mockRejectedValueOnce(new Error('network down'));
+
+    await act(async () => {
+      renderChat();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Open support chat'));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Active conversation'));
+    });
+
+    const textarea = await screen.findByPlaceholderText('Type a message...');
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: 'Please do not lose this' } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Send message'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Please do not lose this')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Message not sent')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /retry message/i })).toBeInTheDocument();
+  });
+
+  it('retries failed existing-conversation messages with the same client mutation id', async () => {
+    mockApiClient.getSupportRequests.mockResolvedValue({
+      data: [
+        {
+          id: 'conv1',
+          title: 'Active conversation',
+          status: 'open',
+          description: 'Issue',
+          createdAt: new Date().toISOString(),
+        },
+      ],
+      meta: { total: 1, page: 1, limit: 20, totalPages: 1 },
+    } as any);
+
+    mockApiClient.getSupportRequest.mockResolvedValue({
+      id: 'conv1',
+      title: 'Active conversation',
+      status: 'open',
+      description: 'Issue',
+      messages: [],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    } as any);
+    mockApiClient.addSupportMessage
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce({
+        id: 'msg-retry',
+        requestId: 'conv1',
+        organizationId: 'org-1',
+        userId: 'user-1',
+        role: 'user',
+        content: 'Retry me safely',
+        createdAt: new Date().toISOString(),
+      } as any);
+
+    await act(async () => {
+      renderChat();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Open support chat'));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Active conversation'));
+    });
+
+    const textarea = await screen.findByPlaceholderText('Type a message...');
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: 'Retry me safely' } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Send message'));
+    });
+
+    const retryButton = await screen.findByRole('button', { name: /retry message/i });
+    const firstMutationId = mockApiClient.addSupportMessage.mock.calls[0][2];
+    await act(async () => {
+      fireEvent.click(retryButton);
+    });
+
+    await waitFor(() => {
+      expect(mockApiClient.addSupportMessage).toHaveBeenCalledTimes(2);
+    });
+    expect(mockApiClient.addSupportMessage.mock.calls[1]).toEqual([
+      'conv1',
+      'Retry me safely',
+      firstMutationId,
+    ]);
+  });
+
+  it('keeps failed new-conversation messages visible with retry affordance', async () => {
+    mockApiClient.createSupportRequest.mockRejectedValueOnce(new Error('network down'));
+
+    await act(async () => {
+      renderChat();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Open support chat'));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Get help'));
+    });
+
+    const textarea = screen.getByPlaceholderText('Type a message...');
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: 'I need help with playback' } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Send message'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('I need help with playback')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Message not sent')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /retry message/i })).toBeInTheDocument();
+  });
+
+  it('retries failed new-conversation messages with the same client mutation id', async () => {
+    mockApiClient.createSupportRequest
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce({
+        request: {
+          id: 'req-retry',
+          title: null,
+          status: 'open',
+          description: 'Retry request safely',
+          organizationId: 'org-1',
+          userId: 'user-1',
+          category: 'help_question',
+          priority: 'medium',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+        response: 'Retry accepted',
+      } as any);
+
+    await act(async () => {
+      renderChat();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Open support chat'));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Get help'));
+    });
+
+    const textarea = screen.getByPlaceholderText('Type a message...');
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: 'Retry request safely' } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Send message'));
+    });
+
+    const retryButton = await screen.findByRole('button', { name: /retry message/i });
+    const firstMutationId = (mockApiClient.createSupportRequest.mock.calls[0][0] as any).clientMutationId;
+    await act(async () => {
+      fireEvent.click(retryButton);
+    });
+
+    await waitFor(() => {
+      expect(mockApiClient.createSupportRequest).toHaveBeenCalledTimes(2);
+    });
+    expect(mockApiClient.createSupportRequest.mock.calls[1][0]).toEqual(
+      expect.objectContaining({
+        message: 'Retry request safely',
+        clientMutationId: firstMutationId,
+      }),
+    );
   });
 
   it('displays assistant response after API returns for new conversation', async () => {

--- a/web/src/lib/__tests__/permissions.test.ts
+++ b/web/src/lib/__tests__/permissions.test.ts
@@ -13,6 +13,8 @@ describe('getDashboardPermissions', () => {
       canManagePlaylists: true,
       canDeletePlaylists: true,
       canRemovePlaylistItems: true,
+      canManageSchedules: true,
+      canDeleteSchedules: true,
     });
   });
 
@@ -28,6 +30,8 @@ describe('getDashboardPermissions', () => {
       canManagePlaylists: true,
       canDeletePlaylists: false,
       canRemovePlaylistItems: false,
+      canManageSchedules: true,
+      canDeleteSchedules: false,
     });
   });
 
@@ -39,12 +43,15 @@ describe('getDashboardPermissions', () => {
       canDeleteDevices: false,
       canManagePlaylists: false,
       canDeletePlaylists: false,
+      canManageSchedules: false,
+      canDeleteSchedules: false,
     });
 
     expect(getDashboardPermissions(null)).toMatchObject({
       canManageContent: false,
       canManageDevices: false,
       canManagePlaylists: false,
+      canManageSchedules: false,
     });
   });
 });

--- a/web/src/lib/api/support.ts
+++ b/web/src/lib/api/support.ts
@@ -9,16 +9,16 @@ import { ApiClient } from './client';
 
 declare module './client' {
   interface ApiClient {
-    createSupportRequest(data: { message: string; context?: SupportContext }): Promise<SupportRequestResponse>;
+    createSupportRequest(data: { message: string; context?: SupportContext; clientMutationId?: string }): Promise<SupportRequestResponse>;
     getSupportRequests(params?: SupportQueryParams): Promise<PaginatedResponse<SupportRequest>>;
     getSupportRequest(id: string): Promise<SupportRequest>;
     updateSupportRequest(id: string, data: { status?: string; priority?: string; resolutionNotes?: string }): Promise<SupportRequest>;
-    addSupportMessage(requestId: string, content: string): Promise<SupportMessage>;
+    addSupportMessage(requestId: string, content: string, clientMutationId?: string): Promise<SupportMessage>;
     getSupportStats(): Promise<SupportStats>;
   }
 }
 
-ApiClient.prototype.createSupportRequest = async function (data: { message: string; context?: SupportContext }): Promise<SupportRequestResponse> {
+ApiClient.prototype.createSupportRequest = async function (data: { message: string; context?: SupportContext; clientMutationId?: string }): Promise<SupportRequestResponse> {
   return this.request<SupportRequestResponse>('/support/requests', {
     method: 'POST',
     body: JSON.stringify(data),
@@ -48,10 +48,10 @@ ApiClient.prototype.updateSupportRequest = async function (id: string, data: { s
   });
 };
 
-ApiClient.prototype.addSupportMessage = async function (requestId: string, content: string): Promise<SupportMessage> {
+ApiClient.prototype.addSupportMessage = async function (requestId: string, content: string, clientMutationId?: string): Promise<SupportMessage> {
   return this.request<SupportMessage>(`/support/requests/${requestId}/messages`, {
     method: 'POST',
-    body: JSON.stringify({ content }),
+    body: JSON.stringify({ content, clientMutationId }),
   });
 };
 

--- a/web/src/lib/permissions.ts
+++ b/web/src/lib/permissions.ts
@@ -13,6 +13,8 @@ export type DashboardPermissions = {
   canManagePlaylists: boolean;
   canDeletePlaylists: boolean;
   canRemovePlaylistItems: boolean;
+  canManageSchedules: boolean;
+  canDeleteSchedules: boolean;
 };
 
 const isAdmin = (role?: string | null) => role === 'admin';
@@ -35,5 +37,7 @@ export function getDashboardPermissions(user: RoleUser): DashboardPermissions {
     canManagePlaylists: adminOrManager,
     canDeletePlaylists: admin,
     canRemovePlaylistItems: admin,
+    canManageSchedules: adminOrManager,
+    canDeleteSchedules: admin,
   };
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -615,6 +615,9 @@ export interface SupportMessage {
   role: 'user' | 'assistant' | 'admin';
   content: string;
   createdAt: string;
+  clientMutationId?: string | null;
+  deliveryStatus?: 'sending' | 'sent' | 'failed';
+  errorMessage?: string;
 }
 
 export interface SupportContext {
@@ -635,6 +638,7 @@ export interface SupportStats {
 export interface SupportRequestResponse {
   request: SupportRequest;
   response: string;
+  responseText?: string;
 }
 
 export interface SupportQueryParams {


### PR DESCRIPTION
## Summary
- Gate schedule write controls by dashboard role: viewers are read-only, managers can create/update/duplicate, admins retain delete.
- Preserve failed support chat sends as retryable visible messages and add durable `clientMutationId` idempotency for support requests/messages.
- Fix realtime Docker release path by generating Prisma in the builder stage and excluding nested workspace `node_modules` from Docker context.

## Review
- Schedule/RBAC reviewer: CLEAN after manager update, admin delete, viewer empty-state coverage.
- Support idempotency reviewer: CLEAN after nested create, P2002 re-read, scoped unique indexes, reopen-on-duplicate handling.
- Release/Docker reviewer: CLEAN after runtime-stage Prisma generation removal and recursive Docker ignore.

## Verification
- Red tests reproduced schedule role gaps and failed support-send message loss before implementation.
- `pnpm --filter @vizora/web test -- --runInBand web/src/lib/__tests__/permissions.test.ts web/src/app/dashboard/schedules/__tests__/schedules-page.test.tsx web/src/components/support/__tests__/SupportChat.test.tsx` - 3 suites / 48 tests passed after rebase.
- `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/support/support.service.spec.ts middleware/src/modules/support/support.controller.spec.ts` - 2 suites / 69 tests passed after rebase.
- `pnpm exec prisma validate --schema prisma/schema.prisma` - passed.
- `pnpm exec prisma generate --schema prisma/schema.prisma` - passed.
- Broader pre-rebase: full web Jest 102 suites / 1092 tests passed; full middleware Jest 146 suites / 2975 tests passed; realtime Jest 12 suites / 285 tests passed; web tsc passed; web build passed; middleware/realtime builds passed; `git diff --check` and `pnpm security:no-hardcoded-jwts` passed.
- `docker build -f docker/Dockerfile.realtime -t vizora-realtime-pass43 .` now gets past Docker context loading, then local Docker fails before project code at `npm install -g pnpm@9` with `UNABLE_TO_VERIFY_LEAF_SIGNATURE`; a minimal `node:22-alpine` package fetch has the same TLS trust failure. No insecure TLS bypass added.

## Deploy
Not deployed by this PR. Production checkout remains previously observed dirty/diverged and unsafe for automated deployment until reconciled.