### PR TITLE
fix: bound realtime command HTTP waits

### DIFF
--- a/middleware/src/modules/displays/displays.service.spec.ts
+++ b/middleware/src/modules/displays/displays.service.spec.ts
@@ -358,6 +358,29 @@ describe('DisplaysService', () => {
       expect(result.nickname).toBe('Updated Display');
     });
 
+    it('notifies realtime playlist updates with a bounded HTTP timeout', async () => {
+      const playlist = {
+        id: 'playlist-1',
+        organizationId: mockOrganizationId,
+        items: [],
+      };
+      httpService.post.mockReturnValue(of({ data: { success: true } }) as any);
+
+      await (service as any).notifyPlaylistUpdate(mockDisplayId, playlist);
+
+      expect(httpService.post).toHaveBeenCalledWith(
+        expect.stringContaining('/api/push/playlist'),
+        {
+          deviceId: mockDisplayId,
+          playlist,
+        },
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'x-internal-api-key': expect.any(String) }),
+          timeout: 15000,
+        }),
+      );
+    });
+
     it('should throw NotFoundException if display not found', async () => {
       databaseService.display.findFirst.mockResolvedValue(null);
 
@@ -599,6 +622,7 @@ describe('DisplaysService', () => {
         }),
         expect.objectContaining({
           headers: expect.objectContaining({ 'x-internal-api-key': expect.any(String) }),
+          timeout: 15000,
         }),
       );
     });
@@ -684,6 +708,7 @@ describe('DisplaysService', () => {
         },
         expect.objectContaining({
           headers: expect.objectContaining({ 'x-internal-api-key': expect.any(String) }),
+          timeout: 15000,
         }),
       );
     });
@@ -704,6 +729,7 @@ describe('DisplaysService', () => {
         },
         expect.objectContaining({
           headers: expect.objectContaining({ 'x-internal-api-key': expect.any(String) }),
+          timeout: 15000,
         }),
       );
     });
@@ -1068,6 +1094,17 @@ describe('DisplaysService', () => {
       await expect(
         service.pushContent(mockOrganizationId, mockDisplayId, mockContent.id, 5),
       ).resolves.toEqual({ success: true, message: 'Content pushed to display' });
+
+      expect(httpService.post).toHaveBeenCalledWith(
+        expect.stringContaining('/api/push/content'),
+        expect.objectContaining({
+          deviceId: mockDisplayId,
+        }),
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'x-internal-api-key': expect.any(String) }),
+          timeout: 15000,
+        }),
+      );
     });
 
     it('throws ServiceUnavailableException when realtime reports delivery failure', async () => {

--- a/middleware/src/modules/displays/displays.service.ts
+++ b/middleware/src/modules/displays/displays.service.ts
@@ -41,6 +41,7 @@ const REALTIME_CIRCUIT_CONFIG = {
   successThreshold: 2,
   failureWindow: 60000, // 1 minute
 };
+const REALTIME_HTTP_TIMEOUT_MS = 15000;
 
 @Injectable()
 export class DisplaysService {
@@ -226,7 +227,7 @@ export class DisplaysService {
           this.httpService.post(url, {
             deviceId: displayId,
             playlist,
-          }, { headers }),
+          }, { headers, timeout: REALTIME_HTTP_TIMEOUT_MS }),
         );
         this.logger.log(`Notified realtime service of playlist update for display ${displayId}`);
       },
@@ -559,7 +560,7 @@ export class DisplaysService {
               duration: content.duration,
             },
             duration,
-          }, { headers }),
+          }, { headers, timeout: REALTIME_HTTP_TIMEOUT_MS }),
         );
         this.logger.log(`Pushed content ${contentId} to display ${displayId} for ${duration} min`);
         return response.data as { success?: boolean; message?: string };
@@ -707,7 +708,7 @@ export class DisplaysService {
                 type: 'screenshot',
                 payload: { requestId },
               },
-            }, { headers }),
+            }, { headers, timeout: REALTIME_HTTP_TIMEOUT_MS }),
           );
           if (response.data?.success === false) {
             throw new ServiceUnavailableException(
@@ -865,7 +866,7 @@ export class DisplaysService {
               type: command,
               payload,
             },
-          }, { headers }),
+          }, { headers, timeout: REALTIME_HTTP_TIMEOUT_MS }),
         );
         this.logger.log(`Command '${command}' sent to device ${displayId}`);
       },

--- a/middleware/src/modules/fleet/fleet.service.spec.ts
+++ b/middleware/src/modules/fleet/fleet.service.spec.ts
@@ -309,6 +309,16 @@ describe('FleetService', () => {
       expect(result.devicesDelivered).toBe(0);
       expect(result.devicesQueued).toBe(1);
       expect(result.devicesFailed).toBe(0);
+      expect(httpService.post).toHaveBeenCalledWith(
+        expect.stringContaining('/api/commands/broadcast'),
+        expect.objectContaining({
+          deviceIds: [mockDeviceId],
+        }),
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'x-internal-api-key': expect.any(String) }),
+          timeout: 15000,
+        }),
+      );
     });
 
     it('should resolve content from DB and include it in gateway payload for push_content', async () => {

--- a/middleware/src/modules/fleet/fleet.service.ts
+++ b/middleware/src/modules/fleet/fleet.service.ts
@@ -34,6 +34,8 @@ interface GatewayBroadcastResult {
   failed?: number;
 }
 
+const REALTIME_HTTP_TIMEOUT_MS = 15000;
+
 interface OverrideRecord {
   commandId: string;
   contentId: string;
@@ -274,7 +276,7 @@ export class FleetService {
           this.httpService.post(
             url,
             gatewayBody,
-            { headers },
+            { headers, timeout: REALTIME_HTTP_TIMEOUT_MS },
           ),
         );
         return response.data;

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,87 @@
 # Vizora - Task Tracker
 
-## Active Workstream: Dashboard Settings Trust Pass 51 (2026-06-02)
+## Active Workstream: Realtime Command Timeout Pass 52 (2026-06-02)
+
+**Branch:** `fix/display-realtime-timeouts-pass-52`
+
+**Why now:** PR #191 merged with green CI, but production deployment remains
+blocked by dirty/diverged prod state. The next performance/reliability gap is
+bounded middleware request time for realtime command handoffs: DisplaysService
+and FleetService call the realtime gateway through Axios without an explicit
+timeout, while adjacent realtime paths already use bounded timeouts and the
+realtime gateway's ACK-backed delivery contract waits up to 10s.
+
+**New primitives introduced:** none. This pass reuses the existing
+`HttpService`, circuit-breaker/fallback paths, internal realtime endpoints, and
+NestJS service methods. No new route, model, migration, module, env var,
+process, response shape, realtime event, MCP tool, Hermes skill, or AI/provider
+spend path.
+
+**Hermes-first analysis:** checked per project convention. This is local
+middleware service-to-service timeout hardening, not a business-agent, MCP,
+Hermes runtime, or provider-spend task.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Realtime command HTTP timeout | none applicable | reuse existing Axios `timeout` option above the gateway ACK window |
+| Circuit-breaker fallback | none applicable | preserve existing `CircuitBreakerService` path |
+
+Awesome-hermes-agent ecosystem check: no applicable skill/library primitive for
+NestJS Axios timeout configuration on Vizora's realtime gateway handoffs.
+
+**Plan**
+- [x] Add focused red tests that assert realtime HTTP handoffs include a bounded timeout.
+- [x] Patch DisplaysService realtime calls with shared timeout config.
+- [x] Patch FleetService gateway broadcast calls with the same timeout.
+- [x] Run focused middleware tests.
+- [x] Run multi-vector diff review.
+- [x] Run broader middleware verification.
+- [ ] PR, CI, and merge if green.
+- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+
+**Evidence so far**
+- Current `origin/main`: `c75643b89686e4729a7dca2a1e5abc2a1071ec91`.
+- Drift evidence:
+  - `DisplaysService` had timeout-less `HttpService.post` calls for playlist
+    update notification, direct content push, screenshot request, and
+    enable/disable display commands.
+  - `FleetService` had a timeout-less broadcast call to
+    `/api/commands/broadcast`.
+  - Adjacent realtime paths already use bounded Axios calls:
+    `PlaylistsService` uses `timeout: 5000`, and notification broadcast uses
+    `timeout: 3000`; realtime gateway ACK-backed device delivery waits up to
+    10s.
+- Red focused run:
+  - `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/displays/displays.service.spec.ts src/modules/fleet/fleet.service.spec.ts`
+    failed on 6 expected assertions because realtime handoff options lacked a
+    bounded timeout.
+- Fix:
+  - Added `REALTIME_HTTP_TIMEOUT_MS = 15000` in DisplaysService and FleetService
+    so middleware waits longer than the gateway's 10s ACK window while still
+    bounding broken realtime calls.
+  - Passed the timeout through existing Axios calls without changing routes,
+    payloads, auth headers, response handling, or circuit-breaker names.
+- Green focused run:
+  - Same command => 2 suites / 74 tests passing.
+- Review:
+  - Realtime/circuit reviewer initially found a high-risk timeout-contract
+    mismatch: a 5s middleware timeout would preempt the realtime gateway's
+    10s ACK-backed delivery window and could falsely fail delivered commands.
+    Fixed by raising the shared timeout to 15s; final re-review returned CLEAN.
+  - Test/release reviewer returned CLEAN after independently re-running the
+    focused tests, middleware type-check, full middleware suite, and diff check.
+- Broader verification:
+  - `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` =>
+    passing.
+  - `pnpm --filter @vizora/middleware test -- --runInBand` => 148 suites /
+    3028 tests passing.
+  - `npx nx build @vizora/middleware` => passing, with existing webpack/Nx
+    warnings only.
+  - `pnpm security:no-hardcoded-jwts` => passing.
+  - `git diff --check` => exit 0, with only LF/CRLF normalization warnings for
+    `tasks/todo.md`.
+
+## Completed Workstream: Dashboard Settings Trust Pass 51 (2026-06-02)
 
 **Branch:** `fix/customer-dashboard-settings-pass-51`
 
@@ -34,8 +115,8 @@ React settings-form affordance alignment.
 - [x] Run focused web verification.
 - [x] Run multi-vector diff review.
 - [x] Run broader verification.
-- [ ] PR, CI, and merge if green.
-- [ ] Re-check deployment gate; deploy only if prod checkout is safe.
+- [x] PR, CI, and merge if green.
+- [x] Re-check deployment gate; deploy only if prod checkout is safe.
 
 **Evidence so far**
 - Current `origin/main`: `b07f8e671d680aff389a4dc80c398963bc39773e`.
@@ -69,6 +150,20 @@ React settings-form affordance alignment.
   - Production-like web build with public URLs set to `https://vizora.cloud`:
     `npx nx build @vizora/web` => passing, with existing Nx/Next warnings.
   - `git diff --check` => exit 0, with only LF/CRLF normalization warnings.
+- CI result on PR #191:
+  - audit pass 29s
+  - lint pass 35s
+  - security pass 33s
+  - build pass 1m30s
+  - test pass 4m27s
+  - e2e pass 8m52s
+- PR #191 merged to `origin/main` at
+  `c75643b89686e4729a7dca2a1e5abc2a1071ec91`.
+- Post-merge production deploy gate remained blocked: prod HEAD is still
+  `bb76aa1838740bff5b58623dfef7a906d44f46a6`, remote main is
+  `c75643b89686e4729a7dca2a1e5abc2a1071ec91`, `/opt/vizora/app` has
+  72 dirty/untracked paths and is `ahead 17, behind 164`. No production pull,
+  restart, or deploy was performed.
 
 ## Completed Workstream: Release Readiness Gates Pass 50 (2026-06-02)
 


### PR DESCRIPTION
## Summary
- Add a shared 15s Axios timeout to middleware-to-realtime command handoffs in DisplaysService and FleetService.
- Keep the timeout above the realtime gateway's 10s ACK delivery window so delivered commands are not falsely failed.
- Add focused tests that pin the timeout on playlist updates, content push, screenshot/enable/disable commands, and fleet broadcasts.

## Review
- Realtime/circuit reviewer initially found a high-risk 5s timeout mismatch with the gateway ACK window; fixed by raising the timeout to 15s.
- Realtime/circuit re-review: CLEAN.
- Test/release reviewer: CLEAN.

## Verification
- pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/displays/displays.service.spec.ts src/modules/fleet/fleet.service.spec.ts
- pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false
- pnpm --filter @vizora/middleware test -- --runInBand
- npx nx build @vizora/middleware
- pnpm security:no-hardcoded-jwts
- git diff --check

## Deploy
- Not deployed from this branch. Production deploy remains gated on a clean/safe production checkout.