### PR TITLE
fix: resolve recovered ops watchdog incidents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ Thumbs.db
 # Temporary files
 *.tmp
 *.temp
+.tmp-ops-watchdog-*/
 .cache/
 .turbo/
 .swc/

--- a/scripts/ops/ops-watchdog.test.ts
+++ b/scripts/ops/ops-watchdog.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import type { Incident, OpsState } from './lib/types.js';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const watchedAgents = [
+  'health-guardian',
+  'fleet-manager',
+  'content-lifecycle',
+  'schedule-doctor',
+  'ops-reporter',
+] as const;
+
+function freshLastRun(timestamp: string): Record<string, string> {
+  return Object.fromEntries(watchedAgents.map((agent) => [agent, timestamp]));
+}
+
+function agentSilentIncident(agent: string, detected: string): Incident {
+  return {
+    id: `ops-watchdog:agent-silent:${agent}`,
+    agent: 'ops-watchdog',
+    type: 'agent-silent',
+    severity: 'critical',
+    target: 'agent',
+    targetId: agent,
+    detected,
+    message: `${agent} has not run`,
+    remediation: `pm2 restart ops-${agent}; check pm2 logs ops-${agent}`,
+    status: 'open',
+    attempts: 0,
+  };
+}
+
+function runWatchdogWithState(state: OpsState): { exitCode: number | null; state: OpsState } {
+  const tmpRoot = mkdtempSync(join(repoRoot, '.tmp-ops-watchdog-'));
+
+  try {
+    cpSync(join(repoRoot, 'scripts', 'ops'), join(tmpRoot, 'scripts', 'ops'), {
+      recursive: true,
+    });
+    mkdirSync(join(tmpRoot, 'logs'), { recursive: true });
+
+    writeFileSync(
+      join(tmpRoot, 'logs', 'ops-state.json'),
+      JSON.stringify(state, null, 2),
+    );
+
+    const result = spawnSync(process.execPath, [
+      '--import',
+      'tsx',
+      join(tmpRoot, 'scripts', 'ops', 'ops-watchdog.ts'),
+    ], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        SLACK_WEBHOOK_URL: '',
+      },
+      stdio: 'pipe',
+    });
+
+    assert.notEqual(result.status, 2, result.stderr.toString());
+    return {
+      exitCode: result.status,
+      state: JSON.parse(
+        readFileSync(join(tmpRoot, 'logs', 'ops-state.json'), 'utf8'),
+      ) as OpsState,
+    };
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+test('ops-watchdog resolves recovered agent-silent incidents when agents are fresh', () => {
+  const now = new Date();
+  const { exitCode, state: updated } = runWatchdogWithState({
+    systemStatus: 'CRITICAL',
+    lastUpdated: now.toISOString(),
+    lastRun: freshLastRun(now.toISOString()),
+    incidents: [
+      agentSilentIncident('fleet-manager', new Date(now.getTime() - 60 * 60_000).toISOString()),
+    ],
+    recentRemediations: [],
+    agentResults: {},
+  });
+
+  assert.equal(exitCode, 0);
+  const incident = updated.incidents.find(
+    (item) => item.id === 'ops-watchdog:agent-silent:fleet-manager',
+  );
+
+  assert.equal(incident?.status, 'resolved');
+  assert.ok(incident?.resolvedAt, 'expected recovered incident to record resolvedAt');
+  assert.equal(updated.systemStatus, 'HEALTHY');
+  assert.equal(updated.agentResults['ops-watchdog']?.issuesFixed, 1);
+});
+
+test('ops-watchdog does not resolve stale, missing, or malformed agent records', () => {
+  const now = new Date();
+  const staleAt = new Date(now.getTime() - 61 * 60_000).toISOString();
+  const missingRecordAgent = 'content-lifecycle';
+  const malformedRecordAgent = 'schedule-doctor';
+  const { exitCode, state: updated } = runWatchdogWithState({
+    systemStatus: 'CRITICAL',
+    lastUpdated: now.toISOString(),
+    lastRun: {
+      'health-guardian': now.toISOString(),
+      'fleet-manager': staleAt,
+      'schedule-doctor': 'not-a-date',
+      'ops-reporter': now.toISOString(),
+    },
+    incidents: [
+      agentSilentIncident('health-guardian', staleAt),
+      agentSilentIncident('fleet-manager', staleAt),
+      agentSilentIncident(missingRecordAgent, staleAt),
+      agentSilentIncident(malformedRecordAgent, staleAt),
+    ],
+    recentRemediations: [],
+    agentResults: {},
+  });
+
+  assert.equal(exitCode, 1);
+  const byTarget = new Map(updated.incidents.map((incident) => [incident.targetId, incident]));
+  const incident = updated.incidents.find(
+    (item) => item.id === 'ops-watchdog:agent-silent:health-guardian',
+  );
+
+  assert.equal(incident?.status, 'resolved');
+  assert.equal(byTarget.get('fleet-manager')?.status, 'open');
+  assert.equal(byTarget.get(missingRecordAgent)?.status, 'open');
+  assert.equal(byTarget.get(malformedRecordAgent)?.status, 'open');
+  assert.equal(updated.systemStatus, 'CRITICAL');
+  assert.equal(updated.agentResults['ops-watchdog']?.issuesFound, 1);
+  assert.equal(updated.agentResults['ops-watchdog']?.issuesFixed, 1);
+});

--- a/scripts/ops/ops-watchdog.ts
+++ b/scripts/ops/ops-watchdog.ts
@@ -38,6 +38,8 @@ import { log, sendSlackAlert } from './lib/alerting.js';
 
 const AGENT = 'ops-watchdog';
 
+type StaleAgent = { agent: string; minsSinceRun: number; slaMinutes: number };
+
 /**
  * Per-agent SLA: how long after its last successful run before we
  * consider it silent. Set ~3× the agent's cron interval so we tolerate
@@ -57,6 +59,41 @@ const SLA_MINUTES_BY_AGENT: Record<string, number> = {
   'schedule-doctor':   45,
   'ops-reporter':      90,
 };
+
+function makeAgentSilentIncident(staleAgent: StaleAgent, detected: string): Incident {
+  return {
+    id: `ops-watchdog:agent-silent:${staleAgent.agent}`,
+    agent: AGENT,
+    type: 'agent-silent',
+    severity: 'critical' as const,
+    target: 'agent',
+    targetId: staleAgent.agent,
+    detected,
+    message: `${staleAgent.agent} has not run in ${staleAgent.minsSinceRun} min (sla=${staleAgent.slaMinutes}m)`,
+    remediation: `pm2 restart ops-${staleAgent.agent}; check pm2 logs ops-${staleAgent.agent}`,
+    status: 'open' as const,
+    attempts: 0,
+  };
+}
+
+function resolveRecoveredAgentSilentIncidents(
+  incidents: Incident[],
+  healthyAgents: Set<string>,
+  resolvedAt: string,
+): Incident[] {
+  return incidents
+    .filter((incident) => (
+      incident.agent === AGENT &&
+      incident.type === 'agent-silent' &&
+      incident.status === 'open' &&
+      healthyAgents.has(incident.targetId)
+    ))
+    .map((incident) => ({
+      ...incident,
+      status: 'resolved' as const,
+      resolvedAt,
+    }));
+}
 
 /**
  * Re-alert behaviour: this watchdog runs every 15 min and DOES NOT
@@ -92,7 +129,8 @@ async function main(): Promise<void> {
     return;
   }
 
-  let stale: Array<{ agent: string; minsSinceRun: number; slaMinutes: number }> = [];
+  let stale: StaleAgent[] = [];
+  const healthyAgents = new Set<string>();
   let durationMs = 0;
   let alertSent = false;
 
@@ -120,6 +158,8 @@ async function main(): Promise<void> {
       const minsSinceRun = Math.floor((now - ranAt) / 60_000);
       if (minsSinceRun > slaMinutes) {
         stale.push({ agent, minsSinceRun, slaMinutes });
+      } else {
+        healthyAgents.add(agent);
       }
     }
 
@@ -134,19 +174,7 @@ async function main(): Promise<void> {
         .join(', ');
       log(AGENT, `STALE: ${summary}`);
 
-      const incidents: Incident[] = stale.map((s) => ({
-        id: `ops-watchdog:agent-silent:${s.agent}`,
-        agent: AGENT,
-        type: 'agent-silent',
-        severity: 'critical' as const,
-        target: 'agent',
-        targetId: s.agent,
-        detected: new Date(now).toISOString(),
-        message: `${s.agent} has not run in ${s.minsSinceRun} min (sla=${s.slaMinutes}m)`,
-        remediation: `pm2 restart ops-${s.agent}; check pm2 logs ops-${s.agent}`,
-        status: 'open' as const,
-        attempts: 0,
-      }));
+      const incidents = stale.map((s) => makeAgentSilentIncident(s, new Date(now).toISOString()));
 
       await sendSlackAlert(
         'CRITICAL',
@@ -165,31 +193,27 @@ async function main(): Promise<void> {
     //      via the dashboard / GET /api/v1/health/ops-status).
     //   2. The lock acquired by readOpsState() is released — writeOpsState
     //      always runs in a finally{} inside lib/state.ts.
-    // Mutations are limited to lastRun + agentResults + (when stale)
-    // incidents — all driven through recordAgentRun for consistency.
+    // Mutations are limited to lastRun + agentResults + watchdog-owned
+    // incident updates, all driven through recordAgentRun for consistency.
+    const timestamp = new Date(startTime).toISOString();
+    const resolvedIncidents = resolveRecoveredAgentSilentIncidents(
+      state.incidents,
+      healthyAgents,
+      timestamp,
+    );
     const result: AgentResult = {
       agent: AGENT,
-      timestamp: new Date(startTime).toISOString(),
+      timestamp,
       durationMs: durationMs || (Date.now() - startTime),
       issuesFound: stale.length,
-      // The watchdog doesn't auto-fix anything; an alert is detection,
-      // not fix. Counting stale agents as "escalated" matches the
-      // health-guardian convention for issues that needed human attention.
-      issuesFixed: 0,
+      // The watchdog doesn't remediate stale agents; resolved incidents
+      // mean watched agents recovered on a later run.
+      issuesFixed: resolvedIncidents.length,
       issuesEscalated: alertSent ? stale.length : 0,
-      incidents: stale.map((s) => ({
-        id: `ops-watchdog:agent-silent:${s.agent}`,
-        agent: AGENT,
-        type: 'agent-silent',
-        severity: 'critical' as const,
-        target: 'agent',
-        targetId: s.agent,
-        detected: new Date(startTime).toISOString(),
-        message: `${s.agent} has not run in ${s.minsSinceRun} min (sla=${s.slaMinutes}m)`,
-        remediation: `pm2 restart ops-${s.agent}; check pm2 logs ops-${s.agent}`,
-        status: 'open' as const,
-        attempts: 0,
-      })),
+      incidents: [
+        ...stale.map((s) => makeAgentSilentIncident(s, timestamp)),
+        ...resolvedIncidents,
+      ],
     };
     try {
       recordAgentRun(state, result);

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,106 @@
 # Vizora - Task Tracker
 
+## Active Workstream: Ops State Incident Resolution Pass 55 (2026-06-03)
+
+**Branch:** `fix/ops-state-incident-resolution-20260603`
+
+**Why now:** Weekend production-readiness validation found core prod services,
+health endpoints, CI, deploy SHA, and API smoke checks green, but
+`/api/v1/health/ops-status` still reported `systemStatus: CRITICAL`.
+Runtime evidence showed recent `lastRun` values for the ops cron agents while
+older `ops-watchdog:agent-silent:*` incidents remained open. That makes the
+readiness report noisy and can hide real launch blockers behind stale recovered
+conditions.
+
+**New primitives introduced:** none planned. This pass should reuse the
+existing `scripts/ops` state file, incident IDs, `recordAgentRun`,
+`determineSystemStatus`, and ops-watchdog PM2 cron path. No new route, model,
+migration, env var, process, response shape, realtime event, MCP tool, Hermes
+skill, or AI/provider spend path is expected.
+
+**Hermes-first analysis:** checked per project convention. This is deterministic
+ops-state reconciliation in the existing PM2 cron watchdog, not a business-agent
+decision task, MCP tool, Hermes runtime task, or provider-spend path.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Ops watchdog stale incident closure | none applicable | fix in existing deterministic ops watchdog/state path |
+| Production readiness status calculation | none applicable | reuse existing ops-state status functions |
+
+Awesome-hermes-agent ecosystem check: no applicable skill/library primitive for
+local `ops-state.json` incident lifecycle reconciliation.
+
+**Plan**
+- [x] Drift-check existing ops watchdog/state incident lifecycle and capture
+      file/line evidence before proposing code.
+- [x] Add a focused red test proving recovered ops agents close their own stale
+      `agent-silent` incidents and recalculate `systemStatus`.
+- [x] Implement the smallest Vizora-native fix in the existing ops watchdog/state
+      path.
+- [x] Run focused tests for the watchdog/state lifecycle.
+- [x] Run relevant broader verification for ops scripts and static checks.
+- [x] Request Claude Code review for plan/diff/test evidence and resolve
+      findings.
+- [x] Commit with conventional message and update this section with evidence.
+- [x] Do not deploy by default; hand off deploy/runbook evidence unless explicit
+      deployment approval is given.
+
+**Evidence so far**
+- Current `origin/main`: `2c92b1f8e82c2f05a295e6a90d41167b68a46272`.
+- Current local `HEAD`: `2c92b1f8e82c2f05a295e6a90d41167b68a46272`.
+- Production-runtime evidence from the weekend state check: core PM2 services
+  online, health/readiness endpoints 200, API critical-path smoke 27/27 passing,
+  SMTP startup self-test passing, but ops-state still `CRITICAL` with recovered
+  cron agents and open stale `agent-silent` incidents.
+- Dirty worktree note: pre-existing local modification `web/next-env.d.ts` and
+  many untracked scratch/evidence files remain untouched.
+- Drift-check:
+  - `scripts/ops/lib/state.ts` `recordAgentRun` upserts only incidents present
+    in the current agent result, then recalculates status.
+  - `scripts/ops/fleet-manager.ts` already resolves stale incidents by pushing
+    resolved incident copies before `recordAgentRun`.
+  - `scripts/ops/ops-watchdog.ts` records open `agent-silent` incidents when
+    stale agents exist, but records no resolved incidents when the watched agent
+    becomes fresh again.
+- Red focused run:
+  - `pnpm test:ops` failed as expected in
+    `scripts/ops/ops-watchdog.test.ts`: recovered
+    `ops-watchdog:agent-silent:fleet-manager` remained `open` instead of
+    `resolved`.
+- Fix:
+  - `scripts/ops/ops-watchdog.ts` now tracks agents with valid fresh `lastRun`
+    values and records resolved copies of watchdog-owned `agent-silent`
+    incidents for those recovered agents.
+  - Missing or malformed `lastRun` values are still skipped and do not resolve
+    prior incidents, because they are not proof of recovery.
+- Green verification:
+  - `pnpm test:ops` => 11/11 ops tests passing.
+  - Initial ad-hoc `tsc` check with CommonJS output failed on existing
+    `import.meta` usage in ops scripts; rerun with ESM-compatible flags passed:
+    `pnpm exec tsc --noEmit --pretty false --module esnext --moduleResolution bundler --target es2022 --lib es2022 --strict --types node scripts/ops/ops-watchdog.ts scripts/ops/ops-watchdog.test.ts`
+  - `git diff --check -- .gitignore scripts/ops/ops-watchdog.ts scripts/ops/ops-watchdog.test.ts tasks/todo.md`
+    => exit 0, with LF/CRLF normalization warnings only.
+  - `pnpm security:no-hardcoded-jwts` => passing.
+- Claude Code review:
+  - First review returned `CLEAN` with one low-severity request for mixed
+    guard-path coverage.
+  - Added `ops-watchdog does not resolve stale, missing, or malformed agent
+    records`, proving only positively fresh agents resolve while real stale or
+    unverified records remain open.
+  - Second review returned `CLEAN`; only residual risks were non-blocking:
+    dashboard Redis cache may lag source-of-truth `ops-state.json` until the
+    next `ops-reporter` cycle, and any future removal from
+    `SLA_MINUTES_BY_AGENT` should explicitly resolve/decommission old
+    `agent-silent` incidents.
+- Deploy status:
+  - Not deployed by default. This change is safe for the next reviewed deploy;
+    after deploy, the next `ops-watchdog` firing should update source-of-truth
+    `logs/ops-state.json`, and dashboard-visible status may lag until the next
+    `ops-reporter` sync.
+- Commit:
+  - `fix: resolve recovered ops watchdog incidents` (final hash recorded in
+    handoff; self-referential commit hashes are not embedded in the commit).
+
 ## Active Workstream: Schedule Target Names Pass 54 (2026-06-02)
 
 **Branch:** `fix/schedule-target-names-pass-54`


### PR DESCRIPTION
## Summary
- Resolve recovered `ops-watchdog:agent-silent:*` incidents when a watched agent has a valid fresh `lastRun` again.
- Preserve the guard path: stale, missing, or malformed watched-agent records stay open and keep `systemStatus` critical.
- Add isolated ops-watchdog regression coverage and ignore crash-left `.tmp-ops-watchdog-*` test dirs.

## Evidence
- Red test first reproduced the bug: recovered `ops-watchdog:agent-silent:fleet-manager` stayed `open`.
- `pnpm test:ops` => 11/11 passing.
- `pnpm exec tsc --noEmit --pretty false --module esnext --moduleResolution bundler --target es2022 --lib es2022 --strict --types node scripts/ops/ops-watchdog.ts scripts/ops/ops-watchdog.test.ts` => passing.
- `git diff --check -- .gitignore scripts/ops/ops-watchdog.ts scripts/ops/ops-watchdog.test.ts tasks/todo.md` => passing, LF/CRLF warnings only.
- `pnpm security:no-hardcoded-jwts` => passing.
- Claude Code review: CLEAN after mixed guard-path test was added.

## Runtime / deploy notes
- No API, DB, auth, tenant, env var, realtime, MCP, Hermes, email, or payment surface touched.
- Not deployed by default. After a reviewed deploy, the next `ops-watchdog` firing should correct source-of-truth `logs/ops-state.json`; dashboard-visible `/health/ops-status` can lag until the next `ops-reporter` sync.