### PR TITLE
fix(auth): align email readiness URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,11 +142,48 @@ NEXT_PUBLIC_SOCKET_URL=http://localhost:3002
 # Backend URL used by next.config.js for server-side API proxying
 BACKEND_URL=http://localhost:3000
 
+# Canonical public web URL used by backend-generated email links.
+# Production value should be https://vizora.cloud or the customer-facing app URL.
+APP_URL=http://localhost:3001
+WEB_URL=http://localhost:3001
+
+# Legacy alias accepted by a few older mail paths. Prefer APP_URL/WEB_URL.
+FRONTEND_URL=
+
 # =============================================================================
-# Production URLs (uncomment and configure for deployment)
+# Production URLs (configure for deployment)
 # =============================================================================
 # API_BASE_URL=https://api.vizora.io
-# WEB_URL=https://app.vizora.io
+# APP_URL=https://vizora.cloud
+# WEB_URL=https://vizora.cloud
+
+# =============================================================================
+# Email / SMTP / Resend
+# =============================================================================
+# C1 customer launch blocker: configure these on prod and verify the
+# mail.vizora.cloud domain in Resend (DKIM/SPF/DMARC green) before customer use.
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASS=
+# SMTP_PASSWORD is accepted as a legacy alias for SMTP_PASS; prefer SMTP_PASS.
+# SMTP_PASSWORD=
+
+# Ops/status alert sender and recipient. OPS_ALERT_EMAIL overrides SMTP_TO for
+# ops alerts when it is set, so operational alerts can go to a separate inbox.
+SMTP_FROM=vizora-ops@mail.vizora.cloud
+SMTP_TO=
+OPS_ALERT_EMAIL=
+
+# Default sender for transactional mail such as welcome, trial, billing, and
+# lifecycle emails. Use a sender on the verified mail.vizora.cloud domain.
+EMAIL_FROM=noreply@mail.vizora.cloud
+
+# Customer-lifecycle live-send gate. Keep false unless explicitly cutting over
+# customer-visible lifecycle emails. LIFECYCLE_TEST_EMAILS redirects/allowlists
+# lifecycle mail for verification without sending to real customers.
+LIFECYCLE_LIVE=false
+LIFECYCLE_TEST_EMAILS=
 
 # =============================================================================
 # Internal API Secret (for service-to-service communication)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,9 +173,11 @@ METRICS_TOKEN           # Optional — Bearer token for /internal/metrics from n
 
 ```
 SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, SMTP_FROM, SMTP_TO
+SMTP_PASSWORD           # Legacy alias accepted by middleware; prefer SMTP_PASS
 SLACK_WEBHOOK_URL       # Slack incoming webhook for ops status changes
 HEALTHCHECKS_HEALTH_GUARDIAN_URL  # External heartbeat for the ops dead-man (see "Autonomous Operations")
 EMAIL_FROM              # Default sender for transactional mail
+APP_URL, WEB_URL        # Public web URL for backend-generated email links; must not point at localhost in prod
 ```
 
 ### MCP Server (see also `docs/agents-mcp-server-design.md`)

--- a/backlog.md
+++ b/backlog.md
@@ -111,7 +111,7 @@ Per current readiness reconciliation: the four operator-driven items below are t
 
 | # | Item | Owner | Effort | Status | Notes |
 |---|------|-------|--------|--------|-------|
-| **C1** | **SMTP / Resend on prod — domain `mail.vizora.cloud` verified (DKIM/SPF/DMARC), `SMTP_*`/`EMAIL_FROM` env set, test send works end-to-end** | Sri | 2h | TODO | Without this, customer registration emails + password resets don't send |
+| **C1** | **SMTP / Resend on prod — domain `mail.vizora.cloud` verified (DKIM/SPF/DMARC), `SMTP_*`/`EMAIL_FROM` and public `APP_URL` or `WEB_URL` env set, test send works end-to-end** | Sri | 2h | TODO | Without this, customer registration emails + password resets don't send or link to the wrong host |
 | **C2** | **Customer-1 organization provisioned on prod** (skeleton, admin user invite, plan, quota) | Sri | 1h | TODO | Skip if customer self-registers |
 | **C3** | **Real-device walkthrough on customer hardware** (pair, push playlist, reboot, network-flap) | Sri + customer IT | 2h | TODO | Electron has 0% functional test coverage; this IS the test |
 | **C4** | **Final go-live smoke test on prod** | Claude Code (driven by Sri) | 3h | BLOCKED on C1-C3 | Operator-driven; document in `docs/runbooks/customer-1-go-live-smoke-{DATE}.md` |
@@ -279,7 +279,7 @@ Items the audit listed but we are NOT pursuing live (Engage/kiosk, live remote v
 | Health check layers | 2 | 5 | 5 |
 | Production readiness | 78% | Repo-side ready; operator-gated | C1-C4 cleared |
 
-*Customer-1 remaining gates: C1 SMTP/Resend verification/test send, C2 customer-1 org provisioning, C3 real-device walkthrough, C4 final go-live smoke. Stripe/Razorpay live keys are deferred past customer-1 because customer-1 launches on the free tier.
+*Customer-1 remaining gates: C1 SMTP/Resend verification/test send plus public email-link URL (`APP_URL` or `WEB_URL`), C2 customer-1 org provisioning, C3 real-device walkthrough, C4 final go-live smoke. Stripe/Razorpay live keys are deferred past customer-1 because customer-1 launches on the free tier.
 
 ---
 
@@ -311,7 +311,7 @@ Items the audit listed but we are NOT pursuing live (Engage/kiosk, live remote v
 
 ```
 CUSTOMER-1 LAUNCH:  C1-C4 operator gates
-                     |-- C1: SMTP/Resend prod verification + operator-approved test send
+                     |-- C1: SMTP/Resend prod verification + public email-link URL + operator-approved test send
                      |-- C2: Customer-1 org provisioning
                      |-- C3: Real-device customer hardware walkthrough
                      +-- C4: Final go-live smoke test + report

--- a/docs/runbooks/first-customer-onboarding.md
+++ b/docs/runbooks/first-customer-onboarding.md
@@ -21,9 +21,10 @@ Per `backlog.md` C1. Without this, registration emails + password resets don't s
 
 ```bash
 # On prod VPS (root@vizora.cloud):
-ssh root@vizora.cloud 'grep -E "^SMTP_|^RESEND_|^EMAIL_FROM" /opt/vizora/app/.env' > .ssh_smtp_env.txt 2>&1
+ssh root@vizora.cloud 'grep -E "^SMTP_|^RESEND_|^EMAIL_FROM|^APP_URL|^WEB_URL" /opt/vizora/app/.env' > .ssh_smtp_env.txt 2>&1
 # Read .ssh_smtp_env.txt as a separate step.
-# Verify all of: SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, EMAIL_FROM
+# Verify all of: SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, EMAIL_FROM, and APP_URL or WEB_URL
+# APP_URL or WEB_URL must be the public web URL so email links do not point at localhost
 # Resend domain `mail.vizora.cloud` must be verified (DKIM/SPF/DMARC green)
 ```
 

--- a/middleware/src/modules/auth/auth.service.spec.ts
+++ b/middleware/src/modules/auth/auth.service.spec.ts
@@ -125,6 +125,7 @@ describe('AuthService', () => {
         deleteMany: jest.fn(),
       },
       passwordResetToken: {
+        create: jest.fn(),
         findUnique: jest.fn(),
         update: jest.fn(),
         deleteMany: jest.fn(),
@@ -1388,6 +1389,64 @@ describe('AuthService', () => {
   });
 
   describe('resetPassword', () => {
+    it.each([
+      [
+        'APP_URL before legacy URL fallbacks',
+        {
+          APP_URL: 'https://app.vizora.test',
+          FRONTEND_URL: 'https://legacy.vizora.test',
+          WEB_URL: 'https://web.vizora.test',
+        },
+        'https://app.vizora.test',
+      ],
+      [
+        'FRONTEND_URL when APP_URL is unset',
+        {
+          FRONTEND_URL: 'https://legacy.vizora.test',
+          WEB_URL: 'https://web.vizora.test',
+        },
+        'https://legacy.vizora.test',
+      ],
+      [
+        'WEB_URL when APP_URL and FRONTEND_URL are unset',
+        {
+          WEB_URL: 'https://web.vizora.test',
+        },
+        'https://web.vizora.test',
+      ],
+    ])('uses %s for password-reset email links', async (_label, env, expectedBaseUrl) => {
+      const originalAppUrl = process.env.APP_URL;
+      const originalFrontendUrl = process.env.FRONTEND_URL;
+      const originalWebUrl = process.env.WEB_URL;
+
+      try {
+        delete process.env.APP_URL;
+        delete process.env.FRONTEND_URL;
+        delete process.env.WEB_URL;
+        Object.assign(process.env, env);
+
+        mockDatabaseService.user.findUnique.mockResolvedValue(mockUser);
+        mockDatabaseService.passwordResetToken.create.mockResolvedValue({ id: 'reset-1' });
+
+        await service.forgotPassword(mockUser.email);
+
+        const [email, firstName, resetUrl] = mockMailService.sendPasswordResetEmail.mock.calls[0];
+        expect(email).toBe(mockUser.email);
+        expect(firstName).toBe(mockUser.firstName);
+        expect(resetUrl.startsWith(`${expectedBaseUrl}/reset-password?token=`)).toBe(true);
+        expect(new URL(resetUrl).searchParams.get('token')).toMatch(/^[a-f0-9]{64}$/);
+      } finally {
+        if (originalAppUrl === undefined) delete process.env.APP_URL;
+        else process.env.APP_URL = originalAppUrl;
+
+        if (originalFrontendUrl === undefined) delete process.env.FRONTEND_URL;
+        else process.env.FRONTEND_URL = originalFrontendUrl;
+
+        if (originalWebUrl === undefined) delete process.env.WEB_URL;
+        else process.env.WEB_URL = originalWebUrl;
+      }
+    });
+
     it('writes the pwd_changed marker so the reset kills pre-reset sessions (takeover defense)', async () => {
       // forgot-password reset is the primary account-takeover case: an attacker
       // who resets a stolen-email account must invalidate the legit user's

--- a/middleware/src/modules/auth/auth.service.ts
+++ b/middleware/src/modules/auth/auth.service.ts
@@ -659,7 +659,8 @@ export class AuthService {
     });
 
     // Build reset URL
-    const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3001';
+    const frontendUrl =
+      process.env.APP_URL || process.env.FRONTEND_URL || process.env.WEB_URL || 'http://localhost:3001';
     const resetUrl = `${frontendUrl}/reset-password?token=${rawToken}`;
 
     // Send email (uses raw token, not hashed)

--- a/scripts/ops/release-readiness-gates.test.ts
+++ b/scripts/ops/release-readiness-gates.test.ts
@@ -63,6 +63,39 @@ test('gitignore protects SSH output files captured by operator runbooks', () => 
   assert.match(gitignore, /^\.ssh_\*\.txt$/m);
 });
 
+test('.env.example documents customer-1 email readiness variables', () => {
+  const envExample = readRepoFile('.env.example');
+
+  for (const name of [
+    'APP_URL',
+    'WEB_URL',
+    'FRONTEND_URL',
+    'SMTP_HOST',
+    'SMTP_PORT',
+    'SMTP_USER',
+    'SMTP_PASS',
+    'SMTP_FROM',
+    'SMTP_TO',
+    'OPS_ALERT_EMAIL',
+    'EMAIL_FROM',
+    'LIFECYCLE_LIVE',
+    'LIFECYCLE_TEST_EMAILS',
+  ]) {
+    assert.match(envExample, new RegExp(`^${name}=`, 'm'), `${name} is documented`);
+  }
+
+  assert.match(envExample, /SMTP_PASSWORD.*legacy alias/i);
+  assert.match(envExample, /EMAIL_FROM=.*noreply@mail\.vizora\.cloud/);
+});
+
+test('first-customer C1 runbook verifies email app URL env', () => {
+  const runbook = readRepoFile('docs/runbooks/first-customer-onboarding.md');
+
+  assert.match(runbook, /\^APP_URL\|\^WEB_URL/);
+  assert.match(runbook, /Verify all of: SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, EMAIL_FROM, and APP_URL or WEB_URL/);
+  assert.match(runbook, /email links do not point at localhost/i);
+});
+
 test('backlog uses current customer-1 C-series launch gate truth', () => {
   const backlog = readRepoFile('backlog.md');
 
@@ -84,7 +117,7 @@ test('backlog uses current customer-1 C-series launch gate truth', () => {
   );
   assert.match(
     backlog,
-    /Customer-1 remaining gates: C1 SMTP\/Resend verification\/test send, C2 customer-1 org provisioning, C3 real-device walkthrough, C4 final go-live smoke\./,
+    /Customer-1 remaining gates: C1 SMTP\/Resend verification\/test send plus public email-link URL \(`APP_URL` or `WEB_URL`\), C2 customer-1 org provisioning, C3 real-device walkthrough, C4 final go-live smoke\./,
   );
 });
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,112 @@
 # Vizora - Task Tracker
 
-## Active Workstream: Mail Sender Env + Template Coverage Pass 66 (2026-06-03)
+## Active Workstream: Email Env Example + App URL Readiness Pass 67 (2026-06-03)
+
+**Branch:** `fix/email-env-example-readiness`
+
+**Why now:** C1 SMTP/Resend remains operator-gated, but `.env.example` does not
+list the operator-critical email variables consumed by `MailService`, startup
+self-test, ops alerting, and lifecycle agents. The first-customer runbook also
+checks SMTP credentials and `EMAIL_FROM`, but does not call out `APP_URL`/`WEB_URL`
+even though backend-generated email links use those values and can otherwise
+point at localhost. Drift-check also found the password-reset path still used
+only `FRONTEND_URL`, so the C1 URL guidance could pass while reset links still
+pointed at the wrong host.
+
+**New primitives introduced:** none planned. This pass should update existing
+operator docs, existing env examples, release-readiness static gates, and the
+existing password-reset URL fallback only. No new route, model, migration,
+process, realtime event, MCP tool, Hermes skill, AI/provider spend path,
+customer email send, or production runtime change is expected.
+
+**Hermes-first analysis:** checked per project convention. This is deterministic
+configuration documentation/readiness gating, not a business-agent, MCP, Hermes
+runtime, or provider-spend task.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Email env example documentation | none applicable | update `.env.example` |
+| C1 app URL runbook guidance | none applicable | update existing first-customer runbook |
+| Password-reset URL fallback | none applicable | align existing AuthService fallback order |
+| Static release-readiness regression guard | none applicable | extend existing ops test |
+
+Awesome-hermes-agent ecosystem check: no applicable skill/library primitive for
+local env-example and operator runbook truthfulness updates.
+
+**Plan**
+- [x] Add failing release-readiness gate for email env variables and C1 app URL
+      guidance.
+- [x] Update `.env.example`, first-customer runbook, backlog, and CLAUDE docs so
+      C1 includes SMTP/Resend, transactional sender, ops alert sender, lifecycle
+      gates, and backend app URL guidance.
+- [x] Add focused password-reset regression coverage and align AuthService URL
+      fallback with the documented app URL precedence.
+- [x] Run focused ops tests, broader ops tests, diff hygiene, and secret scan.
+- [x] Request Claude Code review and resolve findings.
+- [ ] Commit, PR, CI, and merge if green.
+- [ ] Do not deploy, send real emails, or touch production SMTP/env state.
+
+**Evidence so far**
+- Current `origin/main`: `9181ff57630d01ecafb7241fe75fed645ae33939`.
+- Drift-check:
+  - `.env.example` has no `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`,
+    `SMTP_FROM`, `SMTP_TO`, `OPS_ALERT_EMAIL`, `EMAIL_FROM`,
+    `LIFECYCLE_LIVE`, or `LIFECYCLE_TEST_EMAILS` entries.
+  - `middleware/src/modules/mail/mail.service.ts` consumes `SMTP_HOST`,
+    `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD || SMTP_PASS`, `EMAIL_FROM`, and
+    `APP_URL || FRONTEND_URL || WEB_URL`.
+  - `middleware/src/modules/health/startup-self-test.service.ts` validates SMTP
+    with `transporter.verify()` when SMTP env is configured.
+  - `scripts/ops/lib/alerting.ts` consumes `SMTP_FROM`, `SMTP_TO`, and
+    `OPS_ALERT_EMAIL`.
+  - `scripts/agents/customer-lifecycle.ts` consumes `LIFECYCLE_LIVE`,
+    `LIFECYCLE_TEST_EMAILS`, `EMAIL_FROM`, `APP_URL`, and `WEB_URL`.
+  - `docs/runbooks/first-customer-onboarding.md` checks SMTP and `EMAIL_FROM`
+    but not the app URL used in generated transactional email links.
+- Red focused runs:
+  - `node --import tsx --test scripts/ops/release-readiness-gates.test.ts`
+    failed as expected before the doc/env patch: `.env.example` lacked
+    `APP_URL` and the runbook lacked `^APP_URL|^WEB_URL` guidance.
+  - `pnpm --filter @vizora/middleware test -- --runTestsByPath src/modules/auth/auth.service.spec.ts`
+    failed as expected before the AuthService fix: password-reset URLs used
+    `FRONTEND_URL` even when `APP_URL` was configured.
+- Fix:
+  - `.env.example` now documents `APP_URL`, `WEB_URL`, legacy `FRONTEND_URL`,
+    SMTP/Resend variables, `SMTP_PASSWORD` legacy alias, ops alert mail vars,
+    `EMAIL_FROM`, and lifecycle live/test gates.
+  - First-customer runbook and backlog C1 now require a public `APP_URL` or
+    `WEB_URL`, so generated email links do not point at localhost.
+  - `AuthService.forgotPassword()` now resolves reset-link base URL as
+    `APP_URL || FRONTEND_URL || WEB_URL || localhost`, matching the mail service
+    precedence while preserving the legacy alias.
+- Green focused runs:
+  - `pnpm --filter @vizora/middleware test -- --runTestsByPath src/modules/auth/auth.service.spec.ts`
+    => 66/66 tests passing after adding coverage for `APP_URL`, legacy
+    `FRONTEND_URL`, and `WEB_URL` fallback tiers.
+  - `node --import tsx --test scripts/ops/release-readiness-gates.test.ts`
+    => 21/21 tests passing.
+- Broader verification:
+  - `pnpm test:ops` => 40/40 ops tests passing.
+  - `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/auth/auth.service.spec.ts src/modules/mail/mail.service.spec.ts src/modules/health/startup-self-test.service.spec.ts src/modules/organizations/organizations.service.spec.ts`
+    => 126/126 tests passing across affected auth/mail/startup/lifecycle suites.
+  - `$env:ESLINT_USE_FLAT_CONFIG='false'; npx eslint middleware/src/modules/auth/auth.service.ts middleware/src/modules/auth/auth.service.spec.ts`
+    => exit 0 with one pre-existing warning in `sanitizeUser()` (`_` unused);
+    left unchanged to keep this PR scoped to email readiness/reset-link behavior.
+  - `npx nx build @vizora/middleware` => passing; existing webpack warnings
+    remain for dynamic/optional dependencies (`@opentelemetry`, Express view,
+    Handlebars `require.extensions`, optional `canvas`, `require-in-the-middle`).
+  - `git diff --check -- .env.example docs/runbooks/first-customer-onboarding.md backlog.md CLAUDE.md middleware/src/modules/auth/auth.service.ts middleware/src/modules/auth/auth.service.spec.ts scripts/ops/release-readiness-gates.test.ts tasks/todo.md`
+    => exit 0, with LF/CRLF normalization warnings only.
+  - `pnpm security:no-hardcoded-jwts` => passing.
+- Claude Code review:
+  - Initial review returned `APPROVE` with low/non-blocking findings only.
+  - Builder resolved two low items anyway: removed the unrelated `sanitizeUser()`
+    cleanup from the diff and added fallback-tier tests for `FRONTEND_URL` and
+    `WEB_URL`.
+  - Final Claude Code re-review returned `APPROVE` with no high/medium
+    actionable issues.
+
+## Completed Workstream: Mail Sender Env + Template Coverage Pass 66 (2026-06-03)
 
 **Branch:** `fix/mail-sender-env-coverage`
 
@@ -39,11 +145,18 @@ local NestJS transactional mail sender selection or HTML template assertions.
 - [x] Run focused mail tests plus adjacent auth/billing mail-caller tests,
       TypeScript/static checks, diff hygiene, and secret scan.
 - [x] Request Claude Code review and resolve findings.
-- [ ] Commit, PR, CI, and merge if green.
-- [ ] Do not deploy, send real emails, or touch production SMTP/env state.
+- [x] Commit, PR, CI, and merge if green.
+- [x] Do not deploy, send real emails, or touch production SMTP/env state.
 
 **Evidence so far**
 - Current `origin/main`: `eab6e910a3baab94f36de047c124a592d501555a`.
+- PR/CI/merge:
+  - PR #206 merged at `9181ff57630d01ecafb7241fe75fed645ae33939`.
+  - Initial CI `test` failure was infrastructure-only: Docker Hub timed out
+    pulling `postgres:16-alpine` during service-container setup before repo
+    tests ran. Reran failed jobs.
+  - Final GitHub CI passed audit, build, e2e, lint, security, and test.
+  - No deploy, customer email send, or production runtime change was performed.
 - Drift-check:
   - `middleware/src/modules/mail/mail.service.ts` defines `fromAddress` as
     `process.env.EMAIL_FROM || SENDERS.noreply.from`, but `sendMail()` ignores

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,6 @@
 # Vizora - Task Tracker
 
-## Active Workstream: Email Env Example + App URL Readiness Pass 67 (2026-06-03)
+## Completed Workstream: Email Env Example + App URL Readiness Pass 67 (2026-06-03)
 
 **Branch:** `fix/email-env-example-readiness`
 
@@ -43,11 +43,18 @@ local env-example and operator runbook truthfulness updates.
       fallback with the documented app URL precedence.
 - [x] Run focused ops tests, broader ops tests, diff hygiene, and secret scan.
 - [x] Request Claude Code review and resolve findings.
-- [ ] Commit, PR, CI, and merge if green.
-- [ ] Do not deploy, send real emails, or touch production SMTP/env state.
+- [x] Commit, PR, CI, and merge if green.
+- [x] Do not deploy, send real emails, or touch production SMTP/env state.
 
 **Evidence so far**
 - Current `origin/main`: `9181ff57630d01ecafb7241fe75fed645ae33939`.
+- Branch/PR:
+  - Branch: `fix/email-env-example-readiness`.
+  - Commit: `ed6bc3d7` (`fix(auth): align email readiness URLs`).
+  - PR #207: `fix(auth): align email readiness URLs`.
+  - GitHub CI passed audit, build, e2e, lint, security, and test before merge.
+  - No deploy, production env change, SMTP/Resend setup, or real email send was
+    performed.
 - Drift-check:
   - `.env.example` has no `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`,
     `SMTP_FROM`, `SMTP_TO`, `OPS_ALERT_EMAIL`, `EMAIL_FROM`,


### PR DESCRIPTION
## Summary
- document existing customer-1 email readiness env vars in `.env.example`, CLAUDE, backlog, and first-customer runbook
- require C1 to verify public `APP_URL` or `WEB_URL` so generated email links do not point at localhost
- align password-reset links with existing mail URL precedence: `APP_URL || FRONTEND_URL || WEB_URL || localhost`
- add static readiness gates plus AuthService regression coverage for all URL fallback tiers

## Verification
- `node --import tsx --test scripts/ops/release-readiness-gates.test.ts` => 21/21
- `pnpm test:ops` => 40/40
- `pnpm --filter @vizora/middleware test -- --runTestsByPath src/modules/auth/auth.service.spec.ts` => 66/66
- `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/auth/auth.service.spec.ts src/modules/mail/mail.service.spec.ts src/modules/health/startup-self-test.service.spec.ts src/modules/organizations/organizations.service.spec.ts` => 126/126
- `$env:ESLINT_USE_FLAT_CONFIG='false'; npx eslint middleware/src/modules/auth/auth.service.ts middleware/src/modules/auth/auth.service.spec.ts` => exit 0, one pre-existing `sanitizeUser` unused `_` warning left unchanged
- `npx nx build @vizora/middleware` => pass, existing webpack dynamic/optional dependency warnings only
- `git diff --check -- ...` => exit 0, LF/CRLF warnings only
- `pnpm security:no-hardcoded-jwts` => pass

## Review
- Claude Code initial review: APPROVE, low/non-blocking findings only
- Follow-up: removed unrelated `sanitizeUser` cleanup and added `FRONTEND_URL`/`WEB_URL` fallback-tier tests
- Claude Code re-review: APPROVE, no high/medium actionable issues

## Operator boundary
No deploy, no production env changes, no real customer email sends, no secrets, no SMTP/Resend setup. C1 remains operator-gated.