### PR TITLE
fix: align admin health readiness display

### DIFF
--- a/middleware/src/modules/admin/services/platform-health.service.spec.ts
+++ b/middleware/src/modules/admin/services/platform-health.service.spec.ts
@@ -155,6 +155,68 @@ describe('PlatformHealthService', () => {
 
       expect(result.overall).toBe('degraded');
     });
+
+    it('should return degraded when web is down', async () => {
+      mockDb.$queryRaw.mockResolvedValue([{ '?column?': 1 }]);
+      mockRedis.healthCheck.mockResolvedValue({ healthy: true, responseTime: 5 });
+
+      jest.spyOn(service, 'checkServicePort')
+        .mockResolvedValueOnce({
+          name: 'middleware',
+          port: 3000,
+          status: 'healthy',
+          responseTime: 10,
+        })
+        .mockResolvedValueOnce({
+          name: 'web',
+          port: 3001,
+          status: 'unhealthy',
+          responseTime: 10,
+          error: 'Connection refused',
+        })
+        .mockResolvedValueOnce({
+          name: 'realtime',
+          port: 3002,
+          status: 'healthy',
+          responseTime: 10,
+        });
+
+      const result = await service.getOverallHealth();
+
+      expect(result.overall).toBe('degraded');
+      expect(result.services.web.status).toBe('unhealthy');
+    });
+
+    it('should return degraded when realtime is down', async () => {
+      mockDb.$queryRaw.mockResolvedValue([{ '?column?': 1 }]);
+      mockRedis.healthCheck.mockResolvedValue({ healthy: true, responseTime: 5 });
+
+      jest.spyOn(service, 'checkServicePort')
+        .mockResolvedValueOnce({
+          name: 'middleware',
+          port: 3000,
+          status: 'healthy',
+          responseTime: 10,
+        })
+        .mockResolvedValueOnce({
+          name: 'web',
+          port: 3001,
+          status: 'healthy',
+          responseTime: 10,
+        })
+        .mockResolvedValueOnce({
+          name: 'realtime',
+          port: 3002,
+          status: 'unhealthy',
+          responseTime: 10,
+          error: 'Connection refused',
+        });
+
+      const result = await service.getOverallHealth();
+
+      expect(result.overall).toBe('degraded');
+      expect(result.services.realtime.status).toBe('unhealthy');
+    });
   });
 
   describe('getServiceStatus', () => {

--- a/middleware/src/modules/admin/services/platform-health.service.ts
+++ b/middleware/src/modules/admin/services/platform-health.service.ts
@@ -76,9 +76,13 @@ export class PlatformHealthService {
     // Determine overall health
     let overall: 'healthy' | 'degraded' | 'unhealthy' = 'healthy';
 
+    const hasUnhealthyAppService = [middlewareStatus, webStatus, realtimeStatus].some(
+      (service) => service.status !== 'healthy',
+    );
+
     if (!dbHealth.healthy) {
       overall = 'unhealthy';
-    } else if (!redisHealth.healthy || middlewareStatus.status !== 'healthy') {
+    } else if (!redisHealth.healthy || hasUnhealthyAppService) {
       overall = 'degraded';
     }
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,105 @@
 # Vizora - Task Tracker
 
+## Active Workstream: Admin Health Overall Status Pass 60 (2026-06-03)
+
+**Branch:** `fix/admin-health-overall-status`
+
+**Why now:** Pass 59 fixed the routes used by `/api/v1/admin/health`, but
+`PlatformHealthService.getOverallHealth()` still only degrades on Redis or
+middleware failure. If web or realtime is unhealthy, the aggregate can still
+return `overall: "healthy"`, which is false readiness evidence for operators.
+
+**New primitives introduced:** none planned. This pass should reuse the
+existing admin health response shape and `ServiceStatus` model. No new route,
+model, migration, env var, process, realtime event, MCP tool, Hermes skill,
+AI/provider spend path, or production runtime change is expected.
+
+**Hermes-first analysis:** checked per project convention. This is
+deterministic aggregate status calculation inside the existing NestJS admin
+module, not a business-agent, MCP, Hermes runtime, or provider-spend task.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Admin aggregate health rollup | none applicable | fix existing NestJS admin health service |
+| App service health status classification | none applicable | reuse existing `ServiceStatus` values |
+
+Awesome-hermes-agent ecosystem check: no applicable skill/library primitive for
+local admin health aggregate calculation.
+
+**Plan**
+- [x] Add red tests proving web and realtime unhealthy statuses degrade the
+      admin aggregate.
+- [x] Preserve database-down as `unhealthy` and Redis/middleware failures as
+      `degraded`.
+- [x] Implement the smallest aggregate predicate without changing response
+      shape or route selection.
+- [x] Fix the admin Health page consumer so it renders the real backend
+      response shape instead of a frontend-only mock shape.
+- [x] Run focused middleware/web tests, TypeScript checks, diff hygiene,
+      production-style web build, and secret scan.
+- [ ] Request Claude Code review and resolve findings.
+- [ ] Commit, PR, CI, and merge if green.
+- [ ] Do not deploy by default; hand off deploy/runtime status and remaining
+      operator-only blockers.
+
+**Evidence so far**
+- Current `origin/main`: `b641953bd2288c7dd07a6a82552378585de9b129`.
+- Drift-check:
+  - `middleware/src/modules/admin/services/platform-health.service.ts`
+    computes `overall: "degraded"` only when Redis is unhealthy or middleware
+    is not healthy.
+  - `webStatus` and `realtimeStatus` are included in the response but ignored
+    by aggregate status calculation.
+  - Claude Code review surfaced a second real consumer gap:
+    `web/src/app/admin/health/page-client.tsx` expected top-level `status` and
+    `services[]`, but `/api/v1/admin/health` returns `overall` and a keyed
+    `services` object.
+- Red focused run:
+  - `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/admin/services/platform-health.service.spec.ts`
+    failed as expected: web-down and realtime-down cases returned
+    `overall: "healthy"` instead of `degraded`.
+- Fix:
+  - Added a small `hasUnhealthyAppService` predicate over middleware, web, and
+    realtime statuses before the existing database/Redis rollup.
+  - Database-down remains `unhealthy`; Redis or any app-service unhealthy
+    status now returns `degraded`.
+  - Updated the shared `PlatformHealth` type to match the backend response.
+  - Added an admin Health page normalizer that maps backend `overall`/service
+    objects into the existing page view model.
+  - Replaced the old healthy mock fallback on load failure with a conservative
+    `System down` unavailable state.
+  - Addressed Claude Code's minor UI hardening notes: malformed backend shape
+    now falls back to unavailable, partial backend service data also falls
+    back to unavailable, zero/unknown uptime and storage metrics no longer
+    render confusing duplicate text, and the server page comment no longer says
+    fallback mock data.
+- Green focused/admin seam run:
+  - `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/admin/services/platform-health.service.spec.ts src/modules/admin/admin.controller.spec.ts`
+    => 53/53 tests passing.
+- Green web run:
+  - `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/admin/health/__tests__/health-page.test.tsx`
+    => 15/15 tests passing, including backend-shape normalization,
+    malformed/partial-shape fallback, and load-failure fallback.
+- Static/hygiene verification:
+  - `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` =>
+    passing.
+  - `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` => passing.
+  - `git diff --check -- middleware/src/modules/admin/services/platform-health.service.ts middleware/src/modules/admin/services/platform-health.service.spec.ts web/src/app/admin/health/page-client.tsx web/src/app/admin/health/page.tsx web/src/app/admin/health/__tests__/health-page.test.tsx web/src/lib/types.ts tasks/todo.md`
+    => exit 0, with LF/CRLF normalization warnings only.
+  - `pnpm security:no-hardcoded-jwts` => passing.
+  - First web build attempt with localhost `NEXT_PUBLIC_*` values failed as
+    expected under the production-origin guard.
+  - `$env:NODE_OPTIONS='--max-old-space-size=4096'; $env:NEXT_PUBLIC_API_URL='https://vizora.cloud/api/v1'; $env:NEXT_PUBLIC_SOCKET_URL='https://vizora.cloud'; $env:BACKEND_URL='http://localhost:3000'; pnpm --filter @vizora/web build`
+    => passing, with existing Next.js middleware/proxy and TypeScript project
+    reference warnings only.
+- Claude Code review:
+  - Backend-only review returned `APPROVE` and surfaced the admin Health page
+    shape mismatch as an operator-relevant caveat.
+  - Full backend+web review returned `APPROVE` with four non-blocking notes;
+    those low-cost notes were addressed before commit.
+  - Final residual note about shallow backend-shape guarding was also fixed and
+    covered by a partial-service-data regression test.
+
 ## Active Workstream: Admin Platform Health Routes Pass 59 (2026-06-03)
 
 **Branch:** `fix/admin-platform-health-routes`

--- a/web/src/app/admin/health/__tests__/health-page.test.tsx
+++ b/web/src/app/admin/health/__tests__/health-page.test.tsx
@@ -71,6 +71,18 @@ const mockHealth = {
   errorRate: { last1h: 0.1, last24h: 0.5 },
 };
 
+const backendPlatformHealth = {
+  overall: 'degraded' as const,
+  services: {
+    database: { healthy: true, responseTime: 5 },
+    redis: { healthy: false, responseTime: 100, error: 'Redis down' },
+    middleware: { name: 'middleware', port: 3000, status: 'healthy' as const, responseTime: 12 },
+    web: { name: 'web', port: 3001, status: 'unhealthy' as const, responseTime: 20, error: 'Connection refused' },
+    realtime: { name: 'realtime', port: 3002, status: 'healthy' as const, responseTime: 8 },
+  },
+  timestamp: '2026-06-03T04:00:00.000Z',
+};
+
 describe('AdminHealthClient', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -83,6 +95,8 @@ describe('AdminHealthClient', () => {
   });
 
   it('renders loading state when no initial health data', () => {
+    (apiClient.getPlatformHealth as jest.Mock).mockReturnValue(new Promise(() => {}));
+
     render(<AdminHealthClient initialHealth={null} />);
     expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
   });
@@ -96,6 +110,30 @@ describe('AdminHealthClient', () => {
   it('renders overall system status', () => {
     render(<AdminHealthClient initialHealth={mockHealth} />);
     expect(screen.getByText('System healthy')).toBeInTheDocument();
+  });
+
+  it('normalizes the backend platform health response shape', () => {
+    render(<AdminHealthClient initialHealth={backendPlatformHealth as any} />);
+
+    expect(screen.getByText('System degraded')).toBeInTheDocument();
+    expect(screen.getByText('Middleware')).toBeInTheDocument();
+    expect(screen.getByText('Web')).toBeInTheDocument();
+    expect(screen.getByText('Realtime')).toBeInTheDocument();
+    expect(screen.getByText('20ms')).toBeInTheDocument();
+  });
+
+  it('renders an unavailable state for malformed backend health data', () => {
+    render(<AdminHealthClient initialHealth={{ overall: 'healthy' } as any} />);
+
+    expect(screen.getByText('System down')).toBeInTheDocument();
+    expect(screen.getByText('Admin health API')).toBeInTheDocument();
+  });
+
+  it('renders an unavailable state for partial backend service data', () => {
+    render(<AdminHealthClient initialHealth={{ overall: 'degraded', services: {} } as any} />);
+
+    expect(screen.getByText('System down')).toBeInTheDocument();
+    expect(screen.getByText('Admin health API')).toBeInTheDocument();
   });
 
   it('renders stat cards', () => {
@@ -144,6 +182,8 @@ describe('AdminHealthClient', () => {
 
     await waitFor(() => {
       expect(mockToast.error).toHaveBeenCalledWith('Server error');
+      expect(screen.getByText('System down')).toBeInTheDocument();
+      expect(screen.getByText('Admin health API')).toBeInTheDocument();
     });
   });
 

--- a/web/src/app/admin/health/page-client.tsx
+++ b/web/src/app/admin/health/page-client.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { apiClient } from '@/lib/api';
 import { useToast } from '@/lib/hooks/useToast';
+import type { PlatformHealth, PlatformServiceStatus } from '@/lib/types';
 import { StatCard } from '../components/StatCard';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import {
@@ -40,7 +41,7 @@ interface HealthStatus {
     latency: number;
   };
   storage: {
-    status: 'up' | 'down';
+    status: 'up' | 'down' | 'unknown';
     used: number;
     total: number;
   };
@@ -51,13 +52,111 @@ interface HealthStatus {
   };
 }
 
+type HealthInput = HealthStatus | PlatformHealth;
+
 interface AdminHealthClientProps {
-  initialHealth: HealthStatus | null;
+  initialHealth: HealthInput | null;
+}
+
+const UNAVAILABLE_HEALTH: HealthStatus = {
+  status: 'down',
+  services: [
+    {
+      name: 'Admin health API',
+      status: 'down',
+      details: 'Health status unavailable',
+    },
+  ],
+  database: { status: 'down', connections: 0, maxConnections: 0, latency: 0 },
+  redis: { status: 'down', memory: 0, maxMemory: 0, latency: 0 },
+  storage: { status: 'unknown', used: 0, total: 0 },
+  uptime: 0,
+  errorRate: { last1h: 0, last24h: 0 },
+};
+
+function hasPlatformHealthShape(health: HealthInput): health is PlatformHealth {
+  const maybeHealth = health as Partial<PlatformHealth>;
+  const services = maybeHealth.services as Partial<PlatformHealth['services']> | undefined;
+
+  return (
+    typeof maybeHealth.overall === 'string' &&
+    typeof services === 'object' &&
+    services !== null &&
+    !Array.isArray(services) &&
+    Boolean(services.database) &&
+    Boolean(services.redis) &&
+    Boolean(services.middleware) &&
+    Boolean(services.web) &&
+    Boolean(services.realtime)
+  );
+}
+
+function mapOverallStatus(overall: PlatformHealth['overall']): HealthStatus['status'] {
+  return overall === 'unhealthy' ? 'down' : overall;
+}
+
+function mapServiceStatus(status: PlatformServiceStatus['status']): HealthStatus['services'][number]['status'] {
+  if (status === 'healthy') return 'up';
+  if (status === 'unknown') return 'degraded';
+  return 'down';
+}
+
+function formatServiceName(name: string): string {
+  const labels: Record<string, string> = {
+    middleware: 'Middleware',
+    web: 'Web',
+    realtime: 'Realtime',
+  };
+
+  return labels[name] ?? name;
+}
+
+function normalizeHealthStatus(health: HealthInput | null): HealthStatus | null {
+  if (!health) return null;
+
+  if (!('overall' in health)) {
+    return health;
+  }
+
+  if (!hasPlatformHealthShape(health)) {
+    return UNAVAILABLE_HEALTH;
+  }
+
+  const { services } = health;
+
+  return {
+    status: mapOverallStatus(health.overall),
+    services: [services.middleware, services.web, services.realtime].map((service) => ({
+      name: formatServiceName(service.name),
+      status: mapServiceStatus(service.status),
+      latency: service.responseTime,
+      details: service.error,
+    })),
+    database: {
+      status: services.database.healthy ? 'up' : 'down',
+      connections: 0,
+      maxConnections: 0,
+      latency: services.database.responseTime,
+    },
+    redis: {
+      status: services.redis.healthy ? 'up' : 'down',
+      memory: 0,
+      maxMemory: 0,
+      latency: services.redis.responseTime,
+    },
+    storage: {
+      status: 'unknown',
+      used: 0,
+      total: 0,
+    },
+    uptime: 0,
+    errorRate: { last1h: 0, last24h: 0 },
+  };
 }
 
 export default function AdminHealthClient({ initialHealth }: AdminHealthClientProps) {
   const toast = useToast();
-  const [health, setHealth] = useState<HealthStatus | null>(initialHealth);
+  const [health, setHealth] = useState<HealthInput | null>(initialHealth);
   const [loading, setLoading] = useState(!initialHealth);
   const [refreshing, setRefreshing] = useState(false);
 
@@ -69,7 +168,7 @@ export default function AdminHealthClient({ initialHealth }: AdminHealthClientPr
         setLoading(true);
       }
       const data = await apiClient.getPlatformHealth();
-      setHealth(data as unknown as HealthStatus);
+      setHealth(data);
     } catch (error: any) {
       toast.error(error.message || 'Failed to load health status');
     } finally {
@@ -88,6 +187,7 @@ export default function AdminHealthClient({ initialHealth }: AdminHealthClientPr
   }, []);
 
   const formatUptime = (seconds: number) => {
+    if (seconds <= 0) return 'Not reported';
     const days = Math.floor(seconds / 86400);
     const hours = Math.floor((seconds % 86400) / 3600);
     const minutes = Math.floor((seconds % 3600) / 60);
@@ -103,6 +203,56 @@ export default function AdminHealthClient({ initialHealth }: AdminHealthClientPr
     return `${mb.toFixed(0)} MB`;
   };
 
+  const formatLatency = (value: number | undefined) => {
+    return typeof value === 'number' && Number.isFinite(value) ? `${value}ms latency` : 'Latency not reported';
+  };
+
+  const formatDbConnections = () => {
+    if (healthData.database.maxConnections <= 0) return 'Not reported';
+    return `${healthData.database.connections}/${healthData.database.maxConnections}`;
+  };
+
+  const formatStorageUsed = () => {
+    if (healthData.storage.total <= 0) return 'Not reported';
+    return formatBytes(healthData.storage.used);
+  };
+
+  const formatStorageSubtitle = () => {
+    if (healthData.storage.total <= 0) return 'Usage not reported';
+    return `of ${formatBytes(healthData.storage.total)}`;
+  };
+
+  const formatStorageDetail = () => {
+    if (healthData.storage.total <= 0) return 'Storage metrics not reported';
+    return `${formatBytes(healthData.storage.used)} / ${formatBytes(healthData.storage.total)}`;
+  };
+
+  const formatMemoryUsage = () => {
+    if (healthData.redis.maxMemory <= 0) return 'Not reported';
+    return `${formatBytes(healthData.redis.memory)} / ${formatBytes(healthData.redis.maxMemory)}`;
+  };
+
+  const formatPercentUsed = (used: number, total: number) => {
+    if (total <= 0) return 'Unknown';
+    return `${((used / total) * 100).toFixed(1)}% used`;
+  };
+
+  const getBarWidth = (used: number, total: number) => {
+    if (total <= 0) return '0%';
+    return `${Math.min(100, Math.max(0, (used / total) * 100))}%`;
+  };
+
+  const getOverallMessage = () => {
+    const uptimeSuffix = healthData.uptime > 0 ? ` - Uptime: ${formatUptime(healthData.uptime)}` : '';
+    if (healthData.status === 'healthy') {
+      return `All services operational${uptimeSuffix}`;
+    }
+    if (healthData.status === 'degraded') {
+      return `Some services need attention${uptimeSuffix}`;
+    }
+    return 'Health status unavailable or critical';
+  };
+
   const getStatusIcon = (status: string) => {
     switch (status) {
       case 'up':
@@ -110,6 +260,8 @@ export default function AdminHealthClient({ initialHealth }: AdminHealthClientPr
         return <CheckCircle className="w-5 h-5 text-green-500" />;
       case 'degraded':
         return <AlertTriangle className="w-5 h-5 text-yellow-500" />;
+      case 'unknown':
+        return <AlertTriangle className="w-5 h-5 text-gray-500" />;
       default:
         return <AlertTriangle className="w-5 h-5 text-red-500" />;
     }
@@ -122,6 +274,8 @@ export default function AdminHealthClient({ initialHealth }: AdminHealthClientPr
         return 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400';
       case 'degraded':
         return 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-400';
+      case 'unknown':
+        return 'bg-gray-100 dark:bg-gray-900/30 text-gray-700 dark:text-gray-400';
       default:
         return 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400';
     }
@@ -135,20 +289,7 @@ export default function AdminHealthClient({ initialHealth }: AdminHealthClientPr
     );
   }
 
-  // Fallback mock data if API returns null
-  const healthData = health || {
-    status: 'healthy' as const,
-    services: [
-      { name: 'API Server', status: 'up' as const, latency: 12 },
-      { name: 'WebSocket Gateway', status: 'up' as const, latency: 8 },
-      { name: 'Background Workers', status: 'up' as const },
-    ],
-    database: { status: 'up' as const, connections: 15, maxConnections: 100, latency: 5 },
-    redis: { status: 'up' as const, memory: 256 * 1024 * 1024, maxMemory: 1024 * 1024 * 1024, latency: 1 },
-    storage: { status: 'up' as const, used: 50 * 1024 * 1024 * 1024, total: 500 * 1024 * 1024 * 1024 },
-    uptime: 864000,
-    errorRate: { last1h: 0.1, last24h: 0.5 },
-  };
+  const healthData = normalizeHealthStatus(health) ?? UNAVAILABLE_HEALTH;
 
   return (
     <div className="space-y-6">
@@ -189,7 +330,7 @@ export default function AdminHealthClient({ initialHealth }: AdminHealthClientPr
               System {healthData.status}
             </h2>
             <p className="text-sm text-[var(--foreground-secondary)]">
-              All services operational - Uptime: {formatUptime(healthData.uptime)}
+              {getOverallMessage()}
             </p>
           </div>
         </div>
@@ -207,15 +348,15 @@ export default function AdminHealthClient({ initialHealth }: AdminHealthClientPr
         />
         <StatCard
           title="DB Connections"
-          value={`${healthData.database.connections}/${healthData.database.maxConnections}`}
-          subtitle={`${healthData.database.latency}ms latency`}
+          value={formatDbConnections()}
+          subtitle={formatLatency(healthData.database.latency)}
           icon={<Database className="w-6 h-6" />}
           color="blue"
         />
         <StatCard
           title="Storage Used"
-          value={formatBytes(healthData.storage.used)}
-          subtitle={`of ${formatBytes(healthData.storage.total)}`}
+          value={formatStorageUsed()}
+          subtitle={formatStorageSubtitle()}
           icon={<HardDrive className="w-6 h-6" />}
           color="purple"
         />
@@ -268,13 +409,17 @@ export default function AdminHealthClient({ initialHealth }: AdminHealthClientPr
                 </span>
               </div>
               <div className="flex items-center justify-between text-sm text-[var(--foreground-tertiary)]">
-                <span>{healthData.database.connections} / {healthData.database.maxConnections} connections</span>
-                <span>{healthData.database.latency}ms</span>
+                <span>
+                  {healthData.database.maxConnections > 0
+                    ? `${healthData.database.connections} / ${healthData.database.maxConnections} connections`
+                    : 'Connections not reported'}
+                </span>
+                <span>{formatLatency(healthData.database.latency)}</span>
               </div>
               <div className="mt-2 h-2 bg-[var(--background-tertiary)] rounded-full overflow-hidden">
                 <div
                   className="h-full bg-[#00E5A0] rounded-full transition-all"
-                  style={{ width: `${(healthData.database.connections / healthData.database.maxConnections) * 100}%` }}
+                  style={{ width: getBarWidth(healthData.database.connections, healthData.database.maxConnections) }}
                 />
               </div>
             </div>
@@ -291,13 +436,13 @@ export default function AdminHealthClient({ initialHealth }: AdminHealthClientPr
                 </span>
               </div>
               <div className="flex items-center justify-between text-sm text-[var(--foreground-tertiary)]">
-                <span>{formatBytes(healthData.redis.memory)} / {formatBytes(healthData.redis.maxMemory)}</span>
-                <span>{healthData.redis.latency}ms</span>
+                <span>{formatMemoryUsage()}</span>
+                <span>{formatLatency(healthData.redis.latency)}</span>
               </div>
               <div className="mt-2 h-2 bg-[var(--background-tertiary)] rounded-full overflow-hidden">
                 <div
                   className="h-full bg-red-500 rounded-full transition-all"
-                  style={{ width: `${(healthData.redis.memory / healthData.redis.maxMemory) * 100}%` }}
+                  style={{ width: getBarWidth(healthData.redis.memory, healthData.redis.maxMemory) }}
                 />
               </div>
             </div>
@@ -314,13 +459,13 @@ export default function AdminHealthClient({ initialHealth }: AdminHealthClientPr
                 </span>
               </div>
               <div className="flex items-center justify-between text-sm text-[var(--foreground-tertiary)]">
-                <span>{formatBytes(healthData.storage.used)} / {formatBytes(healthData.storage.total)}</span>
-                <span>{((healthData.storage.used / healthData.storage.total) * 100).toFixed(1)}% used</span>
+                <span>{formatStorageDetail()}</span>
+                <span>{formatPercentUsed(healthData.storage.used, healthData.storage.total)}</span>
               </div>
               <div className="mt-2 h-2 bg-[var(--background-tertiary)] rounded-full overflow-hidden">
                 <div
                   className="h-full bg-purple-500 rounded-full transition-all"
-                  style={{ width: `${(healthData.storage.used / healthData.storage.total) * 100}%` }}
+                  style={{ width: getBarWidth(healthData.storage.used, healthData.storage.total) }}
                 />
               </div>
             </div>

--- a/web/src/app/admin/health/page.tsx
+++ b/web/src/app/admin/health/page.tsx
@@ -7,7 +7,7 @@ export default async function AdminHealthPage() {
   try {
     initialHealth = await serverFetch('/admin/health');
   } catch {
-    // Client has fallback mock data
+    // Client renders a conservative unavailable state.
   }
 
   return <AdminHealthClient initialHealth={initialHealth} />;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -570,10 +570,23 @@ export interface QrOverlayConfig {
 }
 
 // Platform Health
+export interface PlatformServiceStatus {
+  name: string;
+  port: number;
+  status: 'healthy' | 'unhealthy' | 'unknown';
+  responseTime?: number;
+  error?: string;
+}
+
 export interface PlatformHealth {
-  status: string;
-  services: Record<string, { status: string; latency?: number }>;
-  uptime: number;
+  overall: 'healthy' | 'degraded' | 'unhealthy';
+  services: {
+    database: { healthy: boolean; responseTime: number; error?: string };
+    redis: { healthy: boolean; responseTime: number; error?: string };
+    middleware: PlatformServiceStatus;
+    web: PlatformServiceStatus;
+    realtime: PlatformServiceStatus;
+  };
   timestamp: string;
 }
 


### PR DESCRIPTION
## Summary
- Degrade `/api/v1/admin/health` when web or realtime is unhealthy instead of ignoring those service statuses.
- Align the admin Health page with the real backend `PlatformHealth` response shape (`overall`, keyed `services`).
- Replace the old healthy mock fallback with a conservative unavailable/down state, add malformed-response guards, and avoid NaN/duplicate unknown metric rendering.

## Verification
- Red backend: focused service test failed because web-down/realtime-down returned `healthy`.
- Red web: admin Health page failed on the actual backend shape and rendered healthy mock fallback after API error.
- `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/admin/services/platform-health.service.spec.ts src/modules/admin/admin.controller.spec.ts` => 53/53 passing.
- `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/admin/health/__tests__/health-page.test.tsx` => 15/15 passing.
- `pnpm --filter @vizora/middleware exec tsc --noEmit --pretty false` => exit 0.
- `pnpm --filter @vizora/web exec tsc --noEmit --pretty false` => exit 0.
- `git diff --check -- middleware/src/modules/admin/services/platform-health.service.ts middleware/src/modules/admin/services/platform-health.service.spec.ts web/src/app/admin/health/page-client.tsx web/src/app/admin/health/page.tsx web/src/app/admin/health/__tests__/health-page.test.tsx web/src/lib/types.ts tasks/todo.md` => exit 0 with LF/CRLF warnings only.
- `pnpm security:no-hardcoded-jwts` => exit 0.
- Production-style web build with `NEXT_PUBLIC_API_URL=https://vizora.cloud/api/v1`, `NEXT_PUBLIC_SOCKET_URL=https://vizora.cloud`, `BACKEND_URL=http://localhost:3000` => pass with existing Next warnings only.

## Claude Code Review
- Backend-only review: APPROVE; surfaced the admin Health page response-shape mismatch as an operator-relevant caveat.
- Full backend+web review: APPROVE with minor non-blocking notes.
- Final re-reviews after addressing those notes and deepening malformed-shape guard: APPROVE.

## Deployment
- No production deploy or runtime/env mutation in this PR.