### PR TITLE
fix: align middleware container healthchecks

### DIFF
--- a/docker/Dockerfile.middleware
+++ b/docker/Dockerfile.middleware
@@ -57,6 +57,6 @@ USER vizora
 
 EXPOSE 3000
 
-HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD node -e "require('http').get('http://localhost:3000/api/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1) }).on('error', () => process.exit(1))"
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD node -e "require('http').get('http://localhost:3000/api/v1/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1) }).on('error', () => process.exit(1))"
 
 CMD ["node", "middleware/dist/main.js"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,11 +1,12 @@
 # Vizora Docker Setup
 
-This directory contains Docker configuration for running Vizora in production.
+This directory contains Docker infrastructure for Vizora plus optional
+application Dockerfiles. docker-compose.yml starts infrastructure and observability services; application services run under PM2 in the current production topology.
 
 ## Quick Start
 
 ```bash
-# Start all services
+# Start infrastructure services
 docker-compose up -d
 
 # View logs
@@ -20,14 +21,22 @@ docker-compose down -v
 
 ## Services
 
+Compose-managed infrastructure:
+
 - **postgres** (5432): PostgreSQL database for users, organizations, devices
 - **mongodb** (27017): MongoDB for content, playlists, schedules
 - **redis** (6379): Redis for caching, sessions, job queue
 - **minio** (9000, 9001): S3-compatible object storage
 - **clickhouse** (8123, 9002): Analytics database
+- **grafana** (3003): Observability dashboard
+- **prometheus** (9090), **loki** (3100), **promtail**: Metrics and logs
+- **nginx** (80, 443): Production reverse proxy profile
+
+Application ports when started by PM2 or local dev commands:
+
 - **middleware** (3000): NestJS API server
-- **realtime** (3001): Socket.IO WebSocket gateway
-- **web** (3002): Next.js dashboard
+- **web** (3001): Next.js dashboard
+- **realtime** (3002): Socket.IO WebSocket gateway
 
 ## Environment Variables
 
@@ -41,54 +50,47 @@ cp ../.env.example .env
 
 ## Database Setup
 
-After starting services, run migrations:
+After starting infrastructure, run migrations from the repo root:
 
 ```bash
 # Run Prisma migrations
-docker exec vizora-middleware pnpm prisma migrate deploy
+pnpm --filter @vizora/database db:migrate
 
 # Seed data (optional)
-docker exec vizora-middleware pnpm run seed
+pnpm seed
 ```
 
 ## Health Checks
 
-Check service health:
+Check app service health after PM2 or local dev services are running:
 
 ```bash
 # Middleware API
-curl http://localhost:3000/api/health
+curl http://localhost:3000/api/v1/health
 
 # Realtime Gateway
-curl http://localhost:3001/api/health
+curl http://localhost:3002/api/health
 
 # Web Dashboard
-curl http://localhost:3002
+curl http://localhost:3001
 ```
 
 ## Logs
 
 ```bash
-# All services
+# All compose-managed infrastructure services
 docker-compose logs -f
 
-# Specific service
-docker-compose logs -f middleware
-docker-compose logs -f realtime
-docker-compose logs -f web
+# App services
+pm2 logs vizora-middleware
+pm2 logs vizora-realtime
+pm2 logs vizora-web
 ```
 
 ## Scaling
 
-Scale specific services:
-
-```bash
-# Scale middleware to 3 instances
-docker-compose up -d --scale middleware=3
-
-# Scale realtime to 2 instances
-docker-compose up -d --scale realtime=2
-```
+Middleware and web can be horizontally scaled only when containerized behind a
+load balancer that preserves the documented port assignments. Realtime gateway MUST stay single-instance for Socket.IO room and device connection consistency.
 
 ## Production Deployment
 
@@ -99,7 +101,7 @@ For production:
 3. Set up proper firewall rules
 4. Configure backup schedules
 5. Set up monitoring and alerting
-6. Use container orchestration (Kubernetes recommended)
+6. Start app services with `pm2 start ecosystem.config.js --env production`
 
 ## Backup
 

--- a/scripts/ops/release-readiness-gates.test.ts
+++ b/scripts/ops/release-readiness-gates.test.ts
@@ -43,6 +43,40 @@ test('realtime Docker healthcheck probes the prefixed health endpoint', () => {
   assert.doesNotMatch(dockerfile, /localhost:3002\/health['"]/);
 });
 
+test('middleware Docker healthcheck probes the versioned health endpoint', () => {
+  const dockerfile = readRepoFile('docker/Dockerfile.middleware');
+
+  assert.match(dockerfile, /http:\/\/localhost:3000\/api\/v1\/health/);
+  assert.doesNotMatch(dockerfile, /localhost:3000\/api\/health['"]/);
+});
+
+test('Docker README documents current app service health endpoints', () => {
+  const readme = readRepoFile('docker/README.md');
+
+  assert.match(readme, /curl http:\/\/localhost:3000\/api\/v1\/health/);
+  assert.match(readme, /curl http:\/\/localhost:3002\/api\/health/);
+  assert.match(readme, /curl http:\/\/localhost:3001\r?\n/);
+  assert.doesNotMatch(readme, /localhost:3000\/api\/health/);
+  assert.doesNotMatch(readme, /localhost:3001\/api\/health/);
+});
+
+test('Docker README preserves realtime single-instance guidance', () => {
+  const readme = readRepoFile('docker/README.md');
+
+  assert.match(readme, /Realtime gateway[^\r\n]+MUST stay single-instance/i);
+  assert.doesNotMatch(readme, /--scale realtime=2/);
+});
+
+test('Docker README does not present PM2 app services as compose services', () => {
+  const readme = readRepoFile('docker/README.md');
+
+  assert.match(readme, /docker-compose\.yml starts infrastructure/i);
+  assert.match(readme, /application services run under PM2/i);
+  assert.doesNotMatch(readme, /docker exec vizora-middleware/);
+  assert.doesNotMatch(readme, /docker-compose logs -f middleware/);
+  assert.doesNotMatch(readme, /--scale middleware=3/);
+});
+
 test('health guardian probes realtime at the prefixed health endpoint', () => {
   const guardian = readRepoFile('scripts/ops/health-guardian.ts');
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,91 @@
 # Vizora - Task Tracker
 
+## Active Workstream: Middleware Container Healthcheck Truth Pass 57 (2026-06-03)
+
+**Branch:** `fix/overnight-healthchecks`
+
+**Why now:** After PR #196 aligned realtime health probes, the next repo-side
+runtime drift is the middleware container healthcheck path. Middleware is served
+under `/api/v1`, and direct container/compose probes do not pass through the
+public nginx backwards-compat rewrite from `/api/` to `/api/v1/`. A stale
+container probe at `/api/health` can make a healthy middleware container look
+unhealthy in Docker/runtime orchestration.
+
+**New primitives introduced:** none planned. This pass should reconcile
+Dockerfile/docs healthcheck references to the existing middleware health
+routes and align Docker docs with the PM2 app-service topology. No new route,
+model, migration, env var, process, response shape,
+realtime event, MCP tool, Hermes skill, AI/provider spend path, or runtime
+change is expected.
+
+**Hermes-first analysis:** checked per project convention. This is
+deterministic Docker/runtime healthcheck route reconciliation, not a
+business-agent, MCP, Hermes runtime, or provider-spend task.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Middleware container healthcheck route | none applicable | reconcile Docker healthchecks to existing `/api/v1/health` route |
+| Local Docker healthcheck commands | none applicable | update existing docs only |
+| Docker/PM2 deployment topology docs | none applicable | document existing topology, no new process |
+
+Awesome-hermes-agent ecosystem check: no applicable skill/library primitive for
+local Docker healthcheck endpoint reconciliation.
+
+**Plan**
+- [x] Create isolated worktree from current `origin/main` to avoid the dirty
+      primary checkout.
+- [x] Add focused red release-readiness tests proving middleware Dockerfile and
+      Docker README health references use `/api/v1/health`.
+- [x] Update Dockerfile/docs references to match middleware route truth.
+- [x] Run focused ops/release-readiness tests.
+- [x] Run relevant hygiene/static checks.
+- [x] Request Claude Code review and resolve findings.
+- [ ] Commit, PR, CI, and merge if green.
+- [ ] Do not deploy by default; hand off deploy/runtime status and remaining
+      operator-only blockers.
+
+**Evidence so far**
+- Current `origin/main`: `7f6a16f37a481d5cb274e6fb67cc7b3cbe25d13d`.
+- Drift-check:
+  - Middleware sets global prefix `api/v1` in `middleware/src/main.ts`.
+  - `HealthController` is mounted at `@Controller('health')`, so the direct
+    middleware health route is `/api/v1/health`.
+  - `docker/Dockerfile.middleware` still probed `/api/health`.
+  - `docker/docker-compose.yml` has a `/api/health` reference under Grafana,
+    not middleware; it is Grafana's own API health route and remains untouched.
+  - `docker/README.md` had stale app ports, presented PM2 app services as
+    docker-compose services, and told operators to scale realtime to 2
+    instances, conflicting with the single-instance Socket.IO rule.
+- Red focused run:
+  - `pnpm test:ops` failed as expected on the new middleware Dockerfile,
+    Docker README health endpoint, Docker/PM2 topology, and realtime
+    single-instance README guards.
+- Fix:
+  - `docker/Dockerfile.middleware` now probes
+    `http://localhost:3000/api/v1/health`.
+  - `docker/README.md` now documents compose-managed infrastructure separately
+    from PM2/local app services, middleware `3000`, web `3001`, realtime
+    `3002`, the current health endpoints, and the realtime single-instance
+    rule.
+- Green focused run:
+  - `pnpm test:ops` => 18/18 ops/readiness tests passing.
+- Static/hygiene verification:
+  - `pnpm exec tsc --noEmit --pretty false --module esnext --moduleResolution bundler --target es2022 --lib es2022 --strict --types node scripts/ops/release-readiness-gates.test.ts`
+    => passing.
+  - `git diff --check -- docker/Dockerfile.middleware docker/README.md scripts/ops/release-readiness-gates.test.ts tasks/todo.md`
+    => exit 0, with LF/CRLF normalization warnings only.
+  - `pnpm security:no-hardcoded-jwts` => passing.
+- Claude Code review:
+  - Review returned `CLEAN`.
+  - Reviewer independently verified middleware route truth (`api/v1` global
+    prefix + `@Controller('health')`), Docker README PM2/compose topology, port
+    assignments, realtime single-instance guidance, and that the new guards
+    cannot false-positive on Grafana's valid `/api/health` route.
+- PR / CI:
+  - PR #197: `https://github.com/Trivenidigital/Vizora/pull/197`.
+  - Initial CI was green before this evidence update: audit 32s, lint 32s,
+    security 25s, build 1m31s, test 4m26s, e2e 8m41s.
+
 ## Active Workstream: Realtime Health Smoke Truth Pass 56 (2026-06-03)
 
 **Branch:** `fix/realtime-health-smoke-truth-20260603`
@@ -38,7 +124,8 @@ local smoke-script endpoint reconciliation.
 - [x] Run focused ops/release-readiness tests.
 - [x] Run relevant hygiene/security checks.
 - [x] Request Claude Code review and resolve findings.
-- [ ] PR, CI, and merge if green.
+- [x] PR, CI, and merge if green. PR #196 merged at
+      `7f6a16f37a481d5cb274e6fb67cc7b3cbe25d13d`.
 - [ ] Do not deploy by default; hand off deploy/runtime status.
 
 **Evidence so far**


### PR DESCRIPTION
## Summary
- align middleware Dockerfile healthcheck with the real `/api/v1/health` route
- correct Docker README app ports and health endpoints
- clarify that docker-compose is infra/observability while app services run under PM2
- remove unsafe realtime scaling guidance and guard against reintroducing it

## Verification
- RED: `pnpm test:ops` failed on middleware Dockerfile, Docker README health endpoint, Docker/PM2 topology, and realtime single-instance README guards before the fix
- GREEN: `pnpm test:ops` => 18/18 passing
- `pnpm exec tsc --noEmit --pretty false --module esnext --moduleResolution bundler --target es2022 --lib es2022 --strict --types node scripts/ops/release-readiness-gates.test.ts` => passing
- `git diff --check -- docker/Dockerfile.middleware docker/README.md scripts/ops/release-readiness-gates.test.ts tasks/todo.md` => exit 0, CRLF warnings only
- `pnpm security:no-hardcoded-jwts` => passing
- Claude Code review => CLEAN

## Deploy
Not deployed. Repo-side readiness only; production deploy remains operator-gated.