### PR TITLE
fix: align admin platform health probes

### DIFF
--- a/middleware/src/modules/admin/services/platform-health.service.spec.ts
+++ b/middleware/src/modules/admin/services/platform-health.service.spec.ts
@@ -1,6 +1,12 @@
 import { PlatformHealthService } from './platform-health.service';
 import { DatabaseService } from '../../database/database.service';
 import { RedisService } from '../../redis/redis.service';
+import * as http from 'http';
+import { EventEmitter } from 'events';
+
+jest.mock('http', () => ({
+  request: jest.fn(),
+}));
 
 describe('PlatformHealthService', () => {
   let service: PlatformHealthService;
@@ -24,6 +30,27 @@ describe('PlatformHealthService', () => {
       mockRedis as RedisService,
     );
   });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function mockHttpStatus(statusCode = 200) {
+    const request = new EventEmitter() as http.ClientRequest;
+    request.end = jest.fn();
+    request.destroy = jest.fn();
+
+    const requestSpy = http.request as jest.MockedFunction<typeof http.request>;
+    requestSpy.mockImplementation(((
+      _options: http.RequestOptions,
+      callback?: (res: http.IncomingMessage) => void,
+    ) => {
+      callback?.({ statusCode } as http.IncomingMessage);
+      return request;
+    }) as typeof http.request);
+
+    return { requestSpy };
+  }
 
   it('should be defined', () => {
     expect(service).toBeDefined();
@@ -142,6 +169,76 @@ describe('PlatformHealthService', () => {
       const result = await service.getServiceStatus();
 
       expect(result).toHaveLength(3);
+    });
+  });
+
+  describe('checkServicePort', () => {
+    it('probes middleware at the versioned health path', async () => {
+      const { requestSpy } = mockHttpStatus();
+
+      const result = await service.checkServicePort('middleware', 3000);
+
+      expect(result.status).toBe('healthy');
+      expect(requestSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hostname: 'localhost',
+          port: 3000,
+          path: '/api/v1/health',
+          method: 'GET',
+        }),
+        expect.any(Function),
+      );
+    });
+
+    it('probes realtime at the prefixed gateway health path', async () => {
+      const { requestSpy } = mockHttpStatus();
+
+      const result = await service.checkServicePort('realtime', 3002);
+
+      expect(result.status).toBe('healthy');
+      expect(requestSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hostname: 'localhost',
+          port: 3002,
+          path: '/api/health',
+          method: 'GET',
+        }),
+        expect.any(Function),
+      );
+    });
+
+    it('probes web at the root page used by its container healthcheck', async () => {
+      const { requestSpy } = mockHttpStatus();
+
+      const result = await service.checkServicePort('web', 3001);
+
+      expect(result.status).toBe('healthy');
+      expect(requestSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hostname: 'localhost',
+          port: 3001,
+          path: '/',
+          method: 'GET',
+        }),
+        expect.any(Function),
+      );
+    });
+
+    it('keeps the legacy /health fallback for unknown service names', async () => {
+      const { requestSpy } = mockHttpStatus();
+
+      const result = await service.checkServicePort('custom-service', 3999);
+
+      expect(result.status).toBe('healthy');
+      expect(requestSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hostname: 'localhost',
+          port: 3999,
+          path: '/health',
+          method: 'GET',
+        }),
+        expect.any(Function),
+      );
     });
   });
 

--- a/middleware/src/modules/admin/services/platform-health.service.ts
+++ b/middleware/src/modules/admin/services/platform-health.service.ts
@@ -37,6 +37,12 @@ export interface UptimeHistory {
   downtime: number; // minutes
 }
 
+const SERVICE_HEALTH_PATHS: Record<string, string> = {
+  middleware: '/api/v1/health',
+  web: '/',
+  realtime: '/api/health',
+};
+
 @Injectable()
 export class PlatformHealthService {
   private readonly logger = new Logger(PlatformHealthService.name);
@@ -123,7 +129,7 @@ export class PlatformHealthService {
         {
           hostname: 'localhost',
           port,
-          path: '/health',
+          path: SERVICE_HEALTH_PATHS[name] ?? '/health',
           method: 'GET',
           timeout,
         },

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,88 @@
 # Vizora - Task Tracker
 
+## Active Workstream: Admin Platform Health Routes Pass 59 (2026-06-03)
+
+**Branch:** `fix/admin-platform-health-routes`
+
+**Why now:** The admin health endpoint (`/api/v1/admin/health`) is another
+production-readiness surface operators use for launch checks. Its
+`PlatformHealthService` still probes all app services at `/health`, while repo
+and runtime truth now show middleware at `/api/v1/health`, realtime at
+`/api/health`, and web at `/`. That can make an otherwise healthy platform look
+degraded in the admin view.
+
+**New primitives introduced:** none planned. This pass should reuse the
+existing admin `PlatformHealthService`, response shape, controllers, and tests.
+No new route, model, migration, env var, process, realtime event, MCP tool,
+Hermes skill, AI/provider spend path, or production runtime change is expected.
+
+**Hermes-first analysis:** checked per project convention. This is
+deterministic service health probing inside the existing NestJS admin module,
+not a business-agent, MCP, Hermes runtime, or provider-spend task.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Admin service health probe routing | none applicable | fix existing NestJS admin health service |
+| Health-route drift guard | none applicable | add local unit/static tests |
+
+Awesome-hermes-agent ecosystem check: no applicable skill/library primitive for
+local admin health probe route selection.
+
+**Plan**
+- [x] Add red tests proving each platform service is probed at its real health
+      path: middleware `/api/v1/health`, realtime `/api/health`, web `/`.
+- [x] Implement service-specific path selection without changing the public
+      admin health response shape.
+- [x] Decide no extra release-readiness guard is needed because the route map is
+      local to `PlatformHealthService.checkServicePort()` and covered by unit
+      tests.
+- [x] Run focused middleware tests, TypeScript check, diff hygiene, and secret
+      scan.
+- [x] Request Claude Code review and resolve findings.
+- [ ] Commit, PR, CI, and merge if green.
+- [ ] Do not deploy by default; hand off deploy/runtime status and remaining
+      operator-only blockers.
+
+**Evidence so far**
+- Current `origin/main`: `dbc8b915080cc15f715e5d1842c38fb37ce9b83b`.
+- Drift-check:
+  - `middleware/src/modules/admin/services/platform-health.service.ts`
+    `checkServicePort()` hardcodes `path: '/health'` for middleware, web, and
+    realtime.
+  - Middleware health is mounted under global `/api/v1` prefix at
+    `/api/v1/health`.
+  - Realtime health is mounted under global `/api` prefix at `/api/health`.
+  - Web Docker/readiness guidance probes the root page on port 3001.
+- Red focused run:
+  - `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/admin/services/platform-health.service.spec.ts`
+    failed as expected: all three new assertions received `path: '/health'`.
+- Fix:
+  - Added a service-specific health-path map in
+    `middleware/src/modules/admin/services/platform-health.service.ts`.
+  - Added `http.request` unit coverage for middleware `/api/v1/health`,
+    realtime `/api/health`, and web `/`.
+  - Added fallback coverage proving unknown service names still use the legacy
+    `/health` path.
+- Green focused/admin seam run:
+  - `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/admin/services/platform-health.service.spec.ts src/modules/admin/admin.controller.spec.ts`
+    => 51/51 tests passing.
+- Static/hygiene verification:
+  - `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` =>
+    passing.
+  - `git diff --check -- middleware/src/modules/admin/services/platform-health.service.ts middleware/src/modules/admin/services/platform-health.service.spec.ts tasks/todo.md`
+    => exit 0, with LF/CRLF normalization warnings only.
+  - `pnpm security:no-hardcoded-jwts` => passing.
+- Claude Code review:
+  - Initial review returned `APPROVE` with no blocking findings. Reviewer
+    independently confirmed all three route truths and called the liveness
+    endpoint choice correct for `checkServicePort()`.
+  - Non-blocking optional fallback test was added.
+  - Non-blocking note about `docker/docker-compose.yml:142` was triaged as
+    Grafana's internal port 3000 healthcheck, not middleware drift.
+  - Final re-review returned `APPROVE`. Reviewer confirmed the map against
+    source and container healthchecks, noted no auth/security impact, and left
+    only future-maintenance observations.
+
 ## Active Workstream: Ops Escalated Incident Status Pass 58 (2026-06-03)
 
 **Branch:** `fix/ops-escalated-status`


### PR DESCRIPTION
## Summary
- Align admin platform-health service probes with actual app health routes: middleware `/api/v1/health`, realtime `/api/health`, web `/`.
- Preserve the legacy `/health` fallback for unknown service names.
- Add focused unit coverage for all service paths plus the fallback, without changing the admin health response shape.

## Verification
- Red: `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/admin/services/platform-health.service.spec.ts` failed as expected with `/health` received for middleware/web/realtime.
- Green: `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/admin/services/platform-health.service.spec.ts src/modules/admin/admin.controller.spec.ts` => 51/51 passing.
- `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` => exit 0.
- `git diff --check -- middleware/src/modules/admin/services/platform-health.service.ts middleware/src/modules/admin/services/platform-health.service.spec.ts tasks/todo.md` => exit 0 with LF/CRLF warnings only.
- `pnpm security:no-hardcoded-jwts` => exit 0.

## Claude Code Review
- Initial review: APPROVE, no blocking findings.
- Final re-review after adding fallback coverage: APPROVE, no blocking findings.
- Reviewer confirmed route truth against source/container healthchecks and no auth/security impact.

## Notes
- `docker/docker-compose.yml:142` remains Grafana's own internal port 3000 `/api/health` check, not middleware drift.
- No production deploy or runtime/env mutation in this PR.