### PR TITLE
fix(health): validate email app URLs in self-test

### DIFF
--- a/middleware/src/modules/health/startup-self-test.service.spec.ts
+++ b/middleware/src/modules/health/startup-self-test.service.spec.ts
@@ -10,6 +10,29 @@ describe('StartupSelfTestService', () => {
   let mockRedis: Partial<RedisService>;
   let mockStorage: Partial<StorageService>;
 
+  const withEnv = async (
+    overrides: Record<string, string | undefined>,
+    fn: () => Promise<void>,
+  ) => {
+    const originals = new Map<string, string | undefined>();
+    for (const key of Object.keys(overrides)) {
+      originals.set(key, process.env[key]);
+    }
+
+    try {
+      for (const [key, value] of Object.entries(overrides)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      await fn();
+    } finally {
+      for (const [key, value] of originals.entries()) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  };
+
   beforeEach(async () => {
     mockDb = {
       $queryRaw: jest.fn().mockResolvedValue([{ count: 1n }]),
@@ -125,6 +148,118 @@ describe('StartupSelfTestService', () => {
     it('should include configured flag in email result', async () => {
       const result = await service.runSelfTest();
       expect(typeof result.results.email.configured).toBe('boolean');
+    });
+
+    it('fails production email self-test when SMTP is configured without a public app URL', async () => {
+      await withEnv(
+        {
+          NODE_ENV: 'production',
+          SMTP_HOST: 'smtp.example.test',
+          SMTP_USER: 'apikey',
+          SMTP_PASS: 'secret',
+          SMTP_PASSWORD: undefined,
+          APP_URL: undefined,
+          FRONTEND_URL: undefined,
+          WEB_URL: undefined,
+        },
+        async () => {
+          const result = await service.runSelfTest();
+
+          expect(result.results.email.passed).toBe(false);
+          expect(result.results.email.configured).toBe(true);
+          expect(result.results.email.message).toContain('APP_URL');
+          expect(result.results.email.message).toContain('WEB_URL');
+          expect(result.results.email.message).toContain('public');
+        },
+      );
+    });
+
+    it('fails production email self-test when the configured app URL is localhost', async () => {
+      await withEnv(
+        {
+          NODE_ENV: 'production',
+          SMTP_HOST: 'smtp.example.test',
+          SMTP_USER: 'apikey',
+          SMTP_PASS: 'secret',
+          SMTP_PASSWORD: undefined,
+          APP_URL: 'http://localhost:3001',
+          FRONTEND_URL: undefined,
+          WEB_URL: undefined,
+        },
+        async () => {
+          const result = await service.runSelfTest();
+
+          expect(result.results.email.passed).toBe(false);
+          expect(result.results.email.configured).toBe(true);
+          expect(result.results.email.message).toContain('must be a public HTTPS URL');
+        },
+      );
+    });
+
+    it('fails production email self-test when the configured app URL is not HTTPS', async () => {
+      await withEnv(
+        {
+          NODE_ENV: 'production',
+          SMTP_HOST: 'smtp.example.test',
+          SMTP_USER: 'apikey',
+          SMTP_PASS: 'secret',
+          SMTP_PASSWORD: undefined,
+          APP_URL: 'http://vizora.cloud',
+          FRONTEND_URL: undefined,
+          WEB_URL: undefined,
+        },
+        async () => {
+          const result = await service.runSelfTest();
+
+          expect(result.results.email.passed).toBe(false);
+          expect(result.results.email.configured).toBe(true);
+          expect(result.results.email.message).toContain('must be a public HTTPS URL');
+        },
+      );
+    });
+
+    it('fails production email self-test when the configured app URL is an HTTPS loopback host', async () => {
+      await withEnv(
+        {
+          NODE_ENV: 'production',
+          SMTP_HOST: 'smtp.example.test',
+          SMTP_USER: 'apikey',
+          SMTP_PASS: 'secret',
+          SMTP_PASSWORD: undefined,
+          APP_URL: 'https://[::1]',
+          FRONTEND_URL: undefined,
+          WEB_URL: undefined,
+        },
+        async () => {
+          const result = await service.runSelfTest();
+
+          expect(result.results.email.passed).toBe(false);
+          expect(result.results.email.configured).toBe(true);
+          expect(result.results.email.message).toContain('must be a public HTTPS URL');
+        },
+      );
+    });
+
+    it('fails production email self-test when the configured app URL is malformed', async () => {
+      await withEnv(
+        {
+          NODE_ENV: 'production',
+          SMTP_HOST: 'smtp.example.test',
+          SMTP_USER: 'apikey',
+          SMTP_PASS: 'secret',
+          SMTP_PASSWORD: undefined,
+          APP_URL: 'not-a-url',
+          FRONTEND_URL: undefined,
+          WEB_URL: undefined,
+        },
+        async () => {
+          const result = await service.runSelfTest();
+
+          expect(result.results.email.passed).toBe(false);
+          expect(result.results.email.configured).toBe(true);
+          expect(result.results.email.message).toContain('must be a public HTTPS URL');
+        },
+      );
     });
 
     it('should include stripe and razorpay flags in billing result', async () => {

--- a/middleware/src/modules/health/startup-self-test.service.ts
+++ b/middleware/src/modules/health/startup-self-test.service.ts
@@ -333,6 +333,21 @@ export class StartupSelfTestService implements OnApplicationBootstrap {
       };
     }
 
+    const appUrlCheck = this.checkProductionEmailAppUrl();
+    if (!appUrlCheck.passed) {
+      return {
+        passed: false,
+        message: appUrlCheck.message,
+        duration_ms: Date.now() - start,
+        configured,
+        details: {
+          APP_URL: !!process.env.APP_URL,
+          FRONTEND_URL: !!process.env.FRONTEND_URL,
+          WEB_URL: !!process.env.WEB_URL,
+        },
+      };
+    }
+
     // Verify SMTP connectivity (connect only, don't send)
     try {
       const nodemailer = await import('nodemailer');
@@ -359,6 +374,52 @@ export class StartupSelfTestService implements OnApplicationBootstrap {
         message: `SMTP configured but connection failed: ${error instanceof Error ? error.message : String(error)}`,
         duration_ms: Date.now() - start,
         configured,
+      };
+    }
+  }
+
+  private checkProductionEmailAppUrl(): { passed: boolean; message: string } {
+    if (process.env.NODE_ENV !== 'production') {
+      return { passed: true, message: 'Email app URL check skipped outside production' };
+    }
+
+    const source = process.env.APP_URL
+      ? 'APP_URL'
+      : process.env.FRONTEND_URL
+        ? 'FRONTEND_URL'
+        : process.env.WEB_URL
+          ? 'WEB_URL'
+          : null;
+    const appUrl = source ? process.env[source] : undefined;
+
+    if (!appUrl) {
+      return {
+        passed: false,
+        message: 'SMTP configured in production but APP_URL, FRONTEND_URL, or WEB_URL is missing; transactional email links need a public app URL',
+      };
+    }
+
+    try {
+      const parsed = new URL(appUrl);
+      const hostname = parsed.hostname.toLowerCase();
+      const isLocalhost =
+        hostname === 'localhost' ||
+        hostname === '0.0.0.0' ||
+        hostname === '[::1]' ||
+        hostname.startsWith('127.');
+
+      if (parsed.protocol !== 'https:' || isLocalhost) {
+        return {
+          passed: false,
+          message: `${source} must be a public HTTPS URL for production transactional email links`,
+        };
+      }
+
+      return { passed: true, message: `${source} is a public transactional email-link URL` };
+    } catch {
+      return {
+        passed: false,
+        message: `${source} must be a public HTTPS URL for production transactional email links`,
       };
     }
   }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,6 @@
 # Vizora - Task Tracker
 
-## Active Workstream: Startup Email URL Self-Test Pass 68 (2026-06-03)
+## Completed Workstream: Startup Email URL Self-Test Pass 68 (2026-06-03)
 
 **Branch:** `fix/startup-email-url-self-test`
 
@@ -38,11 +38,18 @@ local NestJS config-readiness validation.
 - [x] Run focused health tests, affected ops/static gates, middleware build,
       diff hygiene, and secret scan.
 - [x] Request Claude Code review and resolve findings.
-- [ ] Commit, PR, CI, and merge if green.
-- [ ] Do not deploy, send real emails, or touch production SMTP/env state.
+- [x] Commit, PR, CI, and merge if green.
+- [x] Do not deploy, send real emails, or touch production SMTP/env state.
 
 **Evidence so far**
 - Current `origin/main`: `58650b6bebe50d1fa55264384acb69d154314abd`.
+- Branch/PR:
+  - Branch: `fix/startup-email-url-self-test`.
+  - Commit: `6e49c9ac` (`fix(health): validate email app URLs in self-test`).
+  - PR #208: `fix(health): validate email app URLs in self-test`.
+  - GitHub CI passed audit, build, e2e, lint, security, and test before merge.
+  - No deploy, production env change, SMTP/Resend setup, or real email send was
+    performed.
 - Drift-check:
   - `StartupSelfTestService.checkEmail()` validates SMTP env presence and calls
     `transporter.verify()` when configured.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,94 @@
 # Vizora - Task Tracker
 
+## Active Workstream: Startup Email URL Self-Test Pass 68 (2026-06-03)
+
+**Branch:** `fix/startup-email-url-self-test`
+
+**Why now:** PR #207 made the C1 operator runbook require a public `APP_URL` or
+`WEB_URL` for backend-generated email links, and aligned password-reset links
+with that precedence. The admin-only startup self-test already surfaces SMTP
+configuration/connectivity, but it still cannot warn the operator if SMTP is
+configured while the email-link host is absent or points at localhost in
+production.
+
+**New primitives introduced:** none planned. This pass should extend the
+existing `StartupSelfTestService.checkEmail()` result only. No route, model,
+migration, env var, process, realtime event, MCP tool, Hermes skill,
+AI/provider spend path, customer email send, production env change, or deploy is
+expected.
+
+**Hermes-first analysis:** checked per project convention. This is deterministic
+NestJS health/self-test validation, not a business-agent, MCP, Hermes runtime,
+or provider-spend task.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Email-link URL readiness validation | none applicable | extend existing startup self-test |
+| Admin-only health result coverage | none applicable | extend existing Jest spec |
+
+Awesome-hermes-agent ecosystem check: no applicable skill/library primitive for
+local NestJS config-readiness validation.
+
+**Plan**
+- [ ] Add failing startup self-test coverage for production SMTP configured with
+      missing/localhost email-link URL.
+- [ ] Extend `checkEmail()` so production self-test fails closed for SMTP
+      configured without a public `APP_URL`/`FRONTEND_URL`/`WEB_URL`, while
+      preserving dev behavior and not sending email.
+- [x] Run focused health tests, affected ops/static gates, middleware build,
+      diff hygiene, and secret scan.
+- [x] Request Claude Code review and resolve findings.
+- [ ] Commit, PR, CI, and merge if green.
+- [ ] Do not deploy, send real emails, or touch production SMTP/env state.
+
+**Evidence so far**
+- Current `origin/main`: `58650b6bebe50d1fa55264384acb69d154314abd`.
+- Drift-check:
+  - `StartupSelfTestService.checkEmail()` validates SMTP env presence and calls
+    `transporter.verify()` when configured.
+  - It currently has no awareness of `APP_URL`, `FRONTEND_URL`, or `WEB_URL`.
+  - Public readiness endpoint hides self-test details; admin-only
+    `/api/v1/health/self-test` exposes them.
+- Red focused run:
+  - `pnpm --filter @vizora/middleware test -- --runTestsByPath src/modules/health/startup-self-test.service.spec.ts`
+    failed as expected: production SMTP-configured self-test reported SMTP DNS
+    failure instead of missing/localhost public app URL.
+- Fix:
+  - `checkEmail()` now validates production email-link URL readiness only after
+    SMTP is configured. It accepts `APP_URL || FRONTEND_URL || WEB_URL` and
+    requires the resolved URL to be public HTTPS in production.
+  - Non-production behavior and the no-SMTP warning-only behavior are preserved.
+  - The check verifies configuration only; it does not send email or change
+    production state.
+  - Claude review found a broader pre-existing URL-precedence inconsistency
+    outside transactional email (`billing.service.ts`, `pairing.service.ts`,
+    `organizations.service.ts`). This pass narrows self-test wording to
+    transactional email links and leaves a follow-up candidate to extract a
+    shared public-app-URL resolver for all absolute URL builders.
+  - Review follow-up also added non-HTTPS and malformed URL branch coverage and
+    corrected IPv6 loopback detection for `https://[::1]/`.
+  - Final review follow-up added an HTTPS loopback test so the loopback branch
+    is covered independently of the non-HTTPS branch.
+- Green verification:
+  - `pnpm --filter @vizora/middleware test -- --runTestsByPath src/modules/health/startup-self-test.service.spec.ts`
+    => 21/21 tests passing.
+  - `$env:ESLINT_USE_FLAT_CONFIG='false'; npx eslint middleware/src/modules/health/startup-self-test.service.ts middleware/src/modules/health/startup-self-test.service.spec.ts`
+    => exit 0.
+  - `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/health/startup-self-test.service.spec.ts src/modules/health/health.controller.spec.ts src/modules/health/health.service.spec.ts src/modules/health/continuous-health-monitor.service.spec.ts src/modules/health/regression-guards.spec.ts`
+    => 97/97 tests passing.
+  - `pnpm test:ops` => 40/40 ops tests passing.
+  - `node --import tsx --test scripts/ops/release-readiness-gates.test.ts`
+    => 21/21 tests passing.
+  - `npx nx build @vizora/middleware` => passing; existing webpack warnings
+    remain for dynamic/optional dependencies.
+  - `pnpm security:no-hardcoded-jwts` => passing.
+- Claude Code review:
+  - Initial review returned `APPROVE` and recommended adding non-HTTPS and
+    malformed URL tests plus narrowing wording to transactional email links.
+  - Re-review returned `APPROVE` and requested one more HTTPS loopback test to
+    isolate the `isLocalhost` branch.
+  - Final re-review returned `APPROVE` with no high/medium actionable issues.
+
 ## Completed Workstream: Email Env Example + App URL Readiness Pass 67 (2026-06-03)
 
 **Branch:** `fix/email-env-example-readiness`


### PR DESCRIPTION
## Summary
- make the admin-only startup self-test flag production SMTP configurations whose transactional email-link URL is missing, localhost/loopback, non-HTTPS, or malformed
- preserve existing no-SMTP warning-only behavior and non-production behavior
- keep the check non-sending and non-fatal: it only records self-test failure details for operators
- add focused coverage for missing URL, localhost, non-HTTPS, HTTPS loopback, and malformed URL cases

## Verification
- red first: startup self-test spec failed because current code went straight to SMTP DNS failure instead of URL readiness
- `pnpm --filter @vizora/middleware test -- --runTestsByPath src/modules/health/startup-self-test.service.spec.ts` => 21/21
- `$env:ESLINT_USE_FLAT_CONFIG='false'; npx eslint middleware/src/modules/health/startup-self-test.service.ts middleware/src/modules/health/startup-self-test.service.spec.ts` => exit 0
- `pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/health/startup-self-test.service.spec.ts src/modules/health/health.controller.spec.ts src/modules/health/health.service.spec.ts src/modules/health/continuous-health-monitor.service.spec.ts src/modules/health/regression-guards.spec.ts` => 97/97
- `pnpm test:ops` => 40/40
- `node --import tsx --test scripts/ops/release-readiness-gates.test.ts` => 21/21
- `npx nx build @vizora/middleware` => pass, existing webpack dynamic/optional dependency warnings only
- `git diff --check -- ...` => exit 0, LF/CRLF warnings only
- `pnpm security:no-hardcoded-jwts` => pass

## Review
- Claude Code review: APPROVE after follow-ups
- Follow-ups applied: non-HTTPS/malformed tests, transactional-email wording, IPv6 loopback fix, HTTPS loopback branch test
- Final Claude Code review: APPROVE, no high/medium actionable issues

## Operator boundary
No deploy, no production env changes, no SMTP/Resend setup, and no real emails. C1 remains operator-gated; this only improves the admin-visible self-test signal.