### PR TITLE
fix: treat escalated ops incidents as active

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ Thumbs.db
 *.tmp
 *.temp
 .tmp-ops-watchdog-*/
+.tmp-health-guardian-*/
 .cache/
 .turbo/
 .swc/

--- a/scripts/ops/health-guardian.test.ts
+++ b/scripts/ops/health-guardian.test.ts
@@ -1,0 +1,188 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { createServer, type Server } from 'node:http';
+import {
+  chmodSync,
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import type { Incident, OpsState } from './lib/types.js';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function escalatedPm2Incident(detected: string): Incident {
+  return {
+    id: 'health-guardian:pm2-errored:vizora-middleware:0',
+    agent: 'health-guardian',
+    type: 'pm2-errored',
+    severity: 'critical',
+    target: 'pm2-process',
+    targetId: 'vizora-middleware:0',
+    detected,
+    message: 'PM2 process vizora-middleware:0 is errored and restart attempts exhausted',
+    remediation: 'pm2 restart vizora-middleware',
+    status: 'escalated',
+    attempts: 2,
+    error: 'Process status: errored',
+  };
+}
+
+function startHealthyServer(): Promise<{ server: Server; baseUrl: string }> {
+  const server = createServer((_req, res) => {
+    res.writeHead(200, {
+      'content-type': 'application/json',
+      connection: 'close',
+    });
+    res.end(JSON.stringify({ status: 'ok' }));
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      assert.ok(address && typeof address === 'object');
+      resolve({ server, baseUrl: `http://127.0.0.1:${address.port}` });
+    });
+  });
+}
+
+function writeFakePm2(binDir: string): void {
+  const pm2Js = join(binDir, 'pm2');
+  const pm2Cmd = join(binDir, 'pm2.cmd');
+  const jlist = JSON.stringify([
+    {
+      name: 'vizora-middleware',
+      pm_id: 0,
+      pm2_env: { status: 'online' },
+      monit: { memory: 64 * 1024 * 1024, cpu: 0 },
+    },
+    {
+      name: 'vizora-realtime',
+      pm_id: 0,
+      pm2_env: { status: 'online' },
+      monit: { memory: 64 * 1024 * 1024, cpu: 0 },
+    },
+    {
+      name: 'vizora-web',
+      pm_id: 0,
+      pm2_env: { status: 'online' },
+      monit: { memory: 64 * 1024 * 1024, cpu: 0 },
+    },
+  ]);
+
+  writeFileSync(
+    pm2Js,
+    `#!/usr/bin/env node
+if (process.argv[2] === 'jlist') {
+  process.stdout.write(${JSON.stringify(jlist)});
+  process.exit(0);
+}
+process.exit(0);
+`,
+  );
+  chmodSync(pm2Js, 0o755);
+  writeFileSync(pm2Cmd, `@echo off\r\nnode "%~dp0\\pm2" %*\r\n`);
+}
+
+function runHealthGuardian(
+  tmpRoot: string,
+  baseUrl: string,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null; stdout: string; stderr: string }> {
+  const pathSeparator = process.platform === 'win32' ? ';' : ':';
+  const child = spawn(process.execPath, [
+    '--import',
+    'tsx',
+    join(tmpRoot, 'scripts', 'ops', 'health-guardian.ts'),
+  ], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PATH: `${join(tmpRoot, 'bin')}${pathSeparator}${process.env.PATH ?? ''}`,
+      VALIDATOR_BASE_URL: baseUrl,
+      REALTIME_URL: baseUrl,
+      WEB_URL: baseUrl,
+      HEALTHCHECKS_HEALTH_GUARDIAN_URL: '',
+      SLACK_WEBHOOK_URL: '',
+    },
+    stdio: 'pipe',
+  });
+
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
+
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      child.kill();
+    }, 20_000);
+
+    child.on('exit', (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal, stdout, stderr });
+    });
+  });
+}
+
+test('health-guardian resolves escalated pm2-errored incidents when process is online', async () => {
+  const tmpRoot = mkdtempSync(join(repoRoot, '.tmp-health-guardian-'));
+  const { server, baseUrl } = await startHealthyServer();
+
+  try {
+    cpSync(join(repoRoot, 'scripts', 'ops'), join(tmpRoot, 'scripts', 'ops'), {
+      recursive: true,
+    });
+    mkdirSync(join(tmpRoot, 'logs'), { recursive: true });
+    mkdirSync(join(tmpRoot, 'bin'), { recursive: true });
+    writeFakePm2(join(tmpRoot, 'bin'));
+
+    const now = new Date().toISOString();
+    const state: OpsState = {
+      systemStatus: 'CRITICAL',
+      lastUpdated: now,
+      lastRun: {},
+      incidents: [escalatedPm2Incident(now)],
+      recentRemediations: [],
+      agentResults: {},
+    };
+    writeFileSync(
+      join(tmpRoot, 'logs', 'ops-state.json'),
+      JSON.stringify(state, null, 2),
+    );
+
+    const result = await runHealthGuardian(tmpRoot, baseUrl);
+
+    assert.equal(
+      result.code,
+      0,
+      `${result.stderr}\n${result.stdout}\nsignal=${result.signal ?? 'none'}`,
+    );
+    const updated = JSON.parse(
+      readFileSync(join(tmpRoot, 'logs', 'ops-state.json'), 'utf8'),
+    ) as OpsState;
+    const incident = updated.incidents.find(
+      (item) => item.id === 'health-guardian:pm2-errored:vizora-middleware:0',
+    );
+
+    assert.equal(incident?.status, 'resolved');
+    assert.ok(incident?.resolvedAt, 'expected online process to record resolvedAt');
+    assert.equal(updated.systemStatus, 'HEALTHY');
+  } finally {
+    server.close();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});

--- a/scripts/ops/health-guardian.ts
+++ b/scripts/ops/health-guardian.ts
@@ -347,12 +347,30 @@ async function main(): Promise<void> {
       const memoryLimitMB = Math.round(svc.memoryLimitBytes / (1024 * 1024));
       const memoryPct = svc.memoryLimitBytes > 0 ? (memoryBytes / svc.memoryLimitBytes) * 100 : 0;
       const procLabel = `${svc.pm2Name}:${proc.pm_id}`;
+      const pm2ErroredIncidentId = makeIncidentId(AGENT, 'pm2-errored', procLabel);
+      const existingPm2ErroredIncident = state.incidents.find(
+        i => i.id === pm2ErroredIncidentId,
+      );
+
+      if (
+        status === 'online' &&
+        existingPm2ErroredIncident &&
+        existingPm2ErroredIncident.status !== 'resolved'
+      ) {
+        log(AGENT, `${procLabel}: recovered — resolving incident ${pm2ErroredIncidentId}`);
+        incidents.push({
+          ...existingPm2ErroredIncident,
+          status: 'resolved',
+          resolvedAt: new Date().toISOString(),
+        });
+        issuesFixed++;
+      }
 
       // Check for errored/stopped processes
       if (status === 'errored' || status === 'stopped') {
         issuesFound++;
-        const incidentId = makeIncidentId(AGENT, 'pm2-errored', procLabel);
-        const existingIncident = state.incidents.find(i => i.id === incidentId);
+        const incidentId = pm2ErroredIncidentId;
+        const existingIncident = existingPm2ErroredIncident;
         const previousAttempts = existingIncident?.attempts ?? 0;
 
         if (existingIncident?.status === 'escalated') {

--- a/scripts/ops/lib/alerting.ts
+++ b/scripts/ops/lib/alerting.ts
@@ -101,13 +101,13 @@ export async function pingHeartbeat(
  *
  * @param status         Current system status
  * @param previousStatus Previous system status (for transition context)
- * @param openIncidents  Currently open incidents (top 5 shown)
+ * @param activeIncidents Currently active incidents (top 5 shown)
  * @param fixedCount     Number of issues auto-fixed this cycle
  */
 export async function sendSlackAlert(
   status: SystemStatus,
   previousStatus: SystemStatus | 'unknown',
-  openIncidents: Incident[],
+  activeIncidents: Incident[],
   fixedCount: number,
 ): Promise<void> {
   const webhookUrl = process.env.SLACK_WEBHOOK_URL || '';
@@ -134,14 +134,14 @@ export async function sendSlackAlert(
         type: 'mrkdwn',
         text: [
           `*Previous:* ${previousStatus} *Current:* ${status}`,
-          `*Open incidents:* ${openIncidents.length} | *Auto-fixed:* ${fixedCount}`,
+          `*Active incidents:* ${activeIncidents.length} | *Auto-fixed:* ${fixedCount}`,
         ].join('\n'),
       },
     },
   ];
 
   // Critical incidents (top 5)
-  const criticals = openIncidents.filter(i => i.severity === 'critical');
+  const criticals = activeIncidents.filter(i => i.severity === 'critical');
   if (criticals.length > 0) {
     const list = criticals
       .slice(0, 5)
@@ -157,7 +157,7 @@ export async function sendSlackAlert(
   }
 
   // Warning incidents (top 3, only if no criticals)
-  const warnings = openIncidents.filter(i => i.severity === 'warning');
+  const warnings = activeIncidents.filter(i => i.severity === 'warning');
   if (warnings.length > 0 && criticals.length === 0) {
     const list = warnings
       .slice(0, 3)
@@ -211,12 +211,12 @@ export async function sendSlackAlert(
  * Uses dynamic import for nodemailer to avoid hard dependency.
  *
  * @param status        Current system status
- * @param openIncidents Currently open incidents
+ * @param activeIncidents Currently active incidents
  * @param fixedCount    Number of issues auto-fixed this cycle
  */
 export async function sendEmailAlert(
   status: SystemStatus,
-  openIncidents: Incident[],
+  activeIncidents: Incident[],
   fixedCount: number,
 ): Promise<void> {
   const host = process.env.SMTP_HOST || '';
@@ -237,15 +237,15 @@ export async function sendEmailAlert(
     return;
   }
 
-  const criticals = openIncidents.filter(i => i.severity === 'critical');
-  const warnings = openIncidents.filter(i => i.severity === 'warning');
+  const criticals = activeIncidents.filter(i => i.severity === 'critical');
+  const warnings = activeIncidents.filter(i => i.severity === 'warning');
 
   const statusColor =
     status === 'HEALTHY' ? '#2ecc71' :
     status === 'DEGRADED' ? '#f39c12' :
     '#e74c3c';
 
-  const incidentRows = openIncidents
+  const incidentRows = activeIncidents
     .slice(0, 20)
     .map(
       i =>
@@ -266,7 +266,7 @@ export async function sendEmailAlert(
       <div style="padding:16px;border:1px solid #ddd;border-top:none;border-radius:0 0 4px 4px;">
         <p><strong>Critical:</strong> ${criticals.length} | <strong>Warnings:</strong> ${warnings.length} | <strong>Auto-fixed:</strong> ${fixedCount}</p>
         ${
-          openIncidents.length > 0
+          activeIncidents.length > 0
             ? `<table style="border-collapse:collapse;width:100%;font-size:13px;">
                 <thead>
                   <tr style="background:#f5f5f5;">
@@ -278,8 +278,8 @@ export async function sendEmailAlert(
                 </thead>
                 <tbody>${incidentRows}</tbody>
               </table>
-              ${openIncidents.length > 20 ? `<p style="color:#888;">...and ${openIncidents.length - 20} more</p>` : ''}`
-            : '<p style="color:#2ecc71;">No open incidents.</p>'
+              ${activeIncidents.length > 20 ? `<p style="color:#888;">...and ${activeIncidents.length - 20} more</p>` : ''}`
+            : '<p style="color:#2ecc71;">No active incidents.</p>'
         }
         <hr style="border:none;border-top:1px solid #eee;margin:16px 0;">
         <p style="color:#888;font-size:12px;">Vizora Autonomous Operations | ${new Date().toISOString()}</p>

--- a/scripts/ops/lib/state.test.ts
+++ b/scripts/ops/lib/state.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { determineSystemStatus } from './state.js';
+import type { Incident, OpsState, IncidentStatus, Severity } from './types.js';
+
+function incident(
+  status: IncidentStatus,
+  severity: Severity,
+  id = `${status}-${severity}`,
+): Incident {
+  return {
+    id,
+    agent: 'health-guardian',
+    type: 'service-down',
+    severity,
+    target: 'service',
+    targetId: id,
+    detected: '2026-06-03T00:00:00.000Z',
+    message: `${id} incident`,
+    remediation: 'check service',
+    status,
+    attempts: 2,
+  };
+}
+
+function stateWith(incidents: Incident[]): OpsState {
+  return {
+    systemStatus: 'HEALTHY',
+    lastUpdated: '2026-06-03T00:00:00.000Z',
+    lastRun: {},
+    incidents,
+    recentRemediations: [],
+    agentResults: {},
+  };
+}
+
+test('determineSystemStatus treats escalated critical incidents as active', () => {
+  assert.equal(
+    determineSystemStatus(stateWith([incident('escalated', 'critical')])),
+    'CRITICAL',
+  );
+});
+
+test('determineSystemStatus treats escalated warning incidents as degraded', () => {
+  assert.equal(
+    determineSystemStatus(stateWith([incident('escalated', 'warning')])),
+    'DEGRADED',
+  );
+});
+
+test('determineSystemStatus ignores resolved incidents', () => {
+  assert.equal(
+    determineSystemStatus(stateWith([
+      incident('resolved', 'critical', 'resolved-critical'),
+      incident('resolved', 'warning', 'resolved-warning'),
+    ])),
+    'HEALTHY',
+  );
+});

--- a/scripts/ops/lib/state.ts
+++ b/scripts/ops/lib/state.ts
@@ -196,15 +196,23 @@ export function addRemediation(state: OpsState, action: RemediationAction): void
 // ─── Status Calculation ─────────────────────────────────────────────────────
 
 /**
- * Determine overall system status based on open incidents:
- * - CRITICAL: any open incident with severity 'critical'
- * - DEGRADED: any open incident with severity 'warning'
- * - HEALTHY: no open critical or warning incidents
+ * Return true for incidents that still require operator/system attention.
+ * Escalated incidents are active until an agent records a resolved copy.
+ */
+export function isActiveIncident(incident: Pick<Incident, 'status'>): boolean {
+  return incident.status !== 'resolved';
+}
+
+/**
+ * Determine overall system status based on active incidents:
+ * - CRITICAL: any active incident with severity 'critical'
+ * - DEGRADED: any active incident with severity 'warning'
+ * - HEALTHY: no active critical or warning incidents
  */
 export function determineSystemStatus(state: OpsState): SystemStatus {
-  const open = state.incidents.filter(i => i.status === 'open');
-  if (open.some(i => i.severity === 'critical')) return 'CRITICAL';
-  if (open.some(i => i.severity === 'warning')) return 'DEGRADED';
+  const active = state.incidents.filter(isActiveIncident);
+  if (active.some(i => i.severity === 'critical')) return 'CRITICAL';
+  if (active.some(i => i.severity === 'warning')) return 'DEGRADED';
   return 'HEALTHY';
 }
 

--- a/scripts/ops/ops-reporter.ts
+++ b/scripts/ops/ops-reporter.ts
@@ -24,11 +24,12 @@
  */
 
 import 'dotenv/config';
-import type { SystemStatus, Incident } from './lib/types.js';
+import type { SystemStatus, Incident, RemediationAction } from './lib/types.js';
 import {
   readOpsState,
   writeOpsState,
   determineSystemStatus,
+  isActiveIncident,
 } from './lib/state.js';
 import {
   log,
@@ -184,10 +185,10 @@ function pruneOldIncidents(incidents: Incident[]): { pruned: number; remaining: 
  * Returns the number of remediations pruned.
  */
 function pruneOldRemediations(
-  remediations: { timestamp: string }[],
-): { pruned: number; remaining: typeof remediations } {
+  remediations: RemediationAction[],
+): { pruned: number; remaining: RemediationAction[] } {
   const cutoff = Date.now() - PRUNE_AGE_MS;
-  const remaining: typeof remediations = [];
+  const remaining: RemediationAction[] = [];
   let pruned = 0;
 
   for (const r of remediations) {
@@ -236,7 +237,7 @@ async function main(): Promise<void> {
 
   // ─── 5. Send Alerts ───────────────────────────────────────────────────────
 
-  const openIncidents = state.incidents.filter(i => i.status === 'open');
+  const activeIncidents = state.incidents.filter(isActiveIncident);
   const fixedCount = Object.values(state.agentResults).reduce(
     (sum, r) => sum + r.issuesFixed,
     0,
@@ -246,12 +247,12 @@ async function main(): Promise<void> {
     if (decision.isRecovery) {
       // Recovery — Slack only (good news)
       log(AGENT, 'Sending recovery alert (Slack only)');
-      await sendSlackAlert(currentStatus, previousStatus, openIncidents, fixedCount);
+      await sendSlackAlert(currentStatus, previousStatus, activeIncidents, fixedCount);
     } else {
       // Degraded or Critical — both channels
       log(AGENT, 'Sending alerts (Slack + Email)');
-      await sendSlackAlert(currentStatus, previousStatus, openIncidents, fixedCount);
-      await sendEmailAlert(currentStatus, openIncidents, fixedCount);
+      await sendSlackAlert(currentStatus, previousStatus, activeIncidents, fixedCount);
+      await sendEmailAlert(currentStatus, activeIncidents, fixedCount);
     }
 
     // Record alert timestamp for suppression tracking
@@ -307,17 +308,17 @@ async function main(): Promise<void> {
   // ─── Summary ──────────────────────────────────────────────────────────────
 
   const durationMs = Date.now() - startTime;
-  const openCount = state.incidents.filter(i => i.status === 'open').length;
+  const activeCount = state.incidents.filter(isActiveIncident).length;
   const criticalCount = state.incidents.filter(
-    i => i.status === 'open' && i.severity === 'critical',
+    i => isActiveIncident(i) && i.severity === 'critical',
   ).length;
   const warningCount = state.incidents.filter(
-    i => i.status === 'open' && i.severity === 'warning',
+    i => isActiveIncident(i) && i.severity === 'warning',
   ).length;
 
   log(
     AGENT,
-    `Cycle complete in ${durationMs}ms — status: ${currentStatus}, open: ${openCount} (${criticalCount} critical, ${warningCount} warning), alerted: ${decision.shouldAlert}`,
+    `Cycle complete in ${durationMs}ms — status: ${currentStatus}, active: ${activeCount} (${criticalCount} critical, ${warningCount} warning), alerted: ${decision.shouldAlert}`,
   );
 
   // ─── Exit Code ────────────────────────────────────────────────────────────

--- a/scripts/ops/release-readiness-gates.test.ts
+++ b/scripts/ops/release-readiness-gates.test.ts
@@ -91,6 +91,22 @@ test('health guardian resolves escalated service-down incidents after recovery',
   assert.doesNotMatch(guardian, /existingIncident\.status === 'open'/);
 });
 
+test('ops reporter summarizes active incidents instead of only open incidents', () => {
+  const reporter = readRepoFile('scripts/ops/ops-reporter.ts');
+
+  assert.match(reporter, /isActiveIncident/);
+  assert.doesNotMatch(reporter, /filter\(i => i\.status === 'open'\)/);
+});
+
+test('ops alerting labels unresolved incident lists as active incidents', () => {
+  const alerting = readRepoFile('scripts/ops/lib/alerting.ts');
+
+  assert.match(alerting, /Active incidents/);
+  assert.match(alerting, /No active incidents/);
+  assert.doesNotMatch(alerting, /Open incidents/);
+  assert.doesNotMatch(alerting, /No open incidents/);
+});
+
 test('CI test job runs web unit tests before build-only gates', () => {
   const ciWorkflow = readRepoFile('.github/workflows/ci.yml');
   const testJob = readCiJobBlock(ciWorkflow, 'test');

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,88 @@
 # Vizora - Task Tracker
 
+## Active Workstream: Ops Escalated Incident Status Pass 58 (2026-06-03)
+
+**Branch:** `fix/ops-escalated-status`
+
+**Why now:** The ops dashboard treats any incident with `status !== 'resolved'`
+as active, but the shared ops status calculation and reporter summaries only
+count `status === 'open'`. That means an unresolved `escalated` critical
+incident can be dropped from `systemStatus` and alert details, hiding precisely
+the incidents that need operator attention.
+
+**New primitives introduced:** none planned. This pass should reuse the
+existing ops-state model, `IncidentStatus` union, ops reporter, and
+release-readiness guard tests. No new route, model, migration, env var,
+process, response shape, realtime event, MCP tool, Hermes skill, AI/provider
+spend path, or runtime change is expected.
+
+**Hermes-first analysis:** checked per project convention. This is
+deterministic ops-state severity calculation and reporting, not a
+business-agent, MCP, Hermes runtime, or provider-spend task.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Ops incident severity rollup | none applicable | fix existing deterministic ops-state helper |
+| Ops reporter alert incident selection | none applicable | reuse existing reporter path and active-incident semantics |
+
+Awesome-hermes-agent ecosystem check: no applicable skill/library primitive for
+local ops-state severity rollup.
+
+**Plan**
+- [x] Add focused red tests proving escalated critical/warning incidents affect
+      `systemStatus` until resolved.
+- [x] Add a release-readiness guard proving ops reporter summarizes active
+      non-resolved incidents, not only `open` incidents.
+- [x] Implement the smallest shared helper in the existing ops-state path and
+      update ops reporter/alerting to use active-incident wording.
+- [x] Run focused ops tests and TypeScript checks.
+- [x] Request Claude Code review and resolve findings.
+- [ ] Commit, PR, CI, and merge if green.
+- [ ] Do not deploy by default; hand off deploy/runtime status and remaining
+      operator-only blockers.
+
+**Evidence so far**
+- Current `origin/main`: `a0f136fb3ea426d7d58744926b7c8f6ec5b543da`.
+- Drift-check:
+  - `scripts/ops/lib/state.ts` `determineSystemStatus` filtered only
+    `status === 'open'`.
+  - `scripts/ops/ops-reporter.ts` used the same open-only filter for alert
+    incident lists and summary counts.
+  - `web/src/app/dashboard/ops/page.tsx` already treats incidents with
+    `status !== 'resolved'` as active, so shared state/reporter semantics were
+    narrower than dashboard semantics.
+- Red focused run:
+  - `pnpm test:ops` failed as expected: escalated critical returned `HEALTHY`
+    instead of `CRITICAL`, escalated warning returned `HEALTHY` instead of
+    `DEGRADED`, and the ops reporter static guard found open-only filtering.
+- Fix:
+  - Added shared `isActiveIncident` helper in `scripts/ops/lib/state.ts`.
+  - `determineSystemStatus` and `ops-reporter` now count unresolved incidents
+    (`status !== 'resolved'`) consistently.
+  - `scripts/ops/lib/alerting.ts` now labels those alert lists as "active
+    incidents" instead of "open incidents."
+  - Addressed Claude Code's HIGH finding by adding a health-guardian recovery
+    branch for escalated `pm2-errored` incidents when the PM2 process is back
+    online.
+  - Added `.gitignore` coverage for `.tmp-health-guardian-*/`, matching the
+    existing ops-watchdog temp-dir pattern.
+- Green focused run:
+  - `pnpm test:ops` => 24/24 ops tests passing after adding the alerting label
+    guard and PM2 recovery-resolution regression test.
+- Static/hygiene verification:
+  - `pnpm exec tsc --noEmit --pretty false --module esnext --moduleResolution bundler --target es2022 --lib es2022 --strict --types node scripts/ops/lib/state.ts scripts/ops/lib/state.test.ts scripts/ops/ops-reporter.ts scripts/ops/lib/alerting.ts scripts/ops/health-guardian.ts scripts/ops/health-guardian.test.ts scripts/ops/release-readiness-gates.test.ts`
+    => passing.
+  - `git diff --check -- .gitignore scripts/ops/lib/state.ts scripts/ops/lib/state.test.ts scripts/ops/ops-reporter.ts scripts/ops/lib/alerting.ts scripts/ops/health-guardian.ts scripts/ops/health-guardian.test.ts scripts/ops/release-readiness-gates.test.ts tasks/todo.md`
+    => exit 0, with LF/CRLF normalization warnings only.
+  - `pnpm security:no-hardcoded-jwts` => passing.
+- Claude Code review:
+  - First review approved the active-incident semantics but surfaced one HIGH
+    finding: escalated `pm2-errored` incidents could pin `CRITICAL` forever
+    after process recovery because health-guardian had no PM2 recovery branch.
+  - Final review returned `APPROVE` after the PM2 recovery-resolution test/fix
+    and active-incident alert wording guard. Reviewer independently verified
+    24/24 ops tests passing and cross-platform fake-PM2 test reliability.
+
 ## Active Workstream: Middleware Container Healthcheck Truth Pass 57 (2026-06-03)
 
 **Branch:** `fix/overnight-healthchecks`


### PR DESCRIPTION
## Summary
- Treat unresolved ops incidents (`open` or `escalated`) as active in shared system-status rollups and ops-reporter summaries.
- Resolve prior `pm2-errored` health-guardian incidents when PM2 reports the process back online.
- Add focused regression coverage plus release-readiness guards for active-incident wording and semantics.

## Verification
- `pnpm test:ops` => 24/24 passing
- `pnpm exec tsc --noEmit --pretty false --module esnext --moduleResolution bundler --target es2022 --lib es2022 --strict --types node scripts/ops/lib/state.ts scripts/ops/lib/state.test.ts scripts/ops/ops-reporter.ts scripts/ops/lib/alerting.ts scripts/ops/health-guardian.ts scripts/ops/health-guardian.test.ts scripts/ops/release-readiness-gates.test.ts` => exit 0
- `git diff --cached --check -- .gitignore scripts/ops/lib/state.ts scripts/ops/lib/state.test.ts scripts/ops/ops-reporter.ts scripts/ops/lib/alerting.ts scripts/ops/health-guardian.ts scripts/ops/health-guardian.test.ts scripts/ops/release-readiness-gates.test.ts tasks/todo.md` => exit 0
- `pnpm security:no-hardcoded-jwts` => exit 0

## Claude Code Review
- First review surfaced HIGH: escalated PM2 incidents could pin CRITICAL forever after PM2 recovery.
- Final review: APPROVE after adding the PM2 recovery-resolution regression and fix; reviewer independently verified 24/24 ops tests.

## Deployment
- No production deploy in this PR.