### PR TITLE
fix: gate dashboard writes and normalize layouts

### DIFF
--- a/docs/plans/2026-06-02-dashboard-write-gates-layout-pass-48.md
+++ b/docs/plans/2026-06-02-dashboard-write-gates-layout-pass-48.md
@@ -1,0 +1,175 @@
+# Dashboard Write Gates and Layout Create Pass 48
+
+**Date:** 2026-06-02
+
+**Branch:** `fix/dashboard-write-gates-layout-pass-48`
+
+## Goal
+
+Close two customer-visible dashboard/backend gaps found after the pairing-index
+merge:
+
+- Dashboard-adjacent write endpoints for folders, display groups, widgets,
+  templates, bulk content operations, and layouts bypass the existing
+  subscription-active guard used by the core content controller.
+- The layouts page creates a layout from a preset by sending `name`,
+  `layoutType`, and optional `description`; the backend DTO currently requires
+  `zones`, so normal dashboard creation can fail validation with a 400.
+- The real preset API returns `layoutType`, but the dashboard fallback shape
+  uses `type`; the page must normalize both.
+- The layout editor must open middleware responses where `layoutType` and
+  `zones` are nested in `metadata`.
+- The layout list must also normalize saved layout records where `layoutType`
+  and `zones` are nested in `metadata`.
+
+## Source-of-Truth Check
+
+- `ContentController` already uses the existing `@RequiresSubscription()`
+  decorator, which installs `SubscriptionActiveGuard`.
+- `SubscriptionActiveGuard` allows `GET` and `HEAD` requests, then gates
+  non-read methods by organization subscription status, active trial, and free
+  tier.
+- `DisplayGroupsController`, `FoldersController`,
+  `BulkOperationsController`, `LayoutsController`, `TemplatesController`, and
+  `WidgetsController` currently only use `RolesGuard`.
+- `ContentModule` already imports `BillingModule`; `DisplayGroupsModule` and
+  `FoldersModule` need the same provider wiring when using
+  `@RequiresSubscription()`.
+- Template preview/validation POSTs are stateless and should not be treated as
+  customer data writes for this pass.
+- `web/src/app/dashboard/layouts/page.tsx` creates layouts without `zones`;
+  `CreateLayoutDto` currently requires `zones`.
+
+## New Primitives Introduced
+
+No new service, route, module, database model, migration, env var, PM2 process,
+response shape, realtime path, MCP tool, Hermes skill, or AI/provider spend
+path. This pass only reuses the existing billing guard and existing layout
+preset table.
+
+## Hermes-First Analysis
+
+This is local NestJS dashboard authorization and DTO/service contract repair,
+not a business-agent or MCP/Hermes task.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Dashboard write gating | none applicable | reuse existing `@RequiresSubscription()` decorator |
+| Layout preset materialization | none applicable | reuse existing `LAYOUT_PRESETS` in `ContentService` |
+
+Awesome-Hermes ecosystem check: no applicable Hermes runtime or skill primitive
+for NestJS controller guard metadata or layout DTO validation.
+
+## Design
+
+- Apply `@RequiresSubscription()` at method level to mutating dashboard-adjacent
+  handlers:
+  - display-group create/update/delete/member add/member remove
+  - folder create/update/delete/content move
+  - bulk content update/archive/restore/delete/tag/duration writes
+  - layout create/update/delete
+  - template create/update/refresh
+  - widget create/update/refresh
+- Keep read handlers and stateless preview/validation handlers undecorated so
+  expired paid accounts retain read-only dashboard access and non-mutating
+  diagnostics remain available.
+- Import the existing `BillingModule` into `DisplayGroupsModule` and
+  `FoldersModule` so Nest can resolve `SubscriptionActiveGuard` for those
+  standalone controllers.
+- Make `CreateLayoutDto.zones` optional.
+- In `ContentService.createLayout()`, derive missing `zones` and
+  `gridTemplate` from the matching preset. Preserve explicit zones for custom
+  layouts and dashboard editor updates.
+- Return a clear `BadRequestException` when a non-custom layout type has no
+  preset and no explicit zones. `custom` can still default to a single-zone grid
+  only if explicit zones are supplied.
+- Normalize layout presets on the dashboard list page so both server and
+  fallback preset shapes use a concrete `type` before create.
+- Normalize layout editor responses so top-level fields and `metadata` fields
+  both load into the editor model.
+- Normalize saved layout list responses the same way before rendering preview
+  and preset labels.
+
+## Plan
+
+- [x] Add guard metadata regression coverage for the newly-gated mutating
+  handlers and for stateless template preview/validation remaining ungated.
+- [x] Add executable guard-resolution coverage for display-group and folder
+  modules.
+- [x] Add service regression coverage proving preset-based layout creation
+  succeeds without zones and persists preset zones/grid template.
+- [x] Add dashboard regressions for server-shaped presets and metadata-backed
+  saved/resolved layout loads.
+- [x] Patch controllers, modules, DTO, layout creation service, and dashboard
+  normalization.
+- [x] Run focused controller/service/dashboard tests.
+- [x] Run multi-vector diff reviews before broader tests.
+- [x] Run TypeScript, broader middleware tests/build, lint/security checks.
+- [ ] Open PR, wait for CI, merge if green.
+- [ ] Re-check production deploy gate; deploy only if the dirty/diverged
+  production checkout is made safe.
+
+## Risks
+
+- Over-gating stateless template preview/validation would make the template
+  editor less useful for expired accounts. Method-level decoration avoids this.
+- Materializing default zones server-side must not hide bad custom-layout input.
+  The service only derives from known presets when zones are omitted.
+- Adding subscription guards changes runtime behavior for inactive paid
+  subscriptions on write paths. This aligns with the existing core content
+  controller semantics and still permits free-tier write access through the
+  existing guard.
+
+## Verification
+
+- Focused:
+  `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/content/controllers/layouts.controller.spec.ts src/modules/content/controllers/templates.controller.spec.ts src/modules/content/controllers/widgets.controller.spec.ts src/modules/content/controllers/bulk-operations.controller.spec.ts src/modules/display-groups/display-groups.controller.spec.ts src/modules/folders/folders.controller.spec.ts src/modules/content/content.service.spec.ts`
+- Subscription/layout focused:
+  `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/billing/subscription-write-gates.spec.ts src/modules/content/content.service.spec.ts`
+  => 2 suites / 151 tests passing.
+- Controller slice:
+  `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/content/controllers/layouts.controller.spec.ts src/modules/content/controllers/templates.controller.spec.ts src/modules/content/controllers/widgets.controller.spec.ts src/modules/content/controllers/bulk-operations.controller.spec.ts src/modules/display-groups/display-groups.controller.spec.ts src/modules/folders/folders.controller.spec.ts src/modules/billing/subscription-write-gates.spec.ts`
+  => 7 suites / 149 tests passing.
+- Dashboard focused:
+  `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/dashboard/layouts/__tests__/layouts-page.test.tsx src/app/dashboard/layouts/[id]/__tests__/layout-editor-page.test.tsx`
+  => 2 suites / 13 tests passing; existing React `act()` warnings remain in
+  older layout tests.
+- TypeScript:
+  `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
+  => passing.
+- TypeScript:
+  `pnpm --filter @vizora/web exec tsc --noEmit --pretty false`
+  => passing.
+- Broader middleware:
+  `pnpm --filter @vizora/middleware test -- --runInBand`
+  => 148 suites / 3023 tests passing / 1 snapshot.
+- Broader web:
+  `pnpm --filter @vizora/web test -- --runInBand`
+  => 104 suites / 1103 tests passing; existing React `act()` warnings remain
+  in older unrelated tests.
+- Build:
+  `npx nx build @vizora/middleware`
+  => passing, with existing webpack warnings.
+- Build:
+  `npx nx build @vizora/web`
+  => passing with production env values, with existing Next middleware/proxy
+  warning.
+- Security:
+  `pnpm security:no-hardcoded-jwts`
+  => passing.
+- Diff hygiene:
+  changed-file ESLint => 0 errors / 19 warnings, mostly existing `any`
+  warnings plus existing unused `idx` in the layout editor; `git diff --check`
+  passes with CRLF normalization warnings.
+
+## Review
+
+- Plan/security reviewer found missing `BillingModule` imports for
+  display-groups and folders; fixed and covered by executable guard-resolution
+  tests.
+- Plan/layout reviewer found backend `layoutType` and metadata shape drift
+  against the dashboard list/editor; fixed with normalization and tests.
+- Diff security/module reviewer returned CLEAN.
+- Diff layout reviewer found saved-layout list normalization incomplete; fixed
+  with metadata-backed saved-layout coverage.
+- Follow-up layout reviewer returned CLEAN.

--- a/middleware/src/modules/billing/subscription-write-gates.spec.ts
+++ b/middleware/src/modules/billing/subscription-write-gates.spec.ts
@@ -1,0 +1,145 @@
+import {
+  DynamicModule,
+  ExecutionContext,
+  ForbiddenException,
+  Type,
+} from '@nestjs/common';
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { Test } from '@nestjs/testing';
+import { SubscriptionActiveGuard } from './guards/subscription-active.guard';
+import { DatabaseService } from '../database/database.service';
+import { MailModule } from '../mail/mail.module';
+import { RedisModule } from '../redis/redis.module';
+import { DisplayGroupsModule } from '../display-groups/display-groups.module';
+import { DisplayGroupsController } from '../display-groups/display-groups.controller';
+import { FoldersModule } from '../folders/folders.module';
+import { FoldersController } from '../folders/folders.controller';
+import { BulkOperationsController } from '../content/controllers/bulk-operations.controller';
+import { LayoutsController } from '../content/controllers/layouts.controller';
+import { TemplatesController } from '../content/controllers/templates.controller';
+import { WidgetsController } from '../content/controllers/widgets.controller';
+
+type ControllerClass = {
+  name: string;
+  prototype: object;
+};
+type NestModuleImport = Type<unknown> | DynamicModule;
+
+function methodGuards(controller: ControllerClass, methodName: string) {
+  return Reflect.getMetadata(
+    GUARDS_METADATA,
+    (controller.prototype as Record<string, unknown>)[methodName],
+  ) ?? [];
+}
+
+function guardContext(handler: unknown): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({
+        method: 'POST',
+        user: {
+          id: 'user-expired',
+          organizationId: 'org-expired',
+        },
+      }),
+    }),
+    getHandler: () => handler,
+    getClass: () => class TestController {},
+  } as unknown as ExecutionContext;
+}
+
+describe('dashboard subscription write gates', () => {
+  const guardedWriteHandlers: Array<[ControllerClass, string]> = [
+    [DisplayGroupsController, 'create'],
+    [DisplayGroupsController, 'update'],
+    [DisplayGroupsController, 'remove'],
+    [DisplayGroupsController, 'addDisplays'],
+    [DisplayGroupsController, 'removeDisplays'],
+    [FoldersController, 'create'],
+    [FoldersController, 'update'],
+    [FoldersController, 'remove'],
+    [FoldersController, 'moveContent'],
+    [BulkOperationsController, 'bulkUpdate'],
+    [BulkOperationsController, 'bulkArchive'],
+    [BulkOperationsController, 'bulkRestore'],
+    [BulkOperationsController, 'bulkDelete'],
+    [BulkOperationsController, 'bulkAddTags'],
+    [BulkOperationsController, 'bulkSetDuration'],
+    [LayoutsController, 'createLayout'],
+    [LayoutsController, 'updateLayout'],
+    [LayoutsController, 'deleteLayout'],
+    [TemplatesController, 'createTemplate'],
+    [TemplatesController, 'updateTemplate'],
+    [TemplatesController, 'refreshTemplate'],
+    [WidgetsController, 'createWidget'],
+    [WidgetsController, 'updateWidget'],
+    [WidgetsController, 'refreshWidget'],
+  ];
+
+  it.each(guardedWriteHandlers)(
+    '%s.%s requires an active subscription for writes',
+    (controller, methodName) => {
+      expect(methodGuards(controller, methodName)).toEqual(
+        expect.arrayContaining([SubscriptionActiveGuard]),
+      );
+    },
+  );
+
+  it.each([
+    [TemplatesController, 'previewTemplate'],
+    [TemplatesController, 'validateTemplate'],
+  ] as Array<[ControllerClass, string]>)(
+    '%s.%s stays ungated because it is stateless',
+    (controller, methodName) => {
+      expect(methodGuards(controller, methodName)).not.toContain(
+        SubscriptionActiveGuard,
+      );
+    },
+  );
+
+  it.each([
+    [DisplayGroupsModule, DisplayGroupsController, 'create'],
+    [FoldersModule, FoldersController, 'create'],
+  ] as Array<[NestModuleImport, ControllerClass, string]>)(
+    '%s resolves and executes SubscriptionActiveGuard for %s.%s',
+    async (moduleType, controller, methodName) => {
+      const databaseService = {
+        organization: {
+          findUnique: jest.fn().mockResolvedValue({
+            subscriptionStatus: 'canceled',
+            subscriptionTier: 'pro',
+            trialEndsAt: null,
+          }),
+        },
+      };
+
+      const moduleRef = await Test.createTestingModule({
+        imports: [MailModule, RedisModule, moduleType],
+      })
+        .overrideProvider(DatabaseService)
+        .useValue(databaseService)
+        .compile();
+
+      try {
+        const guard = moduleRef.get(SubscriptionActiveGuard, { strict: false });
+
+        await expect(
+          guard.canActivate(
+            guardContext((controller.prototype as Record<string, unknown>)[methodName]),
+          ),
+        ).rejects.toThrow(ForbiddenException);
+
+        expect(databaseService.organization.findUnique).toHaveBeenCalledWith({
+          where: { id: 'org-expired' },
+          select: {
+            subscriptionStatus: true,
+            subscriptionTier: true,
+            trialEndsAt: true,
+          },
+        });
+      } finally {
+        await moduleRef.close();
+      }
+    },
+  );
+});

--- a/middleware/src/modules/content/content.service.spec.ts
+++ b/middleware/src/modules/content/content.service.spec.ts
@@ -427,6 +427,74 @@ describe('ContentService', () => {
     });
   });
 
+  describe('createLayout', () => {
+    it('materializes preset zones when dashboard creation omits zones', async () => {
+      mockDatabaseService.content.create.mockResolvedValue({
+        ...mockContent,
+        id: 'layout-1',
+        name: 'Lobby Split',
+        type: 'layout',
+        url: '',
+        metadata: {
+          layoutType: 'split-horizontal',
+          zones: [
+            { id: 'left', name: 'Left', gridArea: '1 / 1 / 2 / 2' },
+            { id: 'right', name: 'Right', gridArea: '1 / 2 / 2 / 3' },
+          ],
+          gridTemplate: { columns: '1fr 1fr', rows: '1fr' },
+          gap: 0,
+          backgroundColor: '#000000',
+        },
+      });
+
+      const result = await service.createLayout('org-123', {
+        name: 'Lobby Split',
+        layoutType: 'split-horizontal',
+        description: 'Preset create from dashboard',
+      } as any);
+
+      expect(mockDatabaseService.content.create).toHaveBeenCalledWith({
+        data: {
+          name: 'Lobby Split',
+          description: 'Preset create from dashboard',
+          type: 'layout',
+          url: '',
+          metadata: {
+            layoutType: 'split-horizontal',
+            zones: [
+              { id: 'left', name: 'Left', gridArea: '1 / 1 / 2 / 2' },
+              { id: 'right', name: 'Right', gridArea: '1 / 2 / 2 / 3' },
+            ],
+            gridTemplate: { columns: '1fr 1fr', rows: '1fr' },
+            gap: 0,
+            backgroundColor: '#000000',
+          },
+          organizationId: 'org-123',
+        },
+      });
+      expect(result.metadata).toEqual(
+        expect.objectContaining({
+          layoutType: 'split-horizontal',
+          zones: expect.arrayContaining([
+            expect.objectContaining({ id: 'left', name: 'Left' }),
+            expect.objectContaining({ id: 'right', name: 'Right' }),
+          ]),
+        }),
+      );
+    });
+
+    it('rejects custom layouts without explicit zones', async () => {
+      await expect(
+        service.createLayout('org-123', {
+          name: 'Custom Layout',
+          layoutType: 'custom',
+        } as any),
+      ).rejects.toThrow('Layout zones are required for custom layouts');
+
+      expect(mockDatabaseService.content.create).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getResolvedLayout', () => {
     it('emits display-compatible resolvedPlaylist and resolvedContent zone fields', async () => {
       mockDatabaseService.content.findFirst.mockResolvedValue({

--- a/middleware/src/modules/content/content.service.ts
+++ b/middleware/src/modules/content/content.service.ts
@@ -12,7 +12,7 @@ import { BulkUpdateDto, BulkArchiveDto, BulkRestoreDto, BulkDeleteDto, BulkTagDt
 import { PaginationDto, PaginatedResponse } from '../common/dto/pagination.dto';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { TemplateRenderingService } from './template-rendering.service';
-import { CreateLayoutDto } from './dto/create-layout.dto';
+import { CreateLayoutDto, LayoutZoneDto } from './dto/create-layout.dto';
 import { CreateWidgetDto } from './dto/create-widget.dto';
 import { LAYOUT_PRESETS } from './layout-presets';
 import { DataSourceRegistryService } from './data-source-registry.service';
@@ -1537,9 +1537,18 @@ export class ContentService {
    * Create a new multi-zone layout
    */
   async createLayout(organizationId: string, dto: CreateLayoutDto) {
+    const zones = dto.zones ?? this.getPresetZonesForType(dto.layoutType);
+    if (!zones || zones.length === 0) {
+      throw new BadRequestException(
+        dto.layoutType === 'custom'
+          ? 'Layout zones are required for custom layouts'
+          : `Unknown layout preset: ${dto.layoutType}`,
+      );
+    }
+
     const metadata = {
       layoutType: dto.layoutType,
-      zones: dto.zones,
+      zones,
       gridTemplate: dto.gridTemplate || this.getGridTemplateForType(dto.layoutType),
       gap: dto.gap ?? 0,
       backgroundColor: dto.backgroundColor || '#000000',
@@ -1681,6 +1690,11 @@ export class ContentService {
     }
     // Default for custom layouts
     return { columns: '1fr', rows: '1fr' };
+  }
+
+  private getPresetZonesForType(layoutType: string): LayoutZoneDto[] | undefined {
+    const preset = LAYOUT_PRESETS.find(p => p.layoutType === layoutType);
+    return preset?.zones.map((zone) => ({ ...zone }));
   }
 
   // ============================================================================

--- a/middleware/src/modules/content/controllers/bulk-operations.controller.spec.ts
+++ b/middleware/src/modules/content/controllers/bulk-operations.controller.spec.ts
@@ -8,6 +8,7 @@ jest.mock('isomorphic-dompurify', () => ({
 import { Test, TestingModule } from '@nestjs/testing';
 import { BulkOperationsController } from './bulk-operations.controller';
 import { ContentService } from '../content.service';
+import { DatabaseService } from '../../database/database.service';
 
 describe('BulkOperationsController', () => {
   let controller: BulkOperationsController;
@@ -29,6 +30,7 @@ describe('BulkOperationsController', () => {
       controllers: [BulkOperationsController],
       providers: [
         { provide: ContentService, useValue: mockContentService },
+        { provide: DatabaseService, useValue: { organization: { findUnique: jest.fn() } } },
       ],
     }).compile();
 

--- a/middleware/src/modules/content/controllers/bulk-operations.controller.ts
+++ b/middleware/src/modules/content/controllers/bulk-operations.controller.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/common';
 import { RolesGuard } from '../../auth/guards/roles.guard';
 import { Roles } from '../../auth/decorators/roles.decorator';
+import { RequiresSubscription } from '../../billing/decorators/requires-subscription.decorator';
 import { ContentService } from '../content.service';
 import { BulkUpdateDto, BulkArchiveDto, BulkRestoreDto, BulkDeleteDto, BulkTagDto, BulkDurationDto } from '../dto/bulk-operations.dto';
 import { CurrentUser } from '../../auth/decorators/current-user.decorator';
@@ -19,6 +20,7 @@ export class BulkOperationsController {
 
   @Post('update')
   @Roles('admin', 'manager')
+  @RequiresSubscription()
   @HttpCode(HttpStatus.OK)
   bulkUpdate(
     @CurrentUser('organizationId') organizationId: string,
@@ -29,6 +31,7 @@ export class BulkOperationsController {
 
   @Post('archive')
   @Roles('admin', 'manager')
+  @RequiresSubscription()
   @HttpCode(HttpStatus.OK)
   bulkArchive(
     @CurrentUser('organizationId') organizationId: string,
@@ -39,6 +42,7 @@ export class BulkOperationsController {
 
   @Post('restore')
   @Roles('admin', 'manager')
+  @RequiresSubscription()
   @HttpCode(HttpStatus.OK)
   bulkRestore(
     @CurrentUser('organizationId') organizationId: string,
@@ -49,6 +53,7 @@ export class BulkOperationsController {
 
   @Post('delete')
   @Roles('admin')
+  @RequiresSubscription()
   @HttpCode(HttpStatus.OK)
   bulkDelete(
     @CurrentUser('organizationId') organizationId: string,
@@ -59,6 +64,7 @@ export class BulkOperationsController {
 
   @Post('tags')
   @Roles('admin', 'manager')
+  @RequiresSubscription()
   @HttpCode(HttpStatus.OK)
   bulkAddTags(
     @CurrentUser('organizationId') organizationId: string,
@@ -69,6 +75,7 @@ export class BulkOperationsController {
 
   @Post('duration')
   @Roles('admin', 'manager')
+  @RequiresSubscription()
   @HttpCode(HttpStatus.OK)
   bulkSetDuration(
     @CurrentUser('organizationId') organizationId: string,

--- a/middleware/src/modules/content/controllers/layouts.controller.spec.ts
+++ b/middleware/src/modules/content/controllers/layouts.controller.spec.ts
@@ -8,6 +8,7 @@ jest.mock('isomorphic-dompurify', () => ({
 import { Test, TestingModule } from '@nestjs/testing';
 import { LayoutsController } from './layouts.controller';
 import { ContentService } from '../content.service';
+import { DatabaseService } from '../../database/database.service';
 
 describe('LayoutsController', () => {
   let controller: LayoutsController;
@@ -29,6 +30,7 @@ describe('LayoutsController', () => {
       controllers: [LayoutsController],
       providers: [
         { provide: ContentService, useValue: mockContentService },
+        { provide: DatabaseService, useValue: { organization: { findUnique: jest.fn() } } },
       ],
     }).compile();
 

--- a/middleware/src/modules/content/controllers/layouts.controller.ts
+++ b/middleware/src/modules/content/controllers/layouts.controller.ts
@@ -12,6 +12,7 @@ import {
 import { ParseIdPipe } from '../../common/pipes/parse-id.pipe';
 import { RolesGuard } from '../../auth/guards/roles.guard';
 import { Roles } from '../../auth/decorators/roles.decorator';
+import { RequiresSubscription } from '../../billing/decorators/requires-subscription.decorator';
 import { ContentService } from '../content.service';
 import { CreateLayoutDto } from '../dto/create-layout.dto';
 import { UpdateLayoutDto } from '../dto/update-layout.dto';
@@ -40,6 +41,7 @@ export class LayoutsController {
 
   @Post()
   @Roles('admin', 'manager')
+  @RequiresSubscription()
   createLayout(
     @CurrentUser('organizationId') organizationId: string,
     @Body() dto: CreateLayoutDto,
@@ -49,6 +51,7 @@ export class LayoutsController {
 
   @Patch(':id')
   @Roles('admin', 'manager')
+  @RequiresSubscription()
   updateLayout(
     @CurrentUser('organizationId') organizationId: string,
     @Param('id', ParseIdPipe) id: string,
@@ -68,6 +71,7 @@ export class LayoutsController {
 
   @Delete(':id')
   @Roles('admin', 'manager')
+  @RequiresSubscription()
   deleteLayout(
     @CurrentUser('organizationId') organizationId: string,
     @Param('id', ParseIdPipe) id: string,

--- a/middleware/src/modules/content/controllers/templates.controller.spec.ts
+++ b/middleware/src/modules/content/controllers/templates.controller.spec.ts
@@ -8,6 +8,7 @@ jest.mock('isomorphic-dompurify', () => ({
 import { Test, TestingModule } from '@nestjs/testing';
 import { TemplatesController } from './templates.controller';
 import { ContentService } from '../content.service';
+import { DatabaseService } from '../../database/database.service';
 
 describe('TemplatesController', () => {
   let controller: TemplatesController;
@@ -29,6 +30,7 @@ describe('TemplatesController', () => {
       controllers: [TemplatesController],
       providers: [
         { provide: ContentService, useValue: mockContentService },
+        { provide: DatabaseService, useValue: { organization: { findUnique: jest.fn() } } },
       ],
     }).compile();
 

--- a/middleware/src/modules/content/controllers/templates.controller.ts
+++ b/middleware/src/modules/content/controllers/templates.controller.ts
@@ -12,6 +12,7 @@ import {
 import { ParseIdPipe } from '../../common/pipes/parse-id.pipe';
 import { RolesGuard } from '../../auth/guards/roles.guard';
 import { Roles } from '../../auth/decorators/roles.decorator';
+import { RequiresSubscription } from '../../billing/decorators/requires-subscription.decorator';
 import { ContentService } from '../content.service';
 import { CreateTemplateDto } from '../dto/create-template.dto';
 import { UpdateTemplateDto } from '../dto/update-template.dto';
@@ -26,6 +27,7 @@ export class TemplatesController {
 
   @Post()
   @Roles('admin', 'manager')
+  @RequiresSubscription()
   createTemplate(
     @CurrentUser('organizationId') organizationId: string,
     @Body() dto: CreateTemplateDto,
@@ -35,6 +37,7 @@ export class TemplatesController {
 
   @Patch(':id')
   @Roles('admin', 'manager')
+  @RequiresSubscription()
   updateTemplate(
     @CurrentUser('organizationId') organizationId: string,
     @Param('id', ParseIdPipe) id: string,
@@ -77,6 +80,7 @@ export class TemplatesController {
 
   @Post(':id/refresh')
   @Roles('admin', 'manager')
+  @RequiresSubscription()
   @HttpCode(HttpStatus.OK)
   refreshTemplate(
     @CurrentUser('organizationId') organizationId: string,

--- a/middleware/src/modules/content/controllers/widgets.controller.spec.ts
+++ b/middleware/src/modules/content/controllers/widgets.controller.spec.ts
@@ -12,6 +12,7 @@ jest.mock('dns/promises', () => ({
 import { Test, TestingModule } from '@nestjs/testing';
 import { WidgetsController } from './widgets.controller';
 import { ContentService } from '../content.service';
+import { DatabaseService } from '../../database/database.service';
 import { lookup } from 'dns/promises';
 
 describe('WidgetsController', () => {
@@ -34,6 +35,7 @@ describe('WidgetsController', () => {
       controllers: [WidgetsController],
       providers: [
         { provide: ContentService, useValue: mockContentService },
+        { provide: DatabaseService, useValue: { organization: { findUnique: jest.fn() } } },
       ],
     }).compile();
 

--- a/middleware/src/modules/content/controllers/widgets.controller.ts
+++ b/middleware/src/modules/content/controllers/widgets.controller.ts
@@ -16,6 +16,7 @@ import {
 import { ParseIdPipe } from '../../common/pipes/parse-id.pipe';
 import { RolesGuard } from '../../auth/guards/roles.guard';
 import { Roles } from '../../auth/decorators/roles.decorator';
+import { RequiresSubscription } from '../../billing/decorators/requires-subscription.decorator';
 import { ContentService } from '../content.service';
 import { CreateWidgetDto } from '../dto/create-widget.dto';
 import { PaginationDto } from '../../common/dto/pagination.dto';
@@ -225,6 +226,7 @@ export class WidgetsController {
 
   @Post()
   @Roles('admin', 'manager')
+  @RequiresSubscription()
   createWidget(
     @CurrentUser('organizationId') organizationId: string,
     @Body() dto: CreateWidgetDto,
@@ -234,6 +236,7 @@ export class WidgetsController {
 
   @Patch(':id')
   @Roles('admin', 'manager')
+  @RequiresSubscription()
   updateWidget(
     @CurrentUser('organizationId') organizationId: string,
     @Param('id', ParseIdPipe) id: string,
@@ -244,6 +247,7 @@ export class WidgetsController {
 
   @Post(':id/refresh')
   @Roles('admin', 'manager')
+  @RequiresSubscription()
   @HttpCode(HttpStatus.OK)
   refreshWidget(
     @CurrentUser('organizationId') organizationId: string,

--- a/middleware/src/modules/content/dto/create-layout.dto.ts
+++ b/middleware/src/modules/content/dto/create-layout.dto.ts
@@ -35,10 +35,11 @@ export class CreateLayoutDto {
   @IsEnum(['split-horizontal', 'split-vertical', 'grid-2x2', 'main-sidebar', 'l-shape', 'custom'])
   layoutType: string;
 
+  @IsOptional()
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => LayoutZoneDto)
-  zones: LayoutZoneDto[];
+  zones?: LayoutZoneDto[];
 
   @IsOptional()
   @IsObject()

--- a/middleware/src/modules/display-groups/display-groups.controller.spec.ts
+++ b/middleware/src/modules/display-groups/display-groups.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { NotFoundException } from '@nestjs/common';
 import { DisplayGroupsController } from './display-groups.controller';
 import { DisplayGroupsService } from './display-groups.service';
+import { DatabaseService } from '../database/database.service';
 
 describe('DisplayGroupsController', () => {
   let controller: DisplayGroupsController;
@@ -22,7 +23,10 @@ describe('DisplayGroupsController', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [DisplayGroupsController],
-      providers: [{ provide: DisplayGroupsService, useValue: mockDisplayGroupsService }],
+      providers: [
+        { provide: DisplayGroupsService, useValue: mockDisplayGroupsService },
+        { provide: DatabaseService, useValue: { organization: { findUnique: jest.fn() } } },
+      ],
     }).compile();
 
     controller = module.get<DisplayGroupsController>(DisplayGroupsController);

--- a/middleware/src/modules/display-groups/display-groups.controller.ts
+++ b/middleware/src/modules/display-groups/display-groups.controller.ts
@@ -12,6 +12,7 @@ import {
 import { ParseIdPipe } from '../common/pipes/parse-id.pipe';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
+import { RequiresSubscription } from '../billing/decorators/requires-subscription.decorator';
 import { DisplayGroupsService } from './display-groups.service';
 import { CreateDisplayGroupDto } from './dto/create-display-group.dto';
 import { UpdateDisplayGroupDto } from './dto/update-display-group.dto';
@@ -26,6 +27,7 @@ export class DisplayGroupsController {
 
   @Post()
   @Roles('admin', 'manager')
+  @RequiresSubscription()
   create(
     @CurrentUser('organizationId') organizationId: string,
     @Body() createDisplayGroupDto: CreateDisplayGroupDto,
@@ -51,6 +53,7 @@ export class DisplayGroupsController {
 
   @Patch(':id')
   @Roles('admin', 'manager')
+  @RequiresSubscription()
   update(
     @CurrentUser('organizationId') organizationId: string,
     @Param('id', ParseIdPipe) id: string,
@@ -61,6 +64,7 @@ export class DisplayGroupsController {
 
   @Delete(':id')
   @Roles('admin')
+  @RequiresSubscription()
   remove(
     @CurrentUser('organizationId') organizationId: string,
     @Param('id', ParseIdPipe) id: string,
@@ -70,6 +74,7 @@ export class DisplayGroupsController {
 
   @Post(':id/displays')
   @Roles('admin', 'manager')
+  @RequiresSubscription()
   addDisplays(
     @CurrentUser('organizationId') organizationId: string,
     @Param('id', ParseIdPipe) id: string,
@@ -80,6 +85,7 @@ export class DisplayGroupsController {
 
   @Delete(':id/displays')
   @Roles('admin', 'manager')
+  @RequiresSubscription()
   removeDisplays(
     @CurrentUser('organizationId') organizationId: string,
     @Param('id', ParseIdPipe) id: string,

--- a/middleware/src/modules/display-groups/display-groups.module.ts
+++ b/middleware/src/modules/display-groups/display-groups.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
+import { BillingModule } from '../billing/billing.module';
 import { DisplayGroupsService } from './display-groups.service';
 import { DisplayGroupsController } from './display-groups.controller';
 
 @Module({
+  imports: [BillingModule],
   controllers: [DisplayGroupsController],
   providers: [DisplayGroupsService],
   exports: [DisplayGroupsService],

--- a/middleware/src/modules/folders/folders.controller.spec.ts
+++ b/middleware/src/modules/folders/folders.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { NotFoundException, BadRequestException } from '@nestjs/common';
 import { FoldersController } from './folders.controller';
 import { FoldersService } from './folders.service';
+import { DatabaseService } from '../database/database.service';
 
 describe('FoldersController', () => {
   let controller: FoldersController;
@@ -34,7 +35,10 @@ describe('FoldersController', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [FoldersController],
-      providers: [{ provide: FoldersService, useValue: mockFoldersService }],
+      providers: [
+        { provide: FoldersService, useValue: mockFoldersService },
+        { provide: DatabaseService, useValue: { organization: { findUnique: jest.fn() } } },
+      ],
     }).compile();
 
     controller = module.get<FoldersController>(FoldersController);

--- a/middleware/src/modules/folders/folders.controller.ts
+++ b/middleware/src/modules/folders/folders.controller.ts
@@ -14,6 +14,7 @@ import {
 import { ParseIdPipe } from '../common/pipes/parse-id.pipe';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
+import { RequiresSubscription } from '../billing/decorators/requires-subscription.decorator';
 import { FoldersService } from './folders.service';
 import { CreateFolderDto } from './dto/create-folder.dto';
 import { UpdateFolderDto } from './dto/update-folder.dto';
@@ -28,6 +29,7 @@ export class FoldersController {
 
   @Post()
   @Roles('admin', 'manager')
+  @RequiresSubscription()
   create(
     @CurrentUser('organizationId') organizationId: string,
     @Body() createFolderDto: CreateFolderDto,
@@ -56,6 +58,7 @@ export class FoldersController {
 
   @Patch(':id')
   @Roles('admin', 'manager')
+  @RequiresSubscription()
   update(
     @CurrentUser('organizationId') organizationId: string,
     @Param('id', ParseIdPipe) id: string,
@@ -66,6 +69,7 @@ export class FoldersController {
 
   @Delete(':id')
   @Roles('admin', 'manager')
+  @RequiresSubscription()
   remove(
     @CurrentUser('organizationId') organizationId: string,
     @Param('id', ParseIdPipe) id: string,
@@ -75,6 +79,7 @@ export class FoldersController {
 
   @Post(':id/content')
   @Roles('admin', 'manager')
+  @RequiresSubscription()
   @HttpCode(HttpStatus.OK)
   moveContent(
     @CurrentUser('organizationId') organizationId: string,

--- a/middleware/src/modules/folders/folders.module.ts
+++ b/middleware/src/modules/folders/folders.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
+import { BillingModule } from '../billing/billing.module';
 import { FoldersService } from './folders.service';
 import { FoldersController } from './folders.controller';
 
 @Module({
+  imports: [BillingModule],
   controllers: [FoldersController],
   providers: [FoldersService],
   exports: [FoldersService],

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,101 @@
 # Vizora - Task Tracker
 
-## Active Workstream: Pairing Active Index Pass 47 (2026-06-02)
+## Active Workstream: Dashboard Write Gates and Layout Create Pass 48 (2026-06-02)
+
+**Branch:** `fix/dashboard-write-gates-layout-pass-48`
+
+**Why now:** PR #187 is merged with green CI and no PRs remain open, but
+production deploy remains blocked by dirty/diverged production state. The next
+customer-dashboard findings are small, repo-side, testable regressions:
+dashboard-adjacent write routes miss the existing subscription-active guard,
+and normal dashboard layout creation can fail because the frontend omits
+server-owned preset zones.
+
+**New primitives introduced:** none. This pass reuses the existing
+`@RequiresSubscription()` decorator / `SubscriptionActiveGuard` and the existing
+`LAYOUT_PRESETS` table. No new route, model, migration, module, env var,
+process, response shape, realtime path, MCP tool, Hermes skill, or AI/provider
+spend path.
+
+**Hermes-first analysis:** checked per project convention. This is local
+NestJS controller authorization and layout DTO/service contract repair, not a
+business-agent, MCP, Hermes runtime, or provider-spend task.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Dashboard write gating | none applicable | reuse existing billing guard decorator |
+| Layout preset materialization | none applicable | reuse existing `LAYOUT_PRESETS` |
+
+Awesome-hermes-agent ecosystem check: no applicable skill/library primitive for
+NestJS guard metadata or preset-backed layout creation.
+
+**Plan/design:**
+`docs/plans/2026-06-02-dashboard-write-gates-layout-pass-48.md`
+
+**Plan**
+- [x] Drift-check current guard/decorator usage and dashboard layout payloads.
+- [x] Document pass 48 design and test plan.
+- [x] Add guard metadata regression coverage for newly gated mutating handlers.
+- [x] Add executable guard-resolution coverage for display-group/folder modules.
+- [x] Add service regression coverage for preset-based layout creation without
+  zones.
+- [x] Add dashboard regressions for server-shaped presets and metadata-backed
+  saved-layout/editor loads.
+- [x] Patch controllers, modules, layout DTO, layout creation service, and
+  dashboard normalization.
+- [x] Run focused middleware/web tests.
+- [x] Run multi-vector subagent diff review.
+- [x] Run broader middleware verification and build.
+- [ ] PR, CI, merge if green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Evidence so far**
+- Current `origin/main`: `913ed1b0661209858f45f1b034daac3c695de942`.
+- No open PRs after merging PR #187.
+- Production deploy gate remains blocked: `/opt/vizora/app` is
+  `main...origin/main [ahead 17, behind 164]` with 72 dirty/untracked paths;
+  middleware/web/realtime are online, `/api/v1/health` is 200, and readiness is
+  degraded by high middleware heap memory.
+- Focused verification:
+  - `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/billing/subscription-write-gates.spec.ts src/modules/content/content.service.spec.ts`
+    => 2 suites / 151 tests passing.
+  - `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/dashboard/layouts/__tests__/layouts-page.test.tsx src/app/dashboard/layouts/[id]/__tests__/layout-editor-page.test.tsx`
+    => 2 suites / 13 tests passing; existing React `act()` warnings remain in
+    the older layouts page tests.
+- Targeted controller slice:
+  - `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/content/controllers/layouts.controller.spec.ts src/modules/content/controllers/templates.controller.spec.ts src/modules/content/controllers/widgets.controller.spec.ts src/modules/content/controllers/bulk-operations.controller.spec.ts src/modules/display-groups/display-groups.controller.spec.ts src/modules/folders/folders.controller.spec.ts src/modules/billing/subscription-write-gates.spec.ts`
+    => 7 suites / 149 tests passing.
+- Full verification:
+  - `pnpm --filter @vizora/middleware test -- --runInBand`
+    => 148 suites / 3023 tests passing / 1 snapshot.
+  - `pnpm --filter @vizora/web test -- --runInBand`
+    => 104 suites / 1103 tests passing; existing React `act()` warnings remain
+    in older unrelated tests.
+  - `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
+    => passing.
+  - `pnpm --filter @vizora/web exec tsc --noEmit --pretty false`
+    => passing.
+  - Changed-file ESLint => 0 errors / 19 warnings, mostly existing `any`
+    warnings plus existing unused `idx` in the layout editor.
+  - `git diff --check` => passing, with CRLF normalization warnings.
+  - `npx nx build @vizora/middleware` => passing, with existing webpack
+    warnings.
+  - `npx nx build @vizora/web` with production env values => passing, with
+    existing Next middleware/proxy warning.
+  - `pnpm security:no-hardcoded-jwts` => passing.
+- Review:
+  - Plan/security reviewer found missing `BillingModule` imports for
+    display-groups and folders; fixed and covered with executable guard
+    resolution tests.
+  - Plan/layout reviewer found backend `layoutType`/metadata shape drift
+    against the dashboard; fixed with list/editor normalization and tests.
+  - Diff security/module reviewer returned CLEAN after focused tests and
+    `git diff --check`.
+  - Diff layout reviewer found saved-layout list normalization was still
+    incomplete; fixed with metadata-backed saved-layout coverage.
+  - Follow-up layout reviewer returned CLEAN.
+
+## Completed: Pairing Active Index Pass 47 (2026-06-02)
 
 **Branch:** `feat/dashboard-customer-readiness-pass-47`
 
@@ -42,13 +137,17 @@ an in-process NestJS Redis index on the dashboard pairing hot path.
 - [x] Run focused pairing tests.
 - [x] Run multi-vector subagent diff review.
 - [x] Run broader middleware verification and build.
-- [ ] PR, CI, merge if green.
-- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+- [x] PR, CI, merge if green. PR #187 merged to `origin/main` at
+  `913ed1b0661209858f45f1b034daac3c695de942`.
+- [x] Re-check deployment gate; deploy only if prod checkout is safe. Gate
+  remains blocked by dirty/diverged production checkout.
 
 **Evidence so far**
-- Current `origin/main` merge SHA after Pass 46: `4eef5d5a51afea83a660195d6f374e741a554434`.
+- Current `origin/main` merge SHA after Pass 47: `913ed1b0661209858f45f1b034daac3c695de942`.
 - No open PRs after merging PR #186.
-- Production deploy gate remains blocked: `/opt/vizora/app` is `main...origin/main [ahead 17, behind 161]` with 72 dirty/untracked paths; readiness is degraded by high middleware memory.
+- PR #187: https://github.com/Trivenidigital/Vizora/pull/187.
+- Feature commit: `71fdcb723409c8b2590829da24fc0328e7e64c11`.
+- Production deploy gate remains blocked: `/opt/vizora/app` is `main...origin/main [ahead 17, behind 164]` with 72 dirty/untracked paths; readiness is degraded by high middleware memory.
 - Stale subagent findings were traced to reviewers inspecting `C:\projects\vizora`
   instead of the active isolated worktree. `tasks/lessons.md` now captures the
   worktree-verification rule.
@@ -71,6 +170,8 @@ an in-process NestJS Redis index on the dashboard pairing hot path.
   - CI-gated middleware E2E subset:
     `pnpm --filter @vizora/middleware exec jest --config=jest.e2e.config.js --runInBand --testPathPattern="(agents|customer-critical-path)"`
     => 2 suites / 4 tests passing.
+  - PR #187 CI passed lint, audit, test, build, security, and e2e before
+    merge.
 
 ## Completed: Backend Heartbeat and Notification Scoping Pass 46 (2026-06-02)
 

--- a/web/src/app/dashboard/layouts/[id]/__tests__/layout-editor-page.test.tsx
+++ b/web/src/app/dashboard/layouts/[id]/__tests__/layout-editor-page.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import LayoutEditorPage from '../page';
+
+const mockPush = jest.fn();
+const mockGetResolvedLayout = jest.fn();
+const mockGet = jest.fn();
+const mockGetContent = jest.fn();
+const mockGetPlaylists = jest.fn();
+const mockUpdateLayout = jest.fn();
+
+jest.mock('react', () => {
+  const actual = jest.requireActual('react');
+  return {
+    ...actual,
+    use: jest.fn(() => ({ id: 'layout-1' })),
+  };
+});
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+    back: jest.fn(),
+    forward: jest.fn(),
+  }),
+}));
+
+jest.mock('@/lib/api', () => ({
+  apiClient: {
+    getResolvedLayout: (...args: any[]) => mockGetResolvedLayout(...args),
+    get: (...args: any[]) => mockGet(...args),
+    getContent: (...args: any[]) => mockGetContent(...args),
+    getPlaylists: (...args: any[]) => mockGetPlaylists(...args),
+    updateLayout: (...args: any[]) => mockUpdateLayout(...args),
+  },
+}));
+
+jest.mock('@/lib/hooks/useToast', () => ({
+  useToast: () => ({
+    success: jest.fn(),
+    error: jest.fn(),
+    ToastContainer: () => null,
+  }),
+}));
+
+jest.mock('@/theme/icons', () => ({
+  Icon: ({ name }: { name: string }) => <span data-testid={`icon-${name}`}>{name}</span>,
+}));
+
+jest.mock('@/components/LoadingSpinner', () => {
+  return function MockSpinner() { return <div data-testid="spinner">Loading...</div>; };
+});
+
+function renderPage() {
+  return render(
+    <LayoutEditorPage params={Promise.resolve({ id: 'layout-1' })} />,
+  );
+}
+
+describe('LayoutEditorPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetResolvedLayout.mockResolvedValue({
+      id: 'layout-1',
+      name: 'Lobby Split',
+      description: 'Front lobby screen',
+      type: 'layout',
+      metadata: {
+        layoutType: 'split-horizontal',
+        zones: [
+          { id: 'left', name: 'Left', gridArea: '1 / 1 / 2 / 2' },
+          { id: 'right', name: 'Right', gridArea: '1 / 2 / 2 / 3' },
+        ],
+      },
+    });
+    mockGetContent.mockResolvedValue({ data: [] });
+    mockGetPlaylists.mockResolvedValue({ data: [] });
+  });
+
+  it('opens resolved layouts whose zone metadata is nested under metadata', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Lobby Split')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Split Horizontal Layout -- Front lobby screen')).toBeInTheDocument();
+    expect(screen.getAllByText('Left').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Right').length).toBeGreaterThan(0);
+    expect(mockGetResolvedLayout).toHaveBeenCalledWith('layout-1');
+  });
+});

--- a/web/src/app/dashboard/layouts/[id]/page.tsx
+++ b/web/src/app/dashboard/layouts/[id]/page.tsx
@@ -24,6 +24,10 @@ interface LayoutData {
   zones: Zone[];
   description?: string;
   createdAt?: string;
+  metadata?: {
+    layoutType?: string;
+    zones?: Zone[];
+  };
 }
 
 interface ContentItem {
@@ -72,6 +76,28 @@ function getDefaultZones(layoutType: string): Zone[] {
     default:
       return [{ id: 'zone-a', name: 'Full', gridArea: '1 / 1 / 2 / 2' }];
   }
+}
+
+function normalizeLayoutResponse(data: any): LayoutData | null {
+  if (!data) {
+    return null;
+  }
+
+  const metadata = data.metadata && typeof data.metadata === 'object' && !Array.isArray(data.metadata)
+    ? data.metadata
+    : {};
+  const layoutType = data.layoutType || metadata.layoutType || 'custom';
+  const zones = Array.isArray(data.zones)
+    ? data.zones
+    : Array.isArray(metadata.zones)
+      ? metadata.zones
+      : [];
+
+  return {
+    ...data,
+    layoutType,
+    zones,
+  };
 }
 
 // Get CSS grid template based on layout type
@@ -137,11 +163,14 @@ export default function LayoutEditorPage({ params }: { params: Promise<{ id: str
       }
 
       if (data) {
-        setLayout(data);
+        const normalizedLayout = normalizeLayoutResponse(data);
+        if (!normalizedLayout) return;
+
+        setLayout(normalizedLayout);
         // Use the layout zones if present, otherwise build defaults from type
-        const layoutZones = data.zones && data.zones.length > 0
-          ? data.zones
-          : getDefaultZones(data.layoutType);
+        const layoutZones = normalizedLayout.zones.length > 0
+          ? normalizedLayout.zones
+          : getDefaultZones(normalizedLayout.layoutType);
         setZones(layoutZones);
       }
     } catch (error: any) {

--- a/web/src/app/dashboard/layouts/__tests__/layouts-page.test.tsx
+++ b/web/src/app/dashboard/layouts/__tests__/layouts-page.test.tsx
@@ -168,6 +168,34 @@ describe('LayoutsPage', () => {
     expect(screen.getByText('Dashboard Grid')).toBeInTheDocument();
   });
 
+  it('normalizes backend layout metadata before rendering saved layouts', async () => {
+    mockGet.mockResolvedValue({
+      data: [
+        {
+          id: 'server-layout',
+          name: 'Server Layout',
+          description: 'Layout returned by middleware',
+          metadata: {
+            layoutType: 'split-horizontal',
+            zones: [
+              { id: 'left', name: 'Left', gridArea: '1 / 1 / 2 / 2' },
+              { id: 'right', name: 'Right', gridArea: '1 / 2 / 2 / 3' },
+            ],
+          },
+          createdAt: '2026-02-01T00:00:00Z',
+        },
+      ],
+    });
+
+    render(<LayoutsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Server Layout')).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText('Split Horizontal').length).toBeGreaterThan(1);
+  });
+
   it('handles fetch failure gracefully', async () => {
     mockGetLayoutPresets.mockRejectedValue(new Error('Failed'));
     render(<LayoutsPage />);
@@ -200,5 +228,42 @@ describe('LayoutsPage', () => {
     await waitFor(() => {
       expect(screen.getByText('Split Horizontal')).toBeInTheDocument();
     });
+  });
+
+  it('creates a layout from backend preset data with layoutType', async () => {
+    mockGetLayoutPresets.mockResolvedValue([
+      {
+        id: 'split-horizontal',
+        layoutType: 'split-horizontal',
+        name: 'Server Split',
+        description: 'Two zones from the middleware preset API',
+        zones: [
+          { id: 'left', name: 'Left', gridArea: '1 / 1 / 2 / 2' },
+          { id: 'right', name: 'Right', gridArea: '1 / 2 / 2 / 3' },
+        ],
+      },
+    ]);
+
+    render(<LayoutsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Server Split')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Use Preset'));
+    fireEvent.change(screen.getByPlaceholderText('e.g., Lobby Main Display'), {
+      target: { value: 'Lobby Main Display' },
+    });
+    const createButtons = screen.getAllByRole('button', { name: /create layout/i });
+    fireEvent.click(createButtons[createButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(mockCreateLayout).toHaveBeenCalledWith({
+        name: 'Lobby Main Display',
+        layoutType: 'split-horizontal',
+        description: undefined,
+      });
+    });
+    expect(mockPush).toHaveBeenCalledWith('/dashboard/layouts/new-1');
   });
 });

--- a/web/src/app/dashboard/layouts/page.tsx
+++ b/web/src/app/dashboard/layouts/page.tsx
@@ -139,7 +139,9 @@ const DEFAULT_PRESETS = [
 ];
 
 interface LayoutPreset {
-  type: string;
+  type?: string;
+  layoutType?: string;
+  id?: string;
   name: string;
   description: string;
   zones: number | { id: string; x: number; y: number; width: number; height: number; label?: string }[];
@@ -153,6 +155,47 @@ interface Layout {
   description?: string;
   createdAt?: string;
   updatedAt?: string;
+  metadata?: {
+    layoutType?: string;
+    zones?: any[];
+  };
+}
+
+function getPresetType(preset: LayoutPreset): string {
+  return preset.type || preset.layoutType || preset.id || 'custom';
+}
+
+function getPresetZoneCount(preset: LayoutPreset): number {
+  return Array.isArray(preset.zones) ? preset.zones.length : preset.zones;
+}
+
+function normalizeLayoutPreset(preset: LayoutPreset): LayoutPreset | null {
+  const type = getPresetType(preset);
+  if (!type || !preset.name) {
+    return null;
+  }
+
+  return {
+    ...preset,
+    type,
+    zones: preset.zones ?? 0,
+  };
+}
+
+function normalizeLayout(layout: Layout): Layout {
+  const metadata = layout.metadata && typeof layout.metadata === 'object' && !Array.isArray(layout.metadata)
+    ? layout.metadata
+    : {};
+
+  return {
+    ...layout,
+    layoutType: layout.layoutType || metadata.layoutType || 'custom',
+    zones: Array.isArray(layout.zones)
+      ? layout.zones
+      : Array.isArray(metadata.zones)
+        ? metadata.zones
+        : layout.zones,
+  };
 }
 
 export default function LayoutsPage() {
@@ -184,7 +227,12 @@ export default function LayoutsPage() {
     try {
       const presetData = await apiClient.getLayoutPresets();
       if (presetData && presetData.length > 0) {
-        setPresets(presetData);
+        const normalizedPresets = presetData
+          .map((preset) => normalizeLayoutPreset(preset as LayoutPreset))
+          .filter((preset): preset is LayoutPreset => preset !== null);
+        if (normalizedPresets.length > 0) {
+          setPresets(normalizedPresets);
+        }
       }
     } catch {
       // Use default presets as fallback
@@ -194,7 +242,7 @@ export default function LayoutsPage() {
     try {
       const response = await apiClient.get<any>('/content/layouts');
       const layoutList = response?.data || response || [];
-      setLayouts(Array.isArray(layoutList) ? layoutList : []);
+      setLayouts(Array.isArray(layoutList) ? layoutList.map(normalizeLayout) : []);
     } catch {
       setLayouts([]);
     }
@@ -212,7 +260,7 @@ export default function LayoutsPage() {
     try {
       const newLayout = await apiClient.createLayout({
         name: layoutName.trim(),
-        layoutType: selectedPreset.type,
+        layoutType: getPresetType(selectedPreset),
         description: layoutDescription.trim() || undefined,
       });
       toast.success('Layout created successfully');
@@ -347,7 +395,7 @@ export default function LayoutsPage() {
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
               {presets.map((preset) => (
                 <div
-                  key={preset.type}
+                  key={getPresetType(preset)}
                   className="eh-dash-card rounded-lg border border-[var(--border)] p-5 hover:-translate-y-[2px] hover:border-[rgba(0,229,160,0.2)] hover:shadow-md transition-all duration-300 cursor-pointer group"
                   onClick={() => {
                     setSelectedPreset(preset);
@@ -356,10 +404,10 @@ export default function LayoutsPage() {
                     setIsCreateModalOpen(true);
                   }}
                 >
-                  <LayoutPreviewGrid type={preset.type} />
+                  <LayoutPreviewGrid type={getPresetType(preset)} />
                   <div className="mt-3">
                     <h4 className="font-semibold text-[var(--foreground)] text-sm">{preset.name}</h4>
-                    <p className="text-xs text-[var(--foreground-tertiary)] mt-1">{Array.isArray(preset.zones) ? preset.zones.length : preset.zones} zone{(Array.isArray(preset.zones) ? preset.zones.length : preset.zones) > 1 ? 's' : ''}</p>
+                    <p className="text-xs text-[var(--foreground-tertiary)] mt-1">{getPresetZoneCount(preset)} zone{getPresetZoneCount(preset) > 1 ? 's' : ''}</p>
                     <p className="text-xs text-[var(--foreground-secondary)] mt-1 line-clamp-2">{preset.description}</p>
                   </div>
                   <button
@@ -405,17 +453,17 @@ export default function LayoutsPage() {
               <p className="text-[var(--foreground-secondary)]">Select a layout preset:</p>
               {presets.map((preset) => (
                 <button
-                  key={preset.type}
+                  key={getPresetType(preset)}
                   onClick={() => setSelectedPreset(preset)}
                   className="w-full flex items-center gap-4 p-3 rounded-lg border border-[var(--border)] hover:border-[#00E5A0] hover:bg-[#00E5A0]/5 transition text-left"
                 >
                   <div className="w-24 flex-shrink-0">
-                    <LayoutPreviewGrid type={preset.type} />
+                    <LayoutPreviewGrid type={getPresetType(preset)} />
                   </div>
                   <div>
                     <div className="font-medium text-[var(--foreground)]">{preset.name}</div>
                     <div className="text-xs text-[var(--foreground-tertiary)]">
-                      {Array.isArray(preset.zones) ? preset.zones.length : preset.zones} zone{(Array.isArray(preset.zones) ? preset.zones.length : preset.zones) > 1 ? 's' : ''} -- {preset.description}
+                      {getPresetZoneCount(preset)} zone{getPresetZoneCount(preset) > 1 ? 's' : ''} -- {preset.description}
                     </div>
                   </div>
                 </button>
@@ -426,11 +474,11 @@ export default function LayoutsPage() {
               {/* Selected Preset Preview */}
               <div className="flex items-center gap-4 p-3 bg-[var(--background)] rounded-lg border border-[var(--border)]">
                 <div className="w-20 flex-shrink-0">
-                  <LayoutPreviewGrid type={selectedPreset.type} />
+                  <LayoutPreviewGrid type={getPresetType(selectedPreset)} />
                 </div>
                 <div>
                   <div className="font-medium text-[var(--foreground)]">{selectedPreset.name}</div>
-                  <div className="text-xs text-[var(--foreground-tertiary)]">{Array.isArray(selectedPreset.zones) ? selectedPreset.zones.length : selectedPreset.zones} zones</div>
+                  <div className="text-xs text-[var(--foreground-tertiary)]">{getPresetZoneCount(selectedPreset)} zones</div>
                 </div>
                 <button
                   onClick={() => setSelectedPreset(null)}


### PR DESCRIPTION
## Summary
- add existing subscription-active guard coverage to dashboard-adjacent write endpoints for folders, display groups, content bulk operations, layouts, templates, and widgets
- materialize preset layout zones server-side when dashboard create requests omit zones
- normalize backend `layoutType` / `metadata` layout shapes in the dashboard layout list and editor
- document Pass 48 review and verification evidence

## Review
- plan/security reviewer found missing BillingModule imports for display-groups and folders; fixed with executable guard-resolution coverage
- plan/layout reviewer found backend preset/editor shape drift; fixed with frontend normalization and tests
- diff security/module reviewer: CLEAN
- diff layout reviewer found saved-layout metadata normalization gap; fixed
- follow-up layout reviewer: CLEAN

## Verification
- `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/billing/subscription-write-gates.spec.ts src/modules/content/content.service.spec.ts`
- `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/dashboard/layouts/__tests__/layouts-page.test.tsx src/app/dashboard/layouts/[id]/__tests__/layout-editor-page.test.tsx`
- `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/content/controllers/layouts.controller.spec.ts src/modules/content/controllers/templates.controller.spec.ts src/modules/content/controllers/widgets.controller.spec.ts src/modules/content/controllers/bulk-operations.controller.spec.ts src/modules/display-groups/display-groups.controller.spec.ts src/modules/folders/folders.controller.spec.ts src/modules/billing/subscription-write-gates.spec.ts`
- `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
- `pnpm --filter @vizora/web exec tsc --noEmit --pretty false`
- changed-file ESLint: 0 errors / 19 warnings (mostly existing `any` warnings)
- `git diff --check`
- `pnpm --filter @vizora/middleware test -- --runInBand`
- `pnpm --filter @vizora/web test -- --runInBand`
- `npx nx build @vizora/middleware`
- `npx nx build @vizora/web`
- `pnpm security:no-hardcoded-jwts`