### PR TITLE
fix: harden csrf and pairing authorization

### DIFF
--- a/docs/plans/2026-06-02-csrf-pairing-authorization-pass-44.md
+++ b/docs/plans/2026-06-02-csrf-pairing-authorization-pass-44.md
@@ -1,0 +1,70 @@
+# CSRF + Pairing Authorization Pass 44
+
+**Branch:** `feat/customer-dashboard-improvement-pass-44`
+
+**Goal:** Close two customer-trust/security gaps found by the Pass 44 reviewer
+sweep: CSRF protection is implemented but not mounted in the Nest runtime, and
+dashboard device-pairing completion does not enforce role/subscription/quota
+rules consistently with normal display creation.
+
+**New primitives introduced:** none. Reuse the existing `CsrfMiddleware`,
+`RolesGuard`, `@Roles`, `@RequiresSubscription`, existing screen-quota
+semantics, dashboard permission helper, response envelope, and `/api/v1`
+routing.
+
+**Hermes-first analysis:** checked per project convention. This is local
+dashboard/API authorization and runtime middleware wiring; no business-agent,
+MCP, provider-spend, or Hermes runtime path applies.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| CSRF runtime enforcement | none found | wire existing Nest middleware |
+| Device-pairing role/subscription/quota checks | none found | reuse existing Vizora guards/decorators and quota semantics |
+| Dashboard pairing UI gating | none found | reuse existing web permission helper |
+
+Awesome-hermes-agent ecosystem check: no applicable skill/library primitive for
+Nest CSRF middleware registration or local dashboard permission truth; proceed
+with Vizora-native code.
+
+## Drift Check
+
+- `middleware/src/modules/common/middleware/csrf.middleware.ts` already sets a
+  double-submit CSRF cookie/header and validates unsafe methods.
+- `middleware/src/app/app.module.ts` does not register that middleware, so the
+  runtime never applies it.
+- `middleware/src/modules/displays/displays.controller.ts` protects normal
+  display creation with role, subscription, and screen-quota decorators.
+- `middleware/src/modules/displays/pairing.controller.ts` leaves
+  `POST /devices/pairing/complete` authenticated but not role/subscription
+  guarded; quota must be create-only in the service so same-org re-pairing is
+  not blocked at quota.
+- `web/src/app/dashboard/devices/page-client.tsx` still renders the top-level
+  `Pair New Device` CTA and empty-state `Pair Device` action for viewers.
+- `web/src/app/dashboard/devices/pair/page.tsx` submits pairing for any
+  authenticated dashboard user.
+
+## Implementation Plan
+
+1. Add red coverage for AppModule CSRF wiring, pairing-controller decorators,
+   and viewer dashboard pairing access.
+2. Register `CsrfMiddleware` globally from `AppModule.configure()` while
+   preserving its existing safe-method and public endpoint exemptions.
+3. Decorate `PairingController.completePairing()` with admin/manager roles and
+   active-subscription gating; enforce screen quota inside `PairingService`
+   only when pairing creates a new display.
+4. Add an atomic Redis completion claim and keep completed token-bearing pairing
+   codes out of the dashboard active-pairing list.
+5. Add an explicit `canPairDevices` dashboard permission and use it for
+   top-level device-pairing CTAs, empty states, and the standalone pair page.
+6. Run focused middleware/web tests, dispatch multi-vector review, then run the
+   relevant broader suites before PR/CI/merge.
+
+## Deferred From This Pass
+
+- Team/API-key admin-only UI truth.
+- Settings admin-email read-only/copy cleanup.
+- Content URL update SSRF validation.
+- Realtime public health detail hardening.
+- Dashboard duplicate refresh and `/analytics/summary` query consolidation.
+- Upload quota preflight, short content-search gating, and deferred device-group
+  fetch.

--- a/docs/plans/2026-06-02-csrf-pairing-authorization-pass-44.md
+++ b/docs/plans/2026-06-02-csrf-pairing-authorization-pass-44.md
@@ -52,8 +52,9 @@ with Vizora-native code.
 3. Decorate `PairingController.completePairing()` with admin/manager roles and
    active-subscription gating; enforce screen quota inside `PairingService`
    only when pairing creates a new display.
-4. Add an atomic Redis completion claim and keep completed token-bearing pairing
-   codes out of the dashboard active-pairing list.
+4. Add Redis completion claims: per-code for one-time completion, and
+   org-scoped around new-display quota check/create so two different pairing
+   codes cannot race past screen quota.
 5. Add an explicit `canPairDevices` dashboard permission and use it for
    top-level device-pairing CTAs, empty states, and the standalone pair page.
 6. Run focused middleware/web tests, dispatch multi-vector review, then run the

--- a/middleware/src/app/app.module.spec.ts
+++ b/middleware/src/app/app.module.spec.ts
@@ -1,0 +1,15 @@
+import { AppModule } from './app.module';
+import { CsrfMiddleware } from '../modules/common/middleware/csrf.middleware';
+
+describe('AppModule', () => {
+  it('mounts CSRF middleware for runtime requests', () => {
+    const forRoutes = jest.fn();
+    const apply = jest.fn().mockReturnValue({ forRoutes });
+    const module = new AppModule();
+
+    module.configure({ apply } as any);
+
+    expect(apply).toHaveBeenCalledWith(CsrfMiddleware);
+    expect(forRoutes).toHaveBeenCalledWith('*');
+  });
+});

--- a/middleware/src/app/app.module.ts
+++ b/middleware/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { ScheduleModule } from '@nestjs/schedule';
@@ -35,6 +35,7 @@ import { McpModule } from '../modules/mcp/mcp.module';
 import { WebhooksModule } from '../modules/webhooks/webhooks.module';
 import { TagRulesModule } from '../modules/tag-rules/tag-rules.module';
 import { ProvisioningTemplatesModule } from '../modules/provisioning-templates/provisioning-templates.module';
+import { CsrfMiddleware } from '../modules/common/middleware/csrf.middleware';
 
 @Module({
   imports: [
@@ -135,4 +136,8 @@ import { ProvisioningTemplatesModule } from '../modules/provisioning-templates/p
     },
   ],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(CsrfMiddleware).forRoutes('*');
+  }
+}

--- a/middleware/src/modules/common/middleware/csrf.middleware.spec.ts
+++ b/middleware/src/modules/common/middleware/csrf.middleware.spec.ts
@@ -141,7 +141,12 @@ describe('CsrfMiddleware', () => {
   });
 
   describe('public paths', () => {
-    const publicPaths = ['/api/auth/login', '/api/auth/register'];
+    const publicPaths = [
+      '/api/auth/login',
+      '/api/auth/register',
+      '/api/auth/google',
+      '/api/v1/auth/google',
+    ];
 
     publicPaths.forEach((path) => {
       it(`should skip CSRF validation for ${path}`, () => {
@@ -288,6 +293,26 @@ describe('CsrfMiddleware', () => {
       middleware.use(mockRequest as Request, mockResponse as Response, mockNext);
 
       expect(mockNext).toHaveBeenCalled();
+    });
+
+    it('should allow bearer-only API requests without CSRF', () => {
+      mockRequest.cookies = {};
+      mockRequest.headers = { authorization: 'Bearer service-token' };
+
+      middleware.use(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+      expect(mockResponse.status).not.toHaveBeenCalled();
+    });
+
+    it('should still require CSRF when bearer auth is accompanied by the Vizora auth cookie', () => {
+      mockRequest.cookies = { [AUTH_CONSTANTS.COOKIE_NAME]: 'cookie-token' };
+      mockRequest.headers = { authorization: 'Bearer browser-token' };
+
+      middleware.use(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(mockResponse.status).toHaveBeenCalledWith(403);
     });
 
     it('should reject requests when header token is missing', () => {

--- a/middleware/src/modules/common/middleware/csrf.middleware.ts
+++ b/middleware/src/modules/common/middleware/csrf.middleware.ts
@@ -75,6 +75,7 @@ export class CsrfMiddleware implements NestMiddleware {
     const csrfExemptExactPaths = new Set([
       '/api/v1/auth/login',
       '/api/v1/auth/register',
+      '/api/v1/auth/google',
       '/api/v1/auth/forgot-password',
       '/api/v1/auth/reset-password',
       '/api/v1/devices/pairing/request',
@@ -83,6 +84,7 @@ export class CsrfMiddleware implements NestMiddleware {
       '/api/v1/webhooks/razorpay', // Validates X-Razorpay-Signature
       '/api/auth/login',
       '/api/auth/register',
+      '/api/auth/google',
       '/api/auth/forgot-password',
       '/api/auth/reset-password',
       '/api/devices/pairing/request',
@@ -117,6 +119,19 @@ export class CsrfMiddleware implements NestMiddleware {
       || isInternalRoute;
 
     if (isExempt) {
+      return next();
+    }
+
+    // CSRF protects cookie-auth browser requests. Bearer-only clients
+    // (mobile, ops scripts, MCP-like service callers) provide an explicit
+    // Authorization header that browsers do not attach automatically
+    // cross-site, so they have no CSRF surface unless the Vizora auth cookie
+    // is also present.
+    const authorization = req.headers.authorization;
+    const hasBearerToken =
+      typeof authorization === 'string' && authorization.toLowerCase().startsWith('bearer ');
+    const hasAuthCookie = Boolean(req.cookies?.[AUTH_CONSTANTS.COOKIE_NAME]);
+    if (hasBearerToken && !hasAuthCookie) {
       return next();
     }
 

--- a/middleware/src/modules/displays/pairing.controller.spec.ts
+++ b/middleware/src/modules/displays/pairing.controller.spec.ts
@@ -1,10 +1,16 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { Reflector } from '@nestjs/core';
 import { PairingController } from './pairing.controller';
 import { PairingService } from './pairing.service';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { SubscriptionActiveGuard } from '../billing/guards/subscription-active.guard';
+import { DatabaseService } from '../database/database.service';
 
 describe('PairingController', () => {
   let controller: PairingController;
   let mockPairingService: jest.Mocked<PairingService>;
+  let mockDatabaseService: jest.Mocked<DatabaseService>;
 
   beforeEach(async () => {
     mockPairingService = {
@@ -14,9 +20,25 @@ describe('PairingController', () => {
       getActivePairings: jest.fn(),
     } as any;
 
+    mockDatabaseService = {
+      organization: {
+        findUnique: jest.fn().mockResolvedValue({
+          subscriptionStatus: 'active',
+          subscriptionTier: 'pro',
+          trialEndsAt: null,
+          screenQuota: 100,
+          _count: { displays: 1 },
+        }),
+      },
+    } as any;
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [PairingController],
-      providers: [{ provide: PairingService, useValue: mockPairingService }],
+      providers: [
+        { provide: PairingService, useValue: mockPairingService },
+        { provide: DatabaseService, useValue: mockDatabaseService },
+        Reflector,
+      ],
     }).compile();
 
     controller = module.get<PairingController>(PairingController);
@@ -138,6 +160,20 @@ describe('PairingController', () => {
 
       expect(result).toHaveProperty('success', true);
     });
+
+    it('requires manager-or-admin role plus subscription guard', () => {
+      const reflector = new Reflector();
+      const handler = controller.completePairing;
+      const guards = Reflect.getMetadata(GUARDS_METADATA, handler) ?? [];
+
+      expect(reflector.get<string[]>('roles', handler)).toEqual(['admin', 'manager']);
+      expect(guards).toEqual(
+        expect.arrayContaining([
+          RolesGuard,
+          SubscriptionActiveGuard,
+        ]),
+      );
+    });
   });
 
   describe('getActivePairings', () => {
@@ -172,6 +208,15 @@ describe('PairingController', () => {
       const result = await controller.getActivePairings(organizationId);
 
       expect(result).toEqual([]);
+    });
+
+    it('requires manager-or-admin role for active pairing codes', () => {
+      const reflector = new Reflector();
+      const handler = controller.getActivePairings;
+      const guards = Reflect.getMetadata(GUARDS_METADATA, handler) ?? [];
+
+      expect(reflector.get<string[]>('roles', handler)).toEqual(['admin', 'manager']);
+      expect(guards).toEqual(expect.arrayContaining([RolesGuard]));
     });
   });
 });

--- a/middleware/src/modules/displays/pairing.controller.ts
+++ b/middleware/src/modules/displays/pairing.controller.ts
@@ -4,11 +4,13 @@ import {
   Get,
   Body,
   Param,
-  BadRequestException,
-  NotFoundException,
+  UseGuards,
 } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { Public } from '../auth/decorators/public.decorator';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { RequiresSubscription } from '../billing/decorators/requires-subscription.decorator';
 import { SkipCsrf } from '../common/guards/csrf.guard';
 import { PairingService } from './pairing.service';
 import { RequestPairingDto } from './dto/request-pairing.dto';
@@ -45,6 +47,9 @@ export class PairingController {
    * User completes pairing from web dashboard (Authenticated)
    */
   @Throttle({ default: { limit: 5, ttl: 60000 } })
+  @UseGuards(RolesGuard)
+  @Roles('admin', 'manager')
+  @RequiresSubscription()
   @Post('complete')
   async completePairing(
     @CurrentUser('organizationId') organizationId: string,
@@ -61,6 +66,8 @@ export class PairingController {
   /**
    * Get active pairing requests for organization (Authenticated)
    */
+  @UseGuards(RolesGuard)
+  @Roles('admin', 'manager')
   @Get('active')
   async getActivePairings(
     @CurrentUser('organizationId') organizationId: string,

--- a/middleware/src/modules/displays/pairing.service.spec.ts
+++ b/middleware/src/modules/displays/pairing.service.spec.ts
@@ -14,7 +14,7 @@ describe('PairingService', () => {
   let mockDatabaseService: jest.Mocked<DatabaseService>;
   let mockJwtService: jest.Mocked<JwtService>;
   let mockRedisService: jest.Mocked<RedisService>;
-  let redisClient: { scan: jest.Mock; mget: jest.Mock };
+  let redisClient: { scan: jest.Mock; mget: jest.Mock; set: jest.Mock; eval: jest.Mock };
 
   const sensitiveDisplayFields = ['jwtToken', 'pairingCode', 'pairingCodeExpiresAt', 'socketId'];
   const pairingResultSelect = {
@@ -44,6 +44,12 @@ describe('PairingService', () => {
         findMany: jest.fn(),
         create: jest.fn(),
         update: jest.fn(),
+      },
+      organization: {
+        findUnique: jest.fn().mockResolvedValue({
+          screenQuota: 100,
+          _count: { displays: 0 },
+        }),
       },
     } as any;
 
@@ -79,6 +85,26 @@ describe('PairingService', () => {
           return entry.value;
         });
       }),
+      set: jest.fn().mockImplementation(
+        async (key: string, value: string, _ex: string, ttlSeconds: number, nx: string) => {
+          if (nx === 'NX' && redisStore.has(key)) {
+            return null;
+          }
+          const expiresAt = ttlSeconds ? Date.now() + ttlSeconds * 1000 : 0;
+          redisStore.set(key, { value, ttl: ttlSeconds || 0, expiresAt });
+          return 'OK';
+        },
+      ),
+      eval: jest.fn().mockImplementation(
+        async (_script: string, _keyCount: number, key: string, claimToken: string) => {
+          const entry = redisStore.get(key);
+          if (entry?.value === claimToken) {
+            redisStore.delete(key);
+            return 1;
+          }
+          return 0;
+        },
+      ),
     };
 
     // Create a mock RedisService that uses an in-memory Map to simulate Redis
@@ -428,7 +454,7 @@ describe('PairingService', () => {
       });
       expect(mockDatabaseService.display.findUnique).toHaveBeenNthCalledWith(2, {
         where: { deviceIdentifier: 'new-device' },
-        select: { id: true, location: true },
+        select: { id: true, location: true, organizationId: true },
       });
       expect(mockDatabaseService.display.create).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -445,6 +471,7 @@ describe('PairingService', () => {
         .mockResolvedValueOnce({
           id: 'existing-display-id',
           location: 'Lobby',
+          organizationId,
         } as any); // completePairing check
 
       const pairingResult = await service.requestPairingCode({
@@ -468,7 +495,7 @@ describe('PairingService', () => {
       expect(result.success).toBe(true);
       expect(mockDatabaseService.display.findUnique).toHaveBeenNthCalledWith(2, {
         where: { deviceIdentifier: 'existing-device' },
-        select: { id: true, location: true },
+        select: { id: true, location: true, organizationId: true },
       });
       expect(mockDatabaseService.display.update).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -559,6 +586,130 @@ describe('PairingService', () => {
       const lastSetCall = mockRedisService.set.mock.calls[setCallsAfter - 1];
       const storedData = JSON.parse(lastSetCall[1]);
       expect(storedData.plaintextToken).toBe('mock-jwt-token');
+    });
+
+    it('rejects replay after a pairing code has already been completed', async () => {
+      mockDatabaseService.display.findUnique.mockResolvedValue(null);
+
+      const pairingResult = await service.requestPairingCode({
+        deviceIdentifier: 'replay-device',
+        nickname: 'Replay Test',
+        metadata: {},
+      });
+
+      mockDatabaseService.display.create.mockResolvedValue({
+        id: 'replay-display',
+        nickname: 'Replay Test',
+        deviceIdentifier: 'replay-device',
+        status: 'pairing',
+      } as any);
+
+      await service.completePairing(organizationId, userId, { code: pairingResult.code });
+      mockDatabaseService.display.create.mockClear();
+      mockDatabaseService.display.update.mockClear();
+
+      await expect(
+        service.completePairing('org-other', 'user-other', { code: pairingResult.code }),
+      ).rejects.toThrow('Pairing code has already been completed');
+      expect(mockDatabaseService.display.create).not.toHaveBeenCalled();
+      expect(mockDatabaseService.display.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects a concurrent completion while another dashboard request owns the claim', async () => {
+      mockDatabaseService.display.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null);
+
+      const pairingResult = await service.requestPairingCode({
+        deviceIdentifier: 'concurrent-device',
+        nickname: 'Concurrent Test',
+        metadata: {},
+      });
+      redisStore.set(`pairing-complete-claim:${pairingResult.code}`, {
+        value: 'other-claim-token',
+        ttl: 300,
+        expiresAt: Date.now() + 300_000,
+      });
+
+      await expect(
+        service.completePairing(organizationId, userId, { code: pairingResult.code }),
+      ).rejects.toThrow('Pairing code is already being completed');
+      expect(mockDatabaseService.display.create).not.toHaveBeenCalled();
+      expect(mockDatabaseService.display.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects pairing an existing display that belongs to another organization', async () => {
+      mockDatabaseService.display.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          id: 'display-other-org',
+          location: 'Lobby',
+          organizationId: 'org-other',
+        } as any);
+
+      const pairingResult = await service.requestPairingCode({
+        deviceIdentifier: 'other-org-device',
+        nickname: 'Other Org Display',
+        metadata: {},
+      });
+
+      await expect(
+        service.completePairing(organizationId, userId, { code: pairingResult.code }),
+      ).rejects.toThrow(NotFoundException);
+      expect(mockDatabaseService.display.update).not.toHaveBeenCalled();
+    });
+
+    it('enforces screen quota only when pairing creates a new display', async () => {
+      mockDatabaseService.display.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null);
+      mockDatabaseService.organization.findUnique.mockResolvedValueOnce({
+        screenQuota: 1,
+        _count: { displays: 1 },
+      } as any);
+
+      const pairingResult = await service.requestPairingCode({
+        deviceIdentifier: 'over-quota-device',
+        nickname: 'Over Quota Display',
+        metadata: {},
+      });
+
+      await expect(
+        service.completePairing(organizationId, userId, { code: pairingResult.code }),
+      ).rejects.toThrow('Screen quota exceeded');
+      expect(mockDatabaseService.display.create).not.toHaveBeenCalled();
+    });
+
+    it('allows same-organization existing-display pairing while at screen quota', async () => {
+      mockDatabaseService.display.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          id: 'existing-at-quota-display',
+          location: 'Lobby',
+          organizationId,
+        } as any);
+      mockDatabaseService.organization.findUnique.mockResolvedValueOnce({
+        screenQuota: 1,
+        _count: { displays: 1 },
+      } as any);
+
+      const pairingResult = await service.requestPairingCode({
+        deviceIdentifier: 'existing-at-quota-device',
+        nickname: 'Existing At Quota',
+        metadata: {},
+      });
+
+      mockDatabaseService.display.update.mockResolvedValue({
+        id: 'existing-at-quota-display',
+        nickname: 'Existing At Quota',
+        deviceIdentifier: 'existing-at-quota-device',
+        status: 'pairing',
+      } as any);
+
+      await service.completePairing(organizationId, userId, { code: pairingResult.code });
+
+      expect(mockDatabaseService.organization.findUnique).not.toHaveBeenCalled();
+      expect(mockDatabaseService.display.update).toHaveBeenCalled();
     });
 
     it('should clean up pairing request after device retrieves token', async () => {
@@ -762,7 +913,7 @@ describe('PairingService', () => {
       );
     });
 
-    it('should not query display ownership for already completed org pairings', async () => {
+    it('should not return or query display ownership for completed org pairings', async () => {
       const orgId = 'org-123';
       const userId = 'user-123';
       mockDatabaseService.display.findUnique.mockResolvedValue(null);
@@ -793,8 +944,7 @@ describe('PairingService', () => {
       expect(mockRedisService.get).not.toHaveBeenCalled();
       expect(mockDatabaseService.display.findMany).not.toHaveBeenCalled();
       expect(mockDatabaseService.display.findUnique).not.toHaveBeenCalled();
-      expect(result).toHaveLength(1);
-      expect(result[0]).toEqual(expect.objectContaining({ nickname: 'Completed Display' }));
+      expect(result).toEqual([]);
     });
   });
 

--- a/middleware/src/modules/displays/pairing.service.spec.ts
+++ b/middleware/src/modules/displays/pairing.service.spec.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { PairingService } from './pairing.service';
 import { DatabaseService } from '../database/database.service';
@@ -14,23 +18,38 @@ describe('PairingService', () => {
   let mockDatabaseService: jest.Mocked<DatabaseService>;
   let mockJwtService: jest.Mocked<JwtService>;
   let mockRedisService: jest.Mocked<RedisService>;
-  let redisClient: { scan: jest.Mock; mget: jest.Mock; set: jest.Mock; eval: jest.Mock };
+  let redisClient: {
+    scan: jest.Mock;
+    mget: jest.Mock;
+    set: jest.Mock;
+    eval: jest.Mock;
+  };
 
-  const sensitiveDisplayFields = ['jwtToken', 'pairingCode', 'pairingCodeExpiresAt', 'socketId'];
+  const sensitiveDisplayFields = [
+    'jwtToken',
+    'pairingCode',
+    'pairingCodeExpiresAt',
+    'socketId',
+  ];
   const pairingResultSelect = {
     id: true,
     nickname: true,
     deviceIdentifier: true,
     status: true,
   };
-  const expectSelectToExcludeSensitiveDisplayFields = (select: Record<string, unknown>) => {
+  const expectSelectToExcludeSensitiveDisplayFields = (
+    select: Record<string, unknown>,
+  ) => {
     for (const field of sensitiveDisplayFields) {
       expect(select).not.toHaveProperty(field);
     }
   };
 
   // In-memory store to simulate Redis behavior
-  let redisStore: Map<string, { value: string; ttl: number; expiresAt: number }>;
+  let redisStore: Map<
+    string,
+    { value: string; ttl: number; expiresAt: number }
+  >;
 
   beforeEach(() => {
     // Clear any interval from previous tests
@@ -58,22 +77,32 @@ describe('PairingService', () => {
     } as any;
 
     redisClient = {
-      scan: jest.fn().mockImplementation(async (cursor: string, _match: string, pattern: string, _count: string, _countVal: number) => {
-        // Return all keys matching the pattern on first call
-        const prefix = pattern.replace('*', '');
-        const matchingKeys: string[] = [];
-        for (const [key, entry] of redisStore.entries()) {
-          if (key.startsWith(prefix)) {
-            // Also check TTL
-            if (entry.expiresAt > 0 && Date.now() >= entry.expiresAt) {
-              redisStore.delete(key);
-              continue;
+      scan: jest
+        .fn()
+        .mockImplementation(
+          async (
+            cursor: string,
+            _match: string,
+            pattern: string,
+            _count: string,
+            _countVal: number,
+          ) => {
+            // Return all keys matching the pattern on first call
+            const prefix = pattern.replace('*', '');
+            const matchingKeys: string[] = [];
+            for (const [key, entry] of redisStore.entries()) {
+              if (key.startsWith(prefix)) {
+                // Also check TTL
+                if (entry.expiresAt > 0 && Date.now() >= entry.expiresAt) {
+                  redisStore.delete(key);
+                  continue;
+                }
+                matchingKeys.push(key);
+              }
             }
-            matchingKeys.push(key);
-          }
-        }
-        return ['0', matchingKeys];
-      }),
+            return ['0', matchingKeys];
+          },
+        ),
       mget: jest.fn().mockImplementation(async (...keys: string[]) => {
         return keys.map((key) => {
           const entry = redisStore.get(key);
@@ -85,26 +114,41 @@ describe('PairingService', () => {
           return entry.value;
         });
       }),
-      set: jest.fn().mockImplementation(
-        async (key: string, value: string, _ex: string, ttlSeconds: number, nx: string) => {
-          if (nx === 'NX' && redisStore.has(key)) {
-            return null;
-          }
-          const expiresAt = ttlSeconds ? Date.now() + ttlSeconds * 1000 : 0;
-          redisStore.set(key, { value, ttl: ttlSeconds || 0, expiresAt });
-          return 'OK';
-        },
-      ),
-      eval: jest.fn().mockImplementation(
-        async (_script: string, _keyCount: number, key: string, claimToken: string) => {
-          const entry = redisStore.get(key);
-          if (entry?.value === claimToken) {
-            redisStore.delete(key);
-            return 1;
-          }
-          return 0;
-        },
-      ),
+      set: jest
+        .fn()
+        .mockImplementation(
+          async (
+            key: string,
+            value: string,
+            _ex: string,
+            ttlSeconds: number,
+            nx: string,
+          ) => {
+            if (nx === 'NX' && redisStore.has(key)) {
+              return null;
+            }
+            const expiresAt = ttlSeconds ? Date.now() + ttlSeconds * 1000 : 0;
+            redisStore.set(key, { value, ttl: ttlSeconds || 0, expiresAt });
+            return 'OK';
+          },
+        ),
+      eval: jest
+        .fn()
+        .mockImplementation(
+          async (
+            _script: string,
+            _keyCount: number,
+            key: string,
+            claimToken: string,
+          ) => {
+            const entry = redisStore.get(key);
+            if (entry?.value === claimToken) {
+              redisStore.delete(key);
+              return 1;
+            }
+            return 0;
+          },
+        ),
     };
 
     // Create a mock RedisService that uses an in-memory Map to simulate Redis
@@ -119,11 +163,15 @@ describe('PairingService', () => {
         }
         return entry.value;
       }),
-      set: jest.fn().mockImplementation(async (key: string, value: string, ttlSeconds?: number) => {
-        const expiresAt = ttlSeconds ? Date.now() + ttlSeconds * 1000 : 0;
-        redisStore.set(key, { value, ttl: ttlSeconds || 0, expiresAt });
-        return true;
-      }),
+      set: jest
+        .fn()
+        .mockImplementation(
+          async (key: string, value: string, ttlSeconds?: number) => {
+            const expiresAt = ttlSeconds ? Date.now() + ttlSeconds * 1000 : 0;
+            redisStore.set(key, { value, ttl: ttlSeconds || 0, expiresAt });
+            return true;
+          },
+        ),
       del: jest.fn().mockImplementation(async (key: string) => {
         redisStore.delete(key);
         return true;
@@ -140,11 +188,18 @@ describe('PairingService', () => {
       getClient: jest.fn().mockReturnValue(redisClient),
       isAvailable: jest.fn().mockReturnValue(true),
       ping: jest.fn().mockResolvedValue(true),
-      healthCheck: jest.fn().mockResolvedValue({ healthy: true, responseTime: 1 }),
+      healthCheck: jest
+        .fn()
+        .mockResolvedValue({ healthy: true, responseTime: 1 }),
     } as any;
 
     const mockEventEmitter = { emit: jest.fn() } as any;
-    service = new PairingService(mockDatabaseService, mockJwtService, mockRedisService, mockEventEmitter);
+    service = new PairingService(
+      mockDatabaseService,
+      mockJwtService,
+      mockRedisService,
+      mockEventEmitter,
+    );
   });
 
   afterEach(() => {
@@ -364,7 +419,9 @@ describe('PairingService', () => {
         organizationId: 'org-123',
       } as any);
 
-      await service.completePairing('org-123', 'user-123', { code: pairingResult.code });
+      await service.completePairing('org-123', 'user-123', {
+        code: pairingResult.code,
+      });
 
       // Now checkPairingStatus reads the plaintext token from Redis
       mockDatabaseService.display.findUnique.mockClear();
@@ -402,7 +459,9 @@ describe('PairingService', () => {
         organizationId: 'org-123',
       } as any);
 
-      await service.completePairing('org-123', 'user-123', { code: pairingResult.code });
+      await service.completePairing('org-123', 'user-123', {
+        code: pairingResult.code,
+      });
 
       // Now checkPairingStatus should return paired and clean up
       mockDatabaseService.display.findUnique.mockResolvedValue({
@@ -414,9 +473,9 @@ describe('PairingService', () => {
       await service.checkPairingStatus(pairingResult.code);
 
       // Second check - should throw not found
-      await expect(service.checkPairingStatus(pairingResult.code)).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(
+        service.checkPairingStatus(pairingResult.code),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 
@@ -448,20 +507,37 @@ describe('PairingService', () => {
 
       expect(result.success).toBe(true);
       expect(result.display).toHaveProperty('id');
-      expect(mockDatabaseService.display.findUnique).toHaveBeenNthCalledWith(1, {
-        where: { deviceIdentifier: 'new-device' },
-        select: { jwtToken: true },
-      });
-      expect(mockDatabaseService.display.findUnique).toHaveBeenNthCalledWith(2, {
-        where: { deviceIdentifier: 'new-device' },
-        select: { id: true, location: true, organizationId: true },
-      });
+      expect(mockDatabaseService.display.findUnique).toHaveBeenNthCalledWith(
+        1,
+        {
+          where: { deviceIdentifier: 'new-device' },
+          select: { jwtToken: true },
+        },
+      );
+      expect(mockDatabaseService.display.findUnique).toHaveBeenNthCalledWith(
+        2,
+        {
+          where: { deviceIdentifier: 'new-device' },
+          select: { id: true, location: true, organizationId: true },
+        },
+      );
       expect(mockDatabaseService.display.create).toHaveBeenCalledWith(
         expect.objectContaining({
           select: pairingResultSelect,
         }),
       );
-      const createArgs = mockDatabaseService.display.create.mock.calls[0][0] as any;
+      expect(redisClient.set).toHaveBeenCalledWith(
+        `pairing-new-display-claim:${organizationId}`,
+        expect.any(String),
+        'EX',
+        300,
+        'NX',
+      );
+      expect(
+        redisStore.has(`pairing-new-display-claim:${organizationId}`),
+      ).toBe(false);
+      const createArgs = mockDatabaseService.display.create.mock
+        .calls[0][0] as any;
       expectSelectToExcludeSensitiveDisplayFields(createArgs.select);
     });
 
@@ -493,16 +569,20 @@ describe('PairingService', () => {
       });
 
       expect(result.success).toBe(true);
-      expect(mockDatabaseService.display.findUnique).toHaveBeenNthCalledWith(2, {
-        where: { deviceIdentifier: 'existing-device' },
-        select: { id: true, location: true, organizationId: true },
-      });
+      expect(mockDatabaseService.display.findUnique).toHaveBeenNthCalledWith(
+        2,
+        {
+          where: { deviceIdentifier: 'existing-device' },
+          select: { id: true, location: true, organizationId: true },
+        },
+      );
       expect(mockDatabaseService.display.update).toHaveBeenCalledWith(
         expect.objectContaining({
           select: pairingResultSelect,
         }),
       );
-      const updateArgs = mockDatabaseService.display.update.mock.calls[0][0] as any;
+      const updateArgs = mockDatabaseService.display.update.mock
+        .calls[0][0] as any;
       expectSelectToExcludeSensitiveDisplayFields(updateArgs.select);
     });
 
@@ -525,7 +605,9 @@ describe('PairingService', () => {
       jest.advanceTimersByTime(5 * 60 * 1000 + 1000);
 
       await expect(
-        service.completePairing(organizationId, userId, { code: pairingResult.code }),
+        service.completePairing(organizationId, userId, {
+          code: pairingResult.code,
+        }),
       ).rejects.toThrow();
     });
 
@@ -545,7 +627,9 @@ describe('PairingService', () => {
         status: 'pairing',
       } as any);
 
-      await service.completePairing(organizationId, userId, { code: pairingResult.code });
+      await service.completePairing(organizationId, userId, {
+        code: pairingResult.code,
+      });
 
       expect(mockJwtService.sign).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -576,7 +660,9 @@ describe('PairingService', () => {
       // Reset call count after requestPairingCode
       const setCallsBefore = mockRedisService.set.mock.calls.length;
 
-      await service.completePairing(organizationId, userId, { code: pairingResult.code });
+      await service.completePairing(organizationId, userId, {
+        code: pairingResult.code,
+      });
 
       // completePairing should call set again to update with plaintextToken
       const setCallsAfter = mockRedisService.set.mock.calls.length;
@@ -604,12 +690,16 @@ describe('PairingService', () => {
         status: 'pairing',
       } as any);
 
-      await service.completePairing(organizationId, userId, { code: pairingResult.code });
+      await service.completePairing(organizationId, userId, {
+        code: pairingResult.code,
+      });
       mockDatabaseService.display.create.mockClear();
       mockDatabaseService.display.update.mockClear();
 
       await expect(
-        service.completePairing('org-other', 'user-other', { code: pairingResult.code }),
+        service.completePairing('org-other', 'user-other', {
+          code: pairingResult.code,
+        }),
       ).rejects.toThrow('Pairing code has already been completed');
       expect(mockDatabaseService.display.create).not.toHaveBeenCalled();
       expect(mockDatabaseService.display.update).not.toHaveBeenCalled();
@@ -632,8 +722,45 @@ describe('PairingService', () => {
       });
 
       await expect(
-        service.completePairing(organizationId, userId, { code: pairingResult.code }),
+        service.completePairing(organizationId, userId, {
+          code: pairingResult.code,
+        }),
       ).rejects.toThrow('Pairing code is already being completed');
+      expect(mockDatabaseService.display.create).not.toHaveBeenCalled();
+      expect(mockDatabaseService.display.update).not.toHaveBeenCalled();
+    });
+
+    it('serializes new-display pairing quota checks per organization', async () => {
+      mockDatabaseService.display.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null);
+
+      const pairingResult = await service.requestPairingCode({
+        deviceIdentifier: 'org-lock-device',
+        nickname: 'Org Lock Test',
+        metadata: {},
+      });
+      redisStore.set(`pairing-new-display-claim:${organizationId}`, {
+        value: 'other-org-claim-token',
+        ttl: 300,
+        expiresAt: Date.now() + 300_000,
+      });
+
+      await expect(
+        service.completePairing(organizationId, userId, {
+          code: pairingResult.code,
+        }),
+      ).rejects.toThrow(ConflictException);
+      await expect(
+        service.completePairing(organizationId, userId, {
+          code: pairingResult.code,
+        }),
+      ).rejects.toThrow(
+        'Another display pairing is already being completed for this organization',
+      );
+      expect(
+        mockDatabaseService.organization.findUnique,
+      ).not.toHaveBeenCalled();
       expect(mockDatabaseService.display.create).not.toHaveBeenCalled();
       expect(mockDatabaseService.display.update).not.toHaveBeenCalled();
     });
@@ -654,7 +781,9 @@ describe('PairingService', () => {
       });
 
       await expect(
-        service.completePairing(organizationId, userId, { code: pairingResult.code }),
+        service.completePairing(organizationId, userId, {
+          code: pairingResult.code,
+        }),
       ).rejects.toThrow(NotFoundException);
       expect(mockDatabaseService.display.update).not.toHaveBeenCalled();
     });
@@ -675,7 +804,9 @@ describe('PairingService', () => {
       });
 
       await expect(
-        service.completePairing(organizationId, userId, { code: pairingResult.code }),
+        service.completePairing(organizationId, userId, {
+          code: pairingResult.code,
+        }),
       ).rejects.toThrow('Screen quota exceeded');
       expect(mockDatabaseService.display.create).not.toHaveBeenCalled();
     });
@@ -706,9 +837,13 @@ describe('PairingService', () => {
         status: 'pairing',
       } as any);
 
-      await service.completePairing(organizationId, userId, { code: pairingResult.code });
+      await service.completePairing(organizationId, userId, {
+        code: pairingResult.code,
+      });
 
-      expect(mockDatabaseService.organization.findUnique).not.toHaveBeenCalled();
+      expect(
+        mockDatabaseService.organization.findUnique,
+      ).not.toHaveBeenCalled();
       expect(mockDatabaseService.display.update).toHaveBeenCalled();
     });
 
@@ -728,7 +863,9 @@ describe('PairingService', () => {
         status: 'pairing',
       } as any);
 
-      await service.completePairing(organizationId, userId, { code: pairingResult.code });
+      await service.completePairing(organizationId, userId, {
+        code: pairingResult.code,
+      });
 
       // After completePairing, the request still exists in Redis (has plaintextToken set)
       // checkPairingStatus will return paired and THEN clean up
@@ -741,9 +878,9 @@ describe('PairingService', () => {
       expect(status.status).toBe('paired');
 
       // NOW the code should be cleaned up
-      await expect(service.checkPairingStatus(pairingResult.code)).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(
+        service.checkPairingStatus(pairingResult.code),
+      ).rejects.toThrow(NotFoundException);
     });
 
     // R4-MED11: onboarding subscribes to display.paired with `organizationId`.
@@ -767,7 +904,9 @@ describe('PairingService', () => {
 
       const eventEmitter = (service as any).events;
 
-      await service.completePairing(organizationId, userId, { code: pairingResult.code });
+      await service.completePairing(organizationId, userId, {
+        code: pairingResult.code,
+      });
 
       expect(eventEmitter.emit).toHaveBeenCalledWith(
         'display.paired',
@@ -891,7 +1030,11 @@ describe('PairingService', () => {
       expect(mockDatabaseService.display.findMany).toHaveBeenCalledWith({
         where: {
           deviceIdentifier: {
-            in: expect.arrayContaining(['device-owned', 'device-other-org', 'device-new']),
+            in: expect.arrayContaining([
+              'device-owned',
+              'device-other-org',
+              'device-new',
+            ]),
           },
         },
         select: { deviceIdentifier: true, organizationId: true },
@@ -932,7 +1075,9 @@ describe('PairingService', () => {
         status: 'pairing',
       } as any);
 
-      await service.completePairing(orgId, userId, { code: pairingResult.code });
+      await service.completePairing(orgId, userId, {
+        code: pairingResult.code,
+      });
       mockDatabaseService.display.findUnique.mockClear();
       mockDatabaseService.display.findMany.mockClear();
       mockRedisService.get.mockClear();
@@ -962,9 +1107,9 @@ describe('PairingService', () => {
       jest.advanceTimersByTime(6 * 60 * 1000); // 6 minutes
 
       // Try to check status - should be cleaned up (Redis TTL expired)
-      await expect(service.checkPairingStatus(pairingResult.code)).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(
+        service.checkPairingStatus(pairingResult.code),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 

--- a/middleware/src/modules/displays/pairing.service.ts
+++ b/middleware/src/modules/displays/pairing.service.ts
@@ -4,6 +4,7 @@ import {
   NotFoundException,
   InternalServerErrorException,
   ForbiddenException,
+  ConflictException,
   OnModuleDestroy,
   Logger,
 } from '@nestjs/common';
@@ -23,8 +24,8 @@ interface PairingRequest {
   deviceIdentifier: string;
   nickname: string;
   metadata: Record<string, unknown>;
-  createdAt: string;   // ISO string for JSON serialization
-  expiresAt: string;   // ISO string for JSON serialization
+  createdAt: string; // ISO string for JSON serialization
+  expiresAt: string; // ISO string for JSON serialization
   qrCode?: string;
   organizationId?: string;
   plaintextToken?: string;
@@ -73,6 +74,8 @@ export class PairingService implements OnModuleDestroy {
   private readonly PAIRING_READ_BATCH_SIZE = 100;
   private readonly REDIS_KEY_PREFIX = 'pairing:';
   private readonly REDIS_COMPLETION_CLAIM_PREFIX = 'pairing-complete-claim:';
+  private readonly REDIS_NEW_DISPLAY_CLAIM_PREFIX =
+    'pairing-new-display-claim:';
   private cleanupIntervalId: NodeJS.Timeout | null = null;
 
   constructor(
@@ -84,7 +87,10 @@ export class PairingService implements OnModuleDestroy {
   ) {
     // Cleanup interval as safety net — Redis TTL handles most expiration,
     // but this catches edge cases if Redis is temporarily unavailable.
-    this.cleanupIntervalId = setInterval(() => this.cleanupExpiredRequests(), 60000);
+    this.cleanupIntervalId = setInterval(
+      () => this.cleanupExpiredRequests(),
+      60000,
+    );
   }
 
   onModuleDestroy() {
@@ -104,32 +110,54 @@ export class PairingService implements OnModuleDestroy {
     return `${this.REDIS_COMPLETION_CLAIM_PREFIX}${code}`;
   }
 
-  private async getPairingRequest(code: string): Promise<PairingRequest | null> {
+  private newDisplayClaimKey(organizationId: string): string {
+    return `${this.REDIS_NEW_DISPLAY_CLAIM_PREFIX}${organizationId}`;
+  }
+
+  private async getPairingRequest(
+    code: string,
+  ): Promise<PairingRequest | null> {
     try {
       const data = await this.redisService.get(this.redisKey(code));
       if (!data) return null;
       return this.parsePairingRequest(data, code);
     } catch (error) {
-      this.logger.error(`Failed to get pairing request for code ${code}: ${error}`);
+      this.logger.error(
+        `Failed to get pairing request for code ${code}: ${error}`,
+      );
       return null;
     }
   }
 
-  private parsePairingRequest(data: string, code: string): PairingRequest | null {
+  private parsePairingRequest(
+    data: string,
+    code: string,
+  ): PairingRequest | null {
     try {
       return JSON.parse(data) as PairingRequest;
     } catch (error) {
-      this.logger.error(`Failed to parse pairing request for code ${code}: ${error}`);
+      this.logger.error(
+        `Failed to parse pairing request for code ${code}: ${error}`,
+      );
       return null;
     }
   }
 
-  private async setPairingRequest(code: string, request: PairingRequest): Promise<boolean> {
+  private async setPairingRequest(
+    code: string,
+    request: PairingRequest,
+  ): Promise<boolean> {
     try {
       const data = JSON.stringify(request);
-      return await this.redisService.set(this.redisKey(code), data, this.PAIRING_TTL_SECONDS);
+      return await this.redisService.set(
+        this.redisKey(code),
+        data,
+        this.PAIRING_TTL_SECONDS,
+      );
     } catch (error) {
-      this.logger.error(`Failed to set pairing request for code ${code}: ${error}`);
+      this.logger.error(
+        `Failed to set pairing request for code ${code}: ${error}`,
+      );
       return false;
     }
   }
@@ -138,7 +166,9 @@ export class PairingService implements OnModuleDestroy {
     try {
       return await this.redisService.del(this.redisKey(code));
     } catch (error) {
-      this.logger.error(`Failed to delete pairing request for code ${code}: ${error}`);
+      this.logger.error(
+        `Failed to delete pairing request for code ${code}: ${error}`,
+      );
       return false;
     }
   }
@@ -146,7 +176,9 @@ export class PairingService implements OnModuleDestroy {
   private async claimPairingCompletion(code: string): Promise<string> {
     const client = this.redisService.getClient();
     if (!client) {
-      throw new BadRequestException('Pairing service unavailable. Please try again.');
+      throw new BadRequestException(
+        'Pairing service unavailable. Please try again.',
+      );
     }
 
     const claimToken = crypto.randomUUID();
@@ -160,7 +192,9 @@ export class PairingService implements OnModuleDestroy {
       );
 
       if (result !== 'OK') {
-        throw new BadRequestException('Pairing code is already being completed');
+        throw new BadRequestException(
+          'Pairing code is already being completed',
+        );
       }
 
       return claimToken;
@@ -168,8 +202,12 @@ export class PairingService implements OnModuleDestroy {
       if (error instanceof BadRequestException) {
         throw error;
       }
-      this.logger.error(`Failed to claim pairing completion for code ${code}: ${error}`);
-      throw new BadRequestException('Pairing service unavailable. Please try again.');
+      this.logger.error(
+        `Failed to claim pairing completion for code ${code}: ${error}`,
+      );
+      throw new BadRequestException(
+        'Pairing service unavailable. Please try again.',
+      );
     }
   }
 
@@ -188,7 +226,70 @@ export class PairingService implements OnModuleDestroy {
         claimToken,
       );
     } catch (error) {
-      this.logger.error(`Failed to release pairing completion claim for code ${code}: ${error}`);
+      this.logger.error(
+        `Failed to release pairing completion claim for code ${code}: ${error}`,
+      );
+    }
+  }
+
+  private async claimNewDisplayPairing(
+    organizationId: string,
+  ): Promise<string> {
+    const client = this.redisService.getClient();
+    if (!client) {
+      throw new BadRequestException(
+        'Pairing service unavailable. Please try again.',
+      );
+    }
+
+    const claimToken = crypto.randomUUID();
+    try {
+      const result = await client.set(
+        this.newDisplayClaimKey(organizationId),
+        claimToken,
+        'EX',
+        this.PAIRING_TTL_SECONDS,
+        'NX',
+      );
+
+      if (result !== 'OK') {
+        throw new ConflictException(
+          'Another display pairing is already being completed for this organization',
+        );
+      }
+
+      return claimToken;
+    } catch (error) {
+      if (error instanceof ConflictException) {
+        throw error;
+      }
+      this.logger.error(
+        `Failed to claim new display pairing for org ${organizationId}: ${error}`,
+      );
+      throw new BadRequestException(
+        'Pairing service unavailable. Please try again.',
+      );
+    }
+  }
+
+  private async releaseNewDisplayPairingClaim(
+    organizationId: string,
+    claimToken: string,
+  ): Promise<void> {
+    const client = this.redisService.getClient();
+    if (!client) return;
+
+    try {
+      await client.eval(
+        'if redis.call("GET", KEYS[1]) == ARGV[1] then return redis.call("DEL", KEYS[1]) else return 0 end',
+        1,
+        this.newDisplayClaimKey(organizationId),
+        claimToken,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to release new display pairing claim for org ${organizationId}: ${error}`,
+      );
     }
   }
 
@@ -196,7 +297,9 @@ export class PairingService implements OnModuleDestroy {
     try {
       return await this.redisService.exists(this.redisKey(code));
     } catch (error) {
-      this.logger.error(`Failed to check pairing request for code ${code}: ${error}`);
+      this.logger.error(
+        `Failed to check pairing request for code ${code}: ${error}`,
+      );
       return false;
     }
   }
@@ -221,7 +324,7 @@ export class PairingService implements OnModuleDestroy {
     let attempts = 0;
 
     // Ensure code is unique
-    while (await this.hasPairingRequest(code) && attempts < 10) {
+    while ((await this.hasPairingRequest(code)) && attempts < 10) {
       code = this.generatePairingCode();
       attempts++;
     }
@@ -264,10 +367,14 @@ export class PairingService implements OnModuleDestroy {
 
     const stored = await this.setPairingRequest(code, pairingRequest);
     if (!stored) {
-      throw new BadRequestException('Failed to store pairing request. Please try again.');
+      throw new BadRequestException(
+        'Failed to store pairing request. Please try again.',
+      );
     }
 
-    this.logger.log(`Pairing code generated: ${code} for device ${deviceIdentifier}`);
+    this.logger.log(
+      `Pairing code generated: ${code} for device ${deviceIdentifier}`,
+    );
 
     return {
       code,
@@ -345,137 +452,160 @@ export class PairingService implements OnModuleDestroy {
     // if the template belongs to another org). If unspecified, this resolves
     // to undefined and the Display falls back to Vizora-level defaults.
     const completionClaimToken = await this.claimPairingCompletion(code);
+    let newDisplayClaimToken: string | null = null;
     let releaseCompletionClaim = true;
 
     try {
       const provisioningDefaults = provisioningTemplateId
-      ? await this.provisioningTemplatesService.resolveForPairing(
-          organizationId,
-          provisioningTemplateId,
-        )
-      : undefined;
+        ? await this.provisioningTemplatesService.resolveForPairing(
+            organizationId,
+            provisioningTemplateId,
+          )
+        : undefined;
 
-    // Check if device already exists
-    const existingDisplay = await this.db.display.findUnique({
-      where: { deviceIdentifier: request.deviceIdentifier },
-      select: PAIRING_EXISTING_DISPLAY_SELECT,
-    });
+      // Check if device already exists
+      const existingDisplay = await this.db.display.findUnique({
+        where: { deviceIdentifier: request.deviceIdentifier },
+        select: PAIRING_EXISTING_DISPLAY_SELECT,
+      });
 
-    if (existingDisplay && existingDisplay.organizationId !== organizationId) {
-      throw new NotFoundException('Pairing code not found or expired');
-    }
+      if (
+        existingDisplay &&
+        existingDisplay.organizationId !== organizationId
+      ) {
+        throw new NotFoundException('Pairing code not found or expired');
+      }
 
-    if (!existingDisplay) {
-      await this.enforceScreenQuota(organizationId);
-    }
+      if (!existingDisplay) {
+        newDisplayClaimToken =
+          await this.claimNewDisplayPairing(organizationId);
+        await this.enforceScreenQuota(organizationId);
+      }
 
-    // Generate device JWT token
-    const devicePayload = {
-      sub: existingDisplay?.id || crypto.randomUUID(),
-      deviceIdentifier: request.deviceIdentifier,
-      organizationId,
-      type: 'device',
-    };
+      // Generate device JWT token
+      const devicePayload = {
+        sub: existingDisplay?.id || crypto.randomUUID(),
+        deviceIdentifier: request.deviceIdentifier,
+        organizationId,
+        type: 'device',
+      };
 
-    const deviceSecret = process.env.DEVICE_JWT_SECRET;
-    if (!deviceSecret || deviceSecret.length < 32) {
-      // Server-side misconfiguration — surface as 500 with a clear
-      // message so ops sees the cause in error tracking rather than
-      // an empty 500 from a swallowed generic Error.
-      throw new InternalServerErrorException(
-        'DEVICE_JWT_SECRET must be set and be at least 32 characters',
+      const deviceSecret = process.env.DEVICE_JWT_SECRET;
+      if (!deviceSecret || deviceSecret.length < 32) {
+        // Server-side misconfiguration — surface as 500 with a clear
+        // message so ops sees the cause in error tracking rather than
+        // an empty 500 from a swallowed generic Error.
+        throw new InternalServerErrorException(
+          'DEVICE_JWT_SECRET must be set and be at least 32 characters',
+        );
+      }
+
+      const jwtToken = this.jwtService.sign(devicePayload, {
+        expiresIn: '90d',
+        secret: deviceSecret,
+        algorithm: 'HS256',
+      });
+
+      // Hash the token before storing in database for security
+      // If database is compromised, attacker cannot use the hashed tokens
+      const hashedToken = this.hashToken(jwtToken);
+      let display: Prisma.DisplayGetPayload<{
+        select: typeof PAIRING_RESULT_SELECT;
+      }>;
+
+      if (existingDisplay) {
+        // Update existing display
+        // Set status to 'pairing' - the WebSocket gateway will update to 'online' when device connects
+        display = await this.db.display.update({
+          where: { id: existingDisplay.id },
+          data: {
+            nickname: nickname || request.nickname,
+            organizationId,
+            jwtToken: hashedToken, // Store hash, not plaintext
+            pairedAt: new Date(),
+            lastHeartbeat: new Date(),
+            status: 'pairing',
+            location: completeDto.location || existingDisplay.location,
+            // O6 — apply provisioning-template defaults. Spread last so they
+            // override the Vizora-level defaults but NOT explicit fields above.
+            ...(provisioningDefaults ?? {}),
+          },
+          select: PAIRING_RESULT_SELECT,
+        });
+      } else {
+        // Create new display
+        // Set status to 'pairing' - the WebSocket gateway will update to 'online' when device connects
+        display = await this.db.display.create({
+          data: {
+            id: devicePayload.sub,
+            deviceIdentifier: request.deviceIdentifier,
+            nickname: nickname || request.nickname,
+            organizationId,
+            jwtToken: hashedToken, // Store hash, not plaintext
+            pairedAt: new Date(),
+            lastHeartbeat: new Date(),
+            status: 'pairing',
+            location: request.metadata?.hostname || null,
+            metadata: request.metadata,
+            // O6 — apply provisioning-template defaults. Spread last so they
+            // override the Display model's Prisma defaults (orientation=
+            // 'landscape', timezone='UTC') with the operator's preference.
+            ...(provisioningDefaults ?? {}),
+          },
+          select: PAIRING_RESULT_SELECT,
+        });
+      }
+
+      this.logger.log(
+        `Device paired successfully: ${display.id} to org ${organizationId}`,
       );
-    }
 
-    const jwtToken = this.jwtService.sign(devicePayload, {
-      expiresIn: '90d',
-      secret: deviceSecret,
-      algorithm: 'HS256',
-    });
-
-    // Hash the token before storing in database for security
-    // If database is compromised, attacker cannot use the hashed tokens
-    const hashedToken = this.hashToken(jwtToken);
-    let display: Prisma.DisplayGetPayload<{ select: typeof PAIRING_RESULT_SELECT }>;
-
-    if (existingDisplay) {
-      // Update existing display
-      // Set status to 'pairing' - the WebSocket gateway will update to 'online' when device connects
-      display = await this.db.display.update({
-        where: { id: existingDisplay.id },
-        data: {
-          nickname: nickname || request.nickname,
-          organizationId,
-          jwtToken: hashedToken, // Store hash, not plaintext
-          pairedAt: new Date(),
-          lastHeartbeat: new Date(),
-          status: 'pairing',
-          location: completeDto.location || existingDisplay.location,
-          // O6 — apply provisioning-template defaults. Spread last so they
-          // override the Vizora-level defaults but NOT explicit fields above.
-          ...(provisioningDefaults ?? {}),
-        },
-        select: PAIRING_RESULT_SELECT,
+      // Emit domain event for onboarding tracking. Fire-and-forget; listener
+      // (OnboardingService.onDisplayPaired) has its own try/catch.
+      this.events.emit('display.paired', {
+        organizationId,
+        displayId: display.id,
       });
-    } else {
-      // Create new display
-      // Set status to 'pairing' - the WebSocket gateway will update to 'online' when device connects
-      display = await this.db.display.create({
-        data: {
-          id: devicePayload.sub,
-          deviceIdentifier: request.deviceIdentifier,
-          nickname: nickname || request.nickname,
-          organizationId,
-          jwtToken: hashedToken, // Store hash, not plaintext
-          pairedAt: new Date(),
-          lastHeartbeat: new Date(),
-          status: 'pairing',
-          location: request.metadata?.hostname || null,
-          metadata: request.metadata,
-          // O6 — apply provisioning-template defaults. Spread last so they
-          // override the Display model's Prisma defaults (orientation=
-          // 'landscape', timezone='UTC') with the operator's preference.
-          ...(provisioningDefaults ?? {}),
+
+      // Store the plaintext token in the Redis request so checkPairingStatus
+      // can return it to the device. The DB only has the hashed token.
+      // Don't delete the pairing request here - let checkPairingStatus delete it
+      // after the device retrieves its token (fixes race condition).
+      request.plaintextToken = jwtToken;
+      request.organizationId = organizationId;
+      const finalized = await this.setPairingRequest(code, request);
+      if (!finalized) {
+        releaseCompletionClaim = false;
+        throw new InternalServerErrorException(
+          'Failed to finalize pairing token handoff',
+        );
+      }
+
+      return {
+        success: true,
+        display: {
+          id: display.id,
+          nickname: display.nickname,
+          deviceIdentifier: display.deviceIdentifier,
+          status: display.status,
         },
-        select: PAIRING_RESULT_SELECT,
-      });
-    }
-
-    this.logger.log(`Device paired successfully: ${display.id} to org ${organizationId}`);
-
-    // Emit domain event for onboarding tracking. Fire-and-forget; listener
-    // (OnboardingService.onDisplayPaired) has its own try/catch.
-    this.events.emit('display.paired', { organizationId, displayId: display.id });
-
-    // Store the plaintext token in the Redis request so checkPairingStatus
-    // can return it to the device. The DB only has the hashed token.
-    // Don't delete the pairing request here - let checkPairingStatus delete it
-    // after the device retrieves its token (fixes race condition).
-    request.plaintextToken = jwtToken;
-    request.organizationId = organizationId;
-    const finalized = await this.setPairingRequest(code, request);
-    if (!finalized) {
-      releaseCompletionClaim = false;
-      throw new InternalServerErrorException('Failed to finalize pairing token handoff');
-    }
-
-    return {
-      success: true,
-      display: {
-        id: display.id,
-        nickname: display.nickname,
-        deviceIdentifier: display.deviceIdentifier,
-        status: display.status,
-      },
-    };
+      };
     } finally {
+      if (newDisplayClaimToken) {
+        await this.releaseNewDisplayPairingClaim(
+          organizationId,
+          newDisplayClaimToken,
+        );
+      }
       if (releaseCompletionClaim) {
         await this.releasePairingCompletionClaim(code, completionClaimToken);
       }
     }
   }
 
-  async getActivePairings(organizationId: string): Promise<ActivePairingResponse[]> {
+  async getActivePairings(
+    organizationId: string,
+  ): Promise<ActivePairingResponse[]> {
     // Return active pairing requests filtered by organization
     // Only show pending requests for devices that already belong to this org.
     const activePairings: ActivePairingResponse[] = [];
@@ -503,10 +633,13 @@ export class PairingService implements OnModuleDestroy {
       }
     }
 
-    const displayOrganizationsByDevice = await this.getDisplayOrganizationsByDevice(unclaimedRequests);
+    const displayOrganizationsByDevice =
+      await this.getDisplayOrganizationsByDevice(unclaimedRequests);
 
     for (const request of unclaimedRequests) {
-      const displayOrganizationId = displayOrganizationsByDevice.get(request.deviceIdentifier);
+      const displayOrganizationId = displayOrganizationsByDevice.get(
+        request.deviceIdentifier,
+      );
 
       // Show unclaimed requests only when the device is already owned by
       // this org. Brand-new unclaimed requests are visible only to the
@@ -524,7 +657,9 @@ export class PairingService implements OnModuleDestroy {
     return activePairings;
   }
 
-  private async getPairingRequestRecords(keys: string[]): Promise<PairingRequestRecord[]> {
+  private async getPairingRequestRecords(
+    keys: string[],
+  ): Promise<PairingRequestRecord[]> {
     if (keys.length === 0) return [];
 
     const client = this.redisService.getClient();
@@ -533,8 +668,15 @@ export class PairingService implements OnModuleDestroy {
       try {
         const records: PairingRequestRecord[] = [];
 
-        for (let index = 0; index < keys.length; index += this.PAIRING_READ_BATCH_SIZE) {
-          const batchKeys = keys.slice(index, index + this.PAIRING_READ_BATCH_SIZE);
+        for (
+          let index = 0;
+          index < keys.length;
+          index += this.PAIRING_READ_BATCH_SIZE
+        ) {
+          const batchKeys = keys.slice(
+            index,
+            index + this.PAIRING_READ_BATCH_SIZE,
+          );
           const values = await client.mget(...batchKeys);
 
           values.forEach((data, valueIndex) => {
@@ -572,9 +714,11 @@ export class PairingService implements OnModuleDestroy {
   private async getDisplayOrganizationsByDevice(
     requests: PairingRequest[],
   ): Promise<Map<string, string>> {
-    const deviceIdentifiers = Array.from(new Set(
-      requests.map(request => request.deviceIdentifier).filter(Boolean),
-    ));
+    const deviceIdentifiers = Array.from(
+      new Set(
+        requests.map((request) => request.deviceIdentifier).filter(Boolean),
+      ),
+    );
 
     if (deviceIdentifiers.length === 0) {
       return new Map();
@@ -590,7 +734,10 @@ export class PairingService implements OnModuleDestroy {
     });
 
     return new Map(
-      displays.map(display => [display.deviceIdentifier, display.organizationId]),
+      displays.map((display) => [
+        display.deviceIdentifier,
+        display.organizationId,
+      ]),
     );
   }
 

--- a/middleware/src/modules/displays/pairing.service.ts
+++ b/middleware/src/modules/displays/pairing.service.ts
@@ -3,6 +3,7 @@ import {
   BadRequestException,
   NotFoundException,
   InternalServerErrorException,
+  ForbiddenException,
   OnModuleDestroy,
   Logger,
 } from '@nestjs/common';
@@ -53,6 +54,7 @@ const PAIRING_STATUS_SELECT = {
 const PAIRING_EXISTING_DISPLAY_SELECT = {
   id: true,
   location: true,
+  organizationId: true,
 } as const satisfies Prisma.DisplaySelect;
 
 const PAIRING_RESULT_SELECT = {
@@ -70,6 +72,7 @@ export class PairingService implements OnModuleDestroy {
   private readonly PAIRING_TTL_SECONDS = 300; // 5 minutes
   private readonly PAIRING_READ_BATCH_SIZE = 100;
   private readonly REDIS_KEY_PREFIX = 'pairing:';
+  private readonly REDIS_COMPLETION_CLAIM_PREFIX = 'pairing-complete-claim:';
   private cleanupIntervalId: NodeJS.Timeout | null = null;
 
   constructor(
@@ -95,6 +98,10 @@ export class PairingService implements OnModuleDestroy {
 
   private redisKey(code: string): string {
     return `${this.REDIS_KEY_PREFIX}${code}`;
+  }
+
+  private completionClaimKey(code: string): string {
+    return `${this.REDIS_COMPLETION_CLAIM_PREFIX}${code}`;
   }
 
   private async getPairingRequest(code: string): Promise<PairingRequest | null> {
@@ -133,6 +140,55 @@ export class PairingService implements OnModuleDestroy {
     } catch (error) {
       this.logger.error(`Failed to delete pairing request for code ${code}: ${error}`);
       return false;
+    }
+  }
+
+  private async claimPairingCompletion(code: string): Promise<string> {
+    const client = this.redisService.getClient();
+    if (!client) {
+      throw new BadRequestException('Pairing service unavailable. Please try again.');
+    }
+
+    const claimToken = crypto.randomUUID();
+    try {
+      const result = await client.set(
+        this.completionClaimKey(code),
+        claimToken,
+        'EX',
+        this.PAIRING_TTL_SECONDS,
+        'NX',
+      );
+
+      if (result !== 'OK') {
+        throw new BadRequestException('Pairing code is already being completed');
+      }
+
+      return claimToken;
+    } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
+      this.logger.error(`Failed to claim pairing completion for code ${code}: ${error}`);
+      throw new BadRequestException('Pairing service unavailable. Please try again.');
+    }
+  }
+
+  private async releasePairingCompletionClaim(
+    code: string,
+    claimToken: string,
+  ): Promise<void> {
+    const client = this.redisService.getClient();
+    if (!client) return;
+
+    try {
+      await client.eval(
+        'if redis.call("GET", KEYS[1]) == ARGV[1] then return redis.call("DEL", KEYS[1]) else return 0 end',
+        1,
+        this.completionClaimKey(code),
+        claimToken,
+      );
+    } catch (error) {
+      this.logger.error(`Failed to release pairing completion claim for code ${code}: ${error}`);
     }
   }
 
@@ -274,6 +330,10 @@ export class PairingService implements OnModuleDestroy {
       throw new NotFoundException('Pairing code not found or expired');
     }
 
+    if (request.plaintextToken || request.organizationId) {
+      throw new BadRequestException('Pairing code has already been completed');
+    }
+
     // Check if expired (safety check — Redis TTL should handle this)
     if (new Date() > new Date(request.expiresAt)) {
       await this.deletePairingRequest(code);
@@ -284,7 +344,11 @@ export class PairingService implements OnModuleDestroy {
     // one. Cross-org guard lives inside resolveForPairing (throws NotFound
     // if the template belongs to another org). If unspecified, this resolves
     // to undefined and the Display falls back to Vizora-level defaults.
-    const provisioningDefaults = provisioningTemplateId
+    const completionClaimToken = await this.claimPairingCompletion(code);
+    let releaseCompletionClaim = true;
+
+    try {
+      const provisioningDefaults = provisioningTemplateId
       ? await this.provisioningTemplatesService.resolveForPairing(
           organizationId,
           provisioningTemplateId,
@@ -296,6 +360,14 @@ export class PairingService implements OnModuleDestroy {
       where: { deviceIdentifier: request.deviceIdentifier },
       select: PAIRING_EXISTING_DISPLAY_SELECT,
     });
+
+    if (existingDisplay && existingDisplay.organizationId !== organizationId) {
+      throw new NotFoundException('Pairing code not found or expired');
+    }
+
+    if (!existingDisplay) {
+      await this.enforceScreenQuota(organizationId);
+    }
 
     // Generate device JWT token
     const devicePayload = {
@@ -381,7 +453,11 @@ export class PairingService implements OnModuleDestroy {
     // after the device retrieves its token (fixes race condition).
     request.plaintextToken = jwtToken;
     request.organizationId = organizationId;
-    await this.setPairingRequest(code, request);
+    const finalized = await this.setPairingRequest(code, request);
+    if (!finalized) {
+      releaseCompletionClaim = false;
+      throw new InternalServerErrorException('Failed to finalize pairing token handoff');
+    }
 
     return {
       success: true,
@@ -392,12 +468,16 @@ export class PairingService implements OnModuleDestroy {
         status: display.status,
       },
     };
+    } finally {
+      if (releaseCompletionClaim) {
+        await this.releasePairingCompletionClaim(code, completionClaimToken);
+      }
+    }
   }
 
   async getActivePairings(organizationId: string): Promise<ActivePairingResponse[]> {
     // Return active pairing requests filtered by organization
-    // Only show requests that have been completed for this org,
-    // or where the device already belongs to this org
+    // Only show pending requests for devices that already belong to this org.
     const activePairings: ActivePairingResponse[] = [];
 
     // Use SCAN to find all pairing keys in Redis
@@ -412,14 +492,9 @@ export class PairingService implements OnModuleDestroy {
         continue;
       }
 
-      // If pairing was completed for this org, show it
+      // Completed records temporarily hold a plaintext device token for the
+      // physical display. Do not expose their codes through dashboard list APIs.
       if (request.organizationId === organizationId) {
-        activePairings.push({
-          code,
-          nickname: request.nickname,
-          createdAt: request.createdAt,
-          expiresAt: request.expiresAt,
-        });
         continue;
       }
 
@@ -517,6 +592,33 @@ export class PairingService implements OnModuleDestroy {
     return new Map(
       displays.map(display => [display.deviceIdentifier, display.organizationId]),
     );
+  }
+
+  private async enforceScreenQuota(organizationId: string): Promise<void> {
+    const org = await this.db.organization.findUnique({
+      where: { id: organizationId },
+      select: {
+        screenQuota: true,
+        _count: {
+          select: { displays: { where: { isDisabled: false } } },
+        },
+      },
+    });
+
+    if (!org) {
+      throw new ForbiddenException('Organization not found');
+    }
+
+    if (org.screenQuota === -1) {
+      return;
+    }
+
+    const currentCount = org._count.displays;
+    if (currentCount >= org.screenQuota) {
+      throw new ForbiddenException(
+        `Screen quota exceeded. You have ${currentCount}/${org.screenQuota} screens. Please upgrade your plan to add more screens.`,
+      );
+    }
   }
 
   /**

--- a/middleware/test/customer-critical-path.e2e-spec.ts
+++ b/middleware/test/customer-critical-path.e2e-spec.ts
@@ -3,6 +3,7 @@ import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import request from 'supertest';
 import helmet from 'helmet';
+import cookieParser from 'cookie-parser';
 import { AppModule } from '../src/app/app.module';
 import { DatabaseService } from '../src/modules/database/database.service';
 import { RedisService } from '../src/modules/redis/redis.service';
@@ -15,6 +16,11 @@ type RegisterData = {
     id: string;
     organizationId: string;
   };
+};
+
+type CsrfHeaders = {
+  Cookie: string;
+  'X-CSRF-Token': string;
 };
 
 type PairingRequestData = {
@@ -75,6 +81,22 @@ const dataOf = <T>(body: Envelope<T>): T => {
   return body.data;
 };
 
+const cookieHeaderFromSetCookie = (setCookie: string | string[] | undefined): string => {
+  const cookies = Array.isArray(setCookie)
+    ? setCookie
+    : setCookie
+      ? [setCookie]
+      : [];
+  return cookies.map((cookie) => cookie.split(';')[0]).join('; ');
+};
+
+const withoutCsrfCookie = (cookieHeader: string): string =>
+  cookieHeader
+    .split(';')
+    .map((cookie) => cookie.trim())
+    .filter((cookie) => cookie && !cookie.startsWith('vizora_csrf_token='))
+    .join('; ');
+
 describe('Customer critical path (e2e)', () => {
   let app: INestApplication;
   let db: DatabaseService;
@@ -91,6 +113,7 @@ describe('Customer critical path (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    app.use(cookieParser());
     app.use(
       helmet({
         contentSecurityPolicy: false,
@@ -133,7 +156,37 @@ describe('Customer critical path (e2e)', () => {
     await app.close();
   }, 60000);
 
-  const registerAccount = async (suffix: string) => {
+  const csrfHeaders = async (): Promise<CsrfHeaders> => {
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/health/live')
+      .expect(200);
+
+    const token = res.headers['x-csrf-token'];
+    const setCookie = res.headers['set-cookie'];
+    const cookieHeader = cookieHeaderFromSetCookie(setCookie);
+
+    expect(token).toBeTruthy();
+    expect(cookieHeader).toContain('vizora_csrf_token=');
+
+    return {
+      Cookie: cookieHeader,
+      'X-CSRF-Token': String(token),
+    };
+  };
+
+  const browserCsrfHeaders = async (authCookie: string) => {
+    const csrf = await csrfHeaders();
+
+    return {
+      Cookie: [withoutCsrfCookie(authCookie), csrf.Cookie].filter(Boolean).join('; '),
+      'X-CSRF-Token': csrf['X-CSRF-Token'],
+    };
+  };
+
+  const registerAccount = async (
+    suffix: string,
+    role: 'admin' | 'manager' | 'viewer' = 'admin',
+  ) => {
     const email = `customer-path-${suffix}-${timestamp}@example.com`;
     const password = 'SecureP@ssw0rd!';
     const registerRes = await request(app.getHttpServer())
@@ -151,6 +204,13 @@ describe('Customer critical path (e2e)', () => {
     userIds.push(registerData.user.id);
     organizationIds.push(registerData.user.organizationId);
 
+    if (role !== 'admin') {
+      await db.user.update({
+        where: { id: registerData.user.id },
+        data: { role },
+      });
+    }
+
     const loginRes = await request(app.getHttpServer())
       .post('/api/v1/auth/login')
       .send({ email, password })
@@ -161,12 +221,13 @@ describe('Customer critical path (e2e)', () => {
 
     return {
       authToken: loginData.access_token,
+      authCookie: cookieHeaderFromSetCookie(loginRes.headers['set-cookie']),
       userId: registerData.user.id,
       organizationId: registerData.user.organizationId,
     };
   };
 
-  const pairDisplay = async (authToken: string, suffix: string) => {
+  const pairDisplay = async (authCookie: string, suffix: string) => {
     const deviceIdentifier = `customer-path-${suffix}-display-${timestamp}`;
     const pairingRequestRes = await request(app.getHttpServer())
       .post('/api/v1/devices/pairing/request')
@@ -182,7 +243,7 @@ describe('Customer critical path (e2e)', () => {
 
     const pairingCompleteRes = await request(app.getHttpServer())
       .post('/api/v1/devices/pairing/complete')
-      .set('Authorization', `Bearer ${authToken}`)
+      .set(await browserCsrfHeaders(authCookie))
       .send({
         code: pairingRequest.code,
         nickname: `Customer Path ${suffix} Display`,
@@ -209,14 +270,60 @@ describe('Customer critical path (e2e)', () => {
     };
   };
 
+  it('rejects protected dashboard mutations without a CSRF token', async () => {
+    const account = await registerAccount('missing-csrf');
+
+    await request(app.getHttpServer())
+      .post('/api/v1/content')
+      .set('Cookie', account.authCookie)
+      .send({
+        name: 'Missing CSRF Content',
+        type: 'url',
+        url: `https://example.com/vizora-missing-csrf-${timestamp}`,
+        duration: 10,
+      })
+      .expect(403);
+  });
+
+  it('rejects viewer pairing completion at the API boundary', async () => {
+    const viewerAccount = await registerAccount('viewer', 'viewer');
+    const deviceIdentifier = `customer-path-viewer-display-${timestamp}`;
+    const pairingRequestRes = await request(app.getHttpServer())
+      .post('/api/v1/devices/pairing/request')
+      .send({
+        deviceIdentifier,
+        nickname: 'Viewer Display',
+        metadata: { platform: 'e2e' },
+      })
+      .expect(201);
+    const pairingRequest = dataOf<PairingRequestData>(pairingRequestRes.body);
+    pairingCodes.push(pairingRequest.code);
+
+    await request(app.getHttpServer())
+      .post('/api/v1/devices/pairing/complete')
+      .set(await browserCsrfHeaders(viewerAccount.authCookie))
+      .send({
+        code: pairingRequest.code,
+        nickname: 'Viewer Display',
+        location: 'Customer Test Lab',
+      })
+      .expect(403);
+
+    const pairingStatusRes = await request(app.getHttpServer())
+      .get(`/api/v1/devices/pairing/status/${pairingRequest.code}`)
+      .expect(200);
+    const pairingStatus = dataOf<{ status: string }>(pairingStatusRes.body);
+    expect(pairingStatus.status).toBe('pending');
+  });
+
   it('delivers scheduled playlist content to a newly paired display', async () => {
     const primaryAccount = await registerAccount('primary');
-    const primaryDisplay = await pairDisplay(primaryAccount.authToken, 'primary');
+    const primaryDisplay = await pairDisplay(primaryAccount.authCookie, 'primary');
     expect(primaryDisplay.organizationId).toBe(primaryAccount.organizationId);
 
     const contentRes = await request(app.getHttpServer())
       .post('/api/v1/content')
-      .set('Authorization', `Bearer ${primaryAccount.authToken}`)
+      .set(await browserCsrfHeaders(primaryAccount.authCookie))
       .send({
         name: 'Customer Path Menu',
         type: 'url',
@@ -229,7 +336,7 @@ describe('Customer critical path (e2e)', () => {
 
     const playlistRes = await request(app.getHttpServer())
       .post('/api/v1/playlists')
-      .set('Authorization', `Bearer ${primaryAccount.authToken}`)
+      .set(await browserCsrfHeaders(primaryAccount.authCookie))
       .send({
         name: 'Customer Path Playlist',
         loop: true,
@@ -245,7 +352,7 @@ describe('Customer critical path (e2e)', () => {
     const allDays = [0, 1, 2, 3, 4, 5, 6];
     const scheduleRes = await request(app.getHttpServer())
       .post('/api/v1/schedules')
-      .set('Authorization', `Bearer ${primaryAccount.authToken}`)
+      .set(await browserCsrfHeaders(primaryAccount.authCookie))
       .send({
         name: 'Customer Path Schedule',
         startDate,
@@ -283,7 +390,7 @@ describe('Customer critical path (e2e)', () => {
       .expect(401);
 
     const otherAccount = await registerAccount('other');
-    const otherDisplay = await pairDisplay(otherAccount.authToken, 'other');
+    const otherDisplay = await pairDisplay(otherAccount.authCookie, 'other');
     expect(otherDisplay.organizationId).toBe(otherAccount.organizationId);
 
     await request(app.getHttpServer())
@@ -293,7 +400,7 @@ describe('Customer critical path (e2e)', () => {
 
     await request(app.getHttpServer())
       .post('/api/v1/playlists')
-      .set('Authorization', `Bearer ${otherAccount.authToken}`)
+      .set(await browserCsrfHeaders(otherAccount.authCookie))
       .send({
         name: 'Cross Org Playlist',
         loop: true,
@@ -303,7 +410,7 @@ describe('Customer critical path (e2e)', () => {
 
     const otherContentRes = await request(app.getHttpServer())
       .post('/api/v1/content')
-      .set('Authorization', `Bearer ${otherAccount.authToken}`)
+      .set(await browserCsrfHeaders(otherAccount.authCookie))
       .send({
         name: 'Other Org Menu',
         type: 'url',
@@ -315,7 +422,7 @@ describe('Customer critical path (e2e)', () => {
 
     const otherPlaylistRes = await request(app.getHttpServer())
       .post('/api/v1/playlists')
-      .set('Authorization', `Bearer ${otherAccount.authToken}`)
+      .set(await browserCsrfHeaders(otherAccount.authCookie))
       .send({
         name: 'Other Org Playlist',
         loop: true,
@@ -326,7 +433,7 @@ describe('Customer critical path (e2e)', () => {
 
     await request(app.getHttpServer())
       .post('/api/v1/schedules')
-      .set('Authorization', `Bearer ${otherAccount.authToken}`)
+      .set(await browserCsrfHeaders(otherAccount.authCookie))
       .send({
         name: 'Cross Org Schedule',
         startDate,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,112 @@
 # Vizora - Task Tracker
 
+## Active: CSRF + Pairing Authorization Pass 44 (2026-06-02)
+
+**Branch:** `feat/customer-dashboard-improvement-pass-44`
+
+**Why now:** Pass 44 customer/security/performance review found two high-value
+repo-side gaps that are buildable and testable without operator actions:
+existing CSRF middleware is not mounted in the Nest runtime, and device-pairing
+completion is not protected by the same role/subscription/quota path as normal
+display creation. The current dashboard also exposes the top-level pair flow to
+viewers.
+
+**New primitives introduced:** none. Reuse existing `CsrfMiddleware`,
+`RolesGuard`, `@Roles`, `@RequiresSubscription`, existing screen-quota
+semantics, dashboard permission helper, response envelope, and `/api/v1`
+routing.
+
+**Hermes-first analysis:** checked per project convention. These are local
+dashboard/API authorization and runtime middleware wiring concerns, not
+business-agent, MCP, provider-spend, or Hermes runtime tasks.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| CSRF runtime enforcement | none found | wire existing Nest middleware |
+| Device-pairing role/subscription/quota checks | none found | reuse existing Vizora guards/decorators and quota semantics |
+| Dashboard pairing UI gating | none found | reuse existing web permission helper |
+
+Awesome-hermes-agent ecosystem check: no applicable skill/library primitive for
+Nest CSRF middleware registration or local dashboard permission truth; proceed
+with Vizora-native code.
+
+**Plan/design:**
+`docs/plans/2026-06-02-csrf-pairing-authorization-pass-44.md`
+
+**Plan**
+- [x] Run multi-vector customer/security/performance review and select scoped
+  target.
+- [x] Reconcile stale Pass 43 note: device row actions were gated, but top-level
+  viewer pairing CTAs and backend complete-pairing guard gaps still exist.
+- [x] Add red coverage for CSRF runtime wiring and pairing authorization/UI.
+- [x] Implement CSRF middleware registration and pairing backend/frontend gates.
+- [x] Run focused tests.
+- [x] Run multi-vector code review.
+- [ ] Run broader verification, PR, CI, merge, and deployment gate.
+
+**Evidence so far**
+- Red verification:
+  `pnpm --filter @vizora/middleware test -- --runInBand src/app/app.module.spec.ts src/modules/displays/pairing.controller.spec.ts`
+  failed as expected because `AppModule.configure()` did not exist and
+  `completePairing` had no roles/quota metadata.
+- Red verification:
+  `pnpm --filter @vizora/web test -- --runInBand web/src/lib/__tests__/permissions.test.ts web/src/app/dashboard/devices/__tests__/devices-page.test.tsx web/src/app/dashboard/devices/pair/__tests__/pair-device-page.test.tsx`
+  failed as expected because the permission helper lacked `canPairDevices`,
+  viewers still saw pair CTAs/actions, and the direct pair page rendered the
+  pairing form for viewers.
+- Focused green verification:
+  `pnpm --filter @vizora/middleware test -- --runInBand src/app/app.module.spec.ts src/modules/displays/pairing.controller.spec.ts`
+  passed 2 suites / 12 tests after implementation.
+- Focused green verification:
+  `pnpm --filter @vizora/web test -- --runInBand web/src/lib/__tests__/permissions.test.ts web/src/app/dashboard/devices/__tests__/devices-page.test.tsx web/src/app/dashboard/devices/pair/__tests__/pair-device-page.test.tsx`
+  passed 3 suites / 25 tests after implementation.
+- Review findings fixed:
+  - CSRF now allows bearer-only service/mobile/API clients while still
+    requiring CSRF when the Vizora auth cookie is present.
+  - Pairing completion rejects Redis replay, rejects existing displays owned by
+    another tenant, and enforces screen quota only when creating a new display.
+  - Viewer pairing UI no longer exposes the direct form, QR deep-link success,
+    empty-state CTA, or existing-device pair action.
+- Focused review-fix verification:
+  `pnpm --filter @vizora/middleware test -- --runInBand src/modules/common/middleware/csrf.middleware.spec.ts src/app/app.module.spec.ts src/modules/displays/pairing.controller.spec.ts src/modules/displays/pairing.service.spec.ts`
+  passed 4 suites / 82 tests after adding concurrent pairing-claim coverage.
+- Review audit findings fixed:
+  - Pairing completion's Redis claim helpers were present but incomplete in the
+    dead-session state; the service now rejects concurrent completion claims
+    before display creation/update.
+  - Completed pairing records carry the plaintext device-token handoff and are
+    now suppressed from `getActivePairings()` dashboard list responses.
+  - E2E browser-CSRF helpers strip stale CSRF cookies from auth-cookie bundles so
+    duplicate CSRF cookies cannot make valid browser writes fail.
+- Runtime E2E verification:
+  `pnpm --filter @vizora/middleware test:e2e -- --runInBand --testPathPattern="customer-critical-path"`
+  passed 1 suite / 3 tests, including missing-CSRF rejection, viewer pairing
+  API rejection, and the scheduled playlist delivery path.
+- Focused web verification:
+  `pnpm --filter @vizora/web test -- --runInBand web/src/lib/__tests__/permissions.test.ts web/src/app/dashboard/devices/__tests__/devices-page.test.tsx web/src/app/dashboard/devices/pair/__tests__/pair-device-page.test.tsx`
+  passed 3 suites / 27 tests.
+- Broader verification:
+  - `npx nx build @vizora/middleware` passed with the existing webpack warning
+    class.
+  - `pnpm --filter @vizora/web exec tsc --noEmit` passed.
+  - `pnpm security:no-hardcoded-jwts` passed.
+  - `git diff --check` passed aside from existing CRLF conversion warnings.
+  - Plain `npx nx build @vizora/web` failed before compilation because
+    `NEXT_PUBLIC_SOCKET_URL` is intentionally required for production CSP.
+    Rerun with local production URLs
+    (`NEXT_PUBLIC_SOCKET_URL=http://localhost:3002`,
+    `NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1`,
+    `BACKEND_URL=http://localhost:3000`) passed.
+
+**Deferred from Pass 44**
+- Team/API-key admin-only UI truth.
+- Settings admin-email read-only/copy cleanup.
+- Content URL update SSRF validation.
+- Realtime public health detail hardening.
+- Dashboard duplicate refresh and `/analytics/summary` query consolidation.
+- Upload quota preflight, short content-search gating, and deferred device-group
+  fetch.
+
 ## Completed: Dashboard Role Truth Pass 43 (2026-06-02)
 
 **Branch:** `feat/dashboard-role-truth-pass-43`

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -69,7 +69,8 @@ with Vizora-native code.
     empty-state CTA, or existing-device pair action.
 - Focused review-fix verification:
   `pnpm --filter @vizora/middleware test -- --runInBand src/modules/common/middleware/csrf.middleware.spec.ts src/app/app.module.spec.ts src/modules/displays/pairing.controller.spec.ts src/modules/displays/pairing.service.spec.ts`
-  passed 4 suites / 82 tests after adding concurrent pairing-claim coverage.
+  passed 4 suites / 86 tests after adding concurrent pairing-claim and
+  org-level new-display serialization coverage.
 - Review audit findings fixed:
   - Pairing completion's Redis claim helpers were present but incomplete in the
     dead-session state; the service now rejects concurrent completion claims
@@ -78,6 +79,18 @@ with Vizora-native code.
     now suppressed from `getActivePairings()` dashboard list responses.
   - E2E browser-CSRF helpers strip stale CSRF cookies from auth-cookie bundles so
     duplicate CSRF cookies cannot make valid browser writes fail.
+  - Backend clean-gate found quota enforcement was still raceable across two
+    different new-device pairing codes for the same org; new-display pairing
+    now takes an org-scoped Redis claim before quota check/create and releases
+    it after the create/failure path.
+  - Google auth endpoints are explicitly exempted from CSRF so raw OAuth POST
+    callbacks are not gated by dashboard CSRF cookies.
+- Latest focused quota-race verification:
+  `pnpm --filter @vizora/middleware test -- --runInBand src/modules/displays/pairing.service.spec.ts`
+  passed 1 suite / 39 tests, including org-level new-display serialization.
+- Latest focused middleware verification:
+  `pnpm --filter @vizora/middleware test -- --runInBand src/modules/common/middleware/csrf.middleware.spec.ts src/app/app.module.spec.ts src/modules/displays/pairing.controller.spec.ts src/modules/displays/pairing.service.spec.ts`
+  passed 4 suites / 86 tests.
 - Runtime E2E verification:
   `pnpm --filter @vizora/middleware test:e2e -- --runInBand --testPathPattern="customer-critical-path"`
   passed 1 suite / 3 tests, including missing-CSRF rejection, viewer pairing

--- a/web/src/app/dashboard/devices/__tests__/devices-page.test.tsx
+++ b/web/src/app/dashboard/devices/__tests__/devices-page.test.tsx
@@ -114,7 +114,15 @@ jest.mock('@/components/LoadingSpinner', () => {
 });
 
 jest.mock('@/components/EmptyState', () => {
-  return function MockEmpty({ title }: any) { return <div data-testid="empty-state">{title || 'No items'}</div>; };
+  return function MockEmpty({ title, description, action }: any) {
+    return (
+      <div data-testid="empty-state">
+        {title || 'No items'}
+        {description && <p>{description}</p>}
+        {action && <button onClick={action.onClick}>{action.label}</button>}
+      </div>
+    );
+  };
 });
 
 jest.mock('@/components/Modal', () => {
@@ -375,7 +383,7 @@ describe('DevicesClient', () => {
 
     expect(screen.queryByTestId('fleet-dropdown')).not.toBeInTheDocument();
     expect(screen.queryByText('Emergency Override')).not.toBeInTheDocument();
-    expect(screen.getByText('Pair New Device')).toBeInTheDocument();
+    expect(screen.queryByText('Pair New Device')).not.toBeInTheDocument();
     expect(screen.queryByText('Edit')).not.toBeInTheDocument();
     expect(screen.queryByText('Pair')).not.toBeInTheDocument();
     expect(screen.queryByText('Delete')).not.toBeInTheDocument();
@@ -386,6 +394,28 @@ describe('DevicesClient', () => {
 
     expect(screen.getByTestId('device-preview-modal')).toBeInTheDocument();
     expect(screen.queryByText('Refresh Screenshot')).not.toBeInTheDocument();
+  });
+
+  it('does not show an empty-state pairing action to viewers', async () => {
+    mockUser = { ...mockUser, role: 'viewer' };
+    mockGetDisplays.mockResolvedValue({ data: [], meta: { total: 0 } });
+
+    render(
+      <DevicesClient
+        initialDevices={[]}
+        initialPlaylists={samplePlaylists as any}
+        initialDevicesComplete
+        initialPlaylistsComplete
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toHaveTextContent('No devices yet');
+    });
+
+    expect(screen.getByTestId('empty-state')).toHaveTextContent('A manager or admin can add the first screen');
+    expect(screen.queryByText('Get started by pairing your first display device')).not.toBeInTheDocument();
+    expect(screen.queryByText('Pair Device')).not.toBeInTheDocument();
   });
 
   it('allows managers to pair and assign devices without exposing admin-only deletes or emergency override', async () => {

--- a/web/src/app/dashboard/devices/page-client.tsx
+++ b/web/src/app/dashboard/devices/page-client.tsx
@@ -476,6 +476,7 @@ export default function DevicesClient({
  <span>Emergency Override</span>
  </button>
  )}
+ {permissions.canPairDevices && (
  <button
  onClick={() => router.push('/dashboard/devices/pair')}
  className="eh-btn-neon rounded-xl px-6 py-3 flex items-center gap-2"
@@ -483,6 +484,7 @@ export default function DevicesClient({
  <Icon name="add" size="lg" className="text-white" />
  <span>Pair New Device</span>
  </button>
+ )}
  </div>
  </div>
 
@@ -543,11 +545,13 @@ export default function DevicesClient({
  <EmptyState
  icon="devices"
  title="No devices yet"
- description="Get started by pairing your first display device"
- action={{
+ description={permissions.canPairDevices
+ ? 'Get started by pairing your first display device'
+ : 'No displays are paired yet. A manager or admin can add the first screen.'}
+ action={permissions.canPairDevices ? {
  label: 'Pair Device',
  onClick: () => router.push('/dashboard/devices/pair'),
- }}
+ } : undefined}
  />
  ) : (
  <>
@@ -621,7 +625,7 @@ export default function DevicesClient({
  {permissions.canManageDevices && (
  <button onClick={() => handleEdit(device)} className="eh-icon-btn">Edit</button>
  )}
- {permissions.canManageDevices && (
+ {permissions.canPairDevices && (
  <button onClick={() => handleGeneratePairingCode(device)} className="eh-icon-btn">Pair</button>
  )}
  {permissions.canDeleteDevices && (
@@ -690,7 +694,7 @@ export default function DevicesClient({
  </div>
  </Modal>
 
- <Modal isOpen={isPairingModalOpen && permissions.canManageDevices} onClose={() => setIsPairingModalOpen(false)} title="Pairing Token">
+ <Modal isOpen={isPairingModalOpen && permissions.canPairDevices} onClose={() => setIsPairingModalOpen(false)} title="Pairing Token">
  <div className="text-center space-y-5">
  <p className="text-[var(--foreground-secondary)]">Use this token on your display device to pair it:</p>
  <div className="bg-[var(--background-secondary)] rounded-lg p-6">

--- a/web/src/app/dashboard/devices/pair/__tests__/pair-device-page.test.tsx
+++ b/web/src/app/dashboard/devices/pair/__tests__/pair-device-page.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import PairDevicePage from '../page';
+
+const mockPush = jest.fn();
+let mockSearchParams = new URLSearchParams();
+const mockCompletePairing = jest.fn();
+
+let mockUser: any = {
+  id: 'u1',
+  email: 'manager@example.com',
+  role: 'manager',
+  organizationId: 'org-1',
+};
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+  useSearchParams: () => mockSearchParams,
+}));
+
+jest.mock('@/lib/api', () => ({
+  apiClient: {
+    completePairing: (...args: any[]) => mockCompletePairing(...args),
+  },
+}));
+
+jest.mock('@/lib/hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: mockUser,
+    loading: false,
+    isAuthenticated: !!mockUser,
+  }),
+}));
+
+const mockToast = {
+  success: jest.fn(),
+  error: jest.fn(),
+};
+
+jest.mock('@/lib/hooks/useToast', () => ({
+  useToast: () => ({
+    success: mockToast.success,
+    error: mockToast.error,
+    ToastContainer: () => null,
+  }),
+}));
+
+jest.mock('@/components/LoadingSpinner', () => {
+  return function MockSpinner() { return <span>Loading</span>; };
+});
+
+jest.mock('@/theme/icons', () => ({
+  Icon: ({ name }: { name: string }) => <span aria-hidden="true" data-testid={`icon-${name}`}>{name}</span>,
+}));
+
+jest.mock('qrcode.react', () => ({
+  QRCodeSVG: () => <div data-testid="qr-code" />,
+}));
+
+describe('PairDevicePage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
+    mockUser = {
+      id: 'u1',
+      email: 'manager@example.com',
+      role: 'manager',
+      organizationId: 'org-1',
+    };
+    mockCompletePairing.mockResolvedValue({ success: true });
+  });
+
+  it('blocks viewer users from the direct pairing form', () => {
+    mockUser = { ...mockUser, role: 'viewer' };
+
+    render(<PairDevicePage />);
+
+    expect(screen.getByText('Device pairing requires manager or admin access')).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Pairing Code/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Pair Device' })).not.toBeInTheDocument();
+  });
+
+  it('does not show QR autofill success for denied viewer users', () => {
+    mockUser = { ...mockUser, role: 'viewer' };
+    mockSearchParams = new URLSearchParams('code=ABC123');
+
+    render(<PairDevicePage />);
+
+    expect(screen.getByText('Device pairing requires manager or admin access')).toBeInTheDocument();
+    expect(mockToast.success).not.toHaveBeenCalledWith('Code autofilled from QR scan!');
+  });
+
+  it('autofills QR code once for managers when the toast hook identity changes', async () => {
+    mockSearchParams = new URLSearchParams('code=abc123');
+
+    render(<PairDevicePage />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Pairing Code/i)).toHaveValue('ABC123');
+    });
+    expect(mockToast.success).toHaveBeenCalledTimes(1);
+    expect(mockToast.success).toHaveBeenCalledWith('Code autofilled from QR scan!');
+  });
+
+  it('allows managers to complete pairing', async () => {
+    render(<PairDevicePage />);
+
+    fireEvent.change(screen.getByLabelText(/Pairing Code/i), { target: { value: 'abc123' } });
+    fireEvent.change(screen.getByLabelText(/Device Name/i), { target: { value: 'Lobby Display' } });
+    fireEvent.change(screen.getByLabelText(/Location/i), { target: { value: 'Lobby' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Pair Device' }));
+
+    await waitFor(() => {
+      expect(mockCompletePairing).toHaveBeenCalledWith({
+        code: 'ABC123',
+        nickname: 'Lobby Display',
+        location: 'Lobby',
+      });
+    });
+  });
+});

--- a/web/src/app/dashboard/devices/pair/page.tsx
+++ b/web/src/app/dashboard/devices/pair/page.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { apiClient } from '@/lib/api';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import { useToast } from '@/lib/hooks/useToast';
+import { useAuth } from '@/lib/hooks/useAuth';
+import { getDashboardPermissions } from '@/lib/permissions';
 import { QRCodeSVG } from 'qrcode.react';
 import { Icon } from '@/theme/icons';
 
@@ -12,21 +14,31 @@ export default function PairDevicePage() {
  const router = useRouter();
  const searchParams = useSearchParams();
  const toast = useToast();
+ const { user, loading: authLoading } = useAuth();
+ const permissions = getDashboardPermissions(user);
  const [form, setForm] = useState({
  pairingCode: '',
  deviceName: '',
  location: '',
  });
  const [loading, setLoading] = useState(false);
+ const lastAutofilledCodeRef = useRef<string | null>(null);
 
  // Auto-fill code from QR scan
  useEffect(() => {
- const code = searchParams?.get('code');
- if (code && code.length === 6) {
- setForm(prev => ({ ...prev, pairingCode: code.toUpperCase() }));
+ const code = searchParams?.get('code')?.toUpperCase();
+ if (
+ !authLoading &&
+ permissions.canPairDevices &&
+ code &&
+ code.length === 6 &&
+ lastAutofilledCodeRef.current !== code
+ ) {
+ lastAutofilledCodeRef.current = code;
+ setForm(prev => ({ ...prev, pairingCode: code }));
  toast.success('Code autofilled from QR scan!');
  }
- }, [searchParams]);
+ }, [authLoading, permissions.canPairDevices, searchParams, toast]);
 
  const handlePairing = async () => {
  if (!form.pairingCode.trim() || form.pairingCode.length !== 6) {
@@ -71,6 +83,41 @@ export default function PairDevicePage() {
  setForm({ ...form, pairingCode: value });
  };
 
+ if (authLoading) {
+ return (
+ <div className="max-w-2xl mx-auto p-8 flex justify-center">
+ <LoadingSpinner size="lg" />
+ </div>
+ );
+ }
+
+ if (!permissions.canPairDevices) {
+ return (
+ <div className="max-w-2xl mx-auto space-y-6">
+ <toast.ToastContainer />
+ <div className="bg-[var(--surface)] rounded-lg shadow-md p-8 text-center space-y-4">
+ <div className="mx-auto h-12 w-12 rounded-full bg-yellow-500/10 flex items-center justify-center">
+ <Icon name="warning" size="xl" className="text-yellow-600 dark:text-yellow-400" />
+ </div>
+ <div>
+ <h2 className="text-2xl font-bold text-[var(--foreground)]">
+ Device pairing requires manager or admin access
+ </h2>
+ <p className="mt-2 text-[var(--foreground-secondary)]">
+ You can still view paired devices, but a manager or admin must add new screens.
+ </p>
+ </div>
+ <button
+ onClick={() => router.push('/dashboard/devices')}
+ className="px-6 py-3 text-sm font-medium text-[var(--foreground-secondary)] bg-[var(--surface)] border border-[var(--border)] rounded-lg hover:bg-[var(--surface-hover)] transition"
+ >
+ Back to Devices
+ </button>
+ </div>
+ </div>
+ );
+ }
+
  return (
  <div className="max-w-2xl mx-auto space-y-6">
  <toast.ToastContainer />
@@ -114,11 +161,12 @@ export default function PairDevicePage() {
 
  {/* Pairing Code Input */}
  <div>
- <label className="block text-sm font-medium text-[var(--foreground-secondary)] mb-2">
+ <label htmlFor="pairing-code" className="block text-sm font-medium text-[var(--foreground-secondary)] mb-2">
  Pairing Code *
  <span className="text-xs text-[var(--foreground-tertiary)] ml-2">(6 characters from your display)</span>
  </label>
  <input
+ id="pairing-code"
  type="text"
  value={form.pairingCode}
  onChange={handleCodeChange}
@@ -155,10 +203,11 @@ export default function PairDevicePage() {
 
  {/* Device Name Input */}
  <div>
- <label className="block text-sm font-medium text-[var(--foreground-secondary)] mb-2">
+ <label htmlFor="device-name" className="block text-sm font-medium text-[var(--foreground-secondary)] mb-2">
  Device Name *
  </label>
  <input
+ id="device-name"
  type="text"
  value={form.deviceName}
  onChange={(e) => setForm({ ...form, deviceName: e.target.value })}
@@ -172,10 +221,11 @@ export default function PairDevicePage() {
 
  {/* Location Input */}
  <div>
- <label className="block text-sm font-medium text-[var(--foreground-secondary)] mb-2">
+ <label htmlFor="device-location" className="block text-sm font-medium text-[var(--foreground-secondary)] mb-2">
  Location (Optional)
  </label>
  <input
+ id="device-location"
  type="text"
  value={form.location}
  onChange={(e) => setForm({ ...form, location: e.target.value })}

--- a/web/src/lib/__tests__/permissions.test.ts
+++ b/web/src/lib/__tests__/permissions.test.ts
@@ -7,6 +7,7 @@ describe('getDashboardPermissions', () => {
       canDeleteContent: true,
       canReviewContent: true,
       canManageDevices: true,
+      canPairDevices: true,
       canDeleteDevices: true,
       canUseFleetCommands: true,
       canUseEmergencyOverride: true,
@@ -24,6 +25,7 @@ describe('getDashboardPermissions', () => {
       canDeleteContent: false,
       canReviewContent: true,
       canManageDevices: true,
+      canPairDevices: true,
       canDeleteDevices: false,
       canUseFleetCommands: true,
       canUseEmergencyOverride: false,
@@ -40,6 +42,7 @@ describe('getDashboardPermissions', () => {
       canManageContent: false,
       canDeleteContent: false,
       canManageDevices: false,
+      canPairDevices: false,
       canDeleteDevices: false,
       canManagePlaylists: false,
       canDeletePlaylists: false,
@@ -50,6 +53,7 @@ describe('getDashboardPermissions', () => {
     expect(getDashboardPermissions(null)).toMatchObject({
       canManageContent: false,
       canManageDevices: false,
+      canPairDevices: false,
       canManagePlaylists: false,
       canManageSchedules: false,
     });

--- a/web/src/lib/permissions.ts
+++ b/web/src/lib/permissions.ts
@@ -7,6 +7,7 @@ export type DashboardPermissions = {
   canDeleteContent: boolean;
   canReviewContent: boolean;
   canManageDevices: boolean;
+  canPairDevices: boolean;
   canDeleteDevices: boolean;
   canUseFleetCommands: boolean;
   canUseEmergencyOverride: boolean;
@@ -31,6 +32,7 @@ export function getDashboardPermissions(user: RoleUser): DashboardPermissions {
     canDeleteContent: admin,
     canReviewContent: adminOrManager,
     canManageDevices: adminOrManager,
+    canPairDevices: adminOrManager,
     canDeleteDevices: admin,
     canUseFleetCommands: adminOrManager,
     canUseEmergencyOverride: admin,


### PR DESCRIPTION
## Summary
- Mount the existing CSRF middleware in the Nest runtime and preserve bearer-only/public endpoint behavior.
- Restrict dashboard pairing completion and active pairing visibility to admin/manager users with active subscription checks.
- Add service-level pairing hardening: tenant guard, create-only screen quota enforcement, concurrent Redis completion claims, and suppression of completed token-bearing pairing records from dashboard active lists.
- Gate viewer pairing CTAs/direct pair page access in the dashboard.

## Verification
- `pnpm --filter @vizora/middleware test -- --runInBand src/modules/common/middleware/csrf.middleware.spec.ts src/app/app.module.spec.ts src/modules/displays/pairing.controller.spec.ts src/modules/displays/pairing.service.spec.ts` (4 suites / 82 tests)
- `pnpm --filter @vizora/web test -- --runInBand web/src/lib/__tests__/permissions.test.ts web/src/app/dashboard/devices/__tests__/devices-page.test.tsx web/src/app/dashboard/devices/pair/__tests__/pair-device-page.test.tsx` (3 suites / 27 tests)
- `pnpm --filter @vizora/middleware test:e2e -- --runInBand --testPathPattern=customer-critical-path` (1 suite / 3 tests)
- `npx nx build @vizora/middleware` (passes with existing webpack warnings)
- `pnpm --filter @vizora/web exec tsc --noEmit`
- `pnpm security:no-hardcoded-jwts`
- `git diff --check` (clean aside from CRLF warnings)
- `NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 BACKEND_URL=http://localhost:3000 npx nx build @vizora/web`