### PR TITLE
fix: scope heartbeat and notification delivery

### DIFF
--- a/docs/plans/2026-06-02-backend-heartbeat-notifications-pass-46.md
+++ b/docs/plans/2026-06-02-backend-heartbeat-notifications-pass-46.md
@@ -1,0 +1,50 @@
+# Backend Heartbeat and Notification Scoping Pass 46
+
+**Date:** 2026-06-02
+
+**Branch:** `fix/backend-heartbeat-notifications-pass-46`
+
+**Goal:** Fix two customer-impact backend correctness gaps: REST device heartbeats should update by verified display id, and notification read/realtime surfaces should not expose or mutate another user's personal notifications.
+
+**New primitives introduced:** none. Reuse the existing device JWT verification helper, DisplaysService heartbeat path, Notification model, response envelope, `/api/v1` routing, and `@CurrentUser` identity extraction.
+
+**Hermes-first analysis:** checked per project convention. These are local middleware identity/tenant-boundary fixes, not business-agent, MCP, Hermes runtime, or AI/provider-spend tasks.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| REST display heartbeat identity semantics | none found | build in existing displays controller/service path |
+| Notification user visibility and mutation scoping | none found | build in existing notifications controller/service path |
+| Targeted realtime notification delivery | none found | build in existing Socket.IO org-room delivery path |
+
+Awesome-hermes-agent ecosystem check: no applicable skill/library primitive for NestJS route identity alignment, local Prisma notification filters, or Socket.IO room filtering; proceed with Vizora-native code.
+
+## Evidence Before Code
+
+- `middleware/src/modules/displays/displays.controller.ts` verifies the `:deviceId` route parameter as `expectedDisplayId` through `verifyCurrentDeviceToken`, whose payload `sub` is a display id and whose database lookup is `display.findUnique({ where: { id: payload.sub } })`.
+- The same controller passes that route parameter to `DisplaysService.updateHeartbeat()`.
+- `middleware/src/modules/displays/displays.service.ts` currently names the parameter `deviceIdentifier` and queries `where: { deviceIdentifier }`, so a normal display UUID route cannot update heartbeat unless it happens to equal the hardware identifier.
+- Heartbeat verification and write are separate operations; the write site must carry the verified organization id and token hash so disable/re-pair/token-rotation races cannot set stale devices back online.
+- `middleware/src/modules/notifications/notifications.controller.ts` currently passes only `organizationId` to list/count/read/dismiss methods.
+- `middleware/src/modules/notifications/notifications.service.ts` currently scopes `findAll`, `findOne`, and mutations only by `organizationId`; `getUnreadCount` filters dismissed rows but still lacks user visibility; `findAll` lacks a `dismissedAt: null` predicate before pagination.
+- `realtime/src/gateways/device.gateway.ts` currently emits all `notification:new` payloads to every socket in the org room, so user-targeted notifications can leak live even after REST scoping is fixed.
+
+## Plan
+
+- [ ] Add red display service coverage proving `updateHeartbeat(displayId)` queries and updates by display id even when the display's `deviceIdentifier` differs.
+- [ ] Add red display service coverage proving heartbeat writes re-check the verified org id, token hash, and enabled state at the update site.
+- [ ] Add red notification service coverage proving list/count/read/read-all/dismiss use `organizationId + currentUserId` visibility: org-wide rows (`userId: null`) plus the current user's rows only, with `dismissedAt: null` applied before pagination/mutation.
+- [ ] Add red notification controller coverage proving current user id is forwarded to service methods.
+- [ ] Add red realtime coverage proving `notification:new` with `userId` only emits to the matching dashboard socket.
+- [ ] Implement the minimal service/controller changes.
+- [ ] Implement targeted realtime delivery without changing org-wide notification broadcasts.
+- [ ] Run focused middleware tests for displays and notifications.
+- [ ] Run focused realtime gateway tests.
+- [ ] Run multi-vector subagent diff review for identity/security and runtime/regression risk.
+- [ ] Run broader middleware tests, TypeScript, lint on changed files, build, security check, and diff check.
+- [ ] Open PR, wait for CI, merge if green.
+- [ ] Recheck production deploy gate; deploy only if the dirty/diverged production checkout is made safe.
+
+## Residual Non-Goals
+
+- This pass does not add per-user read/dismiss state for org-wide notifications; those rows still have shared `read` and `dismissedAt` columns until a new per-user state table is designed.
+- This pass does not add content-search indexes, pairing-list Redis scan optimization, or CI/deploy health-route fixes. They remain queued next-pass candidates.

--- a/middleware/src/modules/displays/displays.controller.spec.ts
+++ b/middleware/src/modules/displays/displays.controller.spec.ts
@@ -180,7 +180,10 @@ describe('DisplaysController', () => {
       const result = await controller.heartbeat('device-123', mockReq as any);
 
       expect(result).toEqual(expectedResult);
-      expect(mockDisplaysService.updateHeartbeat).toHaveBeenCalledWith('device-123');
+      expect(mockDisplaysService.updateHeartbeat).toHaveBeenCalledWith('device-123', {
+        organizationId,
+        tokenHash: hashToken('valid-device-token'),
+      });
     });
 
     it('should reject a signed heartbeat token that is not the current stored token', async () => {

--- a/middleware/src/modules/displays/displays.controller.ts
+++ b/middleware/src/modules/displays/displays.controller.ts
@@ -9,7 +9,6 @@ import {
   Query,
   Req,
   UseGuards,
-  UnauthorizedException,
   ParseUUIDPipe,
   HttpCode,
   HttpStatus,
@@ -123,13 +122,16 @@ export class DisplaysController {
   @Post(':deviceId/heartbeat')
   @Public() // Bypass user JWT guard -- device JWT verified manually below
   async heartbeat(@Param('deviceId', ParseUUIDPipe) deviceId: string, @Req() req: Request) {
-    await verifyCurrentDeviceToken({
+    const verified = await verifyCurrentDeviceToken({
       jwtService: this.jwtService,
       databaseService: this.databaseService,
       token: getDeviceTokenFromRequest(req),
       expectedDisplayId: deviceId,
     });
-    return this.displaysService.updateHeartbeat(deviceId);
+    return this.displaysService.updateHeartbeat(verified.payload.sub, {
+      organizationId: verified.payload.organizationId,
+      tokenHash: verified.tokenHash,
+    });
   }
 
   @Delete(':id')

--- a/middleware/src/modules/displays/displays.service.spec.ts
+++ b/middleware/src/modules/displays/displays.service.spec.ts
@@ -3,6 +3,7 @@ import { JwtService } from '@nestjs/jwt';
 import { HttpService } from '@nestjs/axios';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { of } from 'rxjs';
+import { createHash } from 'node:crypto';
 import { DisplaysService } from './displays.service';
 import { DatabaseService } from '../database/database.service';
 import { CircuitBreakerService, CircuitState } from '../common/services/circuit-breaker.service';
@@ -24,6 +25,7 @@ describe('DisplaysService', () => {
   const mockOrganizationId = 'org-123';
   const mockDisplayId = 'display-123';
   const mockDeviceIdentifier = 'device-abc-123';
+  const mockDeviceTokenHash = createHash('sha256').update('valid-device-token').digest('hex');
 
   const mockDisplay = {
     id: mockDisplayId,
@@ -413,20 +415,35 @@ describe('DisplaysService', () => {
     it('should update display heartbeat and status to online', async () => {
       databaseService.display.findFirst.mockResolvedValue({
         id: mockDisplayId,
+        deviceIdentifier: mockDeviceIdentifier,
         status: 'online',
         nickname: 'Test Display',
         organizationId: mockOrganizationId,
       } as any);
       databaseService.display.updateMany.mockResolvedValue({ count: 1 });
 
-      const result = await service.updateHeartbeat(mockDeviceIdentifier);
+      const result = await service.updateHeartbeat(mockDisplayId, {
+        organizationId: mockOrganizationId,
+        tokenHash: mockDeviceTokenHash,
+      });
 
       expect(databaseService.display.findFirst).toHaveBeenCalledWith({
-        where: { deviceIdentifier: mockDeviceIdentifier },
-        select: { id: true, status: true, nickname: true, organizationId: true },
+        where: { id: mockDisplayId },
+        select: {
+          id: true,
+          deviceIdentifier: true,
+          status: true,
+          nickname: true,
+          organizationId: true,
+        },
       });
       expect(databaseService.display.updateMany).toHaveBeenCalledWith({
-        where: { deviceIdentifier: mockDeviceIdentifier },
+        where: {
+          id: mockDisplayId,
+          organizationId: mockOrganizationId,
+          isDisabled: false,
+          jwtToken: mockDeviceTokenHash,
+        },
         data: {
           lastHeartbeat: expect.any(Date),
           status: 'online',
@@ -438,13 +455,17 @@ describe('DisplaysService', () => {
     it('should emit device.online event on status transition from offline', async () => {
       databaseService.display.findFirst.mockResolvedValue({
         id: mockDisplayId,
+        deviceIdentifier: mockDeviceIdentifier,
         status: 'offline',
         nickname: 'Test Display',
         organizationId: mockOrganizationId,
       } as any);
       databaseService.display.updateMany.mockResolvedValue({ count: 1 });
 
-      await service.updateHeartbeat(mockDeviceIdentifier);
+      await service.updateHeartbeat(mockDisplayId, {
+        organizationId: mockOrganizationId,
+        tokenHash: mockDeviceTokenHash,
+      });
 
       const eventEmitter = (service as any).eventEmitter;
       expect(eventEmitter.emit).toHaveBeenCalledWith('device.online', {
@@ -457,13 +478,17 @@ describe('DisplaysService', () => {
     it('should not emit device.online event when already online', async () => {
       databaseService.display.findFirst.mockResolvedValue({
         id: mockDisplayId,
+        deviceIdentifier: mockDeviceIdentifier,
         status: 'online',
         nickname: 'Test Display',
         organizationId: mockOrganizationId,
       } as any);
       databaseService.display.updateMany.mockResolvedValue({ count: 1 });
 
-      await service.updateHeartbeat(mockDeviceIdentifier);
+      await service.updateHeartbeat(mockDisplayId, {
+        organizationId: mockOrganizationId,
+        tokenHash: mockDeviceTokenHash,
+      });
 
       const eventEmitter = (service as any).eventEmitter;
       expect(eventEmitter.emit).not.toHaveBeenCalledWith('device.online', expect.anything());
@@ -472,9 +497,45 @@ describe('DisplaysService', () => {
     it('should throw NotFoundException if device not found', async () => {
       databaseService.display.findFirst.mockResolvedValue(null);
 
-      await expect(service.updateHeartbeat('unknown-device')).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(
+        service.updateHeartbeat('unknown-display', {
+          organizationId: mockOrganizationId,
+          tokenHash: mockDeviceTokenHash,
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should reject if the verified device token is no longer current at write time', async () => {
+      databaseService.display.findFirst.mockResolvedValue({
+        id: mockDisplayId,
+        deviceIdentifier: mockDeviceIdentifier,
+        status: 'offline',
+        nickname: 'Test Display',
+        organizationId: mockOrganizationId,
+      } as any);
+      databaseService.display.updateMany.mockResolvedValue({ count: 0 });
+
+      await expect(
+        service.updateHeartbeat(mockDisplayId, {
+          organizationId: mockOrganizationId,
+          tokenHash: mockDeviceTokenHash,
+        }),
+      ).rejects.toThrow('Device is not authorized');
+
+      expect(databaseService.display.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: mockDisplayId,
+          organizationId: mockOrganizationId,
+          isDisabled: false,
+          jwtToken: mockDeviceTokenHash,
+        },
+        data: {
+          lastHeartbeat: expect.any(Date),
+          status: 'online',
+        },
+      });
+      const eventEmitter = (service as any).eventEmitter;
+      expect(eventEmitter.emit).not.toHaveBeenCalledWith('device.online', expect.anything());
     });
   });
 

--- a/middleware/src/modules/displays/displays.service.ts
+++ b/middleware/src/modules/displays/displays.service.ts
@@ -4,6 +4,7 @@ import {
   ConflictException,
   InternalServerErrorException,
   ServiceUnavailableException,
+  UnauthorizedException,
   Logger,
 } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
@@ -245,15 +246,20 @@ export class DisplaysService {
     );
   }
 
-  async updateHeartbeat(deviceIdentifier: string) {
-    // deviceIdentifier is @unique, and device JWT identity is verified by the controller.
-    // Defense-in-depth: using updateMany with deviceIdentifier ensures no cross-tenant writes
-    // since deviceIdentifier is globally unique (tied to hardware MAC/ID).
-
+  async updateHeartbeat(
+    displayId: string,
+    verifiedDevice: { organizationId: string; tokenHash: string },
+  ) {
     // Check previous status to detect online transition (avoid notification spam on every heartbeat)
     const display = await this.db.display.findFirst({
-      where: { deviceIdentifier },
-      select: { id: true, status: true, nickname: true, organizationId: true },
+      where: { id: displayId },
+      select: {
+        id: true,
+        deviceIdentifier: true,
+        status: true,
+        nickname: true,
+        organizationId: true,
+      },
     });
     if (!display) {
       throw new NotFoundException('Device not found');
@@ -262,21 +268,26 @@ export class DisplaysService {
     const wasOffline = display.status !== 'online';
 
     const result = await this.db.display.updateMany({
-      where: { deviceIdentifier },
+      where: {
+        id: displayId,
+        organizationId: verifiedDevice.organizationId,
+        isDisabled: false,
+        jwtToken: verifiedDevice.tokenHash,
+      },
       data: {
         lastHeartbeat: new Date(),
         status: 'online',
       },
     });
     if (result.count === 0) {
-      throw new NotFoundException('Device not found');
+      throw new UnauthorizedException('Device is not authorized');
     }
 
     // Emit device.online only on status transition (not every heartbeat)
     if (wasOffline) {
       this.eventEmitter.emit('device.online', {
         deviceId: display.id,
-        deviceName: display.nickname || deviceIdentifier,
+        deviceName: display.nickname || display.deviceIdentifier,
         organizationId: display.organizationId,
       });
     }

--- a/middleware/src/modules/notifications/notifications.controller.spec.ts
+++ b/middleware/src/modules/notifications/notifications.controller.spec.ts
@@ -8,6 +8,7 @@ describe('NotificationsController', () => {
   let mockNotificationsService: jest.Mocked<NotificationsService>;
 
   const organizationId = 'org-123';
+  const userId = 'user-123';
 
   const mockNotification = {
     id: 'notif-1',
@@ -107,11 +108,12 @@ describe('NotificationsController', () => {
       mockNotificationsService.findAll.mockResolvedValue(expectedResult as any);
 
       const query = { page: 1, limit: 20 } as any;
-      const result = await controller.findAll(organizationId, query);
+      const result = await (controller as any).findAll(organizationId, userId, query);
 
       expect(result).toEqual(expectedResult);
       expect(mockNotificationsService.findAll).toHaveBeenCalledWith(
         organizationId,
+        userId,
         {},
         { page: 1, limit: 20 },
       );
@@ -121,10 +123,11 @@ describe('NotificationsController', () => {
       mockNotificationsService.findAll.mockResolvedValue({ data: [], meta: {} } as any);
 
       const query = { page: 1, limit: 20, read: 'true' } as any;
-      await controller.findAll(organizationId, query);
+      await (controller as any).findAll(organizationId, userId, query);
 
       expect(mockNotificationsService.findAll).toHaveBeenCalledWith(
         organizationId,
+        userId,
         { read: true },
         { page: 1, limit: 20 },
       );
@@ -134,10 +137,11 @@ describe('NotificationsController', () => {
       mockNotificationsService.findAll.mockResolvedValue({ data: [], meta: {} } as any);
 
       const query = { page: 1, limit: 20, read: 'false' } as any;
-      await controller.findAll(organizationId, query);
+      await (controller as any).findAll(organizationId, userId, query);
 
       expect(mockNotificationsService.findAll).toHaveBeenCalledWith(
         organizationId,
+        userId,
         { read: false },
         { page: 1, limit: 20 },
       );
@@ -147,10 +151,11 @@ describe('NotificationsController', () => {
       mockNotificationsService.findAll.mockResolvedValue({ data: [], meta: {} } as any);
 
       const query = { page: 1, limit: 20, severity: 'warning' } as any;
-      await controller.findAll(organizationId, query);
+      await (controller as any).findAll(organizationId, userId, query);
 
       expect(mockNotificationsService.findAll).toHaveBeenCalledWith(
         organizationId,
+        userId,
         { severity: 'warning' },
         { page: 1, limit: 20 },
       );
@@ -160,10 +165,11 @@ describe('NotificationsController', () => {
       mockNotificationsService.findAll.mockResolvedValue({ data: [], meta: {} } as any);
 
       const query = { page: 1, limit: 20, read: 'false', severity: 'critical' } as any;
-      await controller.findAll(organizationId, query);
+      await (controller as any).findAll(organizationId, userId, query);
 
       expect(mockNotificationsService.findAll).toHaveBeenCalledWith(
         organizationId,
+        userId,
         { read: false, severity: 'critical' },
         { page: 1, limit: 20 },
       );
@@ -177,7 +183,7 @@ describe('NotificationsController', () => {
       mockNotificationsService.findAll.mockResolvedValue(expectedResult as any);
 
       const query = { page: 1, limit: 20 } as any;
-      const result = await controller.findAll(organizationId, query);
+      const result = await (controller as any).findAll(organizationId, userId, query);
 
       expect(result).toEqual(expectedResult);
     });
@@ -187,16 +193,19 @@ describe('NotificationsController', () => {
     it('should return unread count', async () => {
       mockNotificationsService.getUnreadCount.mockResolvedValue(5);
 
-      const result = await controller.getUnreadCount(organizationId);
+      const result = await (controller as any).getUnreadCount(organizationId, userId);
 
       expect(result).toEqual({ count: 5 });
-      expect(mockNotificationsService.getUnreadCount).toHaveBeenCalledWith(organizationId);
+      expect(mockNotificationsService.getUnreadCount).toHaveBeenCalledWith(
+        organizationId,
+        userId,
+      );
     });
 
     it('should return zero when no unread notifications', async () => {
       mockNotificationsService.getUnreadCount.mockResolvedValue(0);
 
-      const result = await controller.getUnreadCount(organizationId);
+      const result = await (controller as any).getUnreadCount(organizationId, userId);
 
       expect(result).toEqual({ count: 0 });
     });
@@ -206,16 +215,19 @@ describe('NotificationsController', () => {
     it('should mark all notifications as read', async () => {
       mockNotificationsService.markAllAsRead.mockResolvedValue({ updated: 10 });
 
-      const result = await controller.markAllAsRead(organizationId);
+      const result = await (controller as any).markAllAsRead(organizationId, userId);
 
       expect(result).toEqual({ updated: 10 });
-      expect(mockNotificationsService.markAllAsRead).toHaveBeenCalledWith(organizationId);
+      expect(mockNotificationsService.markAllAsRead).toHaveBeenCalledWith(
+        organizationId,
+        userId,
+      );
     });
 
     it('should return 0 when no unread notifications', async () => {
       mockNotificationsService.markAllAsRead.mockResolvedValue({ updated: 0 });
 
-      const result = await controller.markAllAsRead(organizationId);
+      const result = await (controller as any).markAllAsRead(organizationId, userId);
 
       expect(result).toEqual({ updated: 0 });
     });
@@ -228,11 +240,12 @@ describe('NotificationsController', () => {
         read: true,
       } as any);
 
-      const result = await controller.markAsRead(organizationId, 'notif-1');
+      const result = await (controller as any).markAsRead(organizationId, userId, 'notif-1');
 
       expect(result.read).toBe(true);
       expect(mockNotificationsService.markAsRead).toHaveBeenCalledWith(
         organizationId,
+        userId,
         'notif-1',
       );
     });
@@ -241,7 +254,7 @@ describe('NotificationsController', () => {
       mockNotificationsService.markAsRead.mockRejectedValue(new NotFoundException());
 
       await expect(
-        controller.markAsRead(organizationId, 'nonexistent'),
+        (controller as any).markAsRead(organizationId, userId, 'nonexistent'),
       ).rejects.toThrow(NotFoundException);
     });
   });
@@ -254,11 +267,12 @@ describe('NotificationsController', () => {
         dismissedAt,
       } as any);
 
-      const result = await controller.dismiss(organizationId, 'notif-1');
+      const result = await (controller as any).dismiss(organizationId, userId, 'notif-1');
 
       expect(result.dismissedAt).toEqual(dismissedAt);
       expect(mockNotificationsService.dismiss).toHaveBeenCalledWith(
         organizationId,
+        userId,
         'notif-1',
       );
     });
@@ -267,7 +281,7 @@ describe('NotificationsController', () => {
       mockNotificationsService.dismiss.mockRejectedValue(new NotFoundException());
 
       await expect(
-        controller.dismiss(organizationId, 'nonexistent'),
+        (controller as any).dismiss(organizationId, userId, 'nonexistent'),
       ).rejects.toThrow(NotFoundException);
     });
   });

--- a/middleware/src/modules/notifications/notifications.controller.ts
+++ b/middleware/src/modules/notifications/notifications.controller.ts
@@ -44,6 +44,7 @@ export class NotificationsController {
   @Get()
   findAll(
     @CurrentUser('organizationId') organizationId: string,
+    @CurrentUser('id') userId: string,
     @Query() query: NotificationQueryDto,
   ) {
     // Parse read filter
@@ -57,7 +58,7 @@ export class NotificationsController {
       filters.severity = query.severity;
     }
 
-    return this.notificationsService.findAll(organizationId, filters, {
+    return this.notificationsService.findAll(organizationId, userId, filters, {
       page: query.page,
       limit: query.limit,
     });
@@ -67,8 +68,11 @@ export class NotificationsController {
    * Get unread notification count
    */
   @Get('unread-count')
-  async getUnreadCount(@CurrentUser('organizationId') organizationId: string) {
-    const count = await this.notificationsService.getUnreadCount(organizationId);
+  async getUnreadCount(
+    @CurrentUser('organizationId') organizationId: string,
+    @CurrentUser('id') userId: string,
+  ) {
+    const count = await this.notificationsService.getUnreadCount(organizationId, userId);
     return { count };
   }
 
@@ -77,8 +81,11 @@ export class NotificationsController {
    */
   @Post('read-all')
   @HttpCode(HttpStatus.OK)
-  markAllAsRead(@CurrentUser('organizationId') organizationId: string) {
-    return this.notificationsService.markAllAsRead(organizationId);
+  markAllAsRead(
+    @CurrentUser('organizationId') organizationId: string,
+    @CurrentUser('id') userId: string,
+  ) {
+    return this.notificationsService.markAllAsRead(organizationId, userId);
   }
 
   /**
@@ -87,9 +94,10 @@ export class NotificationsController {
   @Patch(':id/read')
   markAsRead(
     @CurrentUser('organizationId') organizationId: string,
+    @CurrentUser('id') userId: string,
     @Param('id', ParseIdPipe) id: string,
   ) {
-    return this.notificationsService.markAsRead(organizationId, id);
+    return this.notificationsService.markAsRead(organizationId, userId, id);
   }
 
   /**
@@ -98,8 +106,9 @@ export class NotificationsController {
   @Patch(':id/dismiss')
   dismiss(
     @CurrentUser('organizationId') organizationId: string,
+    @CurrentUser('id') userId: string,
     @Param('id', ParseIdPipe) id: string,
   ) {
-    return this.notificationsService.dismiss(organizationId, id);
+    return this.notificationsService.dismiss(organizationId, userId, id);
   }
 }

--- a/middleware/src/modules/notifications/notifications.service.spec.ts
+++ b/middleware/src/modules/notifications/notifications.service.spec.ts
@@ -9,6 +9,18 @@ describe('NotificationsService', () => {
   let mockHttpService: any;
 
   const organizationId = 'org-123';
+  const userId = 'user-123';
+  const visibleNotificationWhere = (extra: Record<string, unknown> = {}) => ({
+    organizationId,
+    dismissedAt: null,
+    OR: [{ userId: null }, { userId }],
+    ...extra,
+  });
+  const scopedNotificationWhere = (extra: Record<string, unknown> = {}) => ({
+    organizationId,
+    OR: [{ userId: null }, { userId }],
+    ...extra,
+  });
 
   const mockNotification = {
     id: 'notif-1',
@@ -211,7 +223,12 @@ describe('NotificationsService', () => {
       db.notification.findMany.mockResolvedValue([mockNotification]);
       db.notification.count.mockResolvedValue(1);
 
-      const result = await service.findAll(organizationId, {}, { page: 1, limit: 10 });
+      const result = await (service as any).findAll(
+        organizationId,
+        userId,
+        {},
+        { page: 1, limit: 10 },
+      );
 
       expect(result.data).toEqual([mockNotification]);
       expect(result.meta.total).toBe(1);
@@ -223,24 +240,51 @@ describe('NotificationsService', () => {
       db.notification.findMany.mockResolvedValue([]);
       db.notification.count.mockResolvedValue(0);
 
-      await service.findAll(organizationId, { read: false }, { page: 1, limit: 10 });
+      await (service as any).findAll(
+        organizationId,
+        userId,
+        { read: false },
+        { page: 1, limit: 10 },
+      );
 
       expect(db.notification.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { organizationId, read: false },
+          where: visibleNotificationWhere({ read: false }),
         }),
       );
+    });
+
+    it('should filter dismissed notifications before pagination and hide other users personal rows', async () => {
+      db.notification.findMany.mockResolvedValue([]);
+      db.notification.count.mockResolvedValue(0);
+
+      await (service as any).findAll(organizationId, userId, {}, { page: 2, limit: 5 });
+
+      const expectedWhere = visibleNotificationWhere();
+      expect(db.notification.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expectedWhere,
+          skip: 5,
+          take: 5,
+        }),
+      );
+      expect(db.notification.count).toHaveBeenCalledWith({ where: expectedWhere });
     });
 
     it('should filter by severity', async () => {
       db.notification.findMany.mockResolvedValue([]);
       db.notification.count.mockResolvedValue(0);
 
-      await service.findAll(organizationId, { severity: 'warning' }, { page: 1, limit: 10 });
+      await (service as any).findAll(
+        organizationId,
+        userId,
+        { severity: 'warning' },
+        { page: 1, limit: 10 },
+      );
 
       expect(db.notification.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { organizationId, severity: 'warning' },
+          where: visibleNotificationWhere({ severity: 'warning' }),
         }),
       );
     });
@@ -249,11 +293,16 @@ describe('NotificationsService', () => {
       db.notification.findMany.mockResolvedValue([]);
       db.notification.count.mockResolvedValue(0);
 
-      await service.findAll(organizationId, { severity: 'invalid' }, { page: 1, limit: 10 });
+      await (service as any).findAll(
+        organizationId,
+        userId,
+        { severity: 'invalid' },
+        { page: 1, limit: 10 },
+      );
 
       expect(db.notification.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { organizationId },
+          where: visibleNotificationWhere(),
         }),
       );
     });
@@ -262,7 +311,7 @@ describe('NotificationsService', () => {
       db.notification.findMany.mockResolvedValue([]);
       db.notification.count.mockResolvedValue(0);
 
-      await service.findAll(organizationId, {});
+      await (service as any).findAll(organizationId, userId, {});
 
       expect(db.notification.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -276,7 +325,7 @@ describe('NotificationsService', () => {
       db.notification.findMany.mockResolvedValue([]);
       db.notification.count.mockResolvedValue(0);
 
-      await service.findAll(organizationId, {}, { page: 3, limit: 5 });
+      await (service as any).findAll(organizationId, userId, {}, { page: 3, limit: 5 });
 
       expect(db.notification.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -290,11 +339,14 @@ describe('NotificationsService', () => {
       db.notification.findMany.mockResolvedValue([]);
       db.notification.count.mockResolvedValue(0);
 
-      await service.findAll(organizationId, { read: true, severity: 'critical' });
+      await (service as any).findAll(organizationId, userId, {
+        read: true,
+        severity: 'critical',
+      });
 
       expect(db.notification.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { organizationId, read: true, severity: 'critical' },
+          where: visibleNotificationWhere({ read: true, severity: 'critical' }),
         }),
       );
     });
@@ -303,7 +355,7 @@ describe('NotificationsService', () => {
       db.notification.findMany.mockResolvedValue([]);
       db.notification.count.mockResolvedValue(0);
 
-      await service.findAll(organizationId);
+      await (service as any).findAll(organizationId, userId);
 
       expect(db.notification.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -317,18 +369,18 @@ describe('NotificationsService', () => {
     it('should return a notification by id', async () => {
       db.notification.findFirst.mockResolvedValue(mockNotification);
 
-      const result = await service.findOne(organizationId, 'notif-1');
+      const result = await (service as any).findOne(organizationId, userId, 'notif-1');
 
       expect(result).toEqual(mockNotification);
       expect(db.notification.findFirst).toHaveBeenCalledWith({
-        where: { id: 'notif-1', organizationId },
+        where: visibleNotificationWhere({ id: 'notif-1' }),
       });
     });
 
     it('should throw NotFoundException when notification not found', async () => {
       db.notification.findFirst.mockResolvedValue(null);
 
-      await expect(service.findOne(organizationId, 'nonexistent')).rejects.toThrow(
+      await expect((service as any).findOne(organizationId, userId, 'nonexistent')).rejects.toThrow(
         NotFoundException,
       );
     });
@@ -338,22 +390,18 @@ describe('NotificationsService', () => {
     it('should return count of unread notifications', async () => {
       db.notification.count.mockResolvedValue(5);
 
-      const result = await service.getUnreadCount(organizationId);
+      const result = await (service as any).getUnreadCount(organizationId, userId);
 
       expect(result).toBe(5);
       expect(db.notification.count).toHaveBeenCalledWith({
-        where: {
-          organizationId,
-          read: false,
-          dismissedAt: null,
-        },
+        where: visibleNotificationWhere({ read: false }),
       });
     });
 
     it('should return 0 when no unread notifications', async () => {
       db.notification.count.mockResolvedValue(0);
 
-      const result = await service.getUnreadCount(organizationId);
+      const result = await (service as any).getUnreadCount(organizationId, userId);
 
       expect(result).toBe(0);
     });
@@ -361,24 +409,27 @@ describe('NotificationsService', () => {
 
   describe('markAsRead', () => {
     it('should mark a notification as read', async () => {
-      db.notification.findFirst.mockResolvedValue(mockNotification);
-      db.notification.update.mockResolvedValue({ ...mockNotification, read: true });
+      db.notification.updateMany.mockResolvedValue({ count: 1 });
+      db.notification.findFirst.mockResolvedValue({ ...mockNotification, read: true });
 
-      const result = await service.markAsRead(organizationId, 'notif-1');
+      const result = await (service as any).markAsRead(organizationId, userId, 'notif-1');
 
       expect(result.read).toBe(true);
-      expect(db.notification.update).toHaveBeenCalledWith({
-        where: { id: 'notif-1' },
+      expect(db.notification.findFirst).toHaveBeenCalledWith({
+        where: visibleNotificationWhere({ id: 'notif-1' }),
+      });
+      expect(db.notification.updateMany).toHaveBeenCalledWith({
+        where: visibleNotificationWhere({ id: 'notif-1' }),
         data: { read: true },
       });
     });
 
     it('should throw NotFoundException for nonexistent notification', async () => {
-      db.notification.findFirst.mockResolvedValue(null);
+      db.notification.updateMany.mockResolvedValue({ count: 0 });
 
-      await expect(service.markAsRead(organizationId, 'nonexistent')).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(
+        (service as any).markAsRead(organizationId, userId, 'nonexistent'),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 
@@ -386,11 +437,11 @@ describe('NotificationsService', () => {
     it('should mark all unread notifications as read', async () => {
       db.notification.updateMany.mockResolvedValue({ count: 10 });
 
-      const result = await service.markAllAsRead(organizationId);
+      const result = await (service as any).markAllAsRead(organizationId, userId);
 
       expect(result.updated).toBe(10);
       expect(db.notification.updateMany).toHaveBeenCalledWith({
-        where: { organizationId, read: false },
+        where: visibleNotificationWhere({ read: false }),
         data: { read: true },
       });
     });
@@ -398,7 +449,7 @@ describe('NotificationsService', () => {
     it('should return 0 when no unread notifications', async () => {
       db.notification.updateMany.mockResolvedValue({ count: 0 });
 
-      const result = await service.markAllAsRead(organizationId);
+      const result = await (service as any).markAllAsRead(organizationId, userId);
 
       expect(result.updated).toBe(0);
     });
@@ -407,24 +458,27 @@ describe('NotificationsService', () => {
   describe('dismiss', () => {
     it('should dismiss a notification', async () => {
       const dismissedAt = new Date();
-      db.notification.findFirst.mockResolvedValue(mockNotification);
-      db.notification.update.mockResolvedValue({ ...mockNotification, dismissedAt });
+      db.notification.updateMany.mockResolvedValue({ count: 1 });
+      db.notification.findFirst.mockResolvedValue({ ...mockNotification, dismissedAt });
 
-      const result = await service.dismiss(organizationId, 'notif-1');
+      const result = await (service as any).dismiss(organizationId, userId, 'notif-1');
 
       expect(result.dismissedAt).toBeDefined();
-      expect(db.notification.update).toHaveBeenCalledWith({
-        where: { id: 'notif-1' },
+      expect(db.notification.findFirst).toHaveBeenCalledWith({
+        where: scopedNotificationWhere({ id: 'notif-1' }),
+      });
+      expect(db.notification.updateMany).toHaveBeenCalledWith({
+        where: visibleNotificationWhere({ id: 'notif-1' }),
         data: { dismissedAt: expect.any(Date) },
       });
     });
 
     it('should throw NotFoundException for nonexistent notification', async () => {
-      db.notification.findFirst.mockResolvedValue(null);
+      db.notification.updateMany.mockResolvedValue({ count: 0 });
 
-      await expect(service.dismiss(organizationId, 'nonexistent')).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(
+        (service as any).dismiss(organizationId, userId, 'nonexistent'),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 

--- a/middleware/src/modules/notifications/notifications.service.ts
+++ b/middleware/src/modules/notifications/notifications.service.ts
@@ -21,6 +21,31 @@ export class NotificationsService {
     private readonly httpService: HttpService,
   ) {}
 
+  private visibleToUserWhere(
+    organizationId: string,
+    userId: string,
+    extra?: Prisma.NotificationWhereInput,
+  ): Prisma.NotificationWhereInput {
+    return {
+      organizationId,
+      dismissedAt: null,
+      OR: [{ userId: null }, { userId }],
+      ...extra,
+    };
+  }
+
+  private userScopedWhere(
+    organizationId: string,
+    userId: string,
+    extra?: Prisma.NotificationWhereInput,
+  ): Prisma.NotificationWhereInput {
+    return {
+      organizationId,
+      OR: [{ userId: null }, { userId }],
+      ...extra,
+    };
+  }
+
   /**
    * Create a new notification
    */
@@ -60,6 +85,7 @@ export class NotificationsService {
    */
   async findAll(
     organizationId: string,
+    userId: string,
     filters?: NotificationFilters,
     pagination?: PaginationDto,
   ) {
@@ -67,7 +93,10 @@ export class NotificationsService {
     const skip = (page - 1) * limit;
 
     // Build where clause with validated filters
-    const where: Prisma.NotificationWhereInput = { organizationId };
+    const where: Prisma.NotificationWhereInput = this.visibleToUserWhere(
+      organizationId,
+      userId,
+    );
 
     if (filters?.read !== undefined) {
       where.read = filters.read;
@@ -95,9 +124,9 @@ export class NotificationsService {
   /**
    * Get a single notification by ID
    */
-  async findOne(organizationId: string, id: string) {
+  async findOne(organizationId: string, userId: string, id: string) {
     const notification = await this.db.notification.findFirst({
-      where: { id, organizationId },
+      where: this.visibleToUserWhere(organizationId, userId, { id }),
     });
 
     if (!notification) {
@@ -110,26 +139,30 @@ export class NotificationsService {
   /**
    * Get the count of unread notifications for an organization
    */
-  async getUnreadCount(organizationId: string): Promise<number> {
+  async getUnreadCount(organizationId: string, userId: string): Promise<number> {
     return this.db.notification.count({
-      where: {
-        organizationId,
-        read: false,
-        dismissedAt: null,
-      },
+      where: this.visibleToUserWhere(organizationId, userId, { read: false }),
     });
   }
 
   /**
    * Mark a single notification as read
    */
-  async markAsRead(organizationId: string, id: string) {
-    await this.findOne(organizationId, id);
-
-    const notification = await this.db.notification.update({
-      where: { id },
+  async markAsRead(organizationId: string, userId: string, id: string) {
+    const result = await this.db.notification.updateMany({
+      where: this.visibleToUserWhere(organizationId, userId, { id }),
       data: { read: true },
     });
+    if (result.count === 0) {
+      throw new NotFoundException('Notification not found');
+    }
+
+    const notification = await this.db.notification.findFirst({
+      where: this.visibleToUserWhere(organizationId, userId, { id }),
+    });
+    if (!notification) {
+      throw new NotFoundException('Notification not found');
+    }
 
     this.logger.log(`Marked notification ${id} as read`);
     return notification;
@@ -138,9 +171,9 @@ export class NotificationsService {
   /**
    * Mark all notifications as read for an organization
    */
-  async markAllAsRead(organizationId: string) {
+  async markAllAsRead(organizationId: string, userId: string) {
     const result = await this.db.notification.updateMany({
-      where: { organizationId, read: false },
+      where: this.visibleToUserWhere(organizationId, userId, { read: false }),
       data: { read: true },
     });
 
@@ -151,13 +184,21 @@ export class NotificationsService {
   /**
    * Dismiss a notification (soft delete)
    */
-  async dismiss(organizationId: string, id: string) {
-    await this.findOne(organizationId, id);
-
-    const notification = await this.db.notification.update({
-      where: { id },
+  async dismiss(organizationId: string, userId: string, id: string) {
+    const result = await this.db.notification.updateMany({
+      where: this.visibleToUserWhere(organizationId, userId, { id }),
       data: { dismissedAt: new Date() },
     });
+    if (result.count === 0) {
+      throw new NotFoundException('Notification not found');
+    }
+
+    const notification = await this.db.notification.findFirst({
+      where: this.userScopedWhere(organizationId, userId, { id }),
+    });
+    if (!notification) {
+      throw new NotFoundException('Notification not found');
+    }
 
     this.logger.log(`Dismissed notification ${id}`);
     return notification;

--- a/realtime/src/gateways/device.gateway.spec.ts
+++ b/realtime/src/gateways/device.gateway.spec.ts
@@ -1821,6 +1821,47 @@ describe('DeviceGateway', () => {
         }),
       );
     });
+
+    it('should emit targeted notification events only to the matching dashboard user', async () => {
+      const targetDashboardSocket = {
+        id: 'dashboard-target',
+        data: { isDashboard: true, userId: 'user-1', organizationId: 'org-1' },
+        emit: jest.fn(),
+      };
+      const siblingDashboardSocket = {
+        id: 'dashboard-sibling',
+        data: { isDashboard: true, userId: 'user-2', organizationId: 'org-1' },
+        emit: jest.fn(),
+      };
+      const deviceSocket = createDeliverySocket('device-socket');
+      mockServer.in.mockReturnValueOnce({
+        fetchSockets: jest.fn().mockResolvedValue([
+          targetDashboardSocket,
+          siblingDashboardSocket,
+          deviceSocket,
+        ]),
+      });
+
+      await gateway.broadcastToOrganization('org-1', 'notification:new', {
+        id: 'notif-1',
+        title: 'Personal alert',
+        userId: 'user-1',
+      });
+
+      expect(targetDashboardSocket.emit).toHaveBeenCalledWith(
+        'notification:new',
+        expect.objectContaining({
+          id: 'notif-1',
+          userId: 'user-1',
+          timestamp: expect.any(String),
+        }),
+      );
+      expect(siblingDashboardSocket.emit).not.toHaveBeenCalled();
+      expect(deviceSocket.emit).not.toHaveBeenCalledWith(
+        'notification:new',
+        expect.objectContaining({ id: 'notif-1' }),
+      );
+    });
   });
 
   describe('handleJoinOrganization', () => {

--- a/realtime/src/gateways/device.gateway.ts
+++ b/realtime/src/gateways/device.gateway.ts
@@ -264,6 +264,11 @@ export class DeviceGateway
   ): Promise<number> {
     const allSockets = await this.server.in(`org:${organizationId}`).fetchSockets();
     let emitted = 0;
+    const targetedNotificationUserId = event === 'notification:new' &&
+      typeof data.userId === 'string' &&
+      data.userId.trim() !== ''
+      ? data.userId
+      : null;
 
     for (const socket of allSockets as Array<{
       id?: string;
@@ -276,8 +281,18 @@ export class DeviceGateway
       }
 
       if (this.isDashboardSocket(socket)) {
+        if (
+          targetedNotificationUserId &&
+          socket.data?.userId !== targetedNotificationUserId
+        ) {
+          continue;
+        }
         socket.emit?.(event, data);
         emitted += 1;
+        continue;
+      }
+
+      if (targetedNotificationUserId) {
         continue;
       }
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,8 +1,124 @@
 # Vizora - Task Tracker
 
-## Active Workstream: Dashboard Upload Preflight Pass 45 (2026-06-02)
+## Active Workstream: Backend Heartbeat and Notification Scoping Pass 46 (2026-06-02)
+
+**Branch:** `fix/backend-heartbeat-notifications-pass-46`
+
+**Why now:** Pass 45 is merged and deployment remains blocked by dirty/diverged
+production state. The highest-value buildable backend defects from the
+customer-readiness review are both local, testable, and customer-visible:
+device REST heartbeats can miss the row because the controller verifies a
+display id while the service queries by `deviceIdentifier`, personal
+notifications are not scoped to the current user on list/count/read/dismiss
+paths, and targeted `notification:new` events can still leak live through the
+realtime org room.
+
+**New primitives introduced:** none. Reuse existing device JWT verification,
+DisplaysService heartbeat status-transition behavior, NotificationsService,
+Notification model, response envelope, and `/api/v1` routing.
+
+**Hermes-first analysis:** checked per project convention. These are local
+middleware identity/tenant-boundary fixes, not business-agent, MCP, Hermes
+runtime, or AI/provider-spend tasks.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| REST display heartbeat identity semantics | none found | build in existing displays controller/service path |
+| Notification user visibility and mutation scoping | none found | build in existing notifications controller/service path |
+| Targeted realtime notification delivery | none found | build in existing Socket.IO org-room delivery path |
+
+Awesome-hermes-agent ecosystem check: no applicable skill/library primitive for
+NestJS route identity alignment, local Prisma notification filters, or
+Socket.IO room filtering; proceed with Vizora-native code.
+
+**Plan/design:**
+`docs/plans/2026-06-02-backend-heartbeat-notifications-pass-46.md`
+
+**Plan**
+- [x] Add red display service coverage for id/deviceIdentifier mismatch.
+- [x] Add red display service coverage for verified-token write-site races.
+- [x] Add red notification service coverage for user visibility and dismissed
+  filtering before pagination/mutation.
+- [x] Add red notification controller coverage for forwarding current user id.
+- [x] Implement heartbeat id alignment and notification user scoping.
+- [x] Add red realtime coverage for targeted notification delivery.
+- [x] Implement targeted realtime delivery.
+- [x] Run focused middleware/realtime tests.
+- [ ] Run multi-vector subagent diff review.
+- [ ] Run broader middleware/realtime verification and build.
+- [ ] PR, CI, merge if green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Evidence so far**
+- Red middleware verification:
+  `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/displays/displays.service.spec.ts middleware/src/modules/displays/displays.controller.spec.ts middleware/src/modules/notifications/notifications.service.spec.ts middleware/src/modules/notifications/notifications.controller.spec.ts`
+  failed as expected because heartbeat still queried `deviceIdentifier` and
+  notification methods still treated the new `userId` argument as the old
+  filters/id argument.
+- Focused middleware green verification: same command passed 4 suites / 118
+  tests after implementation.
+- Red realtime verification:
+  `pnpm --filter @vizora/realtime test -- --runInBand realtime/src/gateways/device.gateway.spec.ts`
+  failed as expected because sibling dashboard sockets received targeted
+  `notification:new` events.
+- Focused realtime green verification: same command passed 1 suite / 103 tests
+  after targeted delivery filtering.
+- Security review finding fixed: reviewer identified that heartbeat verification
+  and heartbeat update were separate database operations. The controller now
+  passes the verified device `organizationId` and token hash into
+  `DisplaysService.updateHeartbeat()`, and the service update predicate includes
+  `id`, `organizationId`, `isDisabled: false`, and `jwtToken`. If that predicate
+  no longer matches, the service rejects the heartbeat and does not emit
+  `device.online`.
+- Review-fix verification:
+  `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/displays/displays.service.spec.ts middleware/src/modules/displays/displays.controller.spec.ts`
+  passed 2 suites / 69 tests.
+- Post-review focused verification:
+  `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/displays/displays.service.spec.ts middleware/src/modules/displays/displays.controller.spec.ts middleware/src/modules/notifications/notifications.service.spec.ts middleware/src/modules/notifications/notifications.controller.spec.ts`
+  passed 4 suites / 119 tests.
+- Post-review focused realtime verification:
+  `pnpm --filter @vizora/realtime test -- --runInBand realtime/src/gateways/device.gateway.spec.ts`
+  passed 1 suite / 103 tests.
+- Follow-up security review: CLEAN. Reviewer confirmed the heartbeat
+  write-site race is closed, notification REST scoping is intact, and targeted
+  realtime notification delivery skips sibling dashboards and device sockets.
+- Broader verification:
+  - `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
+    passed.
+  - `pnpm --filter @vizora/realtime exec tsc --noEmit --project tsconfig.json --pretty false`
+    passed.
+  - `pnpm --filter @vizora/middleware test -- --runInBand` passed 147 suites /
+    2990 tests.
+  - `pnpm --filter @vizora/realtime test -- --runInBand` passed 12 suites /
+    286 tests.
+  - `pnpm --filter @vizora/web test -- --runInBand web/src/lib/hooks/__tests__/useNotifications.test.ts web/src/components/NotificationBell.test.tsx web/src/components/__tests__/NotificationBell.test.tsx`
+    passed 3 suites / 16 tests with existing React `act(...)` warnings in
+    `useNotifications.test.ts`.
+  - Changed-file ESLint with `ESLINT_USE_FLAT_CONFIG=false` passed with 0
+    errors. Existing warnings remain in touched realtime/test files and
+    `notifications.service.ts`.
+  - `npx nx build @vizora/realtime` passed with existing webpack/source-map
+    warnings.
+  - First `npx nx build @vizora/middleware` run failed in the shared
+    `@vizora/database:build` copy step with a Windows file-lock `EPIPE` while
+    middleware and realtime builds were running concurrently. Sequential rerun
+    passed with existing webpack warnings.
+  - `pnpm security:no-hardcoded-jwts` passed.
+
+## Completed: Dashboard Upload Preflight Pass 45 (2026-06-02)
 
 **Branch:** `feat/customer-dashboard-improvement-pass-45`
+
+**PR:** #185
+
+**Commit:** `e8f84d4553f6a9f40d09011ae8a32d103c5286a4`
+
+**Merge SHA:** `1376aadf44adf7c54006e4d12bb8dea2fc4a06b5`
+
+**CI:** Green - audit, build, e2e, lint, security, and test.
+
+**Deploy:** Not deployed. Production checkout remains dirty/diverged and unsafe
+for automated pull/reload; middleware readiness is degraded by high memory.
 
 **Why now:** PRs #182-#184 are merged and no PRs remain open, but production
 deploy is blocked by dirty/diverged prod state. The next buildable
@@ -41,8 +157,8 @@ preflight; proceed with Vizora-native code.
 - [x] Run focused web tests.
 - [x] Run multi-vector subagent review.
 - [x] Run broader web verification and build.
-- [ ] PR, CI, merge if green.
-- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+- [x] PR, CI, merge if green.
+- [x] Re-check deployment gate; deploy only if prod checkout is safe.
 
 **Evidence so far**
 - Red verification:


### PR DESCRIPTION
﻿## Summary
- fix REST display heartbeat to update by verified display id and re-check org/token/enabled state at the write site
- scope notification list/count/read/dismiss APIs to org-wide plus current-user rows and filter dismissed rows before pagination
- target realtime `notification:new` events to the matching dashboard user when a notification has `userId`

## Review
- security/tenant reviewer found a heartbeat write-site race; fixed with verified org/token write predicate
- follow-up security review: CLEAN
- runtime/regression reviewer: CLEAN

## Tests
- `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/displays/displays.service.spec.ts middleware/src/modules/displays/displays.controller.spec.ts middleware/src/modules/notifications/notifications.service.spec.ts middleware/src/modules/notifications/notifications.controller.spec.ts` passed 4 suites / 119 tests
- `pnpm --filter @vizora/realtime test -- --runInBand realtime/src/gateways/device.gateway.spec.ts` passed 1 suite / 103 tests
- `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` passed
- `pnpm --filter @vizora/realtime exec tsc --noEmit --project tsconfig.json --pretty false` passed
- `pnpm --filter @vizora/middleware test -- --runInBand` passed 147 suites / 2990 tests
- `pnpm --filter @vizora/realtime test -- --runInBand` passed 12 suites / 286 tests
- `pnpm --filter @vizora/web test -- --runInBand web/src/lib/hooks/__tests__/useNotifications.test.ts web/src/components/NotificationBell.test.tsx web/src/components/__tests__/NotificationBell.test.tsx` passed 3 suites / 16 tests with existing React act warnings
- changed-file ESLint passed with 0 errors and existing warnings
- `npx nx build @vizora/middleware` passed on sequential rerun; first concurrent run hit Windows file-lock EPIPE in shared database copy step
- `npx nx build @vizora/realtime` passed with existing webpack/source-map warnings
- `pnpm security:no-hardcoded-jwts` passed
- `git diff --check` passed with Windows CRLF notices only

## Deployment
- Not deployed from this PR yet. Production deploy gate must be rechecked after merge; last known production checkout was dirty/diverged and unsafe for automated pull/reload.
