### PR TITLE
docs: reconcile backlog launch gate truth

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -1,11 +1,11 @@
 # Vizora Backlog
 
-**Last updated:** 2026-05-31 (main at `1b28608`)
-**Production readiness:** ~75% — three operator-driven launch blockers open (see P0 below); technical foundation strongest on record
-**Tests:** 124 middleware suites / 2335 tests, 10 realtime suites / 212 tests, 79 web suites / 864 tests — ALL PASSING (zero failures). Playwright 24 specs at >90% pass post-2026-05-09 refresh. Verified by autonomous pass `docs/plans/2026-05-09-test-results.md`.
-**Customer-1 launch target:** 2026-05-13 (T-2 from today) — **status unconfirmed**; operator must confirm before T-2 prep work continues.
+**Last updated:** 2026-06-03 (main at `5ddabb7a`)
+**Production readiness:** repo-side foundation strongest on record; customer-1 launch remains operator-gated on C1-C4 below.
+**Tests:** 124 middleware suites / 2335 tests, 10 realtime suites / 212 tests, 79 web suites / 864 tests - ALL PASSING (zero failures). Playwright 24 specs at >90% pass post-2026-05-09 refresh. Verified by autonomous pass `docs/plans/2026-05-09-test-results.md`.
+**Customer-1 launch date:** operator-confirmed - do not use historical target dates until the operator confirms the actual launch window.
 
-**Security/realtime/readiness wave (#107–#117, merged through 2026-05-31, main `1b28608`):** session invalidation now spans REST + WebSocket — password-change / account-deactivation force-logout across all devices (REST `#111`, WS connect-time `#112`, WS mid-session 60s sweep `#114`). Customer-1 smoke coverage is hardened (#116), and M12 security alert emails are complete (#117). P1/P2 tables below reconciled to match.
+**Security/realtime/readiness wave (#107-#204, merged through 2026-06-03, main `5ddabb7a`):** session invalidation now spans REST + WebSocket - password-change / account-deactivation force-logout across all devices (REST `#111`, WS connect-time `#112`, WS mid-session 60s sweep `#114`). Customer-1 smoke coverage is hardened (#116), M12 security alert emails are complete (#117), and the latest overnight readiness passes hardened health/readiness gates, validator reporting, admin readiness display, deploy verification, and first-customer runbook truthfulness. P1/P2 tables below reconciled to match.
 
 ---
 
@@ -105,16 +105,16 @@ Triggered by 2026-05-06 OpenRouter credit drain. PR #62 (merged `801b517` on 202
 
 ---
 
-## P0 — LAUNCH BLOCKERS for customer-1 (2026-05-13 target)
+## P0 — LAUNCH BLOCKERS for customer-1 (operator-gated launch)
 
-Per 2026-05-09 readiness pass: the three operator-driven items below are the GO/NO-GO gates. Technical foundation is sound — these are unblockable by code.
+Per current readiness reconciliation: the four operator-driven items below are the GO/NO-GO gates. Technical foundation is sound - these are unblockable by code.
 
 | # | Item | Owner | Effort | Status | Notes |
 |---|------|-------|--------|--------|-------|
 | **C1** | **SMTP / Resend on prod — domain `mail.vizora.cloud` verified (DKIM/SPF/DMARC), `SMTP_*`/`EMAIL_FROM` env set, test send works end-to-end** | Sri | 2h | TODO | Without this, customer registration emails + password resets don't send |
 | **C2** | **Customer-1 organization provisioned on prod** (skeleton, admin user invite, plan, quota) | Sri | 1h | TODO | Skip if customer self-registers |
 | **C3** | **Real-device walkthrough on customer hardware** (pair, push playlist, reboot, network-flap) | Sri + customer IT | 2h | TODO | Electron has 0% functional test coverage; this IS the test |
-| **C4** | B16 60-step go-live smoke test on prod | Claude Code (driven by Sri) | 3h | BLOCKED on C1-C3 | Operator-driven; document in `docs/runbooks/customer-1-go-live-smoke-{DATE}.md` |
+| **C4** | **Final go-live smoke test on prod** | Claude Code (driven by Sri) | 3h | BLOCKED on C1-C3 | Operator-driven; document in `docs/runbooks/customer-1-go-live-smoke-{DATE}.md` |
 
 **Stripe/Razorpay live keys (formerly B8-B15):** DEFERRED past customer-1. Customer-1 launches on free tier. Backlog items kept open for the first paid customer:
 
@@ -269,17 +269,17 @@ Items the audit listed but we are NOT pursuing live (Engage/kiosk, live remote v
 
 | Metric | Start of Week | Current | Target (Launch) |
 |--------|--------------|---------|-----------------|
-| Test suites | ~89 | 93 | 95+ |
-| Total tests | 1,734 | 1,917 | 2,000+ |
+| Test suites | ~89 | 213 service suites verified 2026-05-09 | 213+ and green |
+| Total tests | 1,734 | 3,411 service tests verified 2026-05-09 | No regressions |
 | Test pass rate | 99.9% | 100% | 100% |
-| P0 blockers | 8 | 3* | 0 |
+| P0 customer-1 operator gates | 8 | 4* | 0 |
 | Console errors (dashboard) | Multiple | ~0 | 0 |
 | API endpoints returning 400 | 4 | 0 | 0 |
 | Template thumbnails 404 | 100+ | 0 | 0 |
 | Health check layers | 2 | 5 | 5 |
-| Production readiness | 78% | ~85% | 95%+ |
+| Production readiness | 78% | Repo-side ready; operator-gated | C1-C4 cleared |
 
-*Remaining P0s are config-only: SMTP setup, Stripe/Razorpay keys, final smoke test
+*Customer-1 remaining gates: C1 SMTP/Resend verification/test send, C2 customer-1 org provisioning, C3 real-device walkthrough, C4 final go-live smoke. Stripe/Razorpay live keys are deferred past customer-1 because customer-1 launches on the free tier.
 
 ---
 
@@ -287,9 +287,9 @@ Items the audit listed but we are NOT pursuing live (Engage/kiosk, live remote v
 
 | File | Purpose | Dependencies |
 |------|---------|-------------|
-| `week1-day1-2-email-task.md` | Email verification, invite emails, unsubscribe | SendGrid configured |
-| `week1-day3-4-billing-task.md` | Billing checkout, subscriptions, webhooks | Stripe/Razorpay configured |
-| `week1-day7-8-smoke-test-task.md` | Full go-live smoke test (60 steps) | Day 1-4 complete |
+| `week1-day1-2-email-task.md` | Email verification, invite emails, unsubscribe | SMTP/Resend configured and verified |
+| `week1-day3-4-billing-task.md` | Billing checkout, subscriptions, webhooks | Post-customer-1 payment provider setup |
+| `week1-day7-8-smoke-test-task.md` | Full go-live smoke test (60 steps) | C1-C3 complete |
 | `vizora-comprehensive-e2e-test.md` | Full E2E test (76 tests, 12 suites) | App running |
 | `overnight-hardening-loop-task.md` | Backend hardening (12 areas) | None |
 | `overnight-ui-hardening-task.md` | UI hardening (15 areas) | Dev server running |
@@ -310,15 +310,17 @@ Items the audit listed but we are NOT pursuing live (Engage/kiosk, live remote v
 ## ROADMAP
 
 ```
-WEEK 1 (NOW):       P0 Blockers — SMTP, Billing, Smoke Test
-                     |-- Day 1-2: Email (you: SendGrid, Claude: verification flow)
-                     |-- Day 3-4: Billing (you: Stripe/Razorpay, Claude: test checkout)
-                     +-- Day 7-8: Smoke test + go-live report
+CUSTOMER-1 LAUNCH:  C1-C4 operator gates
+                     |-- C1: SMTP/Resend prod verification + operator-approved test send
+                     |-- C2: Customer-1 org provisioning
+                     |-- C3: Real-device customer hardware walkthrough
+                     +-- C4: Final go-live smoke test + report
 
-SOFT LAUNCH:         After P0 cleared
+SOFT LAUNCH:         After C1-C4 cleared
                      +-- Invite 5-10 beta users (restaurants, small businesses)
 
-WEEKS 2-3:          Remaining P1
+WEEKS 2-3:          Payment live setup + remaining P1
+                     |-- Stripe/Razorpay live keys for first paid customer
                      +-- UptimeRobot setup only (operator/manual)
 
 MONTH 1:            P2 items

--- a/scripts/ops/release-readiness-gates.test.ts
+++ b/scripts/ops/release-readiness-gates.test.ts
@@ -63,6 +63,31 @@ test('gitignore protects SSH output files captured by operator runbooks', () => 
   assert.match(gitignore, /^\.ssh_\*\.txt$/m);
 });
 
+test('backlog uses current customer-1 C-series launch gate truth', () => {
+  const backlog = readRepoFile('backlog.md');
+
+  assert.match(backlog, /Customer-1 launch date:\*\* operator-confirmed/i);
+  assert.match(backlog, /## P0 .*customer-1 \(operator-gated launch\)/i);
+  assert.match(
+    backlog,
+    /\|\s*\*\*C4\*\*\s*\|\s*\*\*Final go-live smoke test on prod\*\*/,
+  );
+  assert.doesNotMatch(backlog, /Customer-1 launch target:\*\* 2026-05-13/);
+  assert.doesNotMatch(backlog, /\|\s*\*\*C4\*\*\s*\|\s*B16/);
+  assert.doesNotMatch(
+    backlog,
+    /Remaining P0s are config-only: SMTP setup, Stripe\/Razorpay keys, final smoke test/,
+  );
+  assert.doesNotMatch(
+    backlog,
+    /WEEK 1 \(NOW\):\s+P0 Blockers .*SMTP, Billing, Smoke Test/,
+  );
+  assert.match(
+    backlog,
+    /Customer-1 remaining gates: C1 SMTP\/Resend verification\/test send, C2 customer-1 org provisioning, C3 real-device walkthrough, C4 final go-live smoke\./,
+  );
+});
+
 test('realtime Docker healthcheck probes the prefixed health endpoint', () => {
   const dockerfile = readRepoFile('docker/Dockerfile.realtime');
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,86 @@
 # Vizora - Task Tracker
 
-## Active Workstream: First-Customer Runbook Reconciliation Pass 64 (2026-06-03)
+## Active Workstream: Backlog Launch Gate Truth Pass 65 (2026-06-03)
+
+**Branch:** `fix/backlog-launch-gate-truth`
+
+**Why now:** `backlog.md` is one of the first files the weekend prompt names as
+source-of-truth material, but it still carried the historical 2026-05-13 launch
+target, "three" launch blockers, and a B16-labeled go-live smoke row. The
+operator-facing runbook is now reconciled, so the backlog needs the same
+C1-C4 launch-gate truth to avoid future sessions re-opening stale work.
+
+**New primitives introduced:** none planned. This pass should reuse the
+existing backlog file and release-readiness static gate tests. No new route,
+model, migration, env var, process, realtime event, MCP tool, Hermes skill,
+AI/provider spend path, or production runtime change is expected.
+
+**Hermes-first analysis:** checked per project convention. This is
+deterministic backlog reconciliation, not a business-agent, MCP, Hermes
+runtime, or provider-spend task.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Backlog launch-gate truthfulness | none applicable | update existing backlog |
+| Static release-readiness regression guard | none applicable | extend existing ops test |
+
+Awesome-hermes-agent ecosystem check: no applicable skill/library primitive for
+local backlog truthfulness/static guard updates.
+
+**Plan**
+- [x] Add a failing release-readiness gate proving `backlog.md` uses the
+      current C1-C4 launch gate truth.
+- [x] Update `backlog.md` to remove the fixed May target, use
+      operator-confirmed launch timing, and label C4 as the final go-live smoke.
+- [x] Run focused ops tests, broader ops tests, TypeScript/static checks, diff
+      hygiene, and secret scan.
+- [x] Request Claude Code review and resolve findings.
+- [ ] Commit, PR, CI, and merge if green.
+- [ ] Do not deploy by default; hand off deploy/runtime status and remaining
+      operator-only blockers.
+
+**Evidence so far**
+- Current `origin/main`: `5ddabb7aa5611c85082a2a7729269637c98d0026`.
+- Drift-check:
+  - `backlog.md` top matter still used `Customer-1 launch target:
+    2026-05-13`.
+  - P0 heading still used `(2026-05-13 target)`.
+  - P0 narrative said "three operator-driven items" despite the current C1-C4
+    gate table.
+  - C4 still read `B16 60-step go-live smoke test on prod`.
+  - Lower-page metrics/roadmap still said three remaining P0s and included
+    billing/payment live setup in the customer-1 launch path.
+- Red focused run:
+  - `node --import tsx --test scripts/ops/release-readiness-gates.test.ts`
+    failed as expected on the new backlog launch-gate test.
+  - Expanded the same gate for lower-page stale summary text; it failed as
+    expected on the remaining P0/billing roadmap wording.
+- Fix:
+  - Updated backlog top matter to `Customer-1 launch date:
+    operator-confirmed`.
+  - Updated P0 heading and narrative to the current four C1-C4 operator gates.
+  - Replaced the B16 C4 row label with `Final go-live smoke test on prod`.
+  - Updated metrics, prompt dependencies, and roadmap text so customer-1
+    remaining gates are C1 SMTP/Resend, C2 provisioning, C3 real-device
+    walkthrough, and C4 go-live smoke; Stripe/Razorpay live keys stay deferred
+    past customer-1.
+- Green focused run:
+  - `node --import tsx --test scripts/ops/release-readiness-gates.test.ts`
+    => 19/19 tests passing.
+- Broader/static verification:
+  - `pnpm test:ops` => 38/38 tests passing.
+  - `pnpm exec tsc --noEmit --pretty false --module ESNext --moduleResolution Bundler --target ES2022 --types node --skipLibCheck scripts/ops/release-readiness-gates.test.ts`
+    => passing.
+  - `rg -n "Customer-1 launch target:\*\* 2026-05-13|\|\s*\*\*C4\*\*\s*\|\s*B16|Remaining P0s are config-only|WEEK 1 \(NOW\):\s+P0 Blockers|SMTP, Billing, Smoke Test|three operator-driven items" backlog.md`
+    => no matches.
+  - `git diff --check -- backlog.md scripts/ops/release-readiness-gates.test.ts tasks/todo.md`
+    => exit 0, with LF/CRLF normalization warnings only.
+  - `pnpm security:no-hardcoded-jwts` => passing.
+- Claude Code review:
+  - Review returned `APPROVE` with no high/medium findings.
+  - Low non-blocking notes only: `backlog.md` wave wording is broad/dense.
+
+## Completed Workstream: First-Customer Runbook Reconciliation Pass 64 (2026-06-03)
 
 **Branch:** `fix/overnight-readiness-next`
 
@@ -36,12 +116,16 @@ local runbook truthfulness/static guard updates.
 - [x] Run focused ops tests, broader ops tests, TypeScript/static checks, diff
       hygiene, and secret scan.
 - [x] Request Claude Code review and resolve findings.
-- [ ] Commit, PR, CI, and merge if green.
-- [ ] Do not deploy by default; hand off deploy/runtime status and remaining
+- [x] Commit, PR, CI, and merge if green.
+- [x] Do not deploy by default; hand off deploy/runtime status and remaining
       operator-only blockers.
 
 **Evidence so far**
 - Current `origin/main`: `21497ed05d190b00f5b238e4d9696d200ac894b4`.
+- PR/CI/merge:
+  - PR #204 merged at `5ddabb7aa5611c85082a2a7729269637c98d0026`; GitHub CI
+    passed audit, build, e2e, lint, security, and test.
+  - No deploy or production runtime change was performed.
 - Drift-check:
   - `docs/runbooks/first-customer-onboarding.md` used the historical May launch
     window in section headings and audience text.


### PR DESCRIPTION
## Summary
- Reconcile backlog.md with current C1-C4 operator-gated customer-1 launch truth.
- Remove stale forward-looking 2026-05-13 target / B16 wording and move Stripe/Razorpay live setup out of the customer-1 path.
- Add release-readiness static guard so the stale backlog wording cannot return silently.

## Verification
- node --import tsx --test scripts/ops/release-readiness-gates.test.ts => 19/19 pass
- pnpm test:ops => 38/38 pass
- pnpm exec tsc --noEmit --pretty false --module ESNext --moduleResolution Bundler --target ES2022 --types node --skipLibCheck scripts/ops/release-readiness-gates.test.ts => pass
- git diff --check -- backlog.md scripts/ops/release-readiness-gates.test.ts tasks/todo.md => pass (LF/CRLF warnings only)
- pnpm security:no-hardcoded-jwts => pass

## Review
- Claude Code review: APPROVE, no high/medium findings

## Deployment
- No deploy or production runtime change.