### PR TITLE
fix(mail): honor default sender env

### DIFF
--- a/middleware/src/modules/mail/mail.service.spec.ts
+++ b/middleware/src/modules/mail/mail.service.spec.ts
@@ -29,10 +29,24 @@ describe('MailService.escapeHtml', () => {
 describe('MailService SMTP config', () => {
   const originalEnv = process.env;
 
+  const configureSmtp = () => {
+    process.env.SMTP_HOST = 'smtp.resend.com';
+    process.env.SMTP_PORT = '587';
+    process.env.SMTP_USER = 'resend';
+    process.env.SMTP_PASS = 'resend-secret';
+  };
+
+  const latestTransport = () =>
+    (nodemailer.createTransport as jest.Mock).mock.results.at(-1)?.value as {
+      sendMail: jest.Mock;
+    };
+
   beforeEach(() => {
     jest.clearAllMocks();
     process.env = { ...originalEnv };
     delete process.env.SMTP_PASSWORD;
+    delete process.env.SMTP_PASS;
+    delete process.env.EMAIL_FROM;
   });
 
   afterEach(() => {
@@ -40,10 +54,7 @@ describe('MailService SMTP config', () => {
   });
 
   it('accepts SMTP_PASS as the documented password alias', () => {
-    process.env.SMTP_HOST = 'smtp.resend.com';
-    process.env.SMTP_PORT = '587';
-    process.env.SMTP_USER = 'resend';
-    process.env.SMTP_PASS = 'resend-secret';
+    configureSmtp();
 
     new MailService();
 
@@ -53,6 +64,56 @@ describe('MailService SMTP config', () => {
         port: 587,
         secure: false,
         auth: { user: 'resend', pass: 'resend-secret' },
+      }),
+    );
+  });
+
+  it('uses EMAIL_FROM for default transactional sender', async () => {
+    configureSmtp();
+    process.env.EMAIL_FROM = 'Vizora Test <noreply@example.test>';
+    const service = new MailService();
+
+    await service.sendWelcomeEmail('user@example.com', 'Ada', 30);
+
+    const message = latestTransport().sendMail.mock.calls[0][0];
+    expect(message).toEqual(
+      expect.objectContaining({
+        from: 'Vizora Test <noreply@example.test>',
+        to: 'user@example.com',
+        subject: 'Welcome to Vizora!',
+      }),
+    );
+    expect(message).not.toHaveProperty('replyTo');
+  });
+
+  it('falls back to the verified noreply sender when EMAIL_FROM is unset', async () => {
+    configureSmtp();
+    const service = new MailService();
+
+    await service.sendWelcomeEmail('user@example.com', 'Ada', 30);
+
+    const message = latestTransport().sendMail.mock.calls[0][0];
+    expect(message).toEqual(
+      expect.objectContaining({
+        from: 'Vizora <noreply@mail.vizora.cloud>',
+        to: 'user@example.com',
+      }),
+    );
+  });
+
+  it('keeps role-specific senders even when EMAIL_FROM is configured', async () => {
+    configureSmtp();
+    process.env.EMAIL_FROM = 'Vizora Test <noreply@example.test>';
+    const service = new MailService();
+
+    await service.sendTrialReminderEmail('user@example.com', 'Ada', 2);
+
+    const message = latestTransport().sendMail.mock.calls[0][0];
+    expect(message).toEqual(
+      expect.objectContaining({
+        from: 'Vizora Billing <billing@mail.vizora.cloud>',
+        replyTo: 'billing@vizora.cloud',
+        to: 'user@example.com',
       }),
     );
   });
@@ -153,5 +214,112 @@ describe('MailService.sendUnrecognizedLoginEmail', () => {
     expect(html).not.toContain('<Ada>');
     expect(html).not.toContain('203.0.113.10"><script>');
     expect(html).not.toContain('<img src=x onerror=alert(1)>');
+  });
+});
+
+describe('MailService customer-visible template escaping', () => {
+  const originalEnv = process.env;
+  let service: MailService;
+  let sendMailSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.SMTP_HOST;
+    delete process.env.SMTP_PORT;
+    delete process.env.SMTP_USER;
+    delete process.env.SMTP_PASS;
+    delete process.env.SMTP_PASSWORD;
+    delete process.env.EMAIL_FROM;
+    service = new MailService();
+    sendMailSpy = jest.spyOn(service as unknown as { sendMail: jest.Func }, 'sendMail').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  it('escapes payment receipt plan, amount, and currency fields', async () => {
+    await service.sendPaymentReceiptEmail(
+      'billing@example.com',
+      '<Ada>',
+      '<Pro>',
+      '<999>',
+      'usd<script>',
+    );
+
+    const [, , html, label, sender] = sendMailSpy.mock.calls[0];
+
+    expect(html).toContain('&lt;Ada&gt;');
+    expect(html).toContain('&lt;Pro&gt;');
+    expect(html).toContain('&lt;999&gt;');
+    expect(html).toContain('USD&lt;SCRIPT&gt;');
+    expect(html).not.toContain('<Ada>');
+    expect(html).not.toContain('<Pro>');
+    expect(html).not.toContain('<999>');
+    expect(html).not.toContain('USD<SCRIPT>');
+    expect(label).toBe('Payment receipt');
+    expect(sender).toBe('billing');
+  });
+
+  it('escapes plan-change plan names', async () => {
+    await service.sendPlanChangedEmail(
+      'billing@example.com',
+      '<Ada>',
+      '<Free>',
+      '<Pro>',
+    );
+
+    const [, , html, label, sender] = sendMailSpy.mock.calls[0];
+
+    expect(html).toContain('&lt;Ada&gt;');
+    expect(html).toContain('&lt;Free&gt;');
+    expect(html).toContain('&lt;Pro&gt;');
+    expect(html).not.toContain('<Ada>');
+    expect(html).not.toContain('<Free>');
+    expect(html).not.toContain('<Pro>');
+    expect(label).toBe('Plan changed');
+    expect(sender).toBe('billing');
+  });
+
+  it('escapes subscription cancellation access date', async () => {
+    await service.sendSubscriptionCanceledEmail(
+      'billing@example.com',
+      '<Ada>',
+      '<script>date</script>',
+    );
+
+    const [, , html, label, sender] = sendMailSpy.mock.calls[0];
+
+    expect(html).toContain('&lt;Ada&gt;');
+    expect(html).toContain('&lt;script&gt;date&lt;/script&gt;');
+    expect(html).not.toContain('<Ada>');
+    expect(html).not.toContain('<script>date</script>');
+    expect(label).toBe('Subscription canceled');
+    expect(sender).toBe('billing');
+  });
+
+  it('escapes CTA href attributes such as password reset URLs', async () => {
+    process.env.SMTP_HOST = 'smtp.resend.com';
+    process.env.SMTP_PORT = '587';
+    process.env.SMTP_USER = 'resend';
+    process.env.SMTP_PASS = 'resend-secret';
+    service = new MailService();
+
+    await service.sendPasswordResetEmail(
+      'user@example.com',
+      'Ada',
+      'https://vizora.test/reset?token="bad"&next=<x>',
+    );
+
+    const transport = (nodemailer.createTransport as jest.Mock).mock.results.at(-1)?.value as {
+      sendMail: jest.Mock;
+    };
+    const message = transport.sendMail.mock.calls[0][0];
+
+    expect(message.html).toContain(
+      'https://vizora.test/reset?token=&quot;bad&quot;&amp;next=&lt;x&gt;',
+    );
+    expect(message.html).not.toContain('token="bad"&next=<x>');
   });
 });

--- a/middleware/src/modules/mail/mail.service.ts
+++ b/middleware/src/modules/mail/mail.service.ts
@@ -46,6 +46,14 @@ export class MailService {
     return process.env.EMAIL_FROM || SENDERS.noreply.from;
   }
 
+  private senderIdentity(sender: SenderKey): { from: string; replyTo?: string } {
+    if (sender === 'noreply') {
+      return { ...SENDERS.noreply, from: this.fromAddress };
+    }
+
+    return SENDERS[sender];
+  }
+
   private get appUrl(): string {
     return process.env.APP_URL || process.env.FRONTEND_URL || process.env.WEB_URL || 'http://localhost:3001';
   }
@@ -69,7 +77,7 @@ export class MailService {
     logLabel: string,
     sender: SenderKey = 'noreply',
   ): Promise<void> {
-    const { from, replyTo } = SENDERS[sender];
+    const { from, replyTo } = this.senderIdentity(sender);
 
     if (!this.transporter) {
       this.logger.warn(`[DEV] ${logLabel} email for ${to} (SMTP not configured)`);
@@ -128,7 +136,9 @@ export class MailService {
   }
 
   private ctaButton(label: string, href: string): string {
-    return `<a href="${href}" style="display:inline-block;background:#00E5A0;color:#061A21;font-size:14px;font-weight:600;text-decoration:none;padding:12px 28px;border-radius:8px;">${label}</a>`;
+    const safeHref = MailService.escapeHtml(href);
+    const safeLabel = MailService.escapeHtml(label);
+    return `<a href="${safeHref}" style="display:inline-block;background:#00E5A0;color:#061A21;font-size:14px;font-weight:600;text-decoration:none;padding:12px 28px;border-radius:8px;">${safeLabel}</a>`;
   }
 
   // ---------------------------------------------------------------------------
@@ -176,6 +186,7 @@ export class MailService {
     const urgency = daysRemaining <= 2 ? 'expires very soon' : 'is ending soon';
     const subject = `Your Vizora trial ${urgency} — ${daysRemaining} day${daysRemaining === 1 ? '' : 's'} left`;
     const safeFirstName = MailService.escapeHtml(firstName);
+    const safePricingAmount = pricing ? MailService.escapeHtml(pricing.amount) : '';
     const html = this.wrapInTemplate(`
           <h1 style="color:#F0ECE8;font-size:22px;font-weight:700;margin:0 0 8px 0;">Your trial ${urgency}</h1>
           <p style="color:#8A9BA3;font-size:14px;line-height:1.6;margin:0 0 24px 0;">
@@ -187,7 +198,7 @@ export class MailService {
             Upgrade now to keep everything running without interruption.
           </p>
           ${pricing ? `<p style="color:#8A9BA3;font-size:14px;line-height:1.6;margin:0 0 24px 0;">
-            Plans start at <strong style="color:#00E5A0;">${pricing.amount}/screen/month</strong>.
+            Plans start at <strong style="color:#00E5A0;">${safePricingAmount}/screen/month</strong>.
           </p>` : ''}
           ${this.ctaButton('View Plans & Upgrade', this.upgradeUrl)}
           <p style="color:#5A6B73;font-size:12px;line-height:1.5;margin:16px 0 0 0;">
@@ -203,10 +214,12 @@ export class MailService {
     pricing?: { amount: string; currency: string },
   ): Promise<void> {
     const subject = 'Your Vizora trial has ended';
+    const safeFirstName = MailService.escapeHtml(firstName);
+    const safePricingAmount = pricing ? MailService.escapeHtml(pricing.amount) : '';
     const html = this.wrapInTemplate(`
           <h1 style="color:#F0ECE8;font-size:22px;font-weight:700;margin:0 0 8px 0;">Your trial has ended</h1>
           <p style="color:#8A9BA3;font-size:14px;line-height:1.6;margin:0 0 24px 0;">
-            Hi ${MailService.escapeHtml(firstName)},<br><br>
+            Hi ${safeFirstName},<br><br>
             Your Vizora free trial has expired. Your account is still active, but premium features — including
             multi-display management, advanced scheduling, and priority support — are now limited.
           </p>
@@ -214,7 +227,7 @@ export class MailService {
             Upgrade today to restore full access and keep your signage running smoothly.
           </p>
           ${pricing ? `<p style="color:#8A9BA3;font-size:14px;line-height:1.6;margin:0 0 24px 0;">
-            Plans start at <strong style="color:#00E5A0;">${pricing.amount}/screen/month</strong>.
+            Plans start at <strong style="color:#00E5A0;">${safePricingAmount}/screen/month</strong>.
           </p>` : ''}
           ${this.ctaButton('Upgrade Now', this.upgradeUrl)}
           <p style="color:#5A6B73;font-size:12px;line-height:1.5;margin:16px 0 0 0;">
@@ -231,24 +244,28 @@ export class MailService {
     amount: string,
     currency: string,
   ): Promise<void> {
-    const subject = `Payment received — Vizora ${planName}`;
+    const safeFirstName = MailService.escapeHtml(firstName);
+    const safePlanName = MailService.escapeHtml(planName);
+    const safeAmount = MailService.escapeHtml(amount);
+    const safeCurrency = MailService.escapeHtml(currency.toUpperCase());
+    const subject = `Payment received — Vizora ${safePlanName}`;
     const html = this.wrapInTemplate(`
           <h1 style="color:#F0ECE8;font-size:22px;font-weight:700;margin:0 0 8px 0;">Payment received</h1>
           <p style="color:#8A9BA3;font-size:14px;line-height:1.6;margin:0 0 24px 0;">
-            Hi ${MailService.escapeHtml(firstName)},<br><br>
+            Hi ${safeFirstName},<br><br>
             We've received your payment. Here's a summary:
           </p>
           <table width="100%" cellpadding="0" cellspacing="0" style="margin:0 0 24px 0;">
             <tr>
               <td style="padding:12px 16px;background:#0A1E26;border-radius:8px 8px 0 0;border-bottom:1px solid #1B3D47;">
                 <span style="color:#5A6B73;font-size:12px;text-transform:uppercase;letter-spacing:0.5px;">Plan</span><br>
-                <span style="color:#F0ECE8;font-size:14px;font-weight:600;">${planName}</span>
+                <span style="color:#F0ECE8;font-size:14px;font-weight:600;">${safePlanName}</span>
               </td>
             </tr>
             <tr>
               <td style="padding:12px 16px;background:#0A1E26;border-radius:0 0 8px 8px;">
                 <span style="color:#5A6B73;font-size:12px;text-transform:uppercase;letter-spacing:0.5px;">Amount</span><br>
-                <span style="color:#00E5A0;font-size:18px;font-weight:700;">${amount} ${currency.toUpperCase()}</span>
+                <span style="color:#00E5A0;font-size:18px;font-weight:700;">${safeAmount} ${safeCurrency}</span>
               </td>
             </tr>
           </table>
@@ -289,11 +306,14 @@ export class MailService {
     oldPlan: string,
     newPlan: string,
   ): Promise<void> {
-    const subject = `Plan updated — now on Vizora ${newPlan}`;
+    const safeFirstName = MailService.escapeHtml(firstName);
+    const safeOldPlan = MailService.escapeHtml(oldPlan);
+    const safeNewPlan = MailService.escapeHtml(newPlan);
+    const subject = `Plan updated — now on Vizora ${safeNewPlan}`;
     const html = this.wrapInTemplate(`
           <h1 style="color:#F0ECE8;font-size:22px;font-weight:700;margin:0 0 8px 0;">Plan updated</h1>
           <p style="color:#8A9BA3;font-size:14px;line-height:1.6;margin:0 0 24px 0;">
-            Hi ${MailService.escapeHtml(firstName)},<br><br>
+            Hi ${safeFirstName},<br><br>
             Your Vizora subscription has been changed:
           </p>
           <table width="100%" cellpadding="0" cellspacing="0" style="margin:0 0 24px 0;">
@@ -301,12 +321,12 @@ export class MailService {
               <td style="padding:12px 16px;background:#0A1E26;border-radius:8px;display:flex;align-items:center;gap:12px;">
                 <div>
                   <span style="color:#5A6B73;font-size:12px;text-transform:uppercase;letter-spacing:0.5px;">Previous</span><br>
-                  <span style="color:#8A9BA3;font-size:14px;text-decoration:line-through;">${oldPlan}</span>
+                  <span style="color:#8A9BA3;font-size:14px;text-decoration:line-through;">${safeOldPlan}</span>
                 </div>
                 <div style="color:#5A6B73;font-size:18px;padding:0 8px;">&rarr;</div>
                 <div>
                   <span style="color:#5A6B73;font-size:12px;text-transform:uppercase;letter-spacing:0.5px;">New plan</span><br>
-                  <span style="color:#00E5A0;font-size:14px;font-weight:600;">${newPlan}</span>
+                  <span style="color:#00E5A0;font-size:14px;font-weight:600;">${safeNewPlan}</span>
                 </div>
               </td>
             </tr>
@@ -325,12 +345,14 @@ export class MailService {
     accessUntil: string,
   ): Promise<void> {
     const subject = 'Your Vizora subscription has been canceled';
+    const safeFirstName = MailService.escapeHtml(firstName);
+    const safeAccessUntil = MailService.escapeHtml(accessUntil);
     const html = this.wrapInTemplate(`
           <h1 style="color:#F0ECE8;font-size:22px;font-weight:700;margin:0 0 8px 0;">Subscription canceled</h1>
           <p style="color:#8A9BA3;font-size:14px;line-height:1.6;margin:0 0 24px 0;">
-            Hi ${MailService.escapeHtml(firstName)},<br><br>
+            Hi ${safeFirstName},<br><br>
             Your Vizora subscription has been canceled as requested. You'll continue to have full access to
-            premium features until <strong style="color:#F0ECE8;">${accessUntil}</strong>.
+            premium features until <strong style="color:#F0ECE8;">${safeAccessUntil}</strong>.
           </p>
           <p style="color:#8A9BA3;font-size:14px;line-height:1.6;margin:0 0 24px 0;">
             After that date, your account will revert to the free tier. Your content and settings will be

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,110 @@
 # Vizora - Task Tracker
 
-## Active Workstream: Backlog Launch Gate Truth Pass 65 (2026-06-03)
+## Active Workstream: Mail Sender Env + Template Coverage Pass 66 (2026-06-03)
+
+**Branch:** `fix/mail-sender-env-coverage`
+
+**Why now:** C1 SMTP/Resend remains operator-gated, but repo-side mail behavior
+can still reduce launch risk without sending real email. The first-customer
+runbook and docs tell the operator to verify `EMAIL_FROM`, yet
+`MailService.sendMail()` ignores the existing `fromAddress` getter and always
+uses hardcoded sender addresses for default transactional mail. The mail spec
+also covers only two customer-visible template families, while backlog B4
+tracks multi-template email testing as blocked on C1.
+
+**New primitives introduced:** none planned. This pass should reuse the
+existing NestJS `MailService`, nodemailer mock pattern, and middleware Jest
+tests. No new route, model, migration, env var, process, realtime event, MCP
+tool, Hermes skill, AI/provider spend path, customer email send, or production
+runtime change is expected.
+
+**Hermes-first analysis:** checked per project convention. This is
+deterministic transactional mail service behavior in NestJS, not a
+business-agent, MCP, Hermes runtime, or provider-spend task.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Transactional email sender selection | none applicable | fix existing MailService |
+| Email template unit coverage | none applicable | extend existing Jest spec |
+
+Awesome-hermes-agent ecosystem check: no applicable skill/library primitive for
+local NestJS transactional mail sender selection or HTML template assertions.
+
+**Plan**
+- [x] Add failing mail-service tests for documented `EMAIL_FROM` default sender
+      behavior and customer-visible template escaping/CTA coverage.
+- [x] Update `MailService` narrowly: default/noreply sender respects
+      `EMAIL_FROM`, role-specific senders keep their verified identities, and
+      CTA/template dynamic values are HTML-escaped.
+- [x] Run focused mail tests plus adjacent auth/billing mail-caller tests,
+      TypeScript/static checks, diff hygiene, and secret scan.
+- [x] Request Claude Code review and resolve findings.
+- [ ] Commit, PR, CI, and merge if green.
+- [ ] Do not deploy, send real emails, or touch production SMTP/env state.
+
+**Evidence so far**
+- Current `origin/main`: `eab6e910a3baab94f36de047c124a592d501555a`.
+- Drift-check:
+  - `middleware/src/modules/mail/mail.service.ts` defines `fromAddress` as
+    `process.env.EMAIL_FROM || SENDERS.noreply.from`, but `sendMail()` ignores
+    it and always uses `SENDERS[sender].from`.
+  - `docs/runbooks/first-customer-onboarding.md` tells the operator to verify
+    `EMAIL_FROM` and expect welcome mail from the configured sender.
+  - `CLAUDE.md` documents `EMAIL_FROM` as the default sender for transactional
+    mail.
+  - `middleware/src/modules/organizations/organizations.service.ts` already
+    uses `EMAIL_FROM` for lifecycle SMTP sends, so the inconsistency is local
+    to `MailService`.
+  - Existing focused baseline:
+    `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/mail/mail.service.spec.ts`
+    => 10/10 tests passing before new red tests.
+- Red focused run:
+  - `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/mail/mail.service.spec.ts`
+    failed as expected: 5 new failures covered `EMAIL_FROM`, payment receipt
+    fields, plan-change fields, subscription cancellation access date, and CTA
+    href escaping.
+- Fix:
+  - `MailService` now uses the documented `EMAIL_FROM` only for the default
+    `noreply` sender path; role-specific `auth`, `billing`, and `support`
+    senders keep their existing verified identities and reply-to addresses.
+  - CTA button labels/hrefs are escaped before rendering into HTML attributes.
+  - Dynamic billing/subscription template fields now escape plan names, amount,
+    currency, pricing amount, and cancellation access date before interpolation.
+- Green focused run:
+  - `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/mail/mail.service.spec.ts`
+    => 17/17 tests passing after adding `EMAIL_FROM` fallback coverage.
+- Adjacent mail-caller verification:
+  - `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/mail/mail.service.spec.ts src/modules/auth/auth.service.spec.ts src/modules/billing/billing.service.spec.ts src/modules/notifications/alert-rules/alert-rule.evaluator.spec.ts src/modules/organizations/organizations.service.spec.ts src/modules/health/startup-self-test.service.spec.ts`
+    => 179/179 tests passing across 6 suites.
+- Static/build verification:
+  - Loose-file `tsc` failed before build with an existing project type-resolution
+    issue: `Cannot find type definition file for 'dompurify'`. This was not a
+    code failure in the touched files.
+  - `npx nx build @vizora/middleware` initially failed because the local
+    worktree lacked `packages/database/src/generated/prisma`. Generated the
+    local Prisma client with:
+    `$env:NODE_OPTIONS='--use-system-ca'; .\node_modules\.bin\prisma generate --schema prisma/schema.prisma`
+    from `packages/database`.
+  - `npx nx build @vizora/middleware` then passed. Existing webpack warnings
+    remained for OpenTelemetry dynamic requires, Express view, Handlebars
+    `require.extensions`, optional `canvas`, and `require-in-the-middle`.
+  - `$env:ESLINT_USE_FLAT_CONFIG='false'; npx eslint middleware/src/modules/mail/mail.service.ts middleware/src/modules/mail/mail.service.spec.ts`
+    => passing.
+  - `git diff --check -- middleware/src/modules/mail/mail.service.ts middleware/src/modules/mail/mail.service.spec.ts tasks/todo.md`
+    => exit 0, with LF/CRLF normalization warnings only.
+  - `pnpm security:no-hardcoded-jwts` => passing.
+- Claude Code review:
+  - Initial review returned `REQUEST CHANGES` with one medium test-hygiene
+    finding: the new CTA-href test set `SMTP_*` env vars without restoring
+    `process.env`, creating cross-suite leakage risk.
+  - Fixed by mirroring the existing env save/restore pattern in the template
+    escaping describe block and adding explicit fallback coverage for
+    `EMAIL_FROM` unset.
+  - Re-ran focused mail tests (17/17), adjacent caller suite (179/179), ESLint,
+    diff hygiene, and hardcoded-JWT scan after the fix.
+  - Final re-review returned `APPROVE` with no high/medium findings.
+
+## Completed Workstream: Backlog Launch Gate Truth Pass 65 (2026-06-03)
 
 **Branch:** `fix/backlog-launch-gate-truth`
 
@@ -35,12 +139,16 @@ local backlog truthfulness/static guard updates.
 - [x] Run focused ops tests, broader ops tests, TypeScript/static checks, diff
       hygiene, and secret scan.
 - [x] Request Claude Code review and resolve findings.
-- [ ] Commit, PR, CI, and merge if green.
-- [ ] Do not deploy by default; hand off deploy/runtime status and remaining
+- [x] Commit, PR, CI, and merge if green.
+- [x] Do not deploy by default; hand off deploy/runtime status and remaining
       operator-only blockers.
 
 **Evidence so far**
 - Current `origin/main`: `5ddabb7aa5611c85082a2a7729269637c98d0026`.
+- PR/CI/merge:
+  - PR #205 merged at `eab6e910a3baab94f36de047c124a592d501555a`; GitHub CI
+    passed audit, build, e2e, lint, security, and test.
+  - No deploy or production runtime change was performed.
 - Drift-check:
   - `backlog.md` top matter still used `Customer-1 launch target:
     2026-05-13`.


### PR DESCRIPTION
## Summary
- Make MailService default/noreply sends honor documented EMAIL_FROM while preserving role-specific auth/billing/support sender identities.
- Escape CTA href/label values and dynamic billing/subscription template fields before rendering customer-visible email HTML.
- Expand MailService unit coverage for EMAIL_FROM set/fallback behavior and customer-visible template escaping.

## Verification
- pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/mail/mail.service.spec.ts => 17/17 pass
- pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/mail/mail.service.spec.ts src/modules/auth/auth.service.spec.ts src/modules/billing/billing.service.spec.ts src/modules/notifications/alert-rules/alert-rule.evaluator.spec.ts src/modules/organizations/organizations.service.spec.ts src/modules/health/startup-self-test.service.spec.ts => 179/179 pass
- npx nx build @vizora/middleware => pass after local Prisma client generation; existing webpack warnings only
- npx eslint middleware/src/modules/mail/mail.service.ts middleware/src/modules/mail/mail.service.spec.ts => pass
- git diff --check -- middleware/src/modules/mail/mail.service.ts middleware/src/modules/mail/mail.service.spec.ts tasks/todo.md => pass (LF/CRLF warnings only)
- pnpm security:no-hardcoded-jwts => pass

## Review
- Claude Code initial review: REQUEST CHANGES for process.env leakage in new tests; fixed.
- Claude Code final re-review: APPROVE, no high/medium findings.

## Deployment
- No deploy, no real customer email sends, no production SMTP/env changes.