### PR TITLE
fix(middleware): unify public app URL resolution

### DIFF
--- a/middleware/src/modules/auth/auth.service.ts
+++ b/middleware/src/modules/auth/auth.service.ts
@@ -26,6 +26,7 @@ import { BillingService } from '../billing/billing.service';
 import { StorageService } from '../storage/storage.service';
 import { getCleanupSafeMinioObjectKey, isMinioUrl } from '../storage/minio-object-key';
 import { AlertRulesService } from '../notifications/alert-rules/alert-rules.service';
+import { resolvePublicAppUrl } from '../common/utils/public-app-url';
 
 // Account lockout constants
 const MAX_LOGIN_ATTEMPTS = 10;
@@ -659,9 +660,7 @@ export class AuthService {
     });
 
     // Build reset URL
-    const frontendUrl =
-      process.env.APP_URL || process.env.FRONTEND_URL || process.env.WEB_URL || 'http://localhost:3001';
-    const resetUrl = `${frontendUrl}/reset-password?token=${rawToken}`;
+    const resetUrl = `${resolvePublicAppUrl()}/reset-password?token=${rawToken}`;
 
     // Send email (uses raw token, not hashed)
     await this.mailService.sendPasswordResetEmail(user.email, user.firstName, resetUrl);

--- a/middleware/src/modules/billing/billing.service.spec.ts
+++ b/middleware/src/modules/billing/billing.service.spec.ts
@@ -1,5 +1,4 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ConfigService } from '@nestjs/config';
 import { NotFoundException, BadRequestException } from '@nestjs/common';
 import { BillingService } from './billing.service';
 import { DatabaseService } from '../database/database.service';
@@ -22,7 +21,6 @@ beforeAll(() => {
 describe('BillingService', () => {
   let service: BillingService;
   let mockDatabaseService: any;
-  let mockConfigService: any;
   let mockStripeProvider: any;
   let mockRazorpayProvider: any;
   let mockRedisService: any;
@@ -90,17 +88,6 @@ describe('BillingService', () => {
       },
     };
 
-    mockConfigService = {
-      get: jest.fn().mockImplementation((key: string) => {
-        const config: Record<string, string> = {
-          APP_URL: 'http://localhost:3001',
-          STRIPE_SECRET_KEY: 'sk_test_123',
-          RAZORPAY_KEY_ID: 'rzp_test_123',
-        };
-        return config[key];
-      }),
-    };
-
     mockStripeProvider = {
       name: 'stripe',
       createCustomer: jest.fn(),
@@ -145,7 +132,6 @@ describe('BillingService', () => {
       providers: [
         BillingService,
         { provide: DatabaseService, useValue: mockDatabaseService },
-        { provide: ConfigService, useValue: mockConfigService },
         { provide: StripeProvider, useValue: mockStripeProvider },
         { provide: RazorpayProvider, useValue: mockRazorpayProvider },
         { provide: MailService, useValue: mockMailService },
@@ -382,6 +368,41 @@ describe('BillingService', () => {
           cancelUrl: expect.stringContaining('/billing/cancel'),
         }),
       );
+    });
+
+    it('should use APP_URL for generated checkout return URLs before legacy fallbacks', async () => {
+      const originalAppUrl = process.env.APP_URL;
+      const originalFrontendUrl = process.env.FRONTEND_URL;
+      const originalWebUrl = process.env.WEB_URL;
+
+      try {
+        process.env.APP_URL = 'https://app.vizora.test';
+        process.env.FRONTEND_URL = 'https://legacy.vizora.test';
+        process.env.WEB_URL = 'https://web.vizora.test';
+        mockDatabaseService.organization.findUnique.mockResolvedValue(mockOrganization);
+        mockStripeProvider.createCheckoutSession.mockResolvedValue({
+          url: 'https://checkout.stripe.com/session123',
+          sessionId: 'cs_test_123',
+        });
+
+        await service.createCheckoutSession('org-123', checkoutDto);
+
+        expect(mockStripeProvider.createCheckoutSession).toHaveBeenCalledWith(
+          expect.objectContaining({
+            successUrl: 'https://app.vizora.test/dashboard/settings/billing/success',
+            cancelUrl: 'https://app.vizora.test/dashboard/settings/billing/cancel',
+          }),
+        );
+      } finally {
+        if (originalAppUrl === undefined) delete process.env.APP_URL;
+        else process.env.APP_URL = originalAppUrl;
+
+        if (originalFrontendUrl === undefined) delete process.env.FRONTEND_URL;
+        else process.env.FRONTEND_URL = originalFrontendUrl;
+
+        if (originalWebUrl === undefined) delete process.env.WEB_URL;
+        else process.env.WEB_URL = originalWebUrl;
+      }
     });
 
     it('should create checkout session with Razorpay for Indian organization', async () => {

--- a/middleware/src/modules/billing/billing.service.ts
+++ b/middleware/src/modules/billing/billing.service.ts
@@ -5,14 +5,11 @@ import {
   NotFoundException,
   OnModuleInit,
 } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { DatabaseService } from '../database/database.service';
 import { StripeProvider } from './providers/stripe.provider';
 import { RazorpayProvider } from './providers/razorpay.provider';
 import {
   PaymentProvider,
-  Subscription,
-  WebhookEvent,
 } from './providers/payment-provider.interface';
 import { CreateCheckoutDto } from './dto/create-checkout.dto';
 import { UpdateSubscriptionDto } from './dto/update-subscription.dto';
@@ -32,6 +29,7 @@ import {
 } from './constants/plans';
 import { MailService } from '../mail/mail.service';
 import { RedisService } from '../redis/redis.service';
+import { resolvePublicAppUrl } from '../common/utils/public-app-url';
 
 /** Webhook event data from Stripe/Razorpay — deeply nested untyped objects */
 interface WebhookData {
@@ -44,7 +42,6 @@ export class BillingService implements OnModuleInit {
 
   constructor(
     private readonly db: DatabaseService,
-    private readonly configService: ConfigService,
     private readonly stripeProvider: StripeProvider,
     private readonly razorpayProvider: RazorpayProvider,
     private readonly mailService: MailService,
@@ -287,7 +284,7 @@ export class BillingService implements OnModuleInit {
       throw new BadRequestException(`Price not configured for ${dto.planId} (${currency})`);
     }
 
-    const baseUrl = this.configService.get<string>('APP_URL') || 'http://localhost:3001';
+    const baseUrl = resolvePublicAppUrl();
     const successUrl = dto.successUrl || `${baseUrl}/dashboard/settings/billing/success`;
     const cancelUrl = dto.cancelUrl || `${baseUrl}/dashboard/settings/billing/cancel`;
 

--- a/middleware/src/modules/common/utils/public-app-url.spec.ts
+++ b/middleware/src/modules/common/utils/public-app-url.spec.ts
@@ -1,0 +1,59 @@
+import {
+  DEFAULT_PUBLIC_APP_URL,
+  resolvePublicAppUrl,
+  resolvePublicAppUrlWithSource,
+} from './public-app-url';
+
+describe('public app URL resolver', () => {
+  const KEYS = ['APP_URL', 'FRONTEND_URL', 'WEB_URL'] as const;
+  let originalEnv: Partial<Record<(typeof KEYS)[number], string | undefined>>;
+
+  beforeEach(() => {
+    originalEnv = {};
+    for (const key of KEYS) {
+      originalEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of KEYS) {
+      const value = originalEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it('prefers APP_URL before legacy fallbacks', () => {
+    process.env.APP_URL = 'https://app.vizora.test/';
+    process.env.FRONTEND_URL = 'https://legacy.vizora.test';
+    process.env.WEB_URL = 'https://web.vizora.test';
+
+    expect(resolvePublicAppUrl()).toBe('https://app.vizora.test');
+    expect(resolvePublicAppUrlWithSource()).toEqual({
+      source: 'APP_URL',
+      url: 'https://app.vizora.test',
+    });
+  });
+
+  it('falls back from FRONTEND_URL to WEB_URL before localhost', () => {
+    process.env.WEB_URL = 'https://web.vizora.test';
+
+    expect(resolvePublicAppUrl()).toBe('https://web.vizora.test');
+
+    process.env.FRONTEND_URL = 'https://frontend.vizora.test';
+
+    expect(resolvePublicAppUrl()).toBe('https://frontend.vizora.test');
+  });
+
+  it('uses the provided fallback when no public URL env var is set', () => {
+    expect(resolvePublicAppUrl()).toBe(DEFAULT_PUBLIC_APP_URL);
+    expect(resolvePublicAppUrlWithSource('https://fallback.vizora.test')).toEqual({
+      source: 'fallback',
+      url: 'https://fallback.vizora.test',
+    });
+  });
+});

--- a/middleware/src/modules/common/utils/public-app-url.ts
+++ b/middleware/src/modules/common/utils/public-app-url.ts
@@ -1,0 +1,38 @@
+export const DEFAULT_PUBLIC_APP_URL = 'http://localhost:3001';
+
+const PUBLIC_APP_URL_ENV_KEYS = ['APP_URL', 'FRONTEND_URL', 'WEB_URL'] as const;
+
+export type PublicAppUrlSource =
+  | (typeof PUBLIC_APP_URL_ENV_KEYS)[number]
+  | 'fallback';
+
+export interface ResolvedPublicAppUrl {
+  url: string;
+  source: PublicAppUrlSource;
+}
+
+function normalizePublicAppUrl(url: string): string {
+  return url.trim().replace(/\/+$/, '');
+}
+
+export function resolvePublicAppUrl(
+  fallback = DEFAULT_PUBLIC_APP_URL,
+): string {
+  return resolvePublicAppUrlWithSource(fallback).url;
+}
+
+export function resolvePublicAppUrlWithSource(
+  fallback = DEFAULT_PUBLIC_APP_URL,
+): ResolvedPublicAppUrl {
+  for (const source of PUBLIC_APP_URL_ENV_KEYS) {
+    const value = process.env[source];
+    if (value?.trim()) {
+      return { source, url: normalizePublicAppUrl(value) };
+    }
+  }
+
+  return {
+    source: 'fallback',
+    url: normalizePublicAppUrl(fallback),
+  };
+}

--- a/middleware/src/modules/displays/pairing.service.spec.ts
+++ b/middleware/src/modules/displays/pairing.service.spec.ts
@@ -437,6 +437,34 @@ describe('PairingService', () => {
       expect(result.pairingUrl).toContain('/dashboard/devices/pair');
     });
 
+    it('should use APP_URL for pairing URLs before legacy fallbacks', async () => {
+      const originalAppUrl = process.env.APP_URL;
+      const originalFrontendUrl = process.env.FRONTEND_URL;
+      const originalWebUrl = process.env.WEB_URL;
+
+      try {
+        process.env.APP_URL = 'https://app.vizora.test';
+        process.env.FRONTEND_URL = 'https://legacy.vizora.test';
+        process.env.WEB_URL = 'https://web.vizora.test';
+        mockDatabaseService.display.findUnique.mockResolvedValue(null);
+
+        const result = await service.requestPairingCode(mockRequestDto);
+
+        expect(result.pairingUrl).toBe(
+          `https://app.vizora.test/dashboard/devices/pair?code=${result.code}`,
+        );
+      } finally {
+        if (originalAppUrl === undefined) delete process.env.APP_URL;
+        else process.env.APP_URL = originalAppUrl;
+
+        if (originalFrontendUrl === undefined) delete process.env.FRONTEND_URL;
+        else process.env.FRONTEND_URL = originalFrontendUrl;
+
+        if (originalWebUrl === undefined) delete process.env.WEB_URL;
+        else process.env.WEB_URL = originalWebUrl;
+      }
+    });
+
     it('should throw if Redis storage fails', async () => {
       mockDatabaseService.display.findUnique.mockResolvedValue(null);
       mockRedisService.set.mockResolvedValueOnce(false);

--- a/middleware/src/modules/displays/pairing.service.ts
+++ b/middleware/src/modules/displays/pairing.service.ts
@@ -13,6 +13,7 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { DatabaseService } from '../database/database.service';
 import { RedisService } from '../redis/redis.service';
 import { ProvisioningTemplatesService } from '../provisioning-templates/provisioning-templates.service';
+import { resolvePublicAppUrl } from '../common/utils/public-app-url';
 import { RequestPairingDto } from './dto/request-pairing.dto';
 import { CompletePairingDto } from './dto/complete-pairing.dto';
 import type { Prisma } from '@vizora/database';
@@ -411,7 +412,7 @@ export class PairingService implements OnModuleDestroy {
     const expiresAt = new Date(now.getTime() + this.PAIRING_EXPIRY_MS);
 
     // Generate QR code
-    const pairingUrl = `${process.env.WEB_URL || 'http://localhost:3001'}/dashboard/devices/pair?code=${code}`;
+    const pairingUrl = `${resolvePublicAppUrl()}/dashboard/devices/pair?code=${code}`;
     let qrCodeDataUrl: string | undefined;
 
     try {

--- a/middleware/src/modules/health/startup-self-test.service.ts
+++ b/middleware/src/modules/health/startup-self-test.service.ts
@@ -5,6 +5,7 @@ import { StorageService } from '../storage/storage.service';
 import * as http from 'http';
 import * as fs from 'fs';
 import * as path from 'path';
+import { resolvePublicAppUrlWithSource } from '../common/utils/public-app-url';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -383,16 +384,8 @@ export class StartupSelfTestService implements OnApplicationBootstrap {
       return { passed: true, message: 'Email app URL check skipped outside production' };
     }
 
-    const source = process.env.APP_URL
-      ? 'APP_URL'
-      : process.env.FRONTEND_URL
-        ? 'FRONTEND_URL'
-        : process.env.WEB_URL
-          ? 'WEB_URL'
-          : null;
-    const appUrl = source ? process.env[source] : undefined;
-
-    if (!appUrl) {
+    const resolved = resolvePublicAppUrlWithSource('');
+    if (resolved.source === 'fallback') {
       return {
         passed: false,
         message: 'SMTP configured in production but APP_URL, FRONTEND_URL, or WEB_URL is missing; transactional email links need a public app URL',
@@ -400,7 +393,7 @@ export class StartupSelfTestService implements OnApplicationBootstrap {
     }
 
     try {
-      const parsed = new URL(appUrl);
+      const parsed = new URL(resolved.url);
       const hostname = parsed.hostname.toLowerCase();
       const isLocalhost =
         hostname === 'localhost' ||
@@ -411,15 +404,15 @@ export class StartupSelfTestService implements OnApplicationBootstrap {
       if (parsed.protocol !== 'https:' || isLocalhost) {
         return {
           passed: false,
-          message: `${source} must be a public HTTPS URL for production transactional email links`,
+          message: `${resolved.source} must be a public HTTPS URL for production transactional email links`,
         };
       }
 
-      return { passed: true, message: `${source} is a public transactional email-link URL` };
+      return { passed: true, message: `${resolved.source} is a public transactional email-link URL` };
     } catch {
       return {
         passed: false,
-        message: `${source} must be a public HTTPS URL for production transactional email links`,
+        message: `${resolved.source} must be a public HTTPS URL for production transactional email links`,
       };
     }
   }

--- a/middleware/src/modules/mail/mail.service.ts
+++ b/middleware/src/modules/mail/mail.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import * as nodemailer from 'nodemailer';
+import { resolvePublicAppUrl } from '../common/utils/public-app-url';
 
 /** Sender identities — from uses verified mail.vizora.cloud, reply-to goes to real inboxes */
 const SENDERS = {
@@ -55,7 +56,7 @@ export class MailService {
   }
 
   private get appUrl(): string {
-    return process.env.APP_URL || process.env.FRONTEND_URL || process.env.WEB_URL || 'http://localhost:3001';
+    return resolvePublicAppUrl();
   }
 
   private get upgradeUrl(): string {

--- a/middleware/src/modules/organizations/organizations.service.spec.ts
+++ b/middleware/src/modules/organizations/organizations.service.spec.ts
@@ -313,6 +313,10 @@ describe('OrganizationsService', () => {
   });
 
   describe('sendOnboardingNudge (customer-lifecycle write — high blast radius)', () => {
+    let originalAppUrl: string | undefined;
+    let originalFrontendUrl: string | undefined;
+    let originalWebUrl: string | undefined;
+
     beforeEach(() => {
       // Default: claim succeeds (existing row had col=null, claim flipped it)
       mockDatabaseService.organizationOnboarding.updateMany.mockResolvedValue({ count: 1 });
@@ -327,6 +331,23 @@ describe('OrganizationsService', () => {
       // Reset env between tests
       delete process.env.LIFECYCLE_LIVE;
       delete process.env.LIFECYCLE_TEST_EMAILS;
+      originalAppUrl = process.env.APP_URL;
+      originalFrontendUrl = process.env.FRONTEND_URL;
+      originalWebUrl = process.env.WEB_URL;
+      delete process.env.APP_URL;
+      delete process.env.FRONTEND_URL;
+      delete process.env.WEB_URL;
+    });
+
+    afterEach(() => {
+      if (originalAppUrl === undefined) delete process.env.APP_URL;
+      else process.env.APP_URL = originalAppUrl;
+
+      if (originalFrontendUrl === undefined) delete process.env.FRONTEND_URL;
+      else process.env.FRONTEND_URL = originalFrontendUrl;
+
+      if (originalWebUrl === undefined) delete process.env.WEB_URL;
+      else process.env.WEB_URL = originalWebUrl;
     });
 
     afterAll(() => {
@@ -390,6 +411,25 @@ describe('OrganizationsService', () => {
       if (out.recipientHashes.length > 0) {
         expect(out.recipientHashes[0]).toMatch(/^[a-f0-9]{16}$/);
       }
+    });
+
+    it('uses the shared public app URL for lifecycle dashboard links', async () => {
+      const sendMail = jest.fn().mockResolvedValue({});
+      (service as unknown as { lifecycleTransporter: { sendMail: typeof sendMail } }).lifecycleTransporter = {
+        sendMail,
+      };
+      process.env.FRONTEND_URL = 'https://frontend.vizora.test/';
+      process.env.WEB_URL = 'https://web.vizora.test';
+      process.env.LIFECYCLE_TEST_EMAILS = 'redirect@example.test';
+
+      const out = await service.sendOnboardingNudge('org-1', 'day1-pair-screen');
+
+      expect(out.reason).toBe('sent');
+      expect(sendMail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining('https://frontend.vizora.test/dashboard'),
+        }),
+      );
     });
 
     it('creates a fresh onboarding row when one does not exist (no double-claim)', async () => {

--- a/middleware/src/modules/organizations/organizations.service.ts
+++ b/middleware/src/modules/organizations/organizations.service.ts
@@ -8,6 +8,7 @@ import { PaginationDto, PaginatedResponse } from '../common/dto/pagination.dto';
 import { StorageService } from '../storage/storage.service';
 import { getCleanupSafeMinioObjectKey, isMinioUrl } from '../storage/minio-object-key';
 import { RedisService } from '../redis/redis.service';
+import { resolvePublicAppUrl } from '../common/utils/public-app-url';
 
 @Injectable()
 export class OrganizationsService {
@@ -401,8 +402,7 @@ export class OrganizationsService {
       };
     }
 
-    const appUrl =
-      process.env.APP_URL || process.env.WEB_URL || 'https://vizora.cloud';
+    const appUrl = resolvePublicAppUrl('https://vizora.cloud');
     const body = `Hi,\n\n${subject}.\n\nOpen your dashboard: ${appUrl}/dashboard\n\n— Vizora`;
     const from = process.env.EMAIL_FROM || 'Vizora <noreply@mail.vizora.cloud>';
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,84 @@
 # Vizora - Task Tracker
 
+## Active Workstream: Shared Public App URL Resolver Pass 69 (2026-06-03)
+
+**Branch:** `fix/public-app-url-resolver`
+
+**Why now:** PR #208 intentionally scoped startup self-test validation to
+transactional email links, but review confirmed a pre-existing false-green risk:
+other absolute URL builders use different env precedence. Customer-1 relevant
+case: pairing QR URLs use `WEB_URL` only, so an operator following C1 guidance
+with `APP_URL` set could still generate localhost pairing links.
+
+**New primitives introduced:** one small middleware utility only:
+`resolvePublicAppUrl()`. No route, model, migration, env var, process, realtime
+event, MCP tool, Hermes skill, AI/provider spend path, customer email send,
+production env change, or deploy is expected.
+
+**Hermes-first analysis:** checked per project convention. This is deterministic
+NestJS URL/env resolution, not a business-agent, MCP, Hermes runtime, or
+provider-spend task.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Public app URL env precedence | none applicable | extract tiny local utility |
+| Pairing QR URL coverage | none applicable | extend existing pairing tests |
+| Billing/organization/mail/auth URL drift | none applicable | reuse utility in existing services |
+
+Awesome-hermes-agent ecosystem check: no applicable skill/library primitive for
+local env-var URL resolution.
+
+**Plan**
+- [x] Add focused failing coverage showing pairing URLs honor `APP_URL` before
+      legacy fallbacks.
+- [x] Add `resolvePublicAppUrl()` and migrate middleware absolute URL builders
+      that currently read `APP_URL`/`FRONTEND_URL`/`WEB_URL` ad hoc.
+- [x] Run focused pairing/auth/mail/billing/organization/health tests, build,
+      diff hygiene, and secret scan.
+- [x] Request Claude Code review and resolve findings.
+- [ ] Commit, PR, CI, and merge if green.
+- [x] Do not deploy, send real emails, or touch production env state.
+
+**Evidence so far**
+- Current `origin/main`: `3aee89941fc851852acbc2060623efaa7a2d6358`.
+- Drift-check:
+  - `mail.service.ts` and `auth.service.ts` use
+    `APP_URL || FRONTEND_URL || WEB_URL || localhost`.
+  - `pairing.service.ts` uses `WEB_URL || localhost`.
+  - `billing.service.ts` uses `APP_URL || localhost`.
+  - `organizations.service.ts` uses `APP_URL || WEB_URL || https://vizora.cloud`.
+  - `StartupSelfTestService` validates only transactional email URL precedence,
+    so it cannot prove the pairing/billing/lifecycle URL builders are aligned.
+- Red test:
+  - `pnpm --filter @vizora/middleware test -- --runTestsByPath src/modules/displays/pairing.service.spec.ts`
+    failed as expected because pairing URLs still preferred `WEB_URL` over
+    `APP_URL`.
+- Implementation:
+  - Added `middleware/src/modules/common/utils/public-app-url.ts` with
+    precedence `APP_URL -> FRONTEND_URL -> WEB_URL -> fallback`.
+  - Migrated pairing QR URLs, password-reset links, mail template links,
+    billing checkout return URLs, lifecycle nudge dashboard links, and the
+    startup self-test URL source check to the shared resolver.
+  - Preserved the lifecycle nudge default fallback of `https://vizora.cloud`.
+- Verification:
+  - Focused middleware tests: 7 suites / 211 tests passed.
+  - Full middleware unit suite: 149 suites / 3055 tests passed.
+  - `pnpm test:ops`: 40/40 passed.
+  - `node --import tsx --test scripts/ops/release-readiness-gates.test.ts`:
+    21/21 passed.
+  - Targeted ESLint exited 0 with one pre-existing auth warning at
+    `auth.service.ts:1225` (`_` unused).
+  - `pnpm build:middleware` passed with the existing webpack warning profile.
+  - `pnpm security:no-hardcoded-jwts` passed.
+  - `git diff --check` passed.
+- Claude Code review:
+  - CLEAN, no high/medium findings. Reviewer explicitly validated resolver
+    precedence, StartupSelfTestService/source alignment, billing `ConfigService`
+    removal safety, test isolation, and operator/deploy boundaries.
+- Runtime/operator boundary:
+  - No production deploy, production env edit, real email send, secret change,
+    payment setup, or hardware action was performed.
+
 ## Completed Workstream: Startup Email URL Self-Test Pass 68 (2026-06-03)
 
 **Branch:** `fix/startup-email-url-self-test`


### PR DESCRIPTION
## Summary
- Add shared middleware public app URL resolver with precedence APP_URL -> FRONTEND_URL -> WEB_URL -> fallback.
- Migrate password reset links, mail template links, billing checkout return URLs, pairing QR URLs, lifecycle nudge dashboard links, and startup self-test source validation to the shared resolver.
- Preserve lifecycle nudge fallback to https://vizora.cloud and make no env/prod/deploy/email/payment changes.

## Verification
- Red pairing test failed before implementation because pairing preferred WEB_URL over APP_URL.
- pnpm --filter @vizora/middleware test -- --runInBand --runTestsByPath src/modules/common/utils/public-app-url.spec.ts src/modules/displays/pairing.service.spec.ts src/modules/auth/auth.service.spec.ts src/modules/mail/mail.service.spec.ts src/modules/billing/billing.service.spec.ts src/modules/organizations/organizations.service.spec.ts src/modules/health/startup-self-test.service.spec.ts: 7 suites / 211 tests passed.
- pnpm --filter @vizora/middleware test -- --runInBand: 149 suites / 3055 tests passed.
- pnpm test:ops: 40/40 passed.
- node --import tsx --test scripts/ops/release-readiness-gates.test.ts: 21/21 passed.
- targeted ESLint exited 0 with one pre-existing auth.service.ts unused '_' warning.
- pnpm build:middleware passed with existing webpack warnings.
- pnpm security:no-hardcoded-jwts passed.
- git diff --check passed.
- Claude Code review CLEAN, no high/medium findings.