### PR TITLE
fix: preflight dashboard upload quota

### DIFF
--- a/docs/plans/2026-06-02-dashboard-upload-preflight-pass-45.md
+++ b/docs/plans/2026-06-02-dashboard-upload-preflight-pass-45.md
@@ -1,0 +1,43 @@
+# Dashboard Upload Preflight Pass 45
+
+**Goal:** Reduce first-dashboard-load duplicate API work and prevent avoidable over-quota upload attempts before the browser sends file bytes.
+
+**Branch:** `feat/customer-dashboard-improvement-pass-45`
+
+**New primitives introduced:** none. Reuse existing server dashboard prefetches, `apiClient.getStorageInfo()`, `uploadContentWithProgress()`, content upload queue state, and dashboard Jest suites.
+
+**Hermes-first analysis:** checked per project convention. This is local dashboard/browser behavior, not a business-agent, MCP, Hermes runtime, or provider-spend task.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Dashboard initial API refresh suppression | none found | build in existing `DashboardClient` |
+| Browser upload quota preflight | none found | build in existing content upload UI using existing storage endpoint |
+
+Awesome-hermes-agent ecosystem check: no applicable skill or library primitive for React dashboard hydration fetch suppression or browser-side storage quota preflight; proceed with Vizora-native code.
+
+## Scope
+
+- Skip the automatic client refresh on `/dashboard` when server rendering already supplied summary-derived stats, content sample, playlist sample, storage info, and readiness state.
+- Keep the existing client recovery behavior when any initial server payload is missing.
+- Before single or queued file uploads, fetch current organization storage once and fail fast if retryable file bytes exceed available quota.
+- Do not change backend quota enforcement; backend remains authoritative for races or concurrent uploads.
+
+## Files
+
+- Modify: `web/src/app/dashboard/page-client.tsx`
+- Modify: `web/src/app/dashboard/__tests__/dashboard-page.test.tsx`
+- Modify: `web/src/app/dashboard/content/page-client.tsx`
+- Modify: `web/src/app/dashboard/content/__tests__/content-page.test.tsx`
+- Modify: `tasks/todo.md`
+
+## Test Plan
+
+1. Add a dashboard test proving no mount-time summary/content/playlist/storage/health refresh happens when all server data is complete.
+2. Add dashboard regression coverage proving missing initial data still triggers recovery refresh.
+3. Add content tests proving single and bulk over-quota uploads do not call `uploadContentWithProgress()`.
+4. Run focused web tests:
+   - `pnpm --filter @vizora/web test -- --runInBand web/src/app/dashboard/__tests__/dashboard-page.test.tsx web/src/app/dashboard/content/__tests__/content-page.test.tsx`
+5. Run broader web verification:
+   - `pnpm --filter @vizora/web test -- --runInBand`
+   - `pnpm --filter @vizora/web exec tsc --noEmit --pretty false`
+   - `NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 BACKEND_URL=http://localhost:3000 pnpm --filter @vizora/web build`

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,100 @@
 # Vizora - Task Tracker
 
+## Active Workstream: Dashboard Upload Preflight Pass 45 (2026-06-02)
+
+**Branch:** `feat/customer-dashboard-improvement-pass-45`
+
+**Why now:** PRs #182-#184 are merged and no PRs remain open, but production
+deploy is blocked by dirty/diverged prod state. The next buildable
+customer-facing performance/trust slice is web-only: dashboard SSR already
+fetches summary/storage/health/activity data but the client still auto-refreshes
+on mount, and content uploads spend browser/server bandwidth before checking
+known organization storage quota.
+
+**New primitives introduced:** none. Reuse existing dashboard server prefetch,
+existing `apiClient.getStorageInfo()`, existing content upload queue/progress
+path, and existing web Jest suites.
+
+**Hermes-first analysis:** checked per project convention. These are dashboard
+hydration and browser upload-preflight behaviors, not business-agent, MCP,
+Hermes runtime, or AI/provider-spend tasks.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Dashboard initial API refresh suppression | none found | build in existing `DashboardClient` |
+| Browser upload quota preflight | none found | build in existing content upload UI using existing storage endpoint |
+
+Awesome-hermes-agent ecosystem check: no applicable skill/library primitive for
+React dashboard hydration fetch suppression or browser-side storage quota
+preflight; proceed with Vizora-native code.
+
+**Plan/design:**
+`docs/plans/2026-06-02-dashboard-upload-preflight-pass-45.md`
+
+**Plan**
+- [x] Reconcile backlog/current-state and choose a repo-side web performance
+  slice.
+- [x] Add red dashboard tests for complete-SSR no-refresh and missing-data
+  recovery.
+- [x] Add red content upload tests for single and bulk quota preflight.
+- [x] Implement dashboard refresh suppression and upload preflight.
+- [x] Run focused web tests.
+- [x] Run multi-vector subagent review.
+- [x] Run broader web verification and build.
+- [ ] PR, CI, merge if green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Evidence so far**
+- Red verification:
+  `pnpm --filter @vizora/web test -- --runInBand web/src/app/dashboard/__tests__/dashboard-page.test.tsx web/src/app/dashboard/content/__tests__/content-page.test.tsx`
+  failed as expected because complete server dashboard snapshots still triggered
+  `getAnalyticsSummary()` on mount and queued uploads never called
+  `getStorageInfo()` before starting XHR uploads.
+- Focused green verification:
+  `pnpm --filter @vizora/web test -- --runInBand web/src/app/dashboard/__tests__/dashboard-page.test.tsx web/src/app/dashboard/content/__tests__/content-page.test.tsx`
+  passed 2 suites / 67 tests after implementation.
+- Diff review finding fixed: both reviewers found the frontend treated
+  `quotaBytes <= 0` as unlimited even though backend quota reservation rejects
+  positive uploads against nonpositive quotas. The preflight now treats
+  nonpositive quota as zero available bytes and keeps the queued files visible
+  and retryable after blocking.
+- Post-review focused verification:
+  `pnpm --filter @vizora/web test -- --runInBand web/src/app/dashboard/__tests__/dashboard-page.test.tsx web/src/app/dashboard/content/__tests__/content-page.test.tsx`
+  passed 2 suites / 68 tests. `pnpm --filter @vizora/web exec tsc --noEmit --pretty false`
+  passed.
+- Follow-up subagent review: CLEAN after the nonpositive-quota fix. Reviewer
+  confirmed preflight semantics align with backend quota reservation, blocked
+  queues remain visible/retryable, and incomplete dashboard snapshots still
+  recover through `loadStats(false)`.
+- Broader verification:
+  - `pnpm --filter @vizora/web test -- --runInBand` passed 103 suites / 1100
+    tests, with existing React `act(...)` and jsdom navigation warning noise in
+    unrelated suites.
+  - `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` passed.
+  - `ESLINT_USE_FLAT_CONFIG=false npx eslint web/src/app/dashboard/page-client.tsx web/src/app/dashboard/content/page-client.tsx web/src/app/dashboard/__tests__/dashboard-page.test.tsx web/src/app/dashboard/content/__tests__/content-page.test.tsx`
+    passed with 0 errors and existing `any` warnings in the touched dashboard
+    files.
+  - `pnpm security:no-hardcoded-jwts` passed.
+  - `git diff --check` passed with Windows CRLF warnings only.
+  - `NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 BACKEND_URL=http://localhost:3000 pnpm --filter @vizora/web build`
+    passed with existing Next middleware/proxy and TypeScript project-reference
+    warnings.
+
+**Queued next-pass findings**
+- Backend/customer: REST heartbeat verifies `:deviceId` as display id but
+  `DisplaysService.updateHeartbeat()` looks up by `deviceIdentifier`; add
+  id/deviceIdentifier mismatch coverage and align the service/controller
+  contract.
+- Backend/security: notification list, read, dismiss, and read-all APIs need
+  current-user scoping for user-targeted notifications and should filter
+  `dismissedAt: null` before pagination.
+- Release safety: CI lacks a web unit job and customer-critical Playwright
+  smoke gate; security/audit gates are advisory in places.
+- Release safety: deploy verification and Docker health checks still probe
+  stale routes (`/templates`, `/devices`, `/api/health`, realtime `/health`)
+  instead of current `/api/v1` routes/auth expectations.
+- Admin trust: hard-coded admin backlog page is stale against `backlog.md`.
+
 ## Completed: CSRF + Pairing Authorization Pass 44 (2026-06-02)
 
 **Branches:** `feat/customer-dashboard-improvement-pass-44`,

--- a/web/src/app/dashboard/__tests__/dashboard-page.test.tsx
+++ b/web/src/app/dashboard/__tests__/dashboard-page.test.tsx
@@ -217,19 +217,7 @@ describe('DashboardClient', () => {
     expect(screen.queryByText('Publish & Schedule')).not.toBeInTheDocument();
   });
 
-  it('does not refetch content and playlists on mount when server summary is present', async () => {
-    (apiClient.getAnalyticsSummary as jest.Mock).mockResolvedValueOnce({
-      totalDevices: 2,
-      onlineDevices: 1,
-      totalContent: 12,
-      processingContent: 3,
-      totalPlaylists: 4,
-      activePlaylists: 2,
-      totalImpressions: 0,
-      totalContentSize: 0,
-      uptimePercent: 0,
-    });
-
+  it('does not auto-refresh dashboard APIs on mount when the server snapshot is complete', async () => {
     await renderDashboardClient({
       initialContent: [{ id: 'c1' }],
       initialPlaylists: [{ id: 'p1', items: [{ id: 'item-1' }] }],
@@ -240,11 +228,20 @@ describe('DashboardClient', () => {
       },
       initialContentSampleReady: true,
       initialPlaylistsSampleReady: true,
+      initialStorageInfo: {
+        usedBytes: 512,
+        quotaBytes: 2048,
+        availableBytes: 1536,
+        usagePercent: 25,
+      },
+      initialSystemHealth: { status: 'ok' },
     });
 
-    expect(apiClient.getAnalyticsSummary).toHaveBeenCalledTimes(1);
+    expect(apiClient.getAnalyticsSummary).not.toHaveBeenCalled();
     expect(apiClient.getContent).not.toHaveBeenCalled();
     expect(apiClient.getPlaylists).not.toHaveBeenCalled();
+    expect(apiClient.getStorageInfo).not.toHaveBeenCalled();
+    expect(apiClient.get).not.toHaveBeenCalledWith('/health/ready');
     await waitFor(() => {
       expect(screen.getByText('Total Devices').parentElement?.parentElement).toHaveTextContent('2');
       expect(screen.getByText('Content Items').parentElement?.parentElement).toHaveTextContent('12');

--- a/web/src/app/dashboard/content/__tests__/content-page.test.tsx
+++ b/web/src/app/dashboard/content/__tests__/content-page.test.tsx
@@ -13,6 +13,7 @@ const mockUpdateContent = jest.fn();
 const mockUploadContent = jest.fn();
 const mockCreateContent = jest.fn();
 const mockUploadContentWithProgress = jest.fn();
+const mockGetStorageInfo = jest.fn();
 const mockGenerateThumbnail = jest.fn();
 const mockAddPlaylistItem = jest.fn();
 const mockValidateForm = jest.fn<Record<string, string>, [unknown, unknown]>(() => ({}));
@@ -32,6 +33,7 @@ jest.mock('@/lib/api', () => ({
     uploadContent: (...args: any[]) => mockUploadContent(...args),
     createContent: (...args: any[]) => mockCreateContent(...args),
     uploadContentWithProgress: (...args: any[]) => mockUploadContentWithProgress(...args),
+    getStorageInfo: (...args: any[]) => mockGetStorageInfo(...args),
     generateThumbnail: (...args: any[]) => mockGenerateThumbnail(...args),
     addPlaylistItem: (...args: any[]) => mockAddPlaylistItem(...args),
   },
@@ -289,6 +291,12 @@ describe('ContentClient', () => {
     mockUploadContent.mockResolvedValue({ id: 'new-1', title: 'New Content' });
     mockCreateContent.mockResolvedValue({ id: 'new-1', title: 'New Content' });
     mockUploadContentWithProgress.mockResolvedValue({ id: 'new-1', title: 'New Content' });
+    mockGetStorageInfo.mockResolvedValue({
+      usedBytes: 0,
+      quotaBytes: 1024 * 1024 * 1024,
+      availableBytes: 1024 * 1024 * 1024,
+      usagePercent: 0,
+    });
     mockGenerateThumbnail.mockResolvedValue({});
     mockAddPlaylistItem.mockResolvedValue({});
     mockValidateForm.mockReturnValue({});
@@ -1267,6 +1275,110 @@ describe('ContentClient', () => {
     expect(mockUploadContentWithProgress.mock.calls[0][0].type).toBe('image');
     expect(mockUploadContentWithProgress.mock.calls[0][0].file).toBe(imageFile);
     expect(mockCreateContent).not.toHaveBeenCalledWith(expect.objectContaining({ file: imageFile }));
+  });
+
+  it('does not start a queued single-file upload when storage quota is already exhausted', async () => {
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+    mockGetStorageInfo.mockResolvedValueOnce({
+      usedBytes: 100,
+      quotaBytes: 104,
+      availableBytes: 4,
+      usagePercent: 96,
+    });
+    render(<ContentClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    fireEvent.click(screen.getAllByText('Upload Content')[0]);
+    const imageFile = new File(['image-bytes'], 'too-large.png', { type: 'image/png' });
+
+    await act(async () => {
+      lastDropzoneOptions.onDrop([imageFile]);
+    });
+
+    fireEvent.click(screen.getByText('Upload 1 File'));
+
+    await waitFor(() => {
+      expect(mockGetStorageInfo).toHaveBeenCalledTimes(1);
+      expect(mockToast.error).toHaveBeenCalledWith(expect.stringContaining('Not enough storage'));
+    });
+    expect(mockUploadContentWithProgress).not.toHaveBeenCalled();
+  });
+
+  it('does not send queued file bytes when storage quota is zero', async () => {
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+    mockGetStorageInfo.mockResolvedValueOnce({
+      usedBytes: 0,
+      quotaBytes: 0,
+      availableBytes: 0,
+      usagePercent: 0,
+    });
+    render(<ContentClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    fireEvent.click(screen.getAllByText('Upload Content')[0]);
+    const imageFile = new File(['image-bytes'], 'zero-quota.png', { type: 'image/png' });
+
+    await act(async () => {
+      lastDropzoneOptions.onDrop([imageFile]);
+    });
+
+    const uploadButton = screen.getByText('Upload 1 File').closest('button');
+    fireEvent.click(uploadButton!);
+
+    await waitFor(() => {
+      expect(mockGetStorageInfo).toHaveBeenCalledTimes(1);
+      expect(mockToast.error).toHaveBeenCalledWith(expect.stringContaining('Not enough storage'));
+    });
+    expect(mockUploadContentWithProgress).not.toHaveBeenCalled();
+    expect(screen.getByText('Upload Queue (1 file)')).toBeInTheDocument();
+    expect(screen.getByText('zero-quota.png')).toBeInTheDocument();
+    expect(uploadButton).not.toBeDisabled();
+  });
+
+  it('does not start queued bulk upload when combined retryable bytes exceed storage quota', async () => {
+    mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+    mockGetStorageInfo.mockResolvedValueOnce({
+      usedBytes: 100,
+      quotaBytes: 110,
+      availableBytes: 10,
+      usagePercent: 91,
+    });
+    render(<ContentClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Welcome Banner')).toBeInTheDocument();
+    });
+    await waitForAuxiliaryRequestsToSettle();
+
+    fireEvent.click(screen.getAllByText('Upload Content')[0]);
+    const files = [
+      new File(['123456'], 'first.png', { type: 'image/png' }),
+      new File(['123456'], 'second.png', { type: 'image/png' }),
+    ];
+
+    await act(async () => {
+      lastDropzoneOptions.onDrop(files);
+    });
+
+    fireEvent.click(screen.getByText('Upload 2 Files'));
+
+    await waitFor(() => {
+      expect(mockGetStorageInfo).toHaveBeenCalledTimes(1);
+      expect(mockToast.error).toHaveBeenCalledWith(expect.stringContaining('Not enough storage'));
+    });
+    expect(mockUploadContentWithProgress).not.toHaveBeenCalled();
+    expect(screen.getByText('Upload Queue (2 files)')).toBeInTheDocument();
+    expect(screen.getByText('first.png')).toBeInTheDocument();
+    expect(screen.getByText('second.png')).toBeInTheDocument();
+    expect(screen.getByText('Upload 2 Files').closest('button')).not.toBeDisabled();
   });
 
   it('keeps queued files visible by blocking URL mode until the queue is cleared', async () => {

--- a/web/src/app/dashboard/content/page-client.tsx
+++ b/web/src/app/dashboard/content/page-client.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useDropzone, type FileRejection } from 'react-dropzone';
 import { apiClient } from '@/lib/api';
 import type { ContentListParams } from '@/lib/api/content';
+import type { StorageInfo } from '@/lib/api/organizations';
 import { fetchAllPaginated } from '@/lib/api/pagination';
 import { Content, Display, PlaylistSummary, ContentFolder } from '@/lib/types';
 import FolderTree from '@/components/FolderTree';
@@ -93,6 +94,28 @@ const getUploadButtonLabel = (queue: UploadQueueItem[]): string => {
  return `Retry ${failedCount} Failed`;
  }
  return `Upload ${retryableCount} File${retryableCount === 1 ? '' : 's'}`;
+};
+
+const formatUploadBytes = (bytes: number): string => {
+ if (bytes < 1024) return `${bytes} B`;
+ const units = ['KB', 'MB', 'GB', 'TB'];
+ let value = bytes / 1024;
+ let unitIndex = 0;
+ while (value >= 1024 && unitIndex < units.length - 1) {
+ value /= 1024;
+ unitIndex += 1;
+ }
+ return `${value.toFixed(value >= 10 ? 0 : 1)} ${units[unitIndex]}`;
+};
+
+const getStorageAvailableBytes = (storageInfo: StorageInfo): number => {
+ if (storageInfo.quotaBytes <= 0) {
+ return 0;
+ }
+ if (Number.isFinite(storageInfo.availableBytes)) {
+ return Math.max(0, storageInfo.availableBytes);
+ }
+ return Math.max(0, storageInfo.quotaBytes - storageInfo.usedBytes);
 };
 
 export default function ContentClient() {
@@ -510,28 +533,46 @@ export default function ContentClient() {
  await devicesLoadPromiseRef.current;
  };
 
- const ensurePlaylistsLoaded = async (forceRefresh = false) => {
+  const ensurePlaylistsLoaded = async (forceRefresh = false) => {
  if (!forceRefresh && playlistsLoadedRef.current) return;
  if (!playlistsLoadPromiseRef.current) {
  playlistsLoadPromiseRef.current = loadPlaylists().finally(() => {
  playlistsLoadPromiseRef.current = null;
  });
  }
- await playlistsLoadPromiseRef.current;
- };
+  await playlistsLoadPromiseRef.current;
+  };
 
- const handleBulkUpload = async () => {
- if (uploadQueue.length === 0) {
- toast.error('No files in queue');
- return;
- }
+  const hasUploadQuotaForBytes = async (bytes: number): Promise<boolean> => {
+  if (bytes <= 0) return true;
 
- setActionLoading(true);
- const uploadTargets = uploadQueue
- .map((item, index) => ({ item, index }))
- .filter(({ item }) => item.status !== 'success');
- const results: Array<'success' | 'error'> = [];
- let nextUploadIndex = 0;
+  try {
+  const storageInfo = await apiClient.getStorageInfo();
+  const availableBytes = getStorageAvailableBytes(storageInfo);
+  if (bytes <= availableBytes) return true;
+
+  toast.error(`Not enough storage for upload. Need ${formatUploadBytes(bytes)}, only ${formatUploadBytes(availableBytes)} available.`);
+  return false;
+  } catch (error) {
+  if (process.env.NODE_ENV === 'development') {
+  console.warn('Storage quota preflight failed; backend quota reservation will enforce the upload.', error);
+  }
+  return true;
+  }
+  };
+
+  const handleBulkUpload = async () => {
+  if (uploadQueue.length === 0) {
+  toast.error('No files in queue');
+  return;
+  }
+
+  setActionLoading(true);
+  const uploadTargets = uploadQueue
+  .map((item, index) => ({ item, index }))
+  .filter(({ item }) => item.status !== 'success');
+  const results: Array<'success' | 'error'> = [];
+  let nextUploadIndex = 0;
 
  const uploadOne = async (item: UploadQueueItem, index: number) => {
  setUploadQueue(prev => prev.map((q, idx) =>
@@ -568,12 +609,17 @@ export default function ContentClient() {
  nextUploadIndex += 1;
  await uploadOne(current.item, current.index);
  }
- };
+  };
 
- try {
- const workerCount = Math.min(
- getBulkUploadConcurrency(uploadTargets.map(({ item }) => item)),
- uploadTargets.length,
+  try {
+  const retryableBytes = uploadTargets.reduce((total, { item }) => total + item.file.size, 0);
+  if (!(await hasUploadQuotaForBytes(retryableBytes))) {
+  return;
+  }
+
+  const workerCount = Math.min(
+  getBulkUploadConcurrency(uploadTargets.map(({ item }) => item)),
+  uploadTargets.length,
  );
  await Promise.all(Array.from({ length: workerCount }, () => worker()));
  } finally {
@@ -637,16 +683,23 @@ export default function ContentClient() {
  const errors = validateForm(contentUploadSchema, uploadForm);
  setFormErrors(errors);
  
- if (Object.keys(errors).length > 0) {
- toast.error('Please fix the errors before submitting');
- return;
- }
+  if (Object.keys(errors).length > 0) {
+  toast.error('Please fix the errors before submitting');
+  return;
+  }
 
- try {
- setActionLoading(true);
- setUploadProgress(0);
+  try {
+  setActionLoading(true);
+  setUploadProgress(0);
 
- if (uploadForm.file && isFileUploadType(uploadForm.type)) {
+  if (uploadForm.file && isFileUploadType(uploadForm.type)) {
+  const hasQuota = await hasUploadQuotaForBytes(uploadForm.file.size);
+  if (!hasQuota) {
+  return;
+  }
+  }
+
+  if (uploadForm.file && isFileUploadType(uploadForm.type)) {
  // Use progress-tracking upload for file uploads
  await apiClient.uploadContentWithProgress(
  { title: uploadForm.title, type: uploadForm.type, file: uploadForm.file },

--- a/web/src/app/dashboard/page-client.tsx
+++ b/web/src/app/dashboard/page-client.tsx
@@ -217,6 +217,11 @@ export default function DashboardClient({
  const activityPlaylistsRef = useRef(initialPlaylists);
  const deviceStatusesRef = useRef(deviceStatuses);
  const initialRefreshCompleteRef = useRef(false);
+ const skipInitialAutoRefreshRef = useRef(!!initialStats
+  && initialContentSampleReady
+  && initialPlaylistsSampleReady
+  && !!initialStorageInfo
+  && !!initialSystemHealth);
  deviceStatusesRef.current = deviceStatuses;
 
  // Initialize stats from server-fetched data
@@ -244,8 +249,12 @@ export default function DashboardClient({
  }, [initialSystemHealth]);
 
  useEffect(() => {
- loadStats(false);
- }, []);
+  if (skipInitialAutoRefreshRef.current) {
+  initialRefreshCompleteRef.current = true;
+  return;
+  }
+  loadStats(false);
+  }, []);
 
  // Update device stats from context (real-time)
  useEffect(() => {


### PR DESCRIPTION
## Summary
- Skips the dashboard mount-time refresh when SSR already provided summary, activity samples, storage, and readiness.
- Adds browser-side storage quota preflight before single and queued content uploads, while keeping backend quota reservation authoritative.
- Keeps blocked upload queues visible and retryable, including zero-quota handling that matches backend semantics.

## Review
- Initial diff reviewers found nonpositive quota was incorrectly treated as unlimited.
- Fixed by treating nonpositive quota as zero available bytes.
- Follow-up reviewer returned CLEAN.

## Test Plan
- `pnpm --filter @vizora/web test -- --runInBand web/src/app/dashboard/__tests__/dashboard-page.test.tsx web/src/app/dashboard/content/__tests__/content-page.test.tsx` — 2 suites / 68 tests pass
- `pnpm --filter @vizora/web test -- --runInBand` — 103 suites / 1100 tests pass
- `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` — pass
- `ESLINT_USE_FLAT_CONFIG=false npx eslint web/src/app/dashboard/page-client.tsx web/src/app/dashboard/content/page-client.tsx web/src/app/dashboard/__tests__/dashboard-page.test.tsx web/src/app/dashboard/content/__tests__/content-page.test.tsx` — 0 errors, existing any warnings
- `pnpm security:no-hardcoded-jwts` — pass
- `git diff --check` — pass, CRLF warnings only
- `NODE_OPTIONS=--max-old-space-size=4096 NEXT_PUBLIC_SOCKET_URL=http://localhost:3002 NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1 BACKEND_URL=http://localhost:3000 pnpm --filter @vizora/web build` — pass

## Deploy
Not deployed. Production checkout remains dirty/diverged and readiness is degraded; automated deploy is blocked until prod-local state is reconciled.