### PR TITLE
fix: require ok readiness in deploy verify

### DIFF
--- a/scripts/deploy-verify.sh
+++ b/scripts/deploy-verify.sh
@@ -9,6 +9,8 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
@@ -28,6 +30,20 @@ TOTAL=0
 # Use a function to avoid quoting issues with curl options
 http_status() {
   curl -s -o /dev/null -w '%{http_code}' --max-time 10 --connect-timeout 5 "$1" 2>/dev/null || echo "000"
+}
+
+parse_readiness_status() {
+  if ! command -v node >/dev/null 2>&1; then
+    echo "node_missing"
+    return 0
+  fi
+
+  if [[ ! -f "$SCRIPT_DIR/ops/readiness-status-parser.mjs" ]]; then
+    echo "parser_missing"
+    return 0
+  fi
+
+  node "$SCRIPT_DIR/ops/readiness-status-parser.mjs" 2>/dev/null || echo "invalid"
 }
 
 # Colors (skip if not a terminal)
@@ -59,8 +75,18 @@ STATUS=$(http_status "$BASE_URL/api/v1/health")
 if [[ "$STATUS" == "200" ]]; then pass "GET /api/v1/health -> $STATUS"; else fail "GET /api/v1/health -> $STATUS (expected 200)"; fi
 
 check
-STATUS=$(http_status "$BASE_URL/api/v1/health/ready")
-if [[ "$STATUS" == "200" ]]; then pass "GET /api/v1/health/ready -> $STATUS"; else fail "GET /api/v1/health/ready -> $STATUS (expected 200)"; fi
+READY_BODY_FILE=$(mktemp)
+STATUS=$(curl -s -o "$READY_BODY_FILE" -w '%{http_code}' --max-time 10 --connect-timeout 5 "$BASE_URL/api/v1/health/ready" 2>/dev/null || echo "000")
+if [[ ! "$STATUS" =~ ^[0-9]{3}$ ]]; then STATUS="000"; fi
+READY_STATUS=$(parse_readiness_status < "$READY_BODY_FILE")
+rm -f "$READY_BODY_FILE"
+if [[ "$STATUS" == "200" && "$READY_STATUS" == "ok" ]]; then
+  pass "GET /api/v1/health/ready -> $STATUS status=ok"
+elif [[ "$STATUS" == "200" && "$READY_STATUS" == "degraded" ]]; then
+  fail "GET /api/v1/health/ready -> $STATUS status=degraded (expected status=ok)"
+else
+  fail "GET /api/v1/health/ready -> $STATUS status=$READY_STATUS (expected 200 status=ok)"
+fi
 
 check
 STATUS=$(http_status "$BASE_URL/api/v1/health/live")

--- a/scripts/ops/deploy-verify-readiness-parser.test.ts
+++ b/scripts/ops/deploy-verify-readiness-parser.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const parserPath = join(repoRoot, 'scripts', 'ops', 'readiness-status-parser.mjs');
+
+function parseReadinessBody(body: string): string {
+  const result = spawnSync(process.execPath, [parserPath], {
+    encoding: 'utf8',
+    input: body,
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stderr, '');
+  return result.stdout.trim();
+}
+
+test('deploy verifier readiness parser unwraps enveloped readiness status', () => {
+  assert.equal(
+    parseReadinessBody(JSON.stringify({ success: true, data: { status: 'ok' } })),
+    'ok',
+  );
+  assert.equal(
+    parseReadinessBody(
+      JSON.stringify({ success: true, data: { status: 'degraded' } }),
+    ),
+    'degraded',
+  );
+  assert.equal(
+    parseReadinessBody(
+      JSON.stringify({ success: true, data: { status: 'unhealthy' } }),
+    ),
+    'unhealthy',
+  );
+});
+
+test('deploy verifier readiness parser preserves bare readiness status', () => {
+  assert.equal(parseReadinessBody(JSON.stringify({ status: 'ok' })), 'ok');
+  assert.equal(
+    parseReadinessBody(JSON.stringify({ status: 'degraded' })),
+    'degraded',
+  );
+  assert.equal(
+    parseReadinessBody(JSON.stringify({ status: 'unhealthy' })),
+    'unhealthy',
+  );
+});
+
+test('deploy verifier readiness parser fails closed on malformed or unknown bodies', () => {
+  assert.equal(parseReadinessBody(''), 'unknown');
+  assert.equal(parseReadinessBody('<html>bad gateway</html>'), 'invalid');
+  assert.equal(parseReadinessBody(JSON.stringify({ success: false })), 'unknown');
+  assert.equal(
+    parseReadinessBody(JSON.stringify({ success: true, data: { status: 'slow' } })),
+    'unknown',
+  );
+});

--- a/scripts/ops/readiness-status-parser.mjs
+++ b/scripts/ops/readiness-status-parser.mjs
@@ -1,0 +1,26 @@
+let input = '';
+
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => {
+  input += chunk;
+});
+
+process.stdin.on('end', () => {
+  try {
+    const body = JSON.parse(input || '{}');
+    const payload =
+      body && typeof body === 'object' && body.data && typeof body.data === 'object'
+        ? body.data
+        : body;
+    const status = payload && typeof payload === 'object' ? payload.status : undefined;
+
+    if (status === 'ok' || status === 'degraded' || status === 'unhealthy') {
+      console.log(status);
+      return;
+    }
+
+    console.log('unknown');
+  } catch {
+    console.log('invalid');
+  }
+});

--- a/scripts/ops/release-readiness-gates.test.ts
+++ b/scripts/ops/release-readiness-gates.test.ts
@@ -118,6 +118,18 @@ test('validate monitor parses readiness body status instead of only HTTP 200', (
   assert.doesNotMatch(monitor, /services\['readiness'\] = res\.ok \? 'healthy'/);
 });
 
+test('deploy verify requires readiness body status ok instead of only HTTP 200', () => {
+  const deployVerify = readRepoFile('scripts/deploy-verify.sh');
+
+  assert.match(deployVerify, /parse_readiness_status\(\)/);
+  assert.match(deployVerify, /status=ok/);
+  assert.match(deployVerify, /status=degraded/);
+  assert.doesNotMatch(
+    deployVerify,
+    /STATUS=\$\(http_status "\$BASE_URL\/api\/v1\/health\/ready"\)\r?\nif \[\[ "\$STATUS" == "200" \]\]; then pass "GET \/api\/v1\/health\/ready -> \$STATUS"/,
+  );
+});
+
 test('CI test job runs web unit tests before build-only gates', () => {
   const ciWorkflow = readRepoFile('.github/workflows/ci.yml');
   const testJob = readCiJobBlock(ciWorkflow, 'test');

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,82 @@
 # Vizora - Task Tracker
 
-## Active Workstream: Validator Readiness Status Pass 62 (2026-06-03)
+## Active Workstream: Deploy Verify Readiness Status Pass 63 (2026-06-03)
+
+**Branch:** `fix/deploy-verify-readiness-status`
+
+**Why now:** `scripts/deploy-verify.sh` is the post-deploy operator gate. It
+still checks `/api/v1/health/ready` by HTTP status only. The middleware
+readiness endpoint can return HTTP 200 with body `status: "degraded"`, so the
+deploy verifier can report a deployment as verified while infrastructure is
+known degraded.
+
+**New primitives introduced:** none planned. This pass should reuse the
+existing deploy verifier, readiness endpoint, response envelope convention, and
+ops release-readiness gate tests. No new route, model, migration, env var,
+process, realtime event, MCP tool, Hermes skill, AI/provider spend path, or
+production runtime change is expected.
+
+**Hermes-first analysis:** checked per project convention. This is
+deterministic Bash/Node readiness response parsing inside an existing deploy
+verification script, not a business-agent, MCP, Hermes runtime, or provider
+spend task.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Deploy readiness JSON status parsing | none applicable | fix existing deploy verifier |
+| Static release-readiness regression guard | none applicable | extend existing ops test |
+
+Awesome-hermes-agent ecosystem check: no applicable skill/library primitive for
+local deploy verifier response parsing.
+
+**Plan**
+- [x] Add a failing ops gate proving `deploy-verify.sh` inspects the readiness
+      JSON status instead of only HTTP 200.
+- [x] Parse the readiness body, unwrapping the global response envelope, and
+      require `status: "ok"` for a deploy-verification pass.
+- [x] Run focused ops tests, Bash syntax check, diff hygiene, and secret scan.
+- [x] Request Claude Code review and resolve findings.
+- [ ] Commit, PR, CI, and merge if green.
+- [ ] Do not deploy by default; hand off deploy/runtime status and remaining
+      operator-only blockers.
+
+**Evidence so far**
+- Current `origin/main`: `982b2825770e6bc1e2b6ff05d57262be574b7309`.
+- Drift-check:
+  - `scripts/deploy-verify.sh` accepted `/api/v1/health/ready` on HTTP 200
+    alone.
+  - `middleware/src/modules/health/health.controller.ts` returns HTTP 200 for
+    degraded readiness and only throws 503 for unhealthy readiness.
+- Red focused run:
+  - `node --import tsx --test scripts/ops/release-readiness-gates.test.ts`
+    failed as expected on the new deploy-verifier body-status parsing gate.
+- Fix:
+  - Added `parse_readiness_status()` using the existing Node deployment runtime
+    and a shared `scripts/ops/readiness-status-parser.mjs` helper.
+  - Unwraps `{ success, data }` response envelopes before reading `status`.
+  - Requires readiness `status=ok`; treats `degraded`, `unhealthy`, invalid,
+    unknown, and missing parser dependencies as deploy-verification failures.
+- Green focused run:
+  - `node --import tsx --test scripts/ops/release-readiness-gates.test.ts`
+    => 15/15 tests passing.
+  - `node --import tsx --test scripts/ops/deploy-verify-readiness-parser.test.ts`
+    => 3/3 tests passing after the red missing-parser run.
+- Broader/static verification:
+  - `pnpm test:ops` => 34/34 tests passing.
+  - `C:\Program Files\Git\bin\bash.exe -n scripts/deploy-verify.sh` => exit 0.
+  - `pnpm exec tsc --noEmit --pretty false --module ESNext --moduleResolution Bundler --target ES2022 --types node --skipLibCheck scripts/ops/release-readiness-gates.test.ts scripts/ops/deploy-verify-readiness-parser.test.ts`
+    => passing.
+  - `git diff --check -- scripts/deploy-verify.sh scripts/ops/release-readiness-gates.test.ts scripts/ops/deploy-verify-readiness-parser.test.ts scripts/ops/readiness-status-parser.mjs tasks/todo.md`
+    => exit 0, with LF/CRLF normalization warnings only.
+  - `pnpm security:no-hardcoded-jwts` => passing.
+- Claude Code review:
+  - Initial review returned `APPROVE` with one medium non-blocking test-strength
+    recommendation. Added executable parser coverage before PR.
+  - Follow-up re-review returned `APPROVE` with no high/medium findings. One
+    optional low note remains for future Bash-glue executable coverage; the
+    false-green path is fail-closed by construction.
+
+## Completed Workstream: Validator Readiness Status Pass 62 (2026-06-03)
 
 **Branch:** `fix/readiness-monitor-status`
 
@@ -38,12 +114,15 @@ local readiness response parsing.
 - [x] Run focused ops tests, TypeScript/script checks, diff hygiene, and secret
       scan.
 - [x] Request Claude Code review and resolve findings.
-- [ ] Commit, PR, CI, and merge if green.
-- [ ] Do not deploy by default; hand off deploy/runtime status and remaining
+- [x] Commit, PR, CI, and merge if green.
+- [x] Do not deploy by default; hand off deploy/runtime status and remaining
       operator-only blockers.
 
 **Evidence so far**
-- Current `origin/main`: `45611bb2b2490065f5021efa3621641357d17c40`.
+- Current `origin/main`: `982b2825770e6bc1e2b6ff05d57262be574b7309`.
+- PR/CI/merge:
+  - PR #202 merged at `982b2825770e6bc1e2b6ff05d57262be574b7309`; GitHub CI
+    passed audit, build, e2e, lint, security, and test.
 - Drift-check:
   - `middleware/src/modules/health/health.controller.ts` returns HTTP 200 for
     degraded readiness and only throws 503 for unhealthy readiness.


### PR DESCRIPTION
## Summary
- require `scripts/deploy-verify.sh` to parse `/api/v1/health/ready` body status and pass only on `status=ok`
- add a reusable readiness status parser that unwraps Vizora response envelopes and fails closed on unknown/malformed bodies
- add static and executable ops tests for deploy-verifier readiness parsing
- update `tasks/todo.md` with Pass 63 evidence and prior Pass 62 merge state

## Verification
- RED: `node --import tsx --test scripts/ops/release-readiness-gates.test.ts` failed on missing deploy-verifier readiness parser
- RED: `node --import tsx --test scripts/ops/deploy-verify-readiness-parser.test.ts` failed on missing parser module
- GREEN: `node --import tsx --test scripts/ops/deploy-verify-readiness-parser.test.ts` => 3/3 pass
- GREEN: `node --import tsx --test scripts/ops/release-readiness-gates.test.ts` => 15/15 pass
- `pnpm test:ops` => 34/34 pass
- `C:\Program Files\Git\bin\bash.exe -n scripts/deploy-verify.sh` => exit 0
- `pnpm exec tsc --noEmit --pretty false --module ESNext --moduleResolution Bundler --target ES2022 --types node --skipLibCheck scripts/ops/release-readiness-gates.test.ts scripts/ops/deploy-verify-readiness-parser.test.ts` => pass
- `git diff --check -- scripts/deploy-verify.sh scripts/ops/release-readiness-gates.test.ts scripts/ops/deploy-verify-readiness-parser.test.ts scripts/ops/readiness-status-parser.mjs tasks/todo.md` => exit 0, LF/CRLF warnings only
- `pnpm security:no-hardcoded-jwts` => pass

## Review
- Claude Code initial review: APPROVE with one medium test-strength recommendation
- Follow-up: executable parser coverage added
- Claude Code re-review: APPROVE, no high/medium findings; one optional low Bash-glue coverage note

## Operator/runtime
- No production deploy performed
- No production env/secrets/runtime/database state changed
- This only hardens the repo-side deploy verification gate