### PR TITLE
fix: index active pairing reads per org

### DIFF
--- a/docs/plans/2026-06-02-pairing-active-index-pass-47.md
+++ b/docs/plans/2026-06-02-pairing-active-index-pass-47.md
@@ -1,0 +1,100 @@
+# Pairing Active Index Pass 47
+
+**Date:** 2026-06-02
+
+**Branch:** `feat/dashboard-customer-readiness-pass-47`
+
+## Goal
+
+Remove the remaining dashboard pairing hot-path scan by indexing active pairing
+codes per organization in Redis. This keeps display pairing responsive when many
+pairing requests exist in a shared/demo environment.
+
+## Source-of-Truth Check
+
+- Current `origin/main` already streams device content with byte ranges and
+  `pipeline()`, so the old media-buffering concern is stale.
+- Current dashboard overview fetches `/health/ready`, so the old hard-coded
+  healthy card concern is stale.
+- Current health page derives status from display records and no longer uses
+  random telemetry.
+- `PairingService.getActivePairings()` still scans all `pairing:*` keys on
+  every org dashboard request, then reads and filters them.
+
+## New Primitives Introduced
+
+One Redis sorted-set key prefix inside the existing pairing service:
+
+- `pairing-active-org:{organizationId}` -> sorted set of pairing-code members
+  scored by `expiresAt` epoch milliseconds, with a 5-minute sliding TTL.
+
+No new database model, migration, NestJS module, route, env var, PM2 process,
+response shape, auth guard, realtime path, MCP tool, Hermes skill, or AI spend
+path.
+
+## Hermes-First Analysis
+
+This is request-serving middleware performance, not an agent or MCP task.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Dashboard pairing Redis index | none applicable | build in existing `PairingService` |
+| Pairing tenant visibility | none applicable | preserve existing service-level visibility rules |
+
+Awesome-Hermes ecosystem check: no relevant Hermes runtime primitive applies to
+an in-process NestJS Redis index for dashboard pairing reads.
+
+## Design
+
+- When a display requests a pairing code and its `deviceIdentifier` belongs to
+  an existing unpaired display, add the code to that display organization's
+  active-pairing zset.
+- Keep brand-new unclaimed pairing requests out of org indexes so they remain
+  visible only on the physical display polling its own code.
+- Keep completed pairing records hidden from dashboard lists. On completion or
+  status handoff cleanup, remove the code from the org-specific active zset when
+  present.
+- Change `getActivePairings(organizationId)` to prune expired zset members,
+  read active code members via `ZRANGEBYSCORE`, batch-read the corresponding
+  primary `pairing:{code}` records, and return pending, unexpired records whose
+  stored `activePairingOrganizationId` still matches the requesting org.
+- Keep the current DB ownership recheck before exposing a code. Redis is only
+  the candidate source; it is not trusted as the tenant authority because display
+  ownership or identifiers can change while the five-minute pairing TTL is live.
+- Leave the periodic expired-request cleanup as a safety net. It can keep using
+  the global scan because it is background maintenance, not a dashboard request.
+
+## Plan
+
+- [x] Add red pairing service coverage proving `getActivePairings()` uses the
+  org-specific zset and does not call Redis `SCAN`.
+- [x] Add red coverage proving indexed completed pairings are removed/hidden.
+- [x] Implement active-index helpers in `PairingService`.
+- [x] Update pairing request storage to index only existing unpaired displays.
+- [x] Update completion and status cleanup paths to remove the index.
+- [x] Run focused pairing service tests.
+- [x] Run multi-vector subagent review for tenant/security and performance.
+- [x] Run broader middleware verification and build.
+- [ ] Open PR, wait for CI, merge if green.
+- [ ] Recheck production deploy gate; deploy only if the dirty/diverged
+  production checkout is made safe.
+
+## Risks
+
+- Missing a code in the org index would hide it from the dashboard active-list
+  panel, but the display still shows the pairing code and the authenticated
+  dashboard pairing form can still complete it manually.
+- Leaving a stale org-index member after completion could waste a Redis read
+  until TTL expiry. The service still reads the primary pairing request and skips
+  completed records, so stale index members do not expose completed tokens.
+- Existing active pairing requests created before this change may not appear in
+  the dashboard active-list panel after deploy. TTL is five minutes; avoiding a
+  fallback global scan keeps the hot path fixed.
+
+## Verification
+
+- Focused red/green: `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/displays/pairing.service.spec.ts`
+- Broader middleware slice: `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/displays/pairing.service.spec.ts middleware/src/modules/displays/pairing.controller.spec.ts`
+- TypeScript: `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
+- Full middleware: `pnpm --filter @vizora/middleware test -- --runInBand`
+- Build: `npx nx build @vizora/middleware`

--- a/middleware/src/modules/displays/pairing.service.spec.ts
+++ b/middleware/src/modules/displays/pairing.service.spec.ts
@@ -23,6 +23,11 @@ describe('PairingService', () => {
     mget: jest.Mock;
     set: jest.Mock;
     eval: jest.Mock;
+    zadd: jest.Mock;
+    zrangebyscore: jest.Mock;
+    zrem: jest.Mock;
+    zremrangebyscore: jest.Mock;
+    expire: jest.Mock;
   };
 
   const sensitiveDisplayFields = [
@@ -50,12 +55,17 @@ describe('PairingService', () => {
     string,
     { value: string; ttl: number; expiresAt: number }
   >;
+  let redisSortedSets: Map<
+    string,
+    { values: Map<string, number>; expiresAt: number }
+  >;
 
   beforeEach(() => {
     // Clear any interval from previous tests
     jest.useFakeTimers();
 
     redisStore = new Map();
+    redisSortedSets = new Map();
 
     mockDatabaseService = {
       display: {
@@ -75,6 +85,23 @@ describe('PairingService', () => {
     mockJwtService = {
       sign: jest.fn().mockReturnValue('mock-jwt-token'),
     } as any;
+
+    const getActiveSortedSet = (
+      key: string,
+    ): { values: Map<string, number>; expiresAt: number } | null => {
+      const entry = redisSortedSets.get(key);
+      if (!entry) return null;
+      if (entry.expiresAt > 0 && Date.now() >= entry.expiresAt) {
+        redisSortedSets.delete(key);
+        return null;
+      }
+      return entry;
+    };
+    const parseScore = (score: string | number): number => {
+      if (score === '-inf') return Number.NEGATIVE_INFINITY;
+      if (score === '+inf') return Number.POSITIVE_INFINITY;
+      return Number(score);
+    };
 
     redisClient = {
       scan: jest
@@ -149,6 +176,75 @@ describe('PairingService', () => {
             return 0;
           },
         ),
+      zadd: jest
+        .fn()
+        .mockImplementation(
+          async (key: string, score: number | string, member: string) => {
+            const entry =
+              getActiveSortedSet(key) ??
+              { values: new Map<string, number>(), expiresAt: 0 };
+            const existed = entry.values.has(member);
+            entry.values.set(member, Number(score));
+            redisSortedSets.set(key, entry);
+            return existed ? 0 : 1;
+          },
+        ),
+      zrangebyscore: jest
+        .fn()
+        .mockImplementation(
+          async (
+            key: string,
+            minScore: string | number,
+            maxScore: string | number,
+          ) => {
+            const entry = getActiveSortedSet(key);
+            if (!entry) return [];
+            const min = parseScore(minScore);
+            const max = parseScore(maxScore);
+            return Array.from(entry.values.entries())
+              .filter(([, score]) => score >= min && score <= max)
+              .sort(([, left], [, right]) => left - right)
+              .map(([member]) => member);
+          },
+        ),
+      zrem: jest.fn().mockImplementation(async (key: string, ...members: string[]) => {
+        const entry = getActiveSortedSet(key);
+        if (!entry) return 0;
+        let removed = 0;
+        for (const member of members) {
+          if (entry.values.delete(member)) removed++;
+        }
+        return removed;
+      }),
+      zremrangebyscore: jest
+        .fn()
+        .mockImplementation(
+          async (
+            key: string,
+            minScore: string | number,
+            maxScore: string | number,
+          ) => {
+            const entry = getActiveSortedSet(key);
+            if (!entry) return 0;
+            const min = parseScore(minScore);
+            const max = parseScore(maxScore);
+            let removed = 0;
+            for (const [member, score] of entry.values.entries()) {
+              if (score >= min && score <= max) {
+                entry.values.delete(member);
+                removed++;
+              }
+            }
+            return removed;
+          },
+        ),
+      expire: jest.fn().mockImplementation(async (key: string, ttlSeconds: number) => {
+        const entry = getActiveSortedSet(key);
+        if (!entry) return 0;
+        entry.expiresAt = Date.now() + ttlSeconds * 1000;
+        redisSortedSets.set(key, entry);
+        return 1;
+      }),
     };
 
     // Create a mock RedisService that uses an in-memory Map to simulate Redis
@@ -228,14 +324,14 @@ describe('PairingService', () => {
       expect(result).toHaveProperty('pairingUrl');
     });
 
-    it('should check existing pairing state with token-only display select', async () => {
+    it('should check existing pairing state with token and organization display select', async () => {
       mockDatabaseService.display.findUnique.mockResolvedValue(null);
 
       await service.requestPairingCode(mockRequestDto);
 
       expect(mockDatabaseService.display.findUnique).toHaveBeenCalledWith({
         where: { deviceIdentifier: 'device-123' },
-        select: { jwtToken: true },
+        select: { jwtToken: true, organizationId: true },
       });
     });
 
@@ -511,7 +607,7 @@ describe('PairingService', () => {
         1,
         {
           where: { deviceIdentifier: 'new-device' },
-          select: { jwtToken: true },
+          select: { jwtToken: true, organizationId: true },
         },
       );
       expect(mockDatabaseService.display.findUnique).toHaveBeenNthCalledWith(
@@ -950,11 +1046,11 @@ describe('PairingService', () => {
       const result = await service.getActivePairings('org-123');
 
       expect(result).toEqual([]);
+      expect(redisClient.scan).not.toHaveBeenCalled();
     });
 
     it('should not return brand-new unclaimed pairing requests to org dashboards', async () => {
       mockDatabaseService.display.findUnique.mockResolvedValue(null);
-      mockDatabaseService.display.findMany.mockResolvedValue([]);
 
       await service.requestPairingCode({
         deviceIdentifier: 'device-1',
@@ -971,11 +1067,16 @@ describe('PairingService', () => {
       const result = await service.getActivePairings('org-123');
 
       expect(result).toEqual([]);
+      expect(redisClient.scan).not.toHaveBeenCalled();
+      expect(redisClient.mget).not.toHaveBeenCalled();
+      expect(mockDatabaseService.display.findMany).not.toHaveBeenCalled();
     });
 
     it('should not return expired pairings', async () => {
-      mockDatabaseService.display.findUnique.mockResolvedValue(null);
-      mockDatabaseService.display.findMany.mockResolvedValue([]);
+      mockDatabaseService.display.findUnique.mockResolvedValue({
+        jwtToken: null,
+        organizationId: 'org-123',
+      } as any);
 
       await service.requestPairingCode({
         deviceIdentifier: 'device-expired',
@@ -985,23 +1086,30 @@ describe('PairingService', () => {
 
       // Advance time past expiration
       jest.advanceTimersByTime(5 * 60 * 1000 + 1000);
+      redisClient.scan.mockClear();
 
       const result = await service.getActivePairings('org-123');
 
       expect(result).toHaveLength(0);
+      expect(redisClient.scan).not.toHaveBeenCalled();
     });
 
     it('should batch Redis reads and only show unclaimed active pairings for displays owned by the org', async () => {
       const orgId = 'org-123';
-      mockDatabaseService.display.findUnique.mockResolvedValue(null);
+      mockDatabaseService.display.findUnique
+        .mockResolvedValueOnce({
+          jwtToken: null,
+          organizationId: orgId,
+        } as any)
+        .mockResolvedValueOnce({
+          jwtToken: null,
+          organizationId: 'org-other',
+        } as any)
+        .mockResolvedValueOnce(null);
       mockDatabaseService.display.findMany.mockResolvedValue([
         {
           deviceIdentifier: 'device-owned',
           organizationId: orgId,
-        },
-        {
-          deviceIdentifier: 'device-other-org',
-          organizationId: 'org-other',
         },
       ] as any);
 
@@ -1024,17 +1132,19 @@ describe('PairingService', () => {
 
       const result = await service.getActivePairings(orgId);
 
+      expect(redisClient.scan).not.toHaveBeenCalled();
+      expect(redisClient.zrangebyscore).toHaveBeenCalledWith(
+        `pairing-active-org:${orgId}`,
+        expect.any(Number),
+        '+inf',
+      );
       expect(redisClient.mget).toHaveBeenCalledTimes(1);
       expect(mockRedisService.get).not.toHaveBeenCalled();
       expect(mockDatabaseService.display.findMany).toHaveBeenCalledTimes(1);
       expect(mockDatabaseService.display.findMany).toHaveBeenCalledWith({
         where: {
           deviceIdentifier: {
-            in: expect.arrayContaining([
-              'device-owned',
-              'device-other-org',
-              'device-new',
-            ]),
+            in: ['device-owned'],
           },
         },
         select: { deviceIdentifier: true, organizationId: true },
@@ -1056,40 +1166,251 @@ describe('PairingService', () => {
       );
     });
 
-    it('should not return or query display ownership for completed org pairings', async () => {
+    it('uses the organization active-pairing zset instead of Redis SCAN', async () => {
       const orgId = 'org-123';
-      const userId = 'user-123';
-      mockDatabaseService.display.findUnique.mockResolvedValue(null);
-      mockDatabaseService.display.findMany.mockResolvedValue([]);
+      mockDatabaseService.display.findUnique
+        .mockResolvedValueOnce({
+          jwtToken: null,
+          organizationId: orgId,
+        } as any)
+        .mockResolvedValueOnce(null);
+      mockDatabaseService.display.findMany.mockResolvedValue([
+        {
+          deviceIdentifier: 'device-owned',
+          organizationId: orgId,
+        },
+      ] as any);
 
-      const pairingResult = await service.requestPairingCode({
-        deviceIdentifier: 'completed-device',
-        nickname: 'Completed Display',
+      await service.requestPairingCode({
+        deviceIdentifier: 'device-owned',
+        nickname: 'Owned Display',
         metadata: {},
       });
-
-      mockDatabaseService.display.create.mockResolvedValue({
-        id: 'new-id',
-        nickname: 'Completed Display',
-        deviceIdentifier: 'completed-device',
-        status: 'pairing',
-      } as any);
-
-      await service.completePairing(orgId, userId, {
-        code: pairingResult.code,
+      await service.requestPairingCode({
+        deviceIdentifier: 'device-new',
+        nickname: 'Brand New Display',
+        metadata: {},
       });
-      mockDatabaseService.display.findUnique.mockClear();
-      mockDatabaseService.display.findMany.mockClear();
-      mockRedisService.get.mockClear();
+      redisClient.scan.mockClear();
       redisClient.mget.mockClear();
+      redisClient.zrangebyscore.mockClear();
+      mockDatabaseService.display.findMany.mockClear();
 
       const result = await service.getActivePairings(orgId);
 
+      expect(redisClient.scan).not.toHaveBeenCalled();
+      expect(redisClient.zrangebyscore).toHaveBeenCalledWith(
+        `pairing-active-org:${orgId}`,
+        expect.any(Number),
+        '+inf',
+      );
       expect(redisClient.mget).toHaveBeenCalledTimes(1);
-      expect(mockRedisService.get).not.toHaveBeenCalled();
-      expect(mockDatabaseService.display.findMany).not.toHaveBeenCalled();
-      expect(mockDatabaseService.display.findUnique).not.toHaveBeenCalled();
-      expect(result).toEqual([]);
+      expect(mockDatabaseService.display.findMany).toHaveBeenCalledWith({
+        where: {
+          deviceIdentifier: {
+            in: ['device-owned'],
+          },
+        },
+        select: { deviceIdentifier: true, organizationId: true },
+      });
+      expect(result).toEqual([
+        expect.objectContaining({
+          nickname: 'Owned Display',
+          code: expect.any(String),
+        }),
+      ]);
+      expect(result).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ nickname: 'Brand New Display' }),
+        ]),
+      );
+    });
+
+    it('removes the organization active-pairing index when pairing completes', async () => {
+      const orgId = 'org-123';
+      const userId = 'user-123';
+      const previousSecret = process.env.DEVICE_JWT_SECRET;
+      process.env.DEVICE_JWT_SECRET =
+        'test-device-secret-that-is-at-least-32-chars';
+      try {
+        mockDatabaseService.display.findUnique.mockResolvedValueOnce({
+          jwtToken: null,
+          organizationId: orgId,
+        } as any);
+
+        const pairingResult = await service.requestPairingCode({
+          deviceIdentifier: 'device-owned',
+          nickname: 'Owned Display',
+          metadata: {},
+        });
+
+        mockDatabaseService.display.findUnique.mockResolvedValueOnce({
+          id: 'display-owned',
+          location: null,
+          organizationId: orgId,
+        } as any);
+        mockDatabaseService.display.update.mockResolvedValue({
+          id: 'display-owned',
+          nickname: 'Owned Display',
+          deviceIdentifier: 'device-owned',
+          status: 'pairing',
+        } as any);
+        redisClient.zrem.mockClear();
+
+        await service.completePairing(orgId, userId, {
+          code: pairingResult.code,
+        });
+
+        expect(redisClient.zrem).toHaveBeenCalledWith(
+          `pairing-active-org:${orgId}`,
+          pairingResult.code,
+        );
+      } finally {
+        process.env.DEVICE_JWT_SECRET = previousSecret;
+      }
+    });
+
+    it('should prune stale indexed records without exposing them', async () => {
+      const orgId = 'org-123';
+      const future = new Date(Date.now() + 300_000).toISOString();
+      const past = new Date(Date.now() - 1_000).toISOString();
+      const validRequest = {
+        code: 'OWNED1',
+        deviceIdentifier: 'device-owned',
+        nickname: 'Owned Display',
+        metadata: {},
+        createdAt: new Date().toISOString(),
+        expiresAt: future,
+        activePairingOrganizationId: orgId,
+      };
+      const requests = [
+        validRequest,
+        {
+          ...validRequest,
+          code: 'MISMAT',
+          deviceIdentifier: 'device-mismatch',
+          nickname: 'Mismatched Display',
+          activePairingOrganizationId: 'org-other',
+        },
+        {
+          ...validRequest,
+          code: 'EXPIRE',
+          deviceIdentifier: 'device-expired',
+          nickname: 'Expired Display',
+          expiresAt: past,
+        },
+        {
+          ...validRequest,
+          code: 'DONE01',
+          deviceIdentifier: 'device-completed',
+          nickname: 'Completed Display',
+          plaintextToken: 'token',
+          organizationId: orgId,
+        },
+      ];
+      for (const request of requests) {
+        redisStore.set(`pairing:${request.code}`, {
+          value: JSON.stringify(request),
+          ttl: 300,
+          expiresAt: Date.now() + 300_000,
+        });
+      }
+      redisSortedSets.set(`pairing-active-org:${orgId}`, {
+        values: new Map([
+          ['MISSING', Date.now() + 300_000],
+          ...requests.map((request) => [
+            request.code,
+            Date.now() + 300_000,
+          ] as [string, number]),
+        ]),
+        expiresAt: Date.now() + 300_000,
+      });
+      mockDatabaseService.display.findMany.mockResolvedValue([
+        {
+          deviceIdentifier: 'device-owned',
+          organizationId: orgId,
+        },
+      ] as any);
+
+      const result = await service.getActivePairings(orgId);
+
+      expect(redisClient.scan).not.toHaveBeenCalled();
+      expect(mockDatabaseService.display.findMany).toHaveBeenCalledWith({
+        where: {
+          deviceIdentifier: {
+            in: ['device-owned'],
+          },
+        },
+        select: { deviceIdentifier: true, organizationId: true },
+      });
+      expect(redisClient.zrem).toHaveBeenCalledWith(
+        `pairing-active-org:${orgId}`,
+        'MISSING',
+        'MISMAT',
+        'EXPIRE',
+        'DONE01',
+      );
+      expect(result).toEqual([
+        expect.objectContaining({
+          code: 'OWNED1',
+          nickname: 'Owned Display',
+        }),
+      ]);
+    });
+
+    it('should not return or query display ownership for completed org pairings', async () => {
+      const orgId = 'org-123';
+      const userId = 'user-123';
+      const previousSecret = process.env.DEVICE_JWT_SECRET;
+      process.env.DEVICE_JWT_SECRET =
+        'test-device-secret-that-is-at-least-32-chars';
+      try {
+        mockDatabaseService.display.findUnique.mockResolvedValueOnce({
+          jwtToken: null,
+          organizationId: orgId,
+        } as any);
+
+        const pairingResult = await service.requestPairingCode({
+          deviceIdentifier: 'completed-device',
+          nickname: 'Completed Display',
+          metadata: {},
+        });
+
+        mockDatabaseService.display.findUnique.mockResolvedValueOnce({
+          id: 'display-owned',
+          location: null,
+          organizationId: orgId,
+        } as any);
+        mockDatabaseService.display.update.mockResolvedValue({
+          id: 'display-owned',
+          nickname: 'Completed Display',
+          deviceIdentifier: 'completed-device',
+          status: 'pairing',
+        } as any);
+
+        await service.completePairing(orgId, userId, {
+          code: pairingResult.code,
+        });
+        await redisClient.zadd(
+          `pairing-active-org:${orgId}`,
+          Date.now() + 300_000,
+          pairingResult.code,
+        );
+        mockDatabaseService.display.findUnique.mockClear();
+        mockDatabaseService.display.findMany.mockClear();
+        mockRedisService.get.mockClear();
+        redisClient.mget.mockClear();
+
+        const result = await service.getActivePairings(orgId);
+
+        expect(redisClient.mget).toHaveBeenCalledTimes(1);
+        expect(mockRedisService.get).not.toHaveBeenCalled();
+        expect(mockDatabaseService.display.findMany).not.toHaveBeenCalled();
+        expect(mockDatabaseService.display.findUnique).not.toHaveBeenCalled();
+        expect(result).toEqual([]);
+      } finally {
+        process.env.DEVICE_JWT_SECRET = previousSecret;
+      }
     });
   });
 

--- a/middleware/src/modules/displays/pairing.service.ts
+++ b/middleware/src/modules/displays/pairing.service.ts
@@ -27,6 +27,7 @@ interface PairingRequest {
   createdAt: string; // ISO string for JSON serialization
   expiresAt: string; // ISO string for JSON serialization
   qrCode?: string;
+  activePairingOrganizationId?: string;
   organizationId?: string;
   plaintextToken?: string;
 }
@@ -45,6 +46,7 @@ interface PairingRequestRecord {
 
 const PAIRING_TOKEN_CHECK_SELECT = {
   jwtToken: true,
+  organizationId: true,
 } as const satisfies Prisma.DisplaySelect;
 
 const PAIRING_STATUS_SELECT = {
@@ -73,6 +75,7 @@ export class PairingService implements OnModuleDestroy {
   private readonly PAIRING_TTL_SECONDS = 300; // 5 minutes
   private readonly PAIRING_READ_BATCH_SIZE = 100;
   private readonly REDIS_KEY_PREFIX = 'pairing:';
+  private readonly REDIS_ACTIVE_ORG_INDEX_PREFIX = 'pairing-active-org:';
   private readonly REDIS_COMPLETION_CLAIM_PREFIX = 'pairing-complete-claim:';
   private readonly REDIS_NEW_DISPLAY_CLAIM_PREFIX =
     'pairing-new-display-claim:';
@@ -104,6 +107,10 @@ export class PairingService implements OnModuleDestroy {
 
   private redisKey(code: string): string {
     return `${this.REDIS_KEY_PREFIX}${code}`;
+  }
+
+  private activeOrgPairingIndexKey(organizationId: string): string {
+    return `${this.REDIS_ACTIVE_ORG_INDEX_PREFIX}${organizationId}`;
   }
 
   private completionClaimKey(code: string): string {
@@ -170,6 +177,73 @@ export class PairingService implements OnModuleDestroy {
         `Failed to delete pairing request for code ${code}: ${error}`,
       );
       return false;
+    }
+  }
+
+  private async setActiveOrgPairingIndex(
+    organizationId: string | undefined,
+    code: string,
+    expiresAt: Date,
+  ): Promise<void> {
+    if (!organizationId) return;
+
+    const client = this.redisService.getClient();
+    if (!client) return;
+
+    try {
+      const indexKey = this.activeOrgPairingIndexKey(organizationId);
+      await client.zadd(indexKey, expiresAt.getTime(), code);
+      await client.expire(indexKey, this.PAIRING_TTL_SECONDS);
+    } catch (error) {
+      this.logger.warn(
+        `Failed to index active pairing code ${code} for org ${organizationId}: ${error}`,
+      );
+    }
+  }
+
+  private async deleteActiveOrgPairingIndex(
+    organizationId: string | undefined,
+    code: string,
+  ): Promise<void> {
+    if (!organizationId) return;
+    await this.removeActiveOrgPairingCodes(organizationId, [code]);
+  }
+
+  private async removeActiveOrgPairingCodes(
+    organizationId: string,
+    codes: string[],
+  ): Promise<void> {
+    if (codes.length === 0) return;
+
+    const client = this.redisService.getClient();
+    if (!client) return;
+
+    try {
+      await client.zrem(this.activeOrgPairingIndexKey(organizationId), ...codes);
+    } catch (error) {
+      this.logger.warn(
+        `Failed to remove active pairing codes for org ${organizationId}: ${error}`,
+      );
+    }
+  }
+
+  private async getActiveOrgPairingCodes(
+    organizationId: string,
+    now: Date,
+  ): Promise<string[]> {
+    const client = this.redisService.getClient();
+    if (!client) return [];
+
+    try {
+      const indexKey = this.activeOrgPairingIndexKey(organizationId);
+      const nowMs = now.getTime();
+      await client.zremrangebyscore(indexKey, '-inf', nowMs);
+      return await client.zrangebyscore(indexKey, nowMs + 1, '+inf');
+    } catch (error) {
+      this.logger.error(
+        `Failed to read active pairing index for org ${organizationId}: ${error}`,
+      );
+      return [];
     }
   }
 
@@ -363,6 +437,7 @@ export class PairingService implements OnModuleDestroy {
       createdAt: now.toISOString(),
       expiresAt: expiresAt.toISOString(),
       qrCode: qrCodeDataUrl,
+      activePairingOrganizationId: existingDisplay?.organizationId,
     };
 
     const stored = await this.setPairingRequest(code, pairingRequest);
@@ -371,6 +446,11 @@ export class PairingService implements OnModuleDestroy {
         'Failed to store pairing request. Please try again.',
       );
     }
+    await this.setActiveOrgPairingIndex(
+      pairingRequest.activePairingOrganizationId,
+      code,
+      expiresAt,
+    );
 
     this.logger.log(
       `Pairing code generated: ${code} for device ${deviceIdentifier}`,
@@ -394,6 +474,10 @@ export class PairingService implements OnModuleDestroy {
 
     // Check if expired (safety check — Redis TTL should handle this)
     if (new Date() > new Date(request.expiresAt)) {
+      await this.deleteActiveOrgPairingIndex(
+        request.activePairingOrganizationId,
+        code,
+      );
       await this.deletePairingRequest(code);
       throw new BadRequestException('Pairing code has expired');
     }
@@ -408,6 +492,10 @@ export class PairingService implements OnModuleDestroy {
       });
 
       // Pairing complete! Clean up request and return plaintext token
+      await this.deleteActiveOrgPairingIndex(
+        request.activePairingOrganizationId,
+        code,
+      );
       await this.deletePairingRequest(code);
 
       return {
@@ -438,11 +526,19 @@ export class PairingService implements OnModuleDestroy {
     }
 
     if (request.plaintextToken || request.organizationId) {
+      await this.deleteActiveOrgPairingIndex(
+        request.activePairingOrganizationId,
+        code,
+      );
       throw new BadRequestException('Pairing code has already been completed');
     }
 
     // Check if expired (safety check — Redis TTL should handle this)
     if (new Date() > new Date(request.expiresAt)) {
+      await this.deleteActiveOrgPairingIndex(
+        request.activePairingOrganizationId,
+        code,
+      );
       await this.deletePairingRequest(code);
       throw new BadRequestException('Pairing code has expired');
     }
@@ -575,11 +671,19 @@ export class PairingService implements OnModuleDestroy {
       request.organizationId = organizationId;
       const finalized = await this.setPairingRequest(code, request);
       if (!finalized) {
+        await this.deleteActiveOrgPairingIndex(
+          request.activePairingOrganizationId,
+          code,
+        );
         releaseCompletionClaim = false;
         throw new InternalServerErrorException(
           'Failed to finalize pairing token handoff',
         );
       }
+      await this.deleteActiveOrgPairingIndex(
+        request.activePairingOrganizationId,
+        code,
+      );
 
       return {
         success: true,
@@ -610,27 +714,34 @@ export class PairingService implements OnModuleDestroy {
     // Only show pending requests for devices that already belong to this org.
     const activePairings: ActivePairingResponse[] = [];
 
-    // Use SCAN to find all pairing keys in Redis
-    const keys = await this.scanPairingKeys();
-    const records = await this.getPairingRequestRecords(keys);
     const now = new Date();
+    const codes = await this.getActiveOrgPairingCodes(organizationId, now);
+    const keys = codes.map((code) => this.redisKey(code));
+    const records = await this.getPairingRequestRecords(keys);
+    const recordCodes = new Set(records.map(({ code }) => code));
+    const staleCodes = codes.filter((code) => !recordCodes.has(code));
     const unclaimedRequests: PairingRequest[] = [];
 
-    for (const { request } of records) {
+    for (const { code, request } of records) {
       // Check if expired (safety check)
       if (now >= new Date(request.expiresAt)) {
+        staleCodes.push(code);
         continue;
       }
 
       // Completed records temporarily hold a plaintext device token for the
       // physical display. Do not expose their codes through dashboard list APIs.
-      if (request.organizationId === organizationId) {
+      if (request.plaintextToken || request.organizationId) {
+        staleCodes.push(code);
         continue;
       }
 
-      if (!request.organizationId) {
-        unclaimedRequests.push(request);
+      if (request.activePairingOrganizationId !== organizationId) {
+        staleCodes.push(code);
+        continue;
       }
+
+      unclaimedRequests.push(request);
     }
 
     const displayOrganizationsByDevice =
@@ -651,8 +762,12 @@ export class PairingService implements OnModuleDestroy {
           createdAt: request.createdAt,
           expiresAt: request.expiresAt,
         });
+      } else {
+        staleCodes.push(request.code);
       }
     }
+
+    await this.removeActiveOrgPairingCodes(organizationId, staleCodes);
 
     return activePairings;
   }
@@ -830,6 +945,10 @@ export class PairingService implements OnModuleDestroy {
       const request = await this.getPairingRequest(code);
 
       if (request && new Date() > new Date(request.expiresAt)) {
+        await this.deleteActiveOrgPairingIndex(
+          request.activePairingOrganizationId,
+          code,
+        );
         await this.deletePairingRequest(code);
         this.logger.debug(`Cleaned up expired pairing code: ${code}`);
       }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -7,6 +7,7 @@
 
 ### Worktree Editing
 - In this environment `apply_patch` defaults to the primary checkout path from the initial context, not necessarily the shell command workdir. For isolated worktree tasks, use absolute paths in `apply_patch` and verify `git status` in both the primary checkout and worktree after the first edit.
+- When dispatching subagents after creating an isolated worktree, put the exact worktree path in the prompt and require them to report `git rev-parse --show-toplevel`, branch, and HEAD before analysis. Otherwise they may inspect the primary checkout and return stale findings from older branches or dirty scratch.
 
 ## Session: 2026-02-09 - Pilot Readiness Fix Sprint
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,8 +1,91 @@
 # Vizora - Task Tracker
 
-## Active Workstream: Backend Heartbeat and Notification Scoping Pass 46 (2026-06-02)
+## Active Workstream: Pairing Active Index Pass 47 (2026-06-02)
+
+**Branch:** `feat/dashboard-customer-readiness-pass-47`
+
+**Why now:** PR #186 is merged and no PRs remain open, but deployment remains
+blocked by dirty/diverged production state. The remaining verified
+customer-critical performance gap in the active worktree is pairing-list
+scalability: `PairingService.getActivePairings()` still scans every `pairing:*`
+Redis key for every dashboard org request. Recent stale-review candidates
+around media streaming, random health telemetry, and hard-coded dashboard health
+do not reproduce on current `origin/main`.
+
+**New primitives introduced:** one Redis sorted-set key prefix inside the
+existing pairing service: `pairing-active-org:{organizationId}` with pairing
+codes scored by expiry and a five-minute sliding TTL. No new route, model,
+migration, module, env var, process, response shape, realtime path, MCP tool,
+Hermes skill, or AI/provider spend path.
+
+**Hermes-first analysis:** checked per project convention. This is local
+NestJS/Redis request-serving performance, not a business-agent, MCP, Hermes
+runtime, or provider-spend task.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Dashboard pairing Redis index | none applicable | build in existing `PairingService` |
+| Pairing tenant visibility | none applicable | preserve existing service-level visibility rules |
+
+Awesome-hermes-agent ecosystem check: no applicable skill/library primitive for
+an in-process NestJS Redis index on the dashboard pairing hot path.
+
+**Plan/design:**
+`docs/plans/2026-06-02-pairing-active-index-pass-47.md`
+
+**Plan**
+- [x] Add red pairing service coverage proving active-list uses the org-specific
+  active zset instead of Redis `SCAN`.
+- [x] Add red pairing service coverage proving completed indexed pairings are
+  removed/hidden.
+- [x] Implement pairing active-index helpers and request/completion cleanup.
+- [x] Run focused pairing tests.
+- [x] Run multi-vector subagent diff review.
+- [x] Run broader middleware verification and build.
+- [ ] PR, CI, merge if green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Evidence so far**
+- Current `origin/main` merge SHA after Pass 46: `4eef5d5a51afea83a660195d6f374e741a554434`.
+- No open PRs after merging PR #186.
+- Production deploy gate remains blocked: `/opt/vizora/app` is `main...origin/main [ahead 17, behind 161]` with 72 dirty/untracked paths; readiness is degraded by high middleware memory.
+- Stale subagent findings were traced to reviewers inspecting `C:\projects\vizora`
+  instead of the active isolated worktree. `tasks/lessons.md` now captures the
+  worktree-verification rule.
+- Focused pairing service test is green:
+  `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/displays/pairing.service.spec.ts`
+  => 42/42 passing.
+- Diff review is CLEAN from both tenant/security and performance/regression
+  subagents after the revised zset design.
+- Verification:
+  - `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` => pass.
+  - `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/displays/pairing.service.spec.ts middleware/src/modules/displays/pairing.controller.spec.ts`
+    => 54/54 passing.
+  - `npx nx build @vizora/middleware` => pass with existing webpack warnings.
+  - `pnpm --filter @vizora/middleware test -- --runInBand` => 147 suites /
+    2993 tests passing.
+  - Root `pnpm lint` is not Windows-compatible (`ESLINT_USE_FLAT_CONFIG=...`);
+    PowerShell-equivalent `$env:ESLINT_USE_FLAT_CONFIG='false'; npx eslint --ext .ts,.tsx middleware/src realtime/src`
+    => pass with warnings only.
+  - `pnpm security:no-hardcoded-jwts` => pass.
+  - CI-gated middleware E2E subset:
+    `pnpm --filter @vizora/middleware exec jest --config=jest.e2e.config.js --runInBand --testPathPattern="(agents|customer-critical-path)"`
+    => 2 suites / 4 tests passing.
+
+## Completed: Backend Heartbeat and Notification Scoping Pass 46 (2026-06-02)
 
 **Branch:** `fix/backend-heartbeat-notifications-pass-46`
+
+**PR:** #186
+
+**Commit:** `5c76f374a77c02da192f81c09a41b2a8cf798d3c`
+
+**Merge SHA:** `4eef5d5a51afea83a660195d6f374e741a554434`
+
+**CI:** Green - audit, build, e2e, lint, security, and test.
+
+**Deploy:** Not deployed. Production checkout remains dirty/diverged and unsafe
+for automated pull/reload; middleware readiness is degraded by high memory.
 
 **Why now:** Pass 45 is merged and deployment remains blocked by dirty/diverged
 production state. The highest-value buildable backend defects from the
@@ -44,10 +127,10 @@ Socket.IO room filtering; proceed with Vizora-native code.
 - [x] Add red realtime coverage for targeted notification delivery.
 - [x] Implement targeted realtime delivery.
 - [x] Run focused middleware/realtime tests.
-- [ ] Run multi-vector subagent diff review.
-- [ ] Run broader middleware/realtime verification and build.
-- [ ] PR, CI, merge if green.
-- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+- [x] Run multi-vector subagent diff review.
+- [x] Run broader middleware/realtime verification and build.
+- [x] PR, CI, merge if green.
+- [x] Re-check deployment gate; deploy only if prod checkout is safe.
 
 **Evidence so far**
 - Red middleware verification:


### PR DESCRIPTION
## Summary
- Replace dashboard active-pairing Redis keyspace scan with a per-org sorted-set candidate index.
- Keep Redis as a candidate source only; active-list responses still recheck display ownership in the DB before exposing a pairing code.
- Prune stale, expired, mismatched, and completed active-index members and document the pass in the task tracker/plan.

## Verification
- `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
- `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/displays/pairing.service.spec.ts`
- `pnpm --filter @vizora/middleware test -- --runInBand middleware/src/modules/displays/pairing.service.spec.ts middleware/src/modules/displays/pairing.controller.spec.ts`
- `npx nx build @vizora/middleware`
- `pnpm --filter @vizora/middleware test -- --runInBand`
- `$env:ESLINT_USE_FLAT_CONFIG='false'; npx eslint --ext .ts,.tsx middleware/src realtime/src`
- `pnpm security:no-hardcoded-jwts`
- `pnpm --filter @vizora/middleware exec jest --config=jest.e2e.config.js --runInBand --testPathPattern=(agents|customer-critical-path)`

## Review
- Tenant/security subagent review: CLEAN.
- Performance/regression subagent review: CLEAN.

## Notes
- Root `pnpm lint` uses POSIX env-var syntax and fails on Windows; the PowerShell-equivalent lint command passed with warnings only.
- Deployment remains blocked until the production checkout divergence/dirty state is resolved.