### PR TITLE
fix: preserve degraded validator readiness

### DIFF
--- a/scripts/ops/release-readiness-gates.test.ts
+++ b/scripts/ops/release-readiness-gates.test.ts
@@ -107,6 +107,17 @@ test('ops alerting labels unresolved incident lists as active incidents', () => 
   assert.doesNotMatch(alerting, /No open incidents/);
 });
 
+test('validate monitor parses readiness body status instead of only HTTP 200', () => {
+  const monitor = readRepoFile('scripts/validate-monitor.ts');
+
+  assert.match(monitor, /function normalizeReadinessStatus/);
+  assert.match(monitor, /const readinessBody = await readJsonBody/);
+  assert.match(monitor, /services\['readiness'\] = readinessStatus/);
+  assert.match(monitor, /health\.degraded/);
+  assert.match(monitor, /INFRA-DEGRADED/);
+  assert.doesNotMatch(monitor, /services\['readiness'\] = res\.ok \? 'healthy'/);
+});
+
 test('CI test job runs web unit tests before build-only gates', () => {
   const ciWorkflow = readRepoFile('.github/workflows/ci.yml');
   const testJob = readCiJobBlock(ciWorkflow, 'test');

--- a/scripts/ops/validate-monitor-readiness.test.ts
+++ b/scripts/ops/validate-monitor-readiness.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  normalizeReadinessStatus,
+  unwrapResponseEnvelope,
+} from '../validate-monitor';
+
+test('validate monitor normalizes enveloped healthy readiness responses', () => {
+  const body = unwrapResponseEnvelope({
+    success: true,
+    data: { status: 'ok' },
+  });
+
+  assert.equal(normalizeReadinessStatus(body, true), 'healthy');
+});
+
+test('validate monitor normalizes enveloped degraded readiness responses', () => {
+  const body = unwrapResponseEnvelope({
+    success: true,
+    data: { status: 'degraded' },
+  });
+
+  assert.equal(normalizeReadinessStatus(body, true), 'degraded');
+});
+
+test('validate monitor preserves non-enveloped readiness responses', () => {
+  const body = unwrapResponseEnvelope({ status: 'ok' });
+
+  assert.equal(normalizeReadinessStatus(body, true), 'healthy');
+});
+
+test('validate monitor treats non-2xx readiness responses as unhealthy', () => {
+  assert.equal(normalizeReadinessStatus(null, false), 'unhealthy');
+});
+
+test('validate monitor fails closed on malformed successful readiness responses', () => {
+  const body = unwrapResponseEnvelope({
+    success: true,
+    data: { state: 'ok' },
+  });
+
+  assert.equal(normalizeReadinessStatus(body, true), 'unhealthy');
+});

--- a/scripts/validate-monitor.ts
+++ b/scripts/validate-monitor.ts
@@ -18,7 +18,8 @@
  */
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // ─── Config ──────────────────────────────────────────────────────────────────
 
@@ -30,7 +31,8 @@ const TIMEOUT_MS = 30_000;
 const MAX_ENTITIES = 500;
 
 // Path to last-known state file (relative to project root)
-const STATE_FILE = join(dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Z]:)/, '$1')), '..', 'logs', 'validator-latest.json');
+const SCRIPT_FILE = fileURLToPath(import.meta.url);
+const STATE_FILE = join(dirname(SCRIPT_FILE), '..', 'logs', 'validator-latest.json');
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -65,6 +67,14 @@ interface MonitorState {
   categories: string[];
   durationMs: number;
   issues: ValidationIssue[];
+}
+
+type InfrastructureHealthStatus = 'healthy' | 'degraded' | 'unhealthy';
+
+interface HealthCheckResult {
+  healthy: boolean;
+  degraded: boolean;
+  services: Record<string, string>;
 }
 
 // ─── API Client ──────────────────────────────────────────────────────────────
@@ -128,7 +138,53 @@ async function login(): Promise<string> {
 
 // ─── Health Check ────────────────────────────────────────────────────────────
 
-async function checkHealth(): Promise<{ healthy: boolean; services: Record<string, string> }> {
+async function readJsonBody(res: Response): Promise<Record<string, unknown> | null> {
+  try {
+    return await res.json() as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export function unwrapResponseEnvelope(body: Record<string, unknown> | null): Record<string, unknown> | null {
+  const payload = body?.success !== undefined && body.data !== undefined
+    ? body.data
+    : body;
+
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return null;
+  }
+
+  return payload as Record<string, unknown>;
+}
+
+export function normalizeReadinessStatus(
+  body: Record<string, unknown> | null,
+  httpOk: boolean,
+): InfrastructureHealthStatus {
+  if (!httpOk) return 'unhealthy';
+
+  if (body?.status === 'ok') return 'healthy';
+  if (body?.status === 'degraded') return 'degraded';
+  if (body?.status === 'unhealthy') return 'unhealthy';
+
+  // Unknown successful readiness shapes are contract drift. Fail closed so
+  // operators never see READY from a response we cannot interpret.
+  return 'unhealthy';
+}
+
+function isUnhealthyServiceStatus(status: string): boolean {
+  return status === 'unhealthy' ||
+    status.startsWith('unhealthy ') ||
+    status.startsWith('unhealthy:') ||
+    status.startsWith('unreachable:');
+}
+
+function isDegradedServiceStatus(status: string): boolean {
+  return status === 'degraded';
+}
+
+async function checkHealth(): Promise<HealthCheckResult> {
   const services: Record<string, string> = {};
   try {
     const controller = new AbortController();
@@ -136,10 +192,10 @@ async function checkHealth(): Promise<{ healthy: boolean; services: Record<strin
     const res = await fetch(`${BASE_URL}/api/v1/health`, { signal: controller.signal });
     clearTimeout(timer);
     services['api'] = res.ok ? 'healthy' : `unhealthy (${res.status})`;
-    if (!res.ok) return { healthy: false, services };
+    if (!res.ok) return { healthy: false, degraded: false, services };
   } catch (err) {
     services['api'] = `unreachable: ${err instanceof Error ? err.message : err}`;
-    return { healthy: false, services };
+    return { healthy: false, degraded: false, services };
   }
 
   try {
@@ -147,13 +203,17 @@ async function checkHealth(): Promise<{ healthy: boolean; services: Record<strin
     const timer = setTimeout(() => controller.abort(), 15_000);
     const res = await fetch(`${BASE_URL}/api/v1/health/ready`, { signal: controller.signal });
     clearTimeout(timer);
-    services['readiness'] = res.ok ? 'healthy' : `unhealthy (${res.status})`;
+    const readinessBody = await readJsonBody(res);
+    const readinessStatus = normalizeReadinessStatus(unwrapResponseEnvelope(readinessBody), res.ok);
+    services['readiness'] = readinessStatus;
   } catch (err) {
     services['readiness'] = `unhealthy: ${err instanceof Error ? err.message : err}`;
   }
 
-  const healthy = !Object.values(services).some(s => s.includes('unhealthy') || s.includes('unreachable'));
-  return { healthy, services };
+  const serviceStatuses = Object.values(services);
+  const healthy = !serviceStatuses.some(isUnhealthyServiceStatus);
+  const degraded = serviceStatuses.some(isDegradedServiceStatus);
+  return { healthy, degraded, services };
 }
 
 // ─── Content Validator (Rules C-001 to C-007, L-001 to L-003, ST-001 to ST-002) ─
@@ -514,7 +574,11 @@ async function main() {
     process.exitCode = 2;
     return;
   }
-  log('Health check passed');
+  if (health.degraded) {
+    log(`Infrastructure DEGRADED: ${JSON.stringify(health.services)}`);
+  } else {
+    log('Health check passed');
+  }
 
   // 2. Authenticate
   log('Authenticating...');
@@ -547,7 +611,18 @@ async function main() {
   ];
 
   // 5. Aggregate
-  const allIssues = results.flatMap(r => r.issues);
+  const infrastructureIssues: ValidationIssue[] = health.degraded
+    ? [{
+        rule: 'INFRA-DEGRADED',
+        severity: 'warning',
+        entity: 'health',
+        entityId: 'readiness',
+        entityName: 'Infrastructure readiness',
+        message: `Infrastructure readiness is degraded: ${JSON.stringify(health.services)}`,
+        recommendation: 'Check /api/v1/health/ready dependencies before launch.',
+      }]
+    : [];
+  const allIssues = [...infrastructureIssues, ...results.flatMap(r => r.issues)];
   const critical = allIssues.filter(i => i.severity === 'critical').length;
   const warning = allIssues.filter(i => i.severity === 'warning').length;
   const info = allIssues.filter(i => i.severity === 'info').length;
@@ -558,7 +633,7 @@ async function main() {
     timestamp: new Date().toISOString(),
     totalIssues: allIssues.length,
     critical, warning, info,
-    categories: results.map(r => r.category),
+    categories: [...(health.degraded ? ['health'] : []), ...results.map(r => r.category)],
     durationMs: Date.now() - runStart,
     issues: allIssues,
   };
@@ -581,7 +656,13 @@ async function main() {
   process.exitCode = readiness === 'READY' ? 0 : 1;
 }
 
-main().catch(err => {
-  log(`FATAL: ${err instanceof Error ? err.message : err}`);
-  process.exitCode = 2;
-});
+function isDirectRun(): boolean {
+  return process.argv[1] !== undefined && resolve(process.argv[1]) === resolve(SCRIPT_FILE);
+}
+
+if (isDirectRun()) {
+  main().catch(err => {
+    log(`FATAL: ${err instanceof Error ? err.message : err}`);
+    process.exitCode = 2;
+  });
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,92 @@
 # Vizora - Task Tracker
 
+## Active Workstream: Validator Readiness Status Pass 62 (2026-06-03)
+
+**Branch:** `fix/readiness-monitor-status`
+
+**Why now:** `scripts/validate-monitor.ts` is an operator-facing readiness
+monitor. It currently treats `/api/v1/health/ready` as healthy whenever the
+HTTP response is 2xx. The Nest readiness endpoint returns HTTP 200 for
+`status: "degraded"` and only throws 503 for `status: "unhealthy"`, so the
+monitor can report overall `READY` while infrastructure is degraded.
+
+**New primitives introduced:** none planned. This pass should reuse the
+existing validator script, readiness response, state file, Slack alert path,
+and ops static gate tests. No new route, model, migration, env var, process,
+realtime event, MCP tool, Hermes skill, AI/provider spend path, or production
+runtime change is expected.
+
+**Hermes-first analysis:** checked per project convention. This is
+deterministic readiness parsing inside an existing TypeScript ops script, not a
+business-agent, MCP, Hermes runtime, or provider-spend task.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Readiness JSON status parsing | none applicable | fix existing validator monitor |
+| Static release-readiness regression guard | none applicable | extend existing ops test |
+
+Awesome-hermes-agent ecosystem check: no applicable skill/library primitive for
+local readiness response parsing.
+
+**Plan**
+- [x] Add a failing ops gate proving `validate-monitor.ts` inspects the
+      readiness JSON status instead of only HTTP 200.
+- [x] Parse `/api/v1/health/ready` body status as `healthy`, `degraded`, or
+      `unhealthy`, failing closed on malformed readiness responses.
+- [x] Carry degraded infrastructure into the final monitor state as a warning so
+      content validators cannot overwrite it back to `READY`.
+- [x] Run focused ops tests, TypeScript/script checks, diff hygiene, and secret
+      scan.
+- [x] Request Claude Code review and resolve findings.
+- [ ] Commit, PR, CI, and merge if green.
+- [ ] Do not deploy by default; hand off deploy/runtime status and remaining
+      operator-only blockers.
+
+**Evidence so far**
+- Current `origin/main`: `45611bb2b2490065f5021efa3621641357d17c40`.
+- Drift-check:
+  - `middleware/src/modules/health/health.controller.ts` returns HTTP 200 for
+    degraded readiness and only throws 503 for unhealthy readiness.
+  - `scripts/validate-monitor.ts` labeled `/api/v1/health/ready` as
+    `healthy` on any 2xx response, so degraded infrastructure could be dropped
+    before final readiness was calculated.
+- Red focused run:
+  - `node --import tsx --test scripts/ops/release-readiness-gates.test.ts`
+    failed as expected on the new `validate-monitor` body-status parsing gate.
+- Fix:
+  - Added `normalizeReadinessStatus()`, `unwrapResponseEnvelope()`, and
+    `readJsonBody()` helpers.
+  - Parse readiness response `status: "ok" | "degraded" | "unhealthy"` and
+    fail closed to unhealthy on malformed successful responses.
+  - Unwrap global response envelopes via `body.data ?? body` before
+    normalizing readiness status.
+  - Guarded the script entrypoint so pure helper tests can import the parser
+    without starting the monitor.
+  - Continue content validators during degraded infrastructure, but add a
+    synthetic `INFRA-DEGRADED` warning so the final monitor state cannot be
+    `READY` while infrastructure readiness is degraded.
+  - Added an explicit fail-closed comment for unknown readiness response shapes
+    and replaced broad substring health aggregation with exact
+    degraded/unhealthy status helpers after Claude Code review.
+- Green verification:
+  - `node --import tsx --test scripts/ops/release-readiness-gates.test.ts`
+    => 14/14 tests passing.
+  - `node --import tsx --test scripts/ops/validate-monitor-readiness.test.ts`
+    => 5/5 tests passing.
+  - `pnpm test:ops` => 30/30 tests passing.
+  - `pnpm exec tsc --noEmit --pretty false --module ESNext --moduleResolution Bundler --target ES2022 --types node --skipLibCheck scripts/validate-monitor.ts scripts/ops/release-readiness-gates.test.ts scripts/ops/validate-monitor-readiness.test.ts`
+    => passing.
+  - `git diff --check -- scripts/validate-monitor.ts scripts/ops/release-readiness-gates.test.ts scripts/ops/validate-monitor-readiness.test.ts tasks/todo.md`
+    => exit 0, with LF/CRLF normalization warnings only.
+  - `pnpm security:no-hardcoded-jwts` => passing.
+- Claude Code review:
+  - Initial review returned `APPROVE` with non-blocking hardening notes.
+  - Follow-up review returned `REQUEST_CHANGES` on a critical envelope parsing
+    gap. Fixed by unwrapping `data ?? body` and adding executable tests for
+    enveloped healthy/degraded/malformed readiness responses.
+  - Final re-review after adding non-enveloped and non-2xx edge tests returned
+    `APPROVE`.
+
 ## Active Workstream: Backlog Readiness Truth Pass 61 (2026-06-03)
 
 **Branch:** `fix/overnight-readiness-followup`
@@ -35,7 +122,7 @@ static backlog/readiness UI truthfulness.
 - [x] Update Pass 60 evidence/checklist now that PR #200 merged green.
 - [x] Run focused web tests, TypeScript, diff hygiene, and secret scan.
 - [x] Request Claude Code review and resolve findings.
-- [ ] Commit, PR, CI, and merge if green.
+- [x] Commit, PR, CI, and merge if green.
 - [ ] Do not deploy by default; hand off deploy/runtime status and remaining
       operator-only blockers.
 
@@ -78,6 +165,9 @@ static backlog/readiness UI truthfulness.
     customer IT`, and `Operator + reviewer`, then added a negative regression
     assertion for the personal name.
   - Final re-review returned `APPROVE`.
+- PR/CI:
+  - PR #201 merged at `45611bb2b2490065f5021efa3621641357d17c40`.
+  - GitHub CI passed: audit, build, lint, security, test, and e2e.
 
 ## Active Workstream: Admin Health Overall Status Pass 60 (2026-06-03)
 


### PR DESCRIPTION
## Summary\n- parses /api/v1/health/ready JSON status instead of treating every HTTP 200 as healthy\n- unwraps the global { success, data } response envelope before readiness normalization\n- preserves degraded infrastructure as an INFRA-DEGRADED warning so validators cannot report READY while readiness is degraded\n- guards validate-monitor main execution so pure parser helpers can be tested without starting the monitor\n\n## Verification\n- node --import tsx --test scripts/ops/release-readiness-gates.test.ts\n- node --import tsx --test scripts/ops/validate-monitor-readiness.test.ts\n- pnpm test:ops\n- pnpm exec tsc --noEmit --pretty false --module ESNext --moduleResolution Bundler --target ES2022 --types node --skipLibCheck scripts/validate-monitor.ts scripts/ops/release-readiness-gates.test.ts scripts/ops/validate-monitor-readiness.test.ts\n- git diff --check -- scripts/validate-monitor.ts scripts/ops/release-readiness-gates.test.ts scripts/ops/validate-monitor-readiness.test.ts tasks/todo.md\n- pnpm security:no-hardcoded-jwts\n- Claude Code review: APPROVE after fixing envelope parsing blocker\n\n## Deployment\nNot deployed. No production state changed.