### PR TITLE
docs: record public app URL resolver handoff

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -1,11 +1,11 @@
 # Vizora Backlog
 
-**Last updated:** 2026-06-03 (main at `5ddabb7a`)
+**Last updated:** 2026-06-03 (main at `5d15fff3`)
 **Production readiness:** repo-side foundation strongest on record; customer-1 launch remains operator-gated on C1-C4 below.
-**Tests:** 124 middleware suites / 2335 tests, 10 realtime suites / 212 tests, 79 web suites / 864 tests - ALL PASSING (zero failures). Playwright 24 specs at >90% pass post-2026-05-09 refresh. Verified by autonomous pass `docs/plans/2026-05-09-test-results.md`.
+**Tests:** Current merge evidence: PR #209 GitHub CI passed audit, build, e2e, lint, security, and test. Local #209 verification included middleware unit tests (149 suites / 3055 tests), ops tests (40/40), release-readiness gates (21/21), middleware build, ESLint, and secret scan. Historical aggregate test report remains in `docs/plans/2026-05-09-test-results.md`; verify fresh counts before relying on older totals.
 **Customer-1 launch date:** operator-confirmed - do not use historical target dates until the operator confirms the actual launch window.
 
-**Security/realtime/readiness wave (#107-#204, merged through 2026-06-03, main `5ddabb7a`):** session invalidation now spans REST + WebSocket - password-change / account-deactivation force-logout across all devices (REST `#111`, WS connect-time `#112`, WS mid-session 60s sweep `#114`). Customer-1 smoke coverage is hardened (#116), M12 security alert emails are complete (#117), and the latest overnight readiness passes hardened health/readiness gates, validator reporting, admin readiness display, deploy verification, and first-customer runbook truthfulness. P1/P2 tables below reconciled to match.
+**Security/realtime/readiness wave (#107-#209, merged through 2026-06-03, main `5d15fff3`):** session invalidation now spans REST + WebSocket - password-change / account-deactivation force-logout across all devices (REST `#111`, WS connect-time `#112`, WS mid-session 60s sweep `#114`). Customer-1 smoke coverage is hardened (#116), M12 security alert emails are complete (#117), and the latest overnight readiness passes hardened health/readiness gates, validator reporting, admin readiness display, deploy verification, first-customer runbook truthfulness, and public app URL precedence for email/reset/pairing/billing/lifecycle links (#209). P1/P2 tables below reconciled to match.
 
 ---
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,6 @@
 # Vizora - Task Tracker
 
-## Active Workstream: Shared Public App URL Resolver Pass 69 (2026-06-03)
+## Completed Workstream: Shared Public App URL Resolver Pass 69 (2026-06-03)
 
 **Branch:** `fix/public-app-url-resolver`
 
@@ -36,11 +36,17 @@ local env-var URL resolution.
 - [x] Run focused pairing/auth/mail/billing/organization/health tests, build,
       diff hygiene, and secret scan.
 - [x] Request Claude Code review and resolve findings.
-- [ ] Commit, PR, CI, and merge if green.
+- [x] Commit, PR, CI, and merge if green.
 - [x] Do not deploy, send real emails, or touch production env state.
 
-**Evidence so far**
-- Current `origin/main`: `3aee89941fc851852acbc2060623efaa7a2d6358`.
+**Evidence**
+- Branch/PR:
+  - Branch: `fix/public-app-url-resolver`.
+  - Commit: `88ecf1bf` (`fix(middleware): unify public app URL resolution`).
+  - PR #209: `fix(middleware): unify public app URL resolution`.
+  - Merge commit: `5d15fff380edd8fef4bf8fe48e15c1f15bdd391b`.
+  - GitHub CI passed audit, build, e2e, lint, security, and test before merge.
+- Starting `origin/main`: `3aee89941fc851852acbc2060623efaa7a2d6358`.
 - Drift-check:
   - `mail.service.ts` and `auth.service.ts` use
     `APP_URL || FRONTEND_URL || WEB_URL || localhost`.


### PR DESCRIPTION
## Summary
- mark Pass 69 public app URL resolver workstream complete after PR #209 merge
- update backlog main SHA and readiness wave through #209
- replace stale aggregate test counts with current #209 merge/local verification evidence

## Verification
- git diff --check -- backlog.md tasks/todo.md
- node --import tsx --test scripts/ops/release-readiness-gates.test.ts
- pnpm test:ops
- Claude Code review: CLEAN

## Operator boundary
- docs-only; no production deploy, env edit, real email send, secret change, payment setup, or hardware action