### PR TITLE
fix: align realtime health probes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/docker/Dockerfile.realtime
+++ b/docker/Dockerfile.realtime
@@ -56,6 +56,6 @@ USER vizora
 
 EXPOSE 3002
 
-HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD node -e "require('http').get('http://localhost:3002/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1) }).on('error', () => process.exit(1))"
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD node -e "require('http').get('http://localhost:3002/api/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1) }).on('error', () => process.exit(1))"
 
 CMD ["node", "realtime/dist/main.js"]

--- a/docs/plans/2026-06-02-release-readiness-gates-pass-50.md
+++ b/docs/plans/2026-06-02-release-readiness-gates-pass-50.md
@@ -7,10 +7,12 @@
 
 Remove three release-readiness gate drifts found after PR #189:
 
-- the customer-critical smoke script probes the realtime gateway at the stale
-  `/api/health` path even though the gateway exposes native `/health`;
-- the first-customer onboarding runbook repeats the same stale realtime health
-  path;
+- the customer-critical smoke script was believed to probe the realtime gateway
+  at a stale `/api/health` path. Pass 56 supersedes this: repo and runtime truth
+  show the gateway health route is `/api/health` because realtime applies the
+  global `api` prefix;
+- the first-customer onboarding runbook was updated under the same assumption;
+  pass 56 supersedes this with `/api/health` as the route truth;
 - CI builds the web dashboard but does not run the web unit-test suite in the
   `test` job.
 
@@ -36,8 +38,9 @@ GitHub Actions coverage or shell smoke endpoint alignment.
 
 ## Drift Evidence
 
-- `realtime/src/app/app.controller.ts` exposes `GET /health`, `GET /health/live`,
-  and `GET /health/ready`.
+- `realtime/src/main.ts` applies global prefix `api`, so
+  `realtime/src/app/app.controller.ts` health handlers are exposed under
+  `/api/health`.
 - `scripts/smoke/api-critical-path.sh` currently probes
   `$RT_BASE/api/health`.
 - `docs/runbooks/first-customer-onboarding.md` currently probes
@@ -50,8 +53,8 @@ GitHub Actions coverage or shell smoke endpoint alignment.
 - Add a static regression test covering the realtime smoke path, the runbook
   realtime path, and web unit-test inclusion in CI.
 - Prove the test fails before fixes.
-- Update the smoke script to use `$RT_BASE/health`.
-- Update the first-customer runbook to document `http://localhost:3002/health`.
+- Superseded by pass 56: keep the smoke script and first-customer runbook on
+  `$RT_BASE/api/health`, matching repo and production runtime truth.
 - Add web unit tests to the CI `test` job.
 - Run focused static tests plus shell syntax checks, ops tests, web tests,
   security scan, and diff checks.

--- a/docs/runbooks/first-customer-onboarding.md
+++ b/docs/runbooks/first-customer-onboarding.md
@@ -28,8 +28,8 @@ ssh root@vizora.cloud 'cd /opt/vizora/app && bash scripts/smoke/api-critical-pat
 # To probe public API/web ingress from the VPS, run:
 ssh root@vizora.cloud 'cd /opt/vizora/app && API_BASE=https://vizora.cloud WEB_BASE=https://vizora.cloud bash scripts/smoke/api-critical-path.sh'
 # Realtime health is still checked locally on the VPS at the default
-# RT_BASE=http://localhost:3002. Public WebSocket ingress is covered by
-# the real-device walkthrough below, not by direct :3002 HTTPS.
+# RT_BASE=http://localhost:3002 and probes /api/health. Public WebSocket
+# ingress is covered by the real-device walkthrough below, not by direct :3002 HTTPS.
 #
 # Then trigger a real welcome email:
 curl -X POST https://vizora.cloud/api/v1/auth/register \
@@ -86,7 +86,7 @@ Run in this order:
 2. `pnpm --filter @vizora/realtime test` → expect 212/212
 3. `pnpm --filter @vizora/web test` → expect 864/864
 4. `bash scripts/smoke/api-critical-path.sh` (against localhost first; creates smoke-test rows)
-5. `ssh root@vizora.cloud 'cd /opt/vizora/app && API_BASE=https://vizora.cloud WEB_BASE=https://vizora.cloud bash scripts/smoke/api-critical-path.sh'` (against prod API/web ingress from the VPS; creates smoke-test rows; realtime health remains local `RT_BASE=http://localhost:3002` and probes `/health`)
+5. `ssh root@vizora.cloud 'cd /opt/vizora/app && API_BASE=https://vizora.cloud WEB_BASE=https://vizora.cloud bash scripts/smoke/api-critical-path.sh'` (against prod API/web ingress from the VPS; creates smoke-test rows; realtime health remains local `RT_BASE=http://localhost:3002` and probes `/api/health`)
 6. Open `https://vizora.cloud` in a fresh incognito browser → verify landing page renders, all CTAs work
 7. Sign up with a NEW disposable email → verify welcome email lands within 60s
 8. Click email verify link → verify landed in dashboard
@@ -177,7 +177,7 @@ cat .ssh_seed.txt
 
 # Check 5: All health endpoints. Realtime is intentionally checked over
 # localhost on the VPS; direct public :3002 HTTPS is not the supported ingress.
-for url in https://vizora.cloud/api/v1/health https://vizora.cloud/ http://localhost:3002/health; do
+for url in https://vizora.cloud/api/v1/health https://vizora.cloud/ http://localhost:3002/api/health; do
   ssh root@vizora.cloud "curl -s -o /dev/null -w '$url -> %{http_code}\n' '$url'"
 done
 ```

--- a/scripts/ops/health-guardian.ts
+++ b/scripts/ops/health-guardian.ts
@@ -61,7 +61,7 @@ function getServiceDefs(): ServiceDef[] {
     },
     {
       name: 'realtime',
-      healthUrl: `${realtimeUrl}/health`,
+      healthUrl: `${realtimeUrl}/api/health`,
       pm2Name: 'vizora-realtime',
       memoryLimitBytes: 512 * 1024 * 1024, // 512 MB
     },
@@ -195,8 +195,9 @@ async function main(): Promise<void> {
     if (result.ok) {
       log(AGENT, `${svc.name}: healthy (status ${result.status})`);
 
-      // Resolve existing incident if service recovered
-      if (existingIncident && existingIncident.status === 'open') {
+      // Resolve existing incident if service recovered, including incidents
+      // that were previously escalated after exhausted restart attempts.
+      if (existingIncident && existingIncident.status !== 'resolved') {
         log(AGENT, `${svc.name}: recovered — resolving incident ${incidentId}`);
         incidents.push({
           ...existingIncident,

--- a/scripts/ops/release-readiness-gates.test.ts
+++ b/scripts/ops/release-readiness-gates.test.ts
@@ -19,21 +19,42 @@ function readCiJobBlock(workflow: string, jobName: string): string {
   return match[0];
 }
 
-test('critical-path smoke probes the realtime gateway native health endpoint', () => {
+test('critical-path smoke probes the realtime gateway prefixed health endpoint', () => {
   const smokeScript = readRepoFile('scripts/smoke/api-critical-path.sh');
 
   assert.match(
     smokeScript,
-    /probe_status "Realtime health" "200" "\$RT_BASE\/health"/,
+    /probe_status "Realtime health" "200" "\$RT_BASE\/api\/health"/,
   );
-  assert.doesNotMatch(smokeScript, /\$RT_BASE\/api\/health/);
+  assert.doesNotMatch(smokeScript, /\$RT_BASE\/health"/);
 });
 
-test('first-customer runbook documents the realtime native health endpoint', () => {
+test('first-customer runbook documents the realtime prefixed health endpoint', () => {
   const runbook = readRepoFile('docs/runbooks/first-customer-onboarding.md');
 
-  assert.match(runbook, /http:\/\/localhost:3002\/health/);
-  assert.doesNotMatch(runbook, /localhost:3002\/api\/health/);
+  assert.match(runbook, /http:\/\/localhost:3002\/api\/health/);
+  assert.doesNotMatch(runbook, /localhost:3002\/health/);
+});
+
+test('realtime Docker healthcheck probes the prefixed health endpoint', () => {
+  const dockerfile = readRepoFile('docker/Dockerfile.realtime');
+
+  assert.match(dockerfile, /http:\/\/localhost:3002\/api\/health/);
+  assert.doesNotMatch(dockerfile, /localhost:3002\/health['"]/);
+});
+
+test('health guardian probes realtime at the prefixed health endpoint', () => {
+  const guardian = readRepoFile('scripts/ops/health-guardian.ts');
+
+  assert.match(guardian, /healthUrl:\s*`\$\{realtimeUrl\}\/api\/health`/);
+  assert.doesNotMatch(guardian, /healthUrl:\s*`\$\{realtimeUrl\}\/health`/);
+});
+
+test('health guardian resolves escalated service-down incidents after recovery', () => {
+  const guardian = readRepoFile('scripts/ops/health-guardian.ts');
+
+  assert.match(guardian, /existingIncident\.status !== 'resolved'/);
+  assert.doesNotMatch(guardian, /existingIncident\.status === 'open'/);
 });
 
 test('CI test job runs web unit tests before build-only gates', () => {

--- a/scripts/smoke/api-critical-path.sh
+++ b/scripts/smoke/api-critical-path.sh
@@ -286,7 +286,7 @@ echo
 # ---------- Health ----------
 probe_status "Middleware health" "200" "$API_BASE/api/v1/health"
 probe_status "Web home" "200" "$WEB_BASE"
-probe_status "Realtime health" "200" "$RT_BASE/health"
+probe_status "Realtime health" "200" "$RT_BASE/api/health"
 
 # ---------- Auth ----------
 echo

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,111 @@
 # Vizora - Task Tracker
 
+## Active Workstream: Realtime Health Smoke Truth Pass 56 (2026-06-03)
+
+**Branch:** `fix/realtime-health-smoke-truth-20260603`
+
+**Why now:** After PR #195 merged, a read-only production snapshot showed
+middleware and web healthy, but realtime returns `404` at
+`http://127.0.0.1:3002/health` and `200` at
+`http://127.0.0.1:3002/api/health`. Repo code matches prod runtime:
+`realtime/src/main.ts` applies global prefix `api`, and
+`realtime/src/app/app.controller.ts` exposes `@Get('health')`, making the
+actual route `/api/health`. The smoke script and first-customer runbook drifted
+to `/health`, which would make a go-live smoke fail for the wrong reason.
+
+**New primitives introduced:** none planned. This pass should reconcile smoke
+and runbook expectations to the existing realtime route. No new route, model,
+migration, env var, process, response shape, realtime event, MCP tool, Hermes
+skill, AI/provider spend path, or runtime change is expected.
+
+**Hermes-first analysis:** checked per project convention. This is deterministic
+smoke/runbook route reconciliation, not a business-agent, MCP, Hermes runtime,
+or provider-spend task.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Realtime health smoke route | none applicable | reconcile smoke/runbook to repo/runtime truth |
+| First-customer runbook health checks | none applicable | update existing runbook text only |
+
+Awesome-hermes-agent ecosystem check: no applicable skill/library primitive for
+local smoke-script endpoint reconciliation.
+
+**Plan**
+- [x] Add a focused red release-readiness test proving smoke/runbook expect
+      realtime `/api/health`.
+- [x] Update `scripts/smoke/api-critical-path.sh` and
+      `docs/runbooks/first-customer-onboarding.md` to match repo/runtime truth.
+- [x] Run focused ops/release-readiness tests.
+- [x] Run relevant hygiene/security checks.
+- [x] Request Claude Code review and resolve findings.
+- [ ] PR, CI, and merge if green.
+- [ ] Do not deploy by default; hand off deploy/runtime status.
+
+**Evidence so far**
+- Current `origin/main`: `72314d3f74de093077a133bf63ad799ded0d0c00`.
+- Production read-only endpoint matrix:
+  - realtime `/health` => `404`
+  - realtime `/api/health` => `200`
+  - realtime `/api/v1/health` => `404`
+  - middleware `/api/v1/health` => `200`
+  - middleware `/api/v1/health/ready` => `200`
+  - web `/` => `200`
+- Local code evidence:
+  - `realtime/src/main.ts` calls `app.setGlobalPrefix('api')`.
+  - `realtime/src/app/app.controller.ts` exposes `@Get('health')`, so the
+    actual route is `/api/health`.
+- Red focused run:
+  - `pnpm test:ops` failed as expected after updating the release-readiness
+    assertions: `scripts/smoke/api-critical-path.sh` and
+    `docs/runbooks/first-customer-onboarding.md` still referenced realtime
+    `/health`.
+- Fix:
+  - `scripts/smoke/api-critical-path.sh` now probes realtime health at
+    `$RT_BASE/api/health`.
+  - `docs/runbooks/first-customer-onboarding.md` now documents the same
+    local-VPS realtime health path in the smoke and pre-flight sections.
+  - `docker/Dockerfile.realtime` now probes the same `/api/health` route in its
+    latent container healthcheck.
+  - `scripts/ops/health-guardian.ts` now probes realtime at `/api/health` and
+    resolves recovered `service-down` incidents even when the old incident had
+    escalated after exhausted restart attempts.
+  - `.gitattributes` now keeps `*.sh` checked out with LF line endings.
+  - `docs/plans/2026-06-02-release-readiness-gates-pass-50.md` now notes that
+    pass 56 supersedes the earlier `/health` assumption.
+- Green verification:
+  - `pnpm test:ops` => 14/14 ops/release-readiness tests passing.
+  - `pnpm exec tsc --noEmit --pretty false --module esnext --moduleResolution bundler --target es2022 --lib es2022 --strict --types node scripts/ops/health-guardian.ts scripts/ops/release-readiness-gates.test.ts`
+    => passing.
+  - `C:\Program Files\Git\bin\bash.exe -n scripts/smoke/api-critical-path.sh`
+    => passing.
+  - `git diff --check -- .gitattributes docker/Dockerfile.realtime docs/plans/2026-06-02-release-readiness-gates-pass-50.md docs/runbooks/first-customer-onboarding.md scripts/smoke/api-critical-path.sh scripts/ops/health-guardian.ts scripts/ops/release-readiness-gates.test.ts tasks/todo.md`
+    => exit 0, with LF/CRLF normalization warnings only.
+  - `pnpm security:no-hardcoded-jwts` => passing.
+  - Generic `bash -n` failed on this Windows host because the WSL relay points
+    at missing `/bin/bash`; Git Bash was used explicitly for Bash syntax.
+- Claude Code review:
+  - First review returned `CLEAN` on the scoped diff and requested folding in
+    the same stale `/health` route in `docker/Dockerfile.realtime`.
+  - Addressed that Dockerfile healthcheck, tightened the runbook negative
+    assertion, added static Dockerfile coverage, added shell LF normalization,
+    and marked the stale pass-50 plan assumption as superseded.
+  - Second review found the active `health-guardian` consumer still probing
+    realtime `/health`; added a red static assertion proving the drift before
+    changing the script.
+- Production runtime attribution:
+  - Read-only grep of `/opt/vizora/app/logs/ops-state.json` found
+    `health-guardian:service-down:realtime` with `status: "escalated"`,
+    `attempts: 2`, and `error: "HTTP 404"`; prod `systemStatus` is still
+    `CRITICAL`.
+  - After this code is deployed, a successful health-guardian run should probe
+    `/api/health` and resolve that existing escalated false incident. Dashboard
+    visibility may still lag until the next ops-reporter sync.
+  - Final Claude Code review returned `CLEAN`. Residual risks are non-blocking:
+    prod still needs a reviewed deploy before the fix runs; realtime `/api/health`
+    is process-health only while `/api/health/ready` dependency parity is a
+    future pass; the old resolved incident may retain its stale `HTTP 404`
+    error text after status changes to `resolved`.
+
 ## Active Workstream: Ops State Incident Resolution Pass 55 (2026-06-03)
 
 **Branch:** `fix/ops-state-incident-resolution-20260603`


### PR DESCRIPTION
## Summary
- Align all realtime health consumers with repo/runtime truth: `/api/health` on port 3002.
- Update customer smoke, first-customer runbook, Dockerfile realtime healthcheck, and health-guardian.
- Allow health-guardian to resolve recovered service-down incidents even if the prior incident escalated after exhausted restart attempts.
- Add release-readiness regression assertions and `*.sh text eol=lf` normalization.

## Runtime evidence
Read-only prod matrix before this PR:
- realtime `/health` => 404
- realtime `/api/health` => 200
- realtime `/api/v1/health` => 404
- middleware `/api/v1/health` => 200
- middleware `/api/v1/health/ready` => 200
- web `/` => 200

Read-only ops-state grep found `health-guardian:service-down:realtime` with `status: escalated`, `attempts: 2`, and `error: HTTP 404`.

## Evidence
- Red test first proved smoke/runbook still referenced `/health`.
- Red test then proved health-guardian still referenced `/health` and only resolved `open` incidents.
- `pnpm test:ops` => 14/14 passing.
- `pnpm exec tsc --noEmit --pretty false --module esnext --moduleResolution bundler --target es2022 --lib es2022 --strict --types node scripts/ops/health-guardian.ts scripts/ops/release-readiness-gates.test.ts` => passing.
- Git Bash syntax check: `bash.exe -n scripts/smoke/api-critical-path.sh` => passing.
- `git diff --check` => passing, normalization warnings only.
- `pnpm security:no-hardcoded-jwts` => passing.
- Claude Code final review: CLEAN.

## Runtime / deploy notes
- No DB, API contract, auth, tenant, env var, payment, MCP, Hermes, or email path changed.
- Not deployed by default. After deploy, the next health-guardian cron should probe `/api/health` and resolve the existing false escalated realtime incident; dashboard cache may lag until ops-reporter syncs.