### PR TITLE
fix: calibrate readiness memory check

### DIFF
--- a/docs/plans/2026-06-02-readiness-memory-calibration-pass-49.md
+++ b/docs/plans/2026-06-02-readiness-memory-calibration-pass-49.md
@@ -1,0 +1,120 @@
+# Readiness Memory Calibration Pass 49
+
+**Date:** 2026-06-02
+
+**Branch:** `feat/customer-dashboard-perf-pass-49`
+
+## Goal
+
+Stop public readiness from reporting degraded/unhealthy solely because the V8
+heap is nearly full at a small absolute size. Use Vizora's existing PM2 memory
+budget as the readiness lever so operators and customers see meaningful health
+signals.
+
+## Source-of-Truth Check
+
+- Production probe after PR #188:
+  - `REMOTE_MAIN=6025c49d794a00297f1caaf4b4d451a0994b55d1`
+  - `PROD_HEAD=bb76aa1838740bff5b58623dfef7a906d44f46a6`
+  - deploy remains blocked by 72 dirty/untracked prod paths.
+  - `/api/v1/health/ready` returned `status: degraded` only because memory was
+    `heapUsedMB=152`, `heapTotalMB=155`, `heapUsagePercent=98.2`, `rssMB=389`.
+- `HealthService.checkMemory()` currently gates status only on
+  `heapUsed / heapTotal`, so normal pre-GC V8 behavior can mark a small process
+  unhealthy.
+- `ecosystem.config.js` and `scripts/ops/health-guardian.ts` both use a 512 MB
+  middleware memory budget. The ops reload threshold is RSS/process memory
+  greater than 85% of that budget, not V8 heap saturation alone.
+
+## New Primitives Introduced
+
+No new route, module, model, migration, env var, PM2 process, response shape,
+realtime path, MCP tool, Hermes skill, or provider spend path. This pass only
+calibrates the existing memory health check.
+
+## Hermes-First Analysis
+
+This is local NestJS health/readiness behavior, not a business-agent, MCP, or
+Hermes runtime task.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Health memory calibration | none applicable | reuse existing `HealthService` |
+| Ops memory budget | none applicable | align with existing PM2/health-guardian 512 MB budget |
+
+Awesome-Hermes ecosystem check: no applicable Hermes skill/library primitive
+for a NestJS memory readiness threshold.
+
+## Design
+
+- Keep reporting heap details (`heapUsedMB`, `heapTotalMB`,
+  `heapUsagePercent`, `rssMB`) for operator visibility.
+- Add `rssUsagePercent` against the existing 512 MB middleware process budget.
+- Mark memory degraded/unhealthy based on RSS budget pressure:
+  - degraded above 85% of 512 MB.
+  - unhealthy above 95% of 512 MB.
+- Treat very large heap saturation as a secondary signal:
+  - degraded when heap is above 85% and heap used is at least 384 MB.
+  - unhealthy when heap is above 95% and heap used is at least 448 MB.
+- This keeps the observed production case (`152/155 MB heap`, `389 MB RSS`)
+  healthy while still degrading before PM2's 512 MB restart budget is exhausted.
+- Do not change liveness, dependency checks, public response shape, or
+  health-guardian remediation behavior.
+
+## Plan
+
+- [x] Add red health-service coverage for the production false-positive memory
+  case: small saturated heap and sub-threshold RSS remains healthy.
+- [x] Add red coverage for real RSS pressure degrading and unhealthy status.
+- [x] Add red coverage for large saturated heap pressure even if RSS is under
+  the hard budget.
+- [x] Implement the calibrated memory thresholds in `HealthService`.
+- [x] Run focused health tests.
+- [x] Run multi-vector diff review.
+- [x] Run broader middleware typecheck/tests/build and security check.
+- [ ] Open PR, wait for CI, merge if green.
+- [ ] Re-check production deploy gate; deploy only if the dirty/diverged
+  production checkout is made safe.
+
+## Verification So Far
+
+- Red run:
+  `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/health/health.service.spec.ts`
+  failed as expected: the current heap-percent-only logic degraded the small
+  saturated heap and missed RSS pressure.
+- Green run:
+  same command passed 1 suite / 26 tests after calibration.
+- Focused health slice:
+  `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/health/health.service.spec.ts src/modules/health/health.controller.spec.ts`
+  passed 2 suites / 37 tests.
+- TypeScript:
+  `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` passed.
+- Changed-file ESLint:
+  `$env:ESLINT_USE_FLAT_CONFIG='false'; npx eslint middleware/src/modules/health/health.service.ts middleware/src/modules/health/health.service.spec.ts`
+  passed with only the existing eslintrc deprecation warning.
+- Security:
+  `pnpm security:no-hardcoded-jwts` passed.
+- Diff hygiene:
+  `git diff --check` passed with CRLF normalization warnings only.
+- Full middleware:
+  `pnpm --filter @vizora/middleware test -- --runInBand` passed 148 suites /
+  3027 tests / 1 snapshot.
+- Build:
+  `npx nx build @vizora/middleware` passed with existing webpack warnings.
+
+## Review
+
+- Health/ops/runtime reviewer: CLEAN. Confirmed the 512 MB budget aligns with
+  `ecosystem.config.js` and `scripts/ops/health-guardian.ts`, real RSS pressure
+  is still surfaced, and public readiness semantics remain unchanged.
+- Code/test/release reviewer: CLEAN. Confirmed threshold math, tests, public
+  response shape, TypeScript, and release-safety evidence.
+
+## Risks
+
+- Under-alerting real memory leaks would be worse than the current false
+  degraded state. The fix keeps RSS thresholds aligned with the PM2 restart
+  budget and keeps large heap saturation as a secondary signal.
+- Changing public readiness can alter health-guardian behavior after deploy.
+  The intended effect is to avoid false degradation below the existing
+  remediation threshold, not to suppress real RSS pressure.

--- a/middleware/src/modules/health/health.service.spec.ts
+++ b/middleware/src/modules/health/health.service.spec.ts
@@ -268,6 +268,84 @@ describe('HealthService', () => {
         // In test environment, memory should be normal
         expect(result.checks.memory.status).toBe('healthy');
       });
+
+      it('should stay healthy when a small V8 heap is saturated but RSS is below the process budget', async () => {
+        memoryUsageSpy.mockReturnValue({
+          heapUsed: 152 * 1024 * 1024,
+          heapTotal: 155 * 1024 * 1024,
+          rss: 389 * 1024 * 1024,
+          external: 10 * 1024 * 1024,
+          arrayBuffers: 5 * 1024 * 1024,
+        } as NodeJS.MemoryUsage);
+
+        const result = await service.check();
+
+        expect(result.status).toBe('ok');
+        expect(result.checks.memory.status).toBe('healthy');
+        expect(result.checks.memory.details).toMatchObject({
+          heapUsedMB: 152,
+          heapTotalMB: 155,
+          heapUsagePercent: 98.1,
+          rssMB: 389,
+          rssUsagePercent: 76,
+        });
+      });
+
+      it('should degrade when RSS exceeds 85 percent of the middleware process budget', async () => {
+        memoryUsageSpy.mockReturnValue({
+          heapUsed: 120 * 1024 * 1024,
+          heapTotal: 256 * 1024 * 1024,
+          rss: 460 * 1024 * 1024,
+          external: 10 * 1024 * 1024,
+          arrayBuffers: 5 * 1024 * 1024,
+        } as NodeJS.MemoryUsage);
+
+        const result = await service.check();
+
+        expect(result.status).toBe('degraded');
+        expect(result.checks.memory.status).toBe('degraded');
+        expect(result.checks.memory.error).toContain('High memory usage');
+        expect(result.checks.memory.details).toMatchObject({
+          rssMB: 460,
+          rssUsagePercent: 89.8,
+        });
+      });
+
+      it('should be unhealthy when RSS exceeds 95 percent of the middleware process budget', async () => {
+        memoryUsageSpy.mockReturnValue({
+          heapUsed: 120 * 1024 * 1024,
+          heapTotal: 256 * 1024 * 1024,
+          rss: 500 * 1024 * 1024,
+          external: 10 * 1024 * 1024,
+          arrayBuffers: 5 * 1024 * 1024,
+        } as NodeJS.MemoryUsage);
+
+        const result = await service.check();
+
+        expect(result.status).toBe('degraded');
+        expect(result.checks.memory.status).toBe('unhealthy');
+        expect(result.checks.memory.error).toContain('High memory usage');
+        expect(result.checks.memory.details).toMatchObject({
+          rssMB: 500,
+          rssUsagePercent: 97.7,
+        });
+      });
+
+      it('should degrade when a large heap is saturated even before RSS reaches the process budget', async () => {
+        memoryUsageSpy.mockReturnValue({
+          heapUsed: 400 * 1024 * 1024,
+          heapTotal: 450 * 1024 * 1024,
+          rss: 420 * 1024 * 1024,
+          external: 10 * 1024 * 1024,
+          arrayBuffers: 5 * 1024 * 1024,
+        } as NodeJS.MemoryUsage);
+
+        const result = await service.check();
+
+        expect(result.status).toBe('degraded');
+        expect(result.checks.memory.status).toBe('degraded');
+        expect(result.checks.memory.error).toContain('High memory usage');
+      });
     });
 
     describe('when both database and redis are unhealthy', () => {

--- a/middleware/src/modules/health/health.service.ts
+++ b/middleware/src/modules/health/health.service.ts
@@ -29,6 +29,12 @@ const HEALTH_CIRCUIT_CONFIG = {
   resetTimeout: 10000,
 };
 
+const MIDDLEWARE_MEMORY_BUDGET_MB = 512;
+const MEMORY_DEGRADED_PERCENT = 85;
+const MEMORY_UNHEALTHY_PERCENT = 95;
+const LARGE_HEAP_DEGRADED_MB = 384;
+const LARGE_HEAP_UNHEALTHY_MB = 448;
+
 @Injectable()
 export class HealthService {
   private static readonly OPS_STATUS_KEY = 'vizora:ops:status';
@@ -246,12 +252,18 @@ export class HealthService {
     const heapTotalMB = Math.round(used.heapTotal / 1024 / 1024);
     const heapUsagePercent = (used.heapUsed / used.heapTotal) * 100;
     const rssMB = Math.round(used.rss / 1024 / 1024);
+    const rssUsagePercent = (rssMB / MIDDLEWARE_MEMORY_BUDGET_MB) * 100;
+    const isRssDegraded = rssUsagePercent > MEMORY_DEGRADED_PERCENT;
+    const isRssUnhealthy = rssUsagePercent > MEMORY_UNHEALTHY_PERCENT;
+    const isLargeHeapDegraded = heapUsagePercent > MEMORY_DEGRADED_PERCENT
+      && heapUsedMB >= LARGE_HEAP_DEGRADED_MB;
+    const isLargeHeapUnhealthy = heapUsagePercent > MEMORY_UNHEALTHY_PERCENT
+      && heapUsedMB >= LARGE_HEAP_UNHEALTHY_MB;
 
-    // Consider degraded if heap usage > 85%, unhealthy if > 95%
     let status: 'healthy' | 'degraded' | 'unhealthy';
-    if (heapUsagePercent > 95) {
+    if (isRssUnhealthy || isLargeHeapUnhealthy) {
       status = 'unhealthy';
-    } else if (heapUsagePercent > 85) {
+    } else if (isRssDegraded || isLargeHeapDegraded) {
       status = 'degraded';
     } else {
       status = 'healthy';
@@ -262,6 +274,8 @@ export class HealthService {
       heapTotalMB,
       heapUsagePercent: Math.round(heapUsagePercent * 10) / 10,
       rssMB,
+      rssUsagePercent: Math.round(rssUsagePercent * 10) / 10,
+      memoryBudgetMB: MIDDLEWARE_MEMORY_BUDGET_MB,
     };
 
     return {
@@ -269,7 +283,7 @@ export class HealthService {
       responseTime: 0,
       details,
       ...(status !== 'healthy' && {
-        error: `High memory usage: ${heapUsedMB}MB / ${heapTotalMB}MB (${heapUsagePercent.toFixed(1)}%)`,
+        error: `High memory usage: RSS ${rssMB}MB / ${MIDDLEWARE_MEMORY_BUDGET_MB}MB (${rssUsagePercent.toFixed(1)}%), heap ${heapUsedMB}MB / ${heapTotalMB}MB (${heapUsagePercent.toFixed(1)}%)`,
       }),
     };
   }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,96 @@
 # Vizora - Task Tracker
 
+## Active Workstream: Readiness Memory Calibration Pass 49 (2026-06-02)
+
+**Branch:** `feat/customer-dashboard-perf-pass-49`
+
+**Why now:** PR #188 is merged with green CI and no open PRs remain, but
+production deployment remains blocked by dirty/diverged prod state. The latest
+prod gate shows `/api/v1/health/ready` degraded only because V8 heap usage is
+98.2% at a small absolute size (`152MB / 155MB`) while RSS is `389MB`, below
+the existing 512 MB middleware PM2/ops budget. This creates a false deploy and
+customer trust signal.
+
+**New primitives introduced:** none. This pass reuses the existing
+`HealthService` memory check and the existing PM2/health-guardian 512 MB
+middleware memory budget. No new route, model, migration, module, env var,
+process, response shape, realtime path, MCP tool, Hermes skill, or AI/provider
+spend path.
+
+**Hermes-first analysis:** checked per project convention. This is local NestJS
+health/readiness calibration, not a business-agent, MCP, Hermes runtime, or
+provider-spend task.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Health memory calibration | none applicable | reuse existing `HealthService` |
+| Ops memory budget | none applicable | align with existing PM2/health-guardian budget |
+
+Awesome-hermes-agent ecosystem check: no applicable skill/library primitive for
+NestJS readiness memory thresholds.
+
+**Plan/design:**
+`docs/plans/2026-06-02-readiness-memory-calibration-pass-49.md`
+
+**Plan**
+- [x] Add red health-service coverage for the production false-positive memory
+  case.
+- [x] Add red health-service coverage for real RSS pressure.
+- [x] Add red health-service coverage for large saturated heap pressure.
+- [x] Implement calibrated memory thresholds.
+- [x] Run focused health tests.
+- [x] Run multi-vector diff review.
+- [x] Run broader middleware verification and build.
+- [ ] PR, CI, merge if green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Evidence so far**
+- Current `origin/main`: `6025c49d794a00297f1caaf4b4d451a0994b55d1`.
+- No open PRs after merging PR #188.
+- Production deploy gate remains blocked: `/opt/vizora/app` is still dirty with
+  72 dirty/untracked paths; production HEAD is
+  `bb76aa1838740bff5b58623dfef7a906d44f46a6`, while remote main is
+  `6025c49d794a00297f1caaf4b4d451a0994b55d1`.
+- Production runtime: middleware/web/realtime are online; most ops/Hermes cron
+  processes are stopped. `/api/v1/health` and `/api/v1/health/live` return OK.
+  `/api/v1/health/ready` is degraded by memory only
+  (`heapUsedMB=152`, `heapTotalMB=155`, `heapUsagePercent=98.2`,
+  `rssMB=389`).
+- Red/green verification:
+  - `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/health/health.service.spec.ts`
+    failed before implementation on the small saturated heap case and RSS
+    pressure cases.
+  - Same command passed after implementation: 1 suite / 26 tests.
+- Review:
+  - Health/ops/runtime reviewer returned CLEAN: the 512 MB budget matches
+    `ecosystem.config.js` and `scripts/ops/health-guardian.ts`, real RSS
+    pressure still surfaces, public readiness semantics are unchanged, and no
+    operator-gated assumption was introduced.
+  - Code/test/release reviewer returned CLEAN: threshold math, tests, public
+    response shape, TypeScript, and release-safety evidence were clean.
+- Full verification:
+  - `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/health/health.service.spec.ts src/modules/health/health.controller.spec.ts`
+    => 2 suites / 37 tests passing.
+  - `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
+    => passing.
+  - Changed-file ESLint => passing with only the existing eslintrc deprecation
+    warning.
+  - `pnpm security:no-hardcoded-jwts` => passing.
+  - `git diff --check` => passing with CRLF normalization warnings.
+  - `pnpm --filter @vizora/middleware test -- --runInBand`
+    => 148 suites / 3027 tests passing / 1 snapshot.
+  - `npx nx build @vizora/middleware` => passing with existing webpack
+    warnings.
+- Deferred follow-up candidates from parallel analysis:
+  - Release-readiness gate drift: smoke script's realtime probe still uses a
+    stale path and CI builds web without running web unit tests.
+  - Dashboard trust: settings admin email appears editable but is not persisted;
+    widgets failures can look like an empty account; playlists list may eagerly
+    fetch content for an unreachable builder.
+  - Middleware hot paths: add realtime HTTP timeouts from `DisplaysService`,
+    align playlist update duplicate-content handling with create, and gate very
+    short content searches.
+
 ## Active Workstream: Dashboard Write Gates and Layout Create Pass 48 (2026-06-02)
 
 **Branch:** `fix/dashboard-write-gates-layout-pass-48`


### PR DESCRIPTION
## Summary
- calibrate middleware memory readiness to the existing 512 MB PM2/health-guardian process budget
- keep small saturated V8 heaps healthy when RSS remains below budget pressure
- still report degraded/unhealthy memory under real RSS pressure and large saturated heaps
- document Pass 49 production evidence, review, and verification

## Review
- health/ops/runtime reviewer: CLEAN; confirmed budget alignment with `ecosystem.config.js` and `scripts/ops/health-guardian.ts`, preserved public readiness semantics, and no operator-gated assumption
- code/test/release reviewer: CLEAN; confirmed threshold math, tests, public response shape, TypeScript, and release-safety evidence

## Verification
- red run: `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/health/health.service.spec.ts` failed on the intended heap/RSS cases before implementation
- `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/health/health.service.spec.ts`
- `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/health/health.service.spec.ts src/modules/health/health.controller.spec.ts`
- `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false`
- changed-file ESLint: `ESLINT_USE_FLAT_CONFIG=false npx eslint middleware/src/modules/health/health.service.ts middleware/src/modules/health/health.service.spec.ts`
- `pnpm security:no-hardcoded-jwts`
- `git diff --check`
- `pnpm --filter @vizora/middleware test -- --runInBand`
- `npx nx build @vizora/middleware`

## Deploy note
Prod deploy remains blocked by dirty/diverged `/opt/vizora/app`; this PR does not deploy or restart production services.