### PR TITLE
fix(display): wire admin auto-update command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -150,6 +150,14 @@ WEB_URL=http://localhost:3001
 # Legacy alias accepted by a few older mail paths. Prefer APP_URL/WEB_URL.
 FRONTEND_URL=
 
+# Comma-separated host allowlist for Electron display auto-update feeds.
+# The backend and display client both enforce this before electron-updater can
+# consume a generic update feed. Values may be bare hostnames or URLs; only the
+# host is used. Packaged display clients reject loopback feeds; only unpackaged
+# local testing can use loopback. Packaged update testing and production rollout
+# require an allowlisted HTTPS host with signed releases.
+DISPLAY_UPDATE_FEED_ALLOWLIST=updates.vizora.cloud
+
 # =============================================================================
 # Production URLs (configure for deployment)
 # =============================================================================

--- a/.env.production.example
+++ b/.env.production.example
@@ -162,6 +162,11 @@ API_BASE_URL=https://api.your-domain.com
 # to generate device pairing QR code links.
 WEB_URL=https://app.your-domain.com
 
+# Comma-separated host allowlist for Electron display auto-update feeds.
+# Values may be bare hostnames or URLs; only the host is used. Keep production
+# feeds on signed HTTPS releases. Packaged display clients reject loopback feeds.
+DISPLAY_UPDATE_FEED_ALLOWLIST=updates.vizora.cloud
+
 # Required. Internal URL the realtime gateway and middleware use to communicate
 # with each other. If all services run on the same host, use localhost.
 REALTIME_URL=http://localhost:3002

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,12 @@ NEXT_PUBLIC_SOCKET_URL  # Realtime gateway URL for web frontend
 BACKEND_URL             # Server-side API URL (used by next.config proxy)
 ```
 
+### Display client
+
+```
+DISPLAY_UPDATE_FEED_ALLOWLIST  # Comma-separated hosts allowed for Electron display auto-update feeds. Bare hostnames or URLs are accepted; only the host is used. Default code allowlist is updates.vizora.cloud. Packaged display clients reject loopback feeds; packaged update testing and production rollout require an allowlisted HTTPS host with signed releases.
+```
+
 ### Storage / S3 / MinIO
 
 ```
@@ -254,7 +260,7 @@ backlog.md                 # P0-P4 active backlog with status + effort estimates
 
 ## Display Clients
 
-**Electron** (`display/`): Desktop app for Windows/macOS/Linux. Webpack + TypeScript. Packages via electron-builder. Packaged display clients configure OS auto-start and use Electron `powerSaveBlocker` to prevent display sleep.
+**Electron** (`display/`): Desktop app for Windows/macOS/Linux. Webpack + TypeScript. Packages via electron-builder. Packaged display clients configure OS auto-start, use Electron `powerSaveBlocker` to prevent display sleep, and can run an admin-triggered `update` fleet command through `electron-updater` when the feed host is in `DISPLAY_UPDATE_FEED_ALLOWLIST`. Production update rollout still requires signed display artifacts on the allowlisted HTTPS feed before operators send the update command; verify the signing/verification story for each target, especially Linux/AppImage, before enabling a live rollout.
 
 **Android TV**: Extracted to standalone repo (`vizora-tv`). Capacitor 6 + Vite + TypeScript. See [github.com/Trivenidigital/vizora-tv](https://github.com/Trivenidigital/vizora-tv).
 

--- a/backlog.md
+++ b/backlog.md
@@ -256,7 +256,7 @@ Items the audit listed but we are NOT pursuing live (Engage/kiosk, live remote v
 |---|-------|----------|--------|-------|
 | K1 | Electron auto-start on boot not configured | Low | FIXED | Packaged display clients configure OS auto-start (Windows/macOS login item, Linux autostart desktop file with AppImage path support) |
 | K2 | Electron powerSaveBlocker not enabled | Low | FIXED | Packaged display clients start `prevent-display-sleep` and stop it on quit |
-| K3 | Electron auto-update not configured | Low | TODO | electron-updater referenced but not wired |
+| K3 | Electron auto-update not configured | Low | REPO-FIXED / OPERATOR-GATED | Admin-only `update` fleet command now reaches packaged display clients through `electron-updater` with backend + client feed allowlist checks; live rollout still requires signed artifacts on an allowlisted HTTPS feed and target-specific signing verification |
 | K4 | Display client has 0 test coverage | Medium | FIXED | Electron display Jest suite, typecheck, and build are CI-gated; real-device walkthrough still required |
 | K5 | 3 pre-existing RSC admin test failures | Low | TODO | React Server Component edge cases |
 | K6 | AI Designer returns "launching soon" stub | Info | TODO | Intentional — needs API budget |

--- a/display/package.json
+++ b/display/package.json
@@ -78,6 +78,7 @@
   },
   "dependencies": {
     "electron-store": "^8.1.0",
+    "electron-updater": "6.8.3",
     "qrcode": "^1.5.4",
     "socket.io-client": "^4.7.0"
   },

--- a/display/src/electron/device-client.spec.ts
+++ b/display/src/electron/device-client.spec.ts
@@ -36,6 +36,11 @@ jest.mock('http', () => {
   };
 });
 
+const mockTriggerDisplayAutoUpdate = jest.fn();
+jest.mock('./display-auto-updater', () => ({
+  triggerDisplayAutoUpdate: (...args: any[]) => mockTriggerDisplayAutoUpdate(...args),
+}));
+
 jest.mock('electron', () => ({
   BrowserWindow: {
     getAllWindows: jest.fn().mockReturnValue([]),
@@ -75,6 +80,10 @@ describe('DeviceClient', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
+    mockTriggerDisplayAutoUpdate.mockReturnValue({
+      status: 'started',
+      feedUrl: 'https://updates.vizora.cloud/display',
+    });
 
     mockConfig = {
       onPairingRequired: jest.fn(),
@@ -705,6 +714,48 @@ describe('DeviceClient', () => {
       expect(mockConfig.onCommand).not.toHaveBeenCalled();
       expect(mockWindow.loadURL).toHaveBeenCalledWith('file:///display/index.html');
       expect(ack).toHaveBeenCalledWith({ ok: true });
+    });
+
+    it('should trigger display auto-update in the main process', async () => {
+      client.connect('test-token');
+
+      const commandCall = mockSocket.on.mock.calls.find(
+        (call: any[]) => call[0] === 'command',
+      );
+      const ack = jest.fn();
+
+      await commandCall![1]({
+        type: 'update',
+        payload: { feedUrl: 'https://updates.vizora.cloud/display' },
+      }, ack);
+
+      expect(mockConfig.onCommand).not.toHaveBeenCalled();
+      expect(mockTriggerDisplayAutoUpdate).toHaveBeenCalledWith(
+        'https://updates.vizora.cloud/display',
+      );
+      expect(ack).toHaveBeenCalledWith({ ok: true });
+    });
+
+    it('should negative-ack update when the updater helper rejects the feed', async () => {
+      mockTriggerDisplayAutoUpdate.mockImplementation(() => {
+        throw new Error('display update feed host is not allowlisted');
+      });
+      client.connect('test-token');
+
+      const commandCall = mockSocket.on.mock.calls.find(
+        (call: any[]) => call[0] === 'command',
+      );
+      const ack = jest.fn();
+
+      await commandCall![1]({
+        type: 'update',
+        payload: { feedUrl: 'https://updates.attacker.example/display' },
+      }, ack);
+
+      expect(ack).toHaveBeenCalledWith({
+        ok: false,
+        error: 'display update feed host is not allowlisted',
+      });
     });
 
     it('should start heartbeat on connect event', () => {

--- a/display/src/electron/device-client.ts
+++ b/display/src/electron/device-client.ts
@@ -1,5 +1,6 @@
 import { io, Socket } from 'socket.io-client';
 import * as os from 'os';
+import { triggerDisplayAutoUpdate } from './display-auto-updater';
 import * as http from 'http';
 
 interface DeviceClientConfig {
@@ -514,7 +515,7 @@ export class DeviceClient {
   }
 
   private isMainProcessOwnedCommand(command: any): boolean {
-    return ['push_content', 'clear_override', 'clear_cache'].includes(command?.type);
+    return ['push_content', 'clear_override', 'clear_cache', 'update'].includes(command?.type);
   }
 
   private async waitForSelfTerminatingCommandAckFlush(): Promise<void> {
@@ -763,11 +764,7 @@ export class DeviceClient {
         break;
       case 'update':
         console.log('[DeviceClient] Update command received');
-        // Stub for autoUpdater integration
-        // In production, this would trigger electron-updater:
-        // const { autoUpdater } = require('electron-updater');
-        // autoUpdater.checkForUpdatesAndNotify();
-        console.log('[DeviceClient] Auto-update not yet configured. Update payload:', command.payload);
+        triggerDisplayAutoUpdate(command.payload?.feedUrl);
         break;
       default:
         console.warn('Unknown command type:', command.type);

--- a/display/src/electron/display-auto-updater.spec.ts
+++ b/display/src/electron/display-auto-updater.spec.ts
@@ -1,0 +1,180 @@
+import {
+  normalizeDisplayUpdateFeedUrl,
+  triggerDisplayAutoUpdate,
+  type AutoUpdaterLike,
+} from './display-auto-updater';
+
+describe('display auto updater helper', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  const createUpdater = () => {
+    const listeners = new Map<string, () => void>();
+    const updater: jest.Mocked<AutoUpdaterLike> = {
+      autoDownload: false,
+      autoInstallOnAppQuit: false,
+      setFeedURL: jest.fn(),
+      checkForUpdates: jest.fn().mockResolvedValue(null),
+      on: jest.fn((event: string, listener: () => void) => {
+        listeners.set(event, listener);
+        return updater;
+      }),
+      quitAndInstall: jest.fn(),
+    };
+    return { updater, listeners };
+  };
+
+  beforeEach(() => {
+    delete process.env.DISPLAY_UPDATE_FEED_ALLOWLIST;
+    restoreNodeEnv();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    delete process.env.DISPLAY_UPDATE_FEED_ALLOWLIST;
+    restoreNodeEnv();
+    jest.useRealTimers();
+  });
+
+  const restoreNodeEnv = () => {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  };
+
+  it('normalizes an allowlisted HTTPS feed URL', () => {
+    process.env.DISPLAY_UPDATE_FEED_ALLOWLIST = 'updates.vizora.cloud';
+
+    expect(
+      normalizeDisplayUpdateFeedUrl('https://updates.vizora.cloud/display/'),
+    ).toBe('https://updates.vizora.cloud/display');
+  });
+
+  it('normalizes URL-shaped allowlist entries to their hostname', () => {
+    process.env.DISPLAY_UPDATE_FEED_ALLOWLIST = 'https://updates.vizora.cloud';
+
+    expect(
+      normalizeDisplayUpdateFeedUrl('https://updates.vizora.cloud/display/'),
+    ).toBe('https://updates.vizora.cloud/display');
+  });
+
+  it('rejects feed hosts outside the allowlist', () => {
+    process.env.DISPLAY_UPDATE_FEED_ALLOWLIST = 'updates.vizora.cloud';
+
+    expect(() =>
+      normalizeDisplayUpdateFeedUrl('https://updates.attacker.example/display'),
+    ).toThrow('not allowlisted');
+  });
+
+  it('rejects non-localhost HTTP feed URLs', () => {
+    expect(() =>
+      normalizeDisplayUpdateFeedUrl('http://updates.vizora.cloud/display'),
+    ).toThrow('must use HTTPS');
+  });
+
+  it('rejects non-HTTP update feed protocols', () => {
+    expect(() =>
+      normalizeDisplayUpdateFeedUrl('file:///tmp/display-update'),
+    ).toThrow('must use HTTP or HTTPS');
+  });
+
+  it('rejects non-loopback feed URLs with explicit ports', () => {
+    expect(() =>
+      normalizeDisplayUpdateFeedUrl('https://updates.vizora.cloud:8443/display'),
+    ).toThrow('must not include a port');
+  });
+
+  it('allows loopback HTTP feeds only outside production', () => {
+    process.env.NODE_ENV = 'test';
+
+    expect(
+      normalizeDisplayUpdateFeedUrl('http://localhost:4876/display/'),
+    ).toBe('http://localhost:4876/display');
+
+    process.env.NODE_ENV = 'production';
+    expect(() =>
+      normalizeDisplayUpdateFeedUrl('http://localhost:4876/display'),
+    ).toThrow('loopback feeds are not allowed in production');
+  });
+
+  it('rejects feed URLs with credentials or query strings', () => {
+    expect(() =>
+      normalizeDisplayUpdateFeedUrl('https://user:pass@updates.vizora.cloud/display'),
+    ).toThrow('must not include credentials');
+
+    expect(() =>
+      normalizeDisplayUpdateFeedUrl('https://updates.vizora.cloud/display?token=abc'),
+    ).toThrow('must not include a query string');
+  });
+
+  it('does not call electron-updater for unpackaged display clients', () => {
+    const { updater } = createUpdater();
+
+    const result = triggerDisplayAutoUpdate(
+      'https://updates.vizora.cloud/display',
+      { isPackaged: false, updater },
+    );
+
+    expect(result).toEqual({
+      status: 'skipped',
+      reason: 'not_packaged',
+    });
+    expect(updater.setFeedURL).not.toHaveBeenCalled();
+    expect(updater.checkForUpdates).not.toHaveBeenCalled();
+  });
+
+  it('throws synchronously for invalid packaged update feeds before updater work', () => {
+    process.env.DISPLAY_UPDATE_FEED_ALLOWLIST = 'updates.vizora.cloud';
+    const { updater } = createUpdater();
+
+    expect(() =>
+      triggerDisplayAutoUpdate('https://updates.attacker.example/display', {
+        isPackaged: true,
+        updater,
+      }),
+    ).toThrow('not allowlisted');
+    expect(updater.setFeedURL).not.toHaveBeenCalled();
+    expect(updater.checkForUpdates).not.toHaveBeenCalled();
+  });
+
+  it('rejects loopback feeds for packaged display clients even when NODE_ENV is unset', () => {
+    delete process.env.NODE_ENV;
+    const { updater } = createUpdater();
+
+    expect(() =>
+      triggerDisplayAutoUpdate('http://localhost:4876/display', {
+        isPackaged: true,
+        updater,
+      }),
+    ).toThrow('loopback feeds are not allowed in production');
+    expect(updater.setFeedURL).not.toHaveBeenCalled();
+    expect(updater.checkForUpdates).not.toHaveBeenCalled();
+  });
+
+  it('configures updater and installs after update-downloaded for packaged clients', () => {
+    process.env.DISPLAY_UPDATE_FEED_ALLOWLIST = 'updates.vizora.cloud';
+    const { updater, listeners } = createUpdater();
+
+    const result = triggerDisplayAutoUpdate(
+      'https://updates.vizora.cloud/display/',
+      { isPackaged: true, updater, installDelayMs: 0 },
+    );
+
+    expect(result).toEqual({
+      status: 'started',
+      feedUrl: 'https://updates.vizora.cloud/display',
+    });
+    expect(updater.autoDownload).toBe(true);
+    expect(updater.autoInstallOnAppQuit).toBe(true);
+    expect(updater.setFeedURL).toHaveBeenCalledWith({
+      provider: 'generic',
+      url: 'https://updates.vizora.cloud/display',
+    });
+    expect(updater.checkForUpdates).toHaveBeenCalledTimes(1);
+
+    listeners.get('update-downloaded')?.();
+    jest.advanceTimersByTime(0);
+    expect(updater.quitAndInstall).toHaveBeenCalledWith(false, true);
+  });
+});

--- a/display/src/electron/display-auto-updater.ts
+++ b/display/src/electron/display-auto-updater.ts
@@ -1,0 +1,178 @@
+export interface AutoUpdaterLike {
+  autoDownload: boolean;
+  autoInstallOnAppQuit: boolean;
+  setFeedURL(options: { provider: 'generic'; url: string }): void;
+  checkForUpdates(): Promise<unknown>;
+  on(event: string, listener: () => void): unknown;
+  quitAndInstall(isSilent?: boolean, isForceRunAfter?: boolean): void;
+}
+
+export type DisplayAutoUpdateResult =
+  | { status: 'started'; feedUrl: string }
+  | { status: 'skipped'; reason: 'not_packaged' };
+
+interface TriggerDisplayAutoUpdateOptions {
+  isPackaged?: boolean;
+  updater?: AutoUpdaterLike;
+  installDelayMs?: number;
+}
+
+interface NormalizeDisplayUpdateFeedUrlOptions {
+  allowLoopback?: boolean;
+}
+
+const DEFAULT_DISPLAY_UPDATE_FEED_HOST = 'updates.vizora.cloud';
+const LOCAL_UPDATE_FEED_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
+const installListeners = new WeakSet<object>();
+
+export function normalizeDisplayUpdateFeedUrl(
+  rawFeedUrl: unknown,
+  options: NormalizeDisplayUpdateFeedUrlOptions = {},
+): string {
+  if (typeof rawFeedUrl !== 'string' || rawFeedUrl.trim().length === 0) {
+    throw new Error('display update feed URL is required');
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(rawFeedUrl.trim());
+  } catch {
+    throw new Error('display update feed URL must be a valid URL');
+  }
+
+  if (!['https:', 'http:'].includes(parsed.protocol)) {
+    throw new Error('display update feed URL must use HTTP or HTTPS');
+  }
+
+  const host = normalizeFeedHost(parsed.hostname);
+  const isLocal = LOCAL_UPDATE_FEED_HOSTS.has(host);
+  const allowLoopback = options.allowLoopback ?? isLoopbackUpdateFeedAllowed();
+  if (isLocal && !allowLoopback) {
+    throw new Error('display update loopback feeds are not allowed in production');
+  }
+  if (parsed.protocol === 'http:' && !isLocal) {
+    throw new Error('display update feed URL must use HTTPS');
+  }
+  if (parsed.port && !isLocal) {
+    throw new Error('display update feed URL must not include a port');
+  }
+
+  if (parsed.username || parsed.password) {
+    throw new Error('display update feed URL must not include credentials');
+  }
+
+  if (parsed.search) {
+    throw new Error('display update feed URL must not include a query string');
+  }
+
+  if (!isLocal && !getAllowedFeedHosts().has(host)) {
+    throw new Error(`display update feed host is not allowlisted: ${host}`);
+  }
+
+  parsed.hash = '';
+  return parsed.toString().replace(/\/+$/, '');
+}
+
+/**
+ * Triggers an unattended display update from an allowlisted generic feed.
+ *
+ * Production rollout requires signed display artifacts on the official update
+ * feed before operators send this command. This helper only constrains where
+ * updates may come from and delegates package verification/install mechanics to
+ * electron-updater.
+ */
+export function triggerDisplayAutoUpdate(
+  rawFeedUrl: unknown,
+  options: TriggerDisplayAutoUpdateOptions = {},
+): DisplayAutoUpdateResult {
+  const isPackaged = options.isPackaged ?? getElectronIsPackaged();
+  if (!isPackaged) {
+    console.log('[DisplayAutoUpdater] Skipping update check because app is not packaged');
+    return { status: 'skipped', reason: 'not_packaged' };
+  }
+
+  const feedUrl = normalizeDisplayUpdateFeedUrl(rawFeedUrl, {
+    allowLoopback: !isPackaged,
+  });
+  const updater = options.updater ?? getElectronAutoUpdater();
+  const installDelayMs = options.installDelayMs ?? 2000;
+
+  updater.autoDownload = true;
+  updater.autoInstallOnAppQuit = true;
+  registerInstallListener(updater, installDelayMs);
+
+  updater.setFeedURL({ provider: 'generic', url: feedUrl });
+  void updater.checkForUpdates().catch((error: unknown) => {
+    console.error('[DisplayAutoUpdater] Update check failed:', error);
+  });
+
+  console.log(`[DisplayAutoUpdater] Update check started from ${feedUrl}`);
+  return { status: 'started', feedUrl };
+}
+
+function registerInstallListener(
+  updater: AutoUpdaterLike,
+  installDelayMs: number,
+): void {
+  if (installListeners.has(updater as object)) {
+    return;
+  }
+
+  updater.on('update-downloaded', () => {
+    console.log('[DisplayAutoUpdater] Update downloaded; installing');
+    setTimeout(() => {
+      try {
+        updater.quitAndInstall(false, true);
+      } catch (error) {
+        console.error('[DisplayAutoUpdater] Failed to install downloaded update:', error);
+      }
+    }, installDelayMs);
+  });
+  installListeners.add(updater as object);
+}
+
+function getAllowedFeedHosts(): Set<string> {
+  const configured =
+    process.env.DISPLAY_UPDATE_FEED_ALLOWLIST ||
+    DEFAULT_DISPLAY_UPDATE_FEED_HOST;
+
+  return new Set(
+    configured
+      .split(',')
+      .map((host) => normalizeAllowedFeedHost(host.trim()))
+      .filter(Boolean),
+  );
+}
+
+function normalizeFeedHost(host: string): string {
+  return host.toLowerCase().replace(/^\[/, '').replace(/\]$/, '');
+}
+
+function normalizeAllowedFeedHost(host: string): string {
+  if (host.includes('://')) {
+    try {
+      return normalizeFeedHost(new URL(host).hostname);
+    } catch {
+      return normalizeFeedHost(host);
+    }
+  }
+  return normalizeFeedHost(host);
+}
+
+function isLoopbackUpdateFeedAllowed(): boolean {
+  return process.env.NODE_ENV !== 'production';
+}
+
+function getElectronIsPackaged(): boolean {
+  try {
+    const { app } = require('electron');
+    return Boolean(app?.isPackaged);
+  } catch {
+    return false;
+  }
+}
+
+function getElectronAutoUpdater(): AutoUpdaterLike {
+  const { autoUpdater } = require('electron-updater');
+  return autoUpdater as AutoUpdaterLike;
+}

--- a/docs/plans/2026-06-03-display-auto-update-pass70.md
+++ b/docs/plans/2026-06-03-display-auto-update-pass70.md
@@ -1,0 +1,108 @@
+# Display Auto-Update Command Pass 70 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Electron display client's `update` command stub with a real, admin-only, audited updater trigger that is safe to run without production env or release-provider changes.
+
+**Architecture:** Reuse the existing fleet command path (`POST /fleet/commands` -> realtime `/api/commands/broadcast` -> Socket.IO `command`) and the existing Electron main-process command handler. The backend validates and forwards an update feed URL constrained by `DISPLAY_UPDATE_FEED_ALLOWLIST`; the display client validates the same host allowlist again, configures `electron-updater` with a generic feed only when packaged, starts a check/download, and installs after `update-downloaded`.
+
+**Tech Stack:** NestJS DTO/controller/service tests, realtime DTO enum validation, Electron main-process TypeScript, Jest, `electron-updater`.
+
+**New primitives introduced:** one focused Electron updater helper at `display/src/electron/display-auto-updater.ts`.
+
+**Hermes-first analysis:**
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Electron app auto-update | none applicable | Use `electron-updater` in the existing Electron client. |
+| Fleet command authorization | none applicable | Reuse existing NestJS fleet controller/service path. |
+| Realtime command fanout | none applicable | Reuse existing Socket.IO command delivery and queued-command path. |
+
+Awesome-Hermes-agent ecosystem check: not applicable; this change does not introduce business-agent workflows, MCP tools, AI provider calls, or spend paths.
+
+## Drift Check
+
+- `display/src/electron/device-client.ts` has an `update` command branch, but it only logs "Auto-update not yet configured."
+- `display/package.json` does not include `electron-updater`.
+- `middleware/src/modules/fleet/dto/send-command.dto.ts` does not allow `update`, so the existing fleet endpoint cannot trigger the display branch.
+- `realtime/src/types/index.ts` does not include `update` in `DeviceCommandType`, so realtime validation would reject it on the production broadcast command path.
+- `docs/plans/2026-05-31-display-runtime-reliability.md` intentionally deferred auto-update because release-provider/signing decisions were out of scope. Pass 70 keeps those operator decisions out of code by requiring a feed URL per admin command.
+
+## Files
+
+- Modify `display/package.json` and `pnpm-lock.yaml`: add `electron-updater`.
+- Create `display/src/electron/display-auto-updater.ts`: URL validation, updater configuration, one-time event listeners, async update check trigger.
+- Create `display/src/electron/display-auto-updater.spec.ts`: focused tests for URL safety and updater calls.
+- Modify `display/src/electron/device-client.ts`: route `update` commands to the helper instead of the stub.
+- Modify `display/src/electron/device-client.spec.ts`: mock the helper and verify `update` executes/negative-acks on helper failure.
+- Modify `middleware/src/modules/fleet/dto/send-command.dto.ts`: allow `update` and validate `feedUrl`.
+- Modify `middleware/src/modules/fleet/fleet.controller.ts` and spec: make `update` admin-only.
+- Modify `middleware/src/modules/fleet/fleet.service.ts` and spec: require/normalize safe update feed URLs and forward only `{ feedUrl }`.
+- Modify `realtime/src/types/index.ts`: add `UPDATE = 'update'` to the command enum.
+- Modify `realtime/src/dto/internal-api.dto.spec.ts`: assert realtime DTO validation accepts `update`.
+- Modify `web/src/lib/api/fleet.ts`: type the optional `feedUrl` payload field.
+- Modify `.env.example`, `.env.production.example`, and `CLAUDE.md`: document `DISPLAY_UPDATE_FEED_ALLOWLIST`.
+- Modify docs/handoff files after verification: `backlog.md` and `tasks/todo.md`.
+
+## Tasks
+
+- [ ] **Task 1: Red tests for backend command validation and auth**
+  - Add middleware tests:
+    - `FleetController` rejects `update` from a manager with `ForbiddenException`.
+    - `FleetController` allows `update` from an admin.
+    - `FleetService` rejects `update` without `payload.feedUrl`.
+    - `FleetService` rejects non-localhost `http://` feed URLs.
+    - `FleetService` rejects hosts outside `DISPLAY_UPDATE_FEED_ALLOWLIST`.
+    - `FleetService` forwards `update` as `{ type: 'update', payload: { feedUrl: 'https://updates.vizora.cloud/display' } }`.
+  - Run:
+    - `pnpm --filter @vizora/middleware test -- --runTestsByPath src/modules/fleet/fleet.controller.spec.ts src/modules/fleet/fleet.service.spec.ts`
+  - Expected before implementation: failures on missing admin-only check and missing update payload behavior.
+
+- [ ] **Task 2: Red tests for display updater execution**
+  - Add `display-auto-updater.spec.ts` with tests for:
+    - HTTPS feed accepted only when host is in `DISPLAY_UPDATE_FEED_ALLOWLIST`, updater `setFeedURL`, `checkForUpdates`, and `update-downloaded` -> `quitAndInstall`.
+    - Non-localhost HTTP feed rejected.
+    - Feed URLs with credentials or query strings rejected.
+    - Unpackaged/dev display clients return a no-op result instead of calling `electron-updater`.
+  - Add `device-client.spec.ts` tests verifying an `update` command calls the helper with `payload.feedUrl` and negative-acks if the helper throws.
+  - Run:
+    - `pnpm --filter @vizora/display test -- --runInBand display-auto-updater device-client`
+  - Expected before implementation: failures because the helper does not exist and the device branch still logs a stub.
+
+- [ ] **Task 3: Implement backend update command path**
+  - Add `feedUrl` to `CommandPayloadDto`.
+  - Add `update` to the command enum in middleware DTO and realtime `DeviceCommandType`.
+  - Add admin-only guard for `update` in `FleetController`.
+  - Add `buildUpdatePayload()` / `normalizeUpdateFeedUrl()` in `FleetService`, enforcing:
+    - `feedUrl` is required.
+    - host is in `DISPLAY_UPDATE_FEED_ALLOWLIST`, defaulting to `updates.vizora.cloud`, with localhost/loopback allowed for dev.
+    - protocol is `https:` unless host is `localhost`, `127.0.0.1`, or `[::1]`.
+    - URL credentials and query strings are rejected.
+    - trailing slash is stripped before forwarding.
+  - Add realtime DTO validation coverage for `DeviceCommandType.UPDATE`.
+  - Run middleware focused tests until green.
+
+- [ ] **Task 4: Implement display updater helper and command branch**
+  - Add `electron-updater` with `NODE_OPTIONS=--use-system-ca pnpm add --filter @vizora/display electron-updater@6.8.3`.
+  - Implement `display-auto-updater.ts`:
+    - validate feed URL with the same safety rules as backend and the same `DISPLAY_UPDATE_FEED_ALLOWLIST` default.
+    - return a logged no-op for unpackaged display clients so local/dev command tests do not invoke updater internals.
+    - configure `autoUpdater.autoDownload = true` and `autoUpdater.autoInstallOnAppQuit = true`.
+    - register `update-downloaded` listener once per updater object.
+    - call `autoUpdater.setFeedURL({ provider: 'generic', url: feedUrl })`.
+    - trigger `checkForUpdates()` asynchronously and log async failures.
+    - document that production rollout requires signed display artifacts on the official update feed before operators send the command.
+  - Replace the `update` stub in `DeviceClient.handleCommand()` with `triggerDisplayAutoUpdate(command.payload?.feedUrl)`.
+  - Run display focused tests until green.
+
+- [ ] **Task 5: Verification, review, and handoff**
+  - Run focused and broader checks:
+    - `pnpm --filter @vizora/middleware test -- --runTestsByPath src/modules/fleet/fleet.controller.spec.ts src/modules/fleet/fleet.service.spec.ts`
+    - `pnpm --filter @vizora/display test:ci`
+    - `pnpm --filter @vizora/display typecheck`
+    - `pnpm --filter @vizora/display build`
+    - `pnpm --filter @vizora/realtime test -- --runTestsByPath src/dto/internal-api.dto.spec.ts`
+    - `git diff --check`
+    - `pnpm security:no-hardcoded-jwts`
+  - Request Claude Code review for display update safety, command authorization, tenant/auth impact, dependency/CI safety, and operator-gated release assumptions.
+  - Update `tasks/todo.md` and `backlog.md` with branch/commit/tests/CI/review evidence. Do not claim production auto-update rollout; the remaining operator action is publishing signed display releases to an allowlisted feed host and then providing that feed URL when sending the admin command.

--- a/middleware/src/modules/fleet/dto/send-command.dto.ts
+++ b/middleware/src/modules/fleet/dto/send-command.dto.ts
@@ -6,6 +6,7 @@ import {
   ValidateNested,
   IsIn,
   IsNumber,
+  IsUrl,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 
@@ -34,10 +35,19 @@ class CommandPayloadDto {
   @IsOptional()
   @IsEnum(['normal', 'emergency'])
   priority?: 'normal' | 'emergency';
+
+  @IsOptional()
+  @IsString()
+  @IsUrl({
+    require_protocol: true,
+    require_tld: false,
+    protocols: ['http', 'https'],
+  })
+  feedUrl?: string;
 }
 
 export class SendCommandDto {
-  @IsEnum(['reload', 'restart', 'reboot', 'clear_cache', 'push_content'])
+  @IsEnum(['reload', 'restart', 'reboot', 'clear_cache', 'push_content', 'update'])
   command!: string;
 
   @ValidateNested()

--- a/middleware/src/modules/fleet/fleet.controller.spec.ts
+++ b/middleware/src/modules/fleet/fleet.controller.spec.ts
@@ -86,6 +86,39 @@ describe('FleetController', () => {
 
       expect(fleetService.sendCommand).toHaveBeenCalled();
     });
+
+    it('should throw ForbiddenException for display update with non-admin', async () => {
+      const user = { id: 'user-1', role: 'manager', organizationId: mockOrgId };
+      const dto = {
+        command: 'update' as const,
+        target: { type: 'device' as const, id: 'dev-1' },
+        payload: { feedUrl: 'https://updates.vizora.cloud/display' },
+      } as any;
+
+      await expect(
+        controller.sendCommand(user, mockOrgId, dto),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(fleetService.sendCommand).not.toHaveBeenCalled();
+    });
+
+    it('should allow display update for admin', async () => {
+      const user = { id: 'user-1', role: 'admin', organizationId: mockOrgId };
+      const dto = {
+        command: 'update' as const,
+        target: { type: 'device' as const, id: 'dev-1' },
+        payload: { feedUrl: 'https://updates.vizora.cloud/display' },
+      } as any;
+
+      await controller.sendCommand(user, mockOrgId, dto);
+
+      expect(fleetService.sendCommand).toHaveBeenCalledWith(
+        mockOrgId,
+        user.id,
+        user.role,
+        dto,
+      );
+    });
   });
 
   describe('getActiveOverrides', () => {

--- a/middleware/src/modules/fleet/fleet.controller.ts
+++ b/middleware/src/modules/fleet/fleet.controller.ts
@@ -33,6 +33,9 @@ export class FleetController {
     if (dto.payload?.priority === 'emergency' && user.role !== 'admin') {
       throw new ForbiddenException('Emergency override requires admin role');
     }
+    if (dto.command === 'update' && user.role !== 'admin') {
+      throw new ForbiddenException('Display app updates require admin role');
+    }
     return this.fleetService.sendCommand(orgId, user.id, user.role, dto);
   }
 

--- a/middleware/src/modules/fleet/fleet.service.spec.ts
+++ b/middleware/src/modules/fleet/fleet.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { HttpService } from '@nestjs/axios';
 import { of } from 'rxjs';
-import { NotFoundException, BadRequestException } from '@nestjs/common';
+import { NotFoundException, BadRequestException, ForbiddenException } from '@nestjs/common';
 import { FleetService, TooManyRequestsException } from './fleet.service';
 import { DatabaseService } from '../database/database.service';
 import { RedisService } from '../redis/redis.service';
@@ -19,6 +19,7 @@ describe('FleetService', () => {
   const mockUserId = 'user-456';
   const mockDeviceId = 'device-789';
   const mockGroupId = 'group-001';
+  const originalNodeEnv = process.env.NODE_ENV;
 
   beforeEach(async () => {
     process.env.INTERNAL_API_SECRET = 'test-secret';
@@ -96,6 +97,12 @@ describe('FleetService', () => {
 
   afterEach(() => {
     delete process.env.INTERNAL_API_SECRET;
+    delete process.env.DISPLAY_UPDATE_FEED_ALLOWLIST;
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
   });
 
   describe('resolveTargetDevices', () => {
@@ -438,6 +445,220 @@ describe('FleetService', () => {
       expect(body.command.payload.content.thumbnail).toBe('/static/thumbnails/content-2.jpg');
       expect(body.command.payload.content.title).toBeUndefined();
       expect(body.command.payload.content.thumbnailUrl).toBeUndefined();
+    });
+
+    it('should throw BadRequestException for update without feedUrl', async () => {
+      db.display.findFirst.mockResolvedValue({
+        id: mockDeviceId,
+        nickname: 'Test',
+        organizationId: mockOrgId,
+      });
+
+      const dto = {
+        command: 'update' as const,
+        target: { type: 'device' as const, id: mockDeviceId },
+        payload: {},
+      } as any;
+
+      await expect(
+        service.sendCommand(mockOrgId, mockUserId, 'admin', dto),
+      ).rejects.toThrow(BadRequestException);
+      expect(httpService.post).not.toHaveBeenCalled();
+    });
+
+    it('should reject update commands for non-admin service callers', async () => {
+      const dto = {
+        command: 'update' as const,
+        target: { type: 'device' as const, id: mockDeviceId },
+        payload: { feedUrl: 'https://updates.vizora.cloud/display' },
+      } as any;
+
+      await expect(
+        service.sendCommand(mockOrgId, mockUserId, 'manager', dto),
+      ).rejects.toThrow(ForbiddenException);
+      expect(db.display.findFirst).not.toHaveBeenCalled();
+      expect(httpService.post).not.toHaveBeenCalled();
+    });
+
+    it('should validate update feed before resolving targets', async () => {
+      const dto = {
+        command: 'update' as const,
+        target: { type: 'device' as const, id: mockDeviceId },
+        payload: { feedUrl: 'https://attacker.example/display' },
+      } as any;
+
+      await expect(
+        service.sendCommand(mockOrgId, mockUserId, 'admin', dto),
+      ).rejects.toThrow(BadRequestException);
+      expect(db.display.findFirst).not.toHaveBeenCalled();
+      expect(httpService.post).not.toHaveBeenCalled();
+    });
+
+    it('should reject update feed URLs that use http for non-loopback hosts', async () => {
+      db.display.findFirst.mockResolvedValue({
+        id: mockDeviceId,
+        nickname: 'Test',
+        organizationId: mockOrgId,
+      });
+
+      const dto = {
+        command: 'update' as const,
+        target: { type: 'device' as const, id: mockDeviceId },
+        payload: { feedUrl: 'http://updates.vizora.cloud/display' },
+      } as any;
+
+      await expect(
+        service.sendCommand(mockOrgId, mockUserId, 'admin', dto),
+      ).rejects.toThrow(BadRequestException);
+      expect(httpService.post).not.toHaveBeenCalled();
+    });
+
+    it('should reject update feed URLs with non-HTTP protocols', async () => {
+      const dto = {
+        command: 'update' as const,
+        target: { type: 'device' as const, id: mockDeviceId },
+        payload: { feedUrl: 'file:///tmp/display-update' },
+      } as any;
+
+      await expect(
+        service.sendCommand(mockOrgId, mockUserId, 'admin', dto),
+      ).rejects.toThrow(BadRequestException);
+      expect(db.display.findFirst).not.toHaveBeenCalled();
+      expect(httpService.post).not.toHaveBeenCalled();
+    });
+
+    it('should reject update feed URLs with credentials or query strings', async () => {
+      await expect(
+        service.sendCommand(mockOrgId, mockUserId, 'admin', {
+          command: 'update' as const,
+          target: { type: 'device' as const, id: mockDeviceId },
+          payload: { feedUrl: 'https://user:pass@updates.vizora.cloud/display' },
+        } as any),
+      ).rejects.toThrow(BadRequestException);
+
+      await expect(
+        service.sendCommand(mockOrgId, mockUserId, 'admin', {
+          command: 'update' as const,
+          target: { type: 'device' as const, id: mockDeviceId },
+          payload: { feedUrl: 'https://updates.vizora.cloud/display?token=abc' },
+        } as any),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(db.display.findFirst).not.toHaveBeenCalled();
+      expect(httpService.post).not.toHaveBeenCalled();
+    });
+
+    it('should reject non-loopback update feed URLs with explicit ports', async () => {
+      const dto = {
+        command: 'update' as const,
+        target: { type: 'device' as const, id: mockDeviceId },
+        payload: { feedUrl: 'https://updates.vizora.cloud:8443/display' },
+      } as any;
+
+      await expect(
+        service.sendCommand(mockOrgId, mockUserId, 'admin', dto),
+      ).rejects.toThrow(BadRequestException);
+      expect(db.display.findFirst).not.toHaveBeenCalled();
+      expect(httpService.post).not.toHaveBeenCalled();
+    });
+
+    it('should allow loopback HTTP update feeds only outside production', async () => {
+      db.display.findFirst.mockResolvedValue({
+        id: mockDeviceId,
+        nickname: 'Test',
+        organizationId: mockOrgId,
+      });
+
+      process.env.NODE_ENV = 'test';
+      await service.sendCommand(mockOrgId, mockUserId, 'admin', {
+        command: 'update' as const,
+        target: { type: 'device' as const, id: mockDeviceId },
+        payload: { feedUrl: 'http://localhost:4876/display/' },
+      } as any);
+      expect(httpService.post.mock.calls[0][1].command.payload).toEqual({
+        feedUrl: 'http://localhost:4876/display',
+      });
+
+      jest.clearAllMocks();
+      process.env.NODE_ENV = 'production';
+      await expect(
+        service.sendCommand(mockOrgId, mockUserId, 'admin', {
+          command: 'update' as const,
+          target: { type: 'device' as const, id: mockDeviceId },
+          payload: { feedUrl: 'http://localhost:4876/display' },
+        } as any),
+      ).rejects.toThrow(BadRequestException);
+      expect(db.display.findFirst).not.toHaveBeenCalled();
+      expect(httpService.post).not.toHaveBeenCalled();
+    });
+
+    it('should normalize URL-shaped update feed allowlist entries', async () => {
+      process.env.DISPLAY_UPDATE_FEED_ALLOWLIST = 'https://updates.vizora.cloud';
+      db.display.findFirst.mockResolvedValue({
+        id: mockDeviceId,
+        nickname: 'Test',
+        organizationId: mockOrgId,
+      });
+
+      await service.sendCommand(mockOrgId, mockUserId, 'admin', {
+        command: 'update' as const,
+        target: { type: 'device' as const, id: mockDeviceId },
+        payload: { feedUrl: 'https://updates.vizora.cloud/display/' },
+      } as any);
+
+      expect(httpService.post.mock.calls[0][1].command.payload).toEqual({
+        feedUrl: 'https://updates.vizora.cloud/display',
+      });
+    });
+
+    it('should reject update feed URLs outside the allowlist', async () => {
+      process.env.DISPLAY_UPDATE_FEED_ALLOWLIST = 'updates.vizora.cloud';
+      db.display.findFirst.mockResolvedValue({
+        id: mockDeviceId,
+        nickname: 'Test',
+        organizationId: mockOrgId,
+      });
+
+      const dto = {
+        command: 'update' as const,
+        target: { type: 'device' as const, id: mockDeviceId },
+        payload: { feedUrl: 'https://updates.attacker.example/display' },
+      } as any;
+
+      await expect(
+        service.sendCommand(mockOrgId, mockUserId, 'admin', dto),
+      ).rejects.toThrow(BadRequestException);
+      expect(httpService.post).not.toHaveBeenCalled();
+    });
+
+    it('should forward update with only a normalized allowlisted feedUrl', async () => {
+      process.env.DISPLAY_UPDATE_FEED_ALLOWLIST = 'updates.vizora.cloud';
+      db.display.findFirst.mockResolvedValue({
+        id: mockDeviceId,
+        nickname: 'Test',
+        organizationId: mockOrgId,
+      });
+
+      const dto = {
+        command: 'update' as const,
+        target: { type: 'device' as const, id: mockDeviceId },
+        payload: {
+          feedUrl: 'https://updates.vizora.cloud/display/',
+          contentId: 'must-not-forward',
+          duration: 60,
+          priority: 'normal',
+        },
+      } as any;
+
+      await service.sendCommand(mockOrgId, mockUserId, 'admin', dto);
+
+      const postCall = httpService.post.mock.calls[0];
+      const body = postCall[1];
+      expect(body.command).toEqual({
+        type: 'update',
+        payload: { feedUrl: 'https://updates.vizora.cloud/display' },
+        commandId: expect.any(String),
+      });
     });
   });
 

--- a/middleware/src/modules/fleet/fleet.service.ts
+++ b/middleware/src/modules/fleet/fleet.service.ts
@@ -3,6 +3,7 @@ import {
   Logger,
   NotFoundException,
   BadRequestException,
+  ForbiddenException,
   ServiceUnavailableException,
 } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
@@ -35,6 +36,8 @@ interface GatewayBroadcastResult {
 }
 
 const REALTIME_HTTP_TIMEOUT_MS = 15000;
+const DEFAULT_DISPLAY_UPDATE_FEED_HOST = 'updates.vizora.cloud';
+const LOCAL_UPDATE_FEED_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
 
 interface OverrideRecord {
   commandId: string;
@@ -69,6 +72,13 @@ export class FleetService {
     userRole: string,
     dto: SendCommandDto,
   ) {
+    if (dto.command === 'update' && userRole !== 'admin') {
+      throw new ForbiddenException('Display app updates require admin role');
+    }
+
+    const updatePayload =
+      dto.command === 'update' ? this.buildUpdatePayload(dto.payload) : null;
+
     // Check rate limit
     await this.checkRateLimit(orgId);
 
@@ -115,6 +125,9 @@ export class FleetService {
         duration,
         priority: dto.payload.priority || 'normal',
       };
+    }
+    if (dto.command === 'update') {
+      gatewayPayload = updatePayload;
     }
 
     // Call gateway broadcast — command shape: { type, payload, commandId }
@@ -294,6 +307,90 @@ export class FleetService {
       queued: result?.queued,
       failed: result?.failed,
     };
+  }
+
+  private buildUpdatePayload(
+    payload?: { feedUrl?: string },
+  ): { feedUrl: string } {
+    return {
+      feedUrl: this.normalizeUpdateFeedUrl(payload?.feedUrl),
+    };
+  }
+
+  private normalizeUpdateFeedUrl(rawFeedUrl?: string): string {
+    if (!rawFeedUrl || typeof rawFeedUrl !== 'string') {
+      throw new BadRequestException('feedUrl required for update');
+    }
+
+    let parsed: URL;
+    try {
+      parsed = new URL(rawFeedUrl.trim());
+    } catch {
+      throw new BadRequestException('feedUrl must be a valid URL');
+    }
+
+    if (!['https:', 'http:'].includes(parsed.protocol)) {
+      throw new BadRequestException('feedUrl must use HTTP or HTTPS');
+    }
+
+    if (parsed.username || parsed.password) {
+      throw new BadRequestException('feedUrl must not include credentials');
+    }
+
+    if (parsed.search) {
+      throw new BadRequestException('feedUrl must not include a query string');
+    }
+
+    const host = this.normalizeUpdateFeedHost(parsed.hostname);
+    const isLocal = LOCAL_UPDATE_FEED_HOSTS.has(host);
+    if (isLocal && !this.isLoopbackUpdateFeedAllowed()) {
+      throw new BadRequestException('feedUrl loopback hosts are not allowed in production');
+    }
+    if (parsed.protocol === 'http:' && !isLocal) {
+      throw new BadRequestException('feedUrl must use HTTPS');
+    }
+    if (parsed.port && !isLocal) {
+      throw new BadRequestException('feedUrl must not include a port');
+    }
+
+    if (!isLocal && !this.getAllowedUpdateFeedHosts().has(host)) {
+      throw new BadRequestException(`feedUrl host is not allowlisted: ${host}`);
+    }
+
+    parsed.hash = '';
+    return parsed.toString().replace(/\/+$/, '');
+  }
+
+  private getAllowedUpdateFeedHosts(): Set<string> {
+    const configured =
+      process.env.DISPLAY_UPDATE_FEED_ALLOWLIST ||
+      DEFAULT_DISPLAY_UPDATE_FEED_HOST;
+
+    return new Set(
+      configured
+        .split(',')
+        .map((host) => this.normalizeAllowedUpdateFeedHost(host.trim()))
+        .filter(Boolean),
+    );
+  }
+
+  private normalizeUpdateFeedHost(host: string): string {
+    return host.toLowerCase().replace(/^\[/, '').replace(/\]$/, '');
+  }
+
+  private normalizeAllowedUpdateFeedHost(host: string): string {
+    if (host.includes('://')) {
+      try {
+        return this.normalizeUpdateFeedHost(new URL(host).hostname);
+      } catch {
+        return this.normalizeUpdateFeedHost(host);
+      }
+    }
+    return this.normalizeUpdateFeedHost(host);
+  }
+
+  private isLoopbackUpdateFeedAllowed(): boolean {
+    return process.env.NODE_ENV !== 'production';
   }
 
   async createOverride(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,9 @@ importers:
       electron-store:
         specifier: ^8.1.0
         version: 8.2.0
+      electron-updater:
+        specifier: 6.8.3
+        version: 6.8.3
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -686,7 +689,7 @@ importers:
         version: 10.1.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
+        version: 29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -698,7 +701,7 @@ importers:
         version: 3.4.19(tsx@4.21.0)(yaml@2.8.2)
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(jest-util@30.2.0)(jest@29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(jest-util@30.2.0)(jest@29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -4882,6 +4885,7 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -5424,6 +5428,10 @@ packages:
 
   builder-util-runtime@9.2.4:
     resolution: {integrity: sha512-upp+biKpN/XZMLim7aguUyW8s0FUpDvOtK6sbanMFDAMBzpHDqdhgVYm6zc9HJ6nWo7u2Lxk60i2M6Jd3aiNrA==}
+    engines: {node: '>=12.0.0'}
+
+  builder-util-runtime@9.5.1:
+    resolution: {integrity: sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==}
     engines: {node: '>=12.0.0'}
 
   builder-util@24.13.1:
@@ -6351,6 +6359,9 @@ packages:
 
   electron-to-chromium@1.5.279:
     resolution: {integrity: sha512-0bblUU5UNdOt5G7XqGiJtpZMONma6WAfq9vsFmtn9x1+joAObr6x1chfqyxFSDCAFwFhCQDrqeAr6MYdpwJ9Hg==}
+
+  electron-updater@6.8.3:
+    resolution: {integrity: sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==}
 
   electron@28.3.3:
     resolution: {integrity: sha512-ObKMLSPNhomtCOBAxFS8P2DW/4umkh72ouZUlUKzXGtYuPzgr1SYhskhFWgzAsPtUzhL2CzyV2sfbHcEW4CXqw==}
@@ -8097,6 +8108,9 @@ packages:
   lodash.difference@4.5.0:
     resolution: {integrity: sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==}
 
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
   lodash.flatten@4.4.0:
     resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
 
@@ -8108,6 +8122,10 @@ packages:
 
   lodash.isboolean@3.0.3:
     resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
@@ -10331,6 +10349,9 @@ packages:
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -14272,7 +14293,7 @@ snapshots:
       ajv: 8.17.1
       enquirer: 2.3.6
       picomatch: 4.0.2
-      semver: 7.7.3
+      semver: 7.7.4
       tsconfig-paths: 4.2.0
       tslib: 2.8.1
       vite: 7.3.1(@types/node@20.19.9)(jiti@2.4.2)(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -14293,7 +14314,7 @@ snapshots:
       '@nx/devkit': 22.4.2(nx@22.4.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18)))
       '@nx/js': 22.4.2(@babel/traverse@7.28.6)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18))(nx@22.4.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18)))
       '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.3)
-      semver: 7.7.3
+      semver: 7.7.4
       tslib: 2.8.1
     optionalDependencies:
       vite: 7.3.1(@types/node@20.19.9)(jiti@2.4.2)(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -16217,12 +16238,12 @@ snapshots:
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.104.1)':
     dependencies:
       webpack: 5.104.1(@swc/core@1.5.29(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack@5.104.1)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.104.1)':
     dependencies:
       webpack: 5.104.1(@swc/core@1.5.29(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack@5.104.1)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.3)(webpack@5.104.1)':
     dependencies:
@@ -16827,7 +16848,7 @@ snapshots:
   bin-version-check@5.1.0:
     dependencies:
       bin-version: 6.0.0
-      semver: 7.7.3
+      semver: 7.7.4
       semver-truncate: 3.0.0
 
   bin-version@6.0.0:
@@ -16954,6 +16975,13 @@ snapshots:
     dependencies:
       debug: 4.4.3
       sax: 1.4.4
+    transitivePeerDependencies:
+      - supports-color
+
+  builder-util-runtime@9.5.1:
+    dependencies:
+      debug: 4.4.3
+      sax: 1.5.0
     transitivePeerDependencies:
       - supports-color
 
@@ -17964,6 +17992,19 @@ snapshots:
 
   electron-to-chromium@1.5.279: {}
 
+  electron-updater@6.8.3:
+    dependencies:
+      builder-util-runtime: 9.5.1
+      fs-extra: 10.1.0
+      js-yaml: 4.1.1
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.4
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   electron@28.3.3:
     dependencies:
       '@electron/get': 2.0.3
@@ -18794,7 +18835,7 @@ snapshots:
       es6-error: 4.1.1
       matcher: 3.0.0
       roarr: 2.15.4
-      semver: 7.7.3
+      semver: 7.7.4
       serialize-error: 7.0.1
     optional: true
 
@@ -19330,7 +19371,7 @@ snapshots:
       '@babel/parser': 7.28.6
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.7.3
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -20047,7 +20088,7 @@ snapshots:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.7.3
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -20072,7 +20113,7 @@ snapshots:
       jest-message-util: 30.2.0
       jest-util: 30.2.0
       pretty-format: 30.2.0
-      semver: 7.7.3
+      semver: 7.7.4
       synckit: 0.11.12
     transitivePeerDependencies:
       - supports-color
@@ -20559,6 +20600,8 @@ snapshots:
 
   lodash.difference@4.5.0: {}
 
+  lodash.escaperegexp@4.1.2: {}
+
   lodash.flatten@4.4.0: {}
 
   lodash.includes@4.3.0: {}
@@ -20566,6 +20609,8 @@ snapshots:
   lodash.isarguments@3.1.0: {}
 
   lodash.isboolean@3.0.3: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash.isinteger@4.0.4: {}
 
@@ -20660,7 +20705,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.7.4
 
   make-error@1.3.6: {}
 
@@ -20903,7 +20948,7 @@ snapshots:
   needle@3.3.1:
     dependencies:
       iconv-lite: 0.6.3
-      sax: 1.4.4
+      sax: 1.5.0
     optional: true
 
   negotiator@0.6.3: {}
@@ -20951,7 +20996,7 @@ snapshots:
 
   node-abi@3.87.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.7.4
 
   node-abort-controller@3.1.1: {}
 
@@ -22084,7 +22129,7 @@ snapshots:
       find-cache-dir: 3.3.2
       fs-extra: 10.1.0
       rollup: 4.59.0
-      semver: 7.7.3
+      semver: 7.7.4
       tslib: 2.8.1
       typescript: 5.9.3
 
@@ -22309,7 +22354,7 @@ snapshots:
 
   semver-truncate@3.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.7.4
 
   semver@5.7.2:
     optional: true
@@ -22999,6 +23044,8 @@ snapshots:
   thunky@1.1.0: {}
 
   tiny-invariant@1.3.3: {}
+
+  tiny-typed-emitter@2.1.0: {}
 
   tinybench@2.9.0:
     optional: true
@@ -23707,7 +23754,7 @@ snapshots:
       watchpack: 2.5.1
       webpack-sources: 3.3.3
     optionalDependencies:
-      webpack-cli: 5.1.4(webpack@5.104.1)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.3)(webpack@5.104.1)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild

--- a/realtime/src/dto/internal-api.dto.spec.ts
+++ b/realtime/src/dto/internal-api.dto.spec.ts
@@ -1,0 +1,23 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+import { BroadcastCommandDto } from './internal-api.dto';
+
+describe('internal API command DTOs', () => {
+  it('accepts update commands on the broadcast path', () => {
+    const dto = plainToInstance(BroadcastCommandDto, {
+      deviceIds: ['display-1'],
+      command: {
+        type: 'update',
+        payload: { feedUrl: 'https://updates.vizora.cloud/display' },
+      },
+    });
+
+    const errors = validateSync(dto, {
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    });
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/realtime/src/types/index.ts
+++ b/realtime/src/types/index.ts
@@ -40,6 +40,7 @@ export interface Playlist {
 export enum DeviceCommandType {
   RELOAD = 'reload',
   RESTART = 'restart',
+  UPDATE = 'update',
   UPDATE_CONFIG = 'update_config',
   CLEAR_CACHE = 'clear_cache',
   SCREENSHOT = 'screenshot',

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -32,20 +32,80 @@ Awesome-hermes-agent ecosystem check: no applicable skill/library primitive for
 Electron update delivery.
 
 **Plan**
-- [ ] Add failing backend tests for admin-only `update`, required `feedUrl`,
+- [x] Add failing backend tests for admin-only `update`, required `feedUrl`,
       allowlisted safe URL validation, and gateway payload shape.
-- [ ] Add failing display tests for updater helper URL safety and
+- [x] Add failing display tests for updater helper URL safety and
       packaged-only `DeviceClient` update command execution.
-- [ ] Implement backend/realtime command support without bypassing auth,
+- [x] Implement backend/realtime command support without bypassing auth,
       tenant, audit, update-feed allowlist, or existing fleet command paths.
-- [ ] Add `electron-updater` and replace the display update stub with a
+- [x] Add `electron-updater` and replace the display update stub with a
       generic-feed updater trigger that refuses non-allowlisted hosts.
-- [ ] Run focused middleware/display tests, display typecheck/build,
+- [x] Run focused middleware/display tests, display typecheck/build,
       relevant realtime checks, diff hygiene, and secret scan.
-- [ ] Request Claude Code review and resolve findings.
+- [x] Request Claude Code review and resolve findings.
 - [ ] Commit, PR, CI, and merge if green.
-- [ ] Do not publish display releases, deploy, edit production env, send real
+- [x] Do not publish display releases, deploy, edit production env, send real
       emails, touch payment setup, or run hardware commands.
+
+**Evidence**
+- Branch: `fix/production-readiness-pass70`.
+- Plan commit: `bb32194e` (`docs: plan display auto-update command`).
+- Red tests:
+  - Middleware focused fleet tests failed before implementation because manager
+    update was not forbidden and update `feedUrl` validation/payload sanitizing
+    did not exist.
+  - Realtime DTO spec failed before implementation because `DeviceCommandType`
+    did not include `update`.
+  - Display focused tests failed before implementation because
+    `display-auto-updater.ts` did not exist and the display `update` command
+    was still a stub.
+- Implementation:
+  - Added `electron-updater@6.8.3` to `@vizora/display`.
+  - Added `display/src/electron/display-auto-updater.ts` with packaged-only
+    execution, HTTPS constraints, host allowlist, no credentials, no query
+    strings, no non-loopback explicit ports, packaged-client loopback rejection,
+    generic provider setup, one-time install listener, and async update check
+    trigger.
+  - Wired the existing display `update` command branch to the helper and kept
+    failed update triggers on the existing negative-ack path.
+  - Extended middleware fleet command validation with `update`, required
+    `payload.feedUrl`, admin-only controller and service checks, early feed URL
+    normalization, and sanitized gateway payload forwarding.
+  - Extended realtime command typing/DTO coverage for `update`.
+  - Documented `DISPLAY_UPDATE_FEED_ALLOWLIST` in tracked env examples and
+    `CLAUDE.md`.
+- Green verification:
+  - `pnpm --filter @vizora/middleware test -- --runTestsByPath src/modules/fleet/fleet.service.spec.ts src/modules/fleet/fleet.controller.spec.ts`: 2 suites / 45 tests passed.
+  - `pnpm --filter @vizora/realtime test -- --runInBand`: 13 suites / 287 tests passed.
+  - `pnpm --filter @vizora/display test -- --runInBand display-auto-updater device-client`: 2 suites / 63 tests passed.
+  - `pnpm --filter @vizora/display test:ci`: 8 suites / 145 tests passed.
+  - `pnpm --filter @vizora/display typecheck`: passed.
+  - `pnpm --filter @vizora/display build`: passed.
+  - `pnpm --filter @vizora/web test -- --runInBand`: 106 suites / 1115 tests passed with pre-existing React `act(...)` warnings.
+  - `npx nx build @vizora/web`: passed after setting non-loopback production placeholder origins for `NEXT_PUBLIC_SOCKET_URL`, `NEXT_PUBLIC_API_URL`, and `BACKEND_URL`. Earlier attempts without those envs, or with localhost values, failed on the existing production security guard as expected.
+  - `npx nx build @vizora/realtime`: passed with existing webpack warnings.
+  - `npx nx build @vizora/middleware`: passed with existing webpack warnings.
+  - `git diff --check`: passed with CRLF warnings only.
+  - `pnpm security:no-hardcoded-jwts`: passed.
+  - `$env:NODE_OPTIONS='--use-system-ca'; pnpm audit --prod --json`: completed and exited nonzero due existing workspace production dependency advisories, including axios/Next-related advisories. This scoped PR does not claim to resolve global dependency audit.
+- Claude Code review:
+  - Local `claude` CLI first review was `NOT CLEAN` because the prompt omitted untracked new files and requested additional URL invariant tests.
+  - Second review, with untracked files and added invariant tests, returned `CLEAN`.
+  - Final narrow review after packaged-client loopback hardening returned `CLEAN`.
+- Build note:
+  - One parallel `npx nx build @vizora/middleware` run failed while
+    `@vizora/realtime` was also building because both builds copied the shared
+    `@vizora/database` generated output at the same time (`EPIPE`, file in use).
+    Rerunning middleware by itself passed.
+- Operator-gated remainder:
+  - No display release was published, no production env was changed, no deploy
+    was performed, no customer email was sent, no payment setup was touched,
+    and no hardware command was run.
+  - Production auto-update rollout still requires signed display artifacts on
+    an allowlisted HTTPS feed host, then an approved admin update command.
+- Documentation caveat:
+  - This isolated worktree does not contain tracked `AGENTS.md`; the primary
+    checkout has an untracked/dirty `AGENTS.md`, so it was not modified.
 
 ## Completed Workstream: Shared Public App URL Resolver Pass 69 (2026-06-03)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,52 @@
 # Vizora - Task Tracker
 
+## Active Workstream: Display Auto-Update Command Pass 70 (2026-06-03)
+
+**Branch:** `fix/production-readiness-pass70`
+
+**Plan:** `docs/plans/2026-06-03-display-auto-update-pass70.md`
+
+**Why now:** `backlog.md` still tracks K3 Electron auto-update as TODO.
+Drift-check shows the display client has an `update` command branch, but it
+only logs a stub, `electron-updater` is not installed, middleware does not
+allow the `update` command through `POST /fleet/commands`, and realtime's
+typed command enum does not include it.
+
+**New primitives introduced:** one focused Electron helper:
+`display/src/electron/display-auto-updater.ts`. No database model, migration,
+route, PM2 process, MCP tool, Hermes skill, AI/provider spend path, production
+env change, release publish, customer email send, payment setup, or deploy is
+planned.
+
+**Hermes-first analysis:** checked per project convention. This is deterministic
+Electron updater plumbing through the existing fleet/realtime command path, not
+a business-agent, MCP, Hermes runtime, or provider-spend task.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Electron app auto-update | none applicable | use `electron-updater` in the existing Electron client |
+| Fleet command authorization | none applicable | reuse existing NestJS fleet controller/service path |
+| Realtime command fanout | none applicable | reuse existing Socket.IO command delivery and queued-command path |
+
+Awesome-hermes-agent ecosystem check: no applicable skill/library primitive for
+Electron update delivery.
+
+**Plan**
+- [ ] Add failing backend tests for admin-only `update`, required `feedUrl`,
+      allowlisted safe URL validation, and gateway payload shape.
+- [ ] Add failing display tests for updater helper URL safety and
+      packaged-only `DeviceClient` update command execution.
+- [ ] Implement backend/realtime command support without bypassing auth,
+      tenant, audit, update-feed allowlist, or existing fleet command paths.
+- [ ] Add `electron-updater` and replace the display update stub with a
+      generic-feed updater trigger that refuses non-allowlisted hosts.
+- [ ] Run focused middleware/display tests, display typecheck/build,
+      relevant realtime checks, diff hygiene, and secret scan.
+- [ ] Request Claude Code review and resolve findings.
+- [ ] Commit, PR, CI, and merge if green.
+- [ ] Do not publish display releases, deploy, edit production env, send real
+      emails, touch payment setup, or run hardware commands.
+
 ## Completed Workstream: Shared Public App URL Resolver Pass 69 (2026-06-03)
 
 **Branch:** `fix/public-app-url-resolver`

--- a/web/src/lib/api/fleet.ts
+++ b/web/src/lib/api/fleet.ts
@@ -5,7 +5,7 @@ declare module './client' {
     sendFleetCommand(data: {
       command: string;
       target: { type: string; id: string };
-      payload?: { contentId?: string; duration?: number; priority?: string };
+      payload?: { contentId?: string; duration?: number; priority?: string; feedUrl?: string };
     }): Promise<{
       commandId: string;
       command: string;


### PR DESCRIPTION
## Summary
- Wire the existing fleet/realtime command path for admin-only packaged display app updates.
- Add a display `electron-updater` helper with backend + client feed URL validation: exact host allowlist, HTTPS for non-loopback, no credentials/query strings, no non-loopback ports, and packaged-client loopback rejection.
- Document `DISPLAY_UPDATE_FEED_ALLOWLIST`, mark K3 repo-fixed/operator-gated, and record production-readiness evidence.

## Operator-gated remainder
- No production deploy/env edit, customer email, payment setup, display release publish, or hardware command was performed.
- Live rollout still requires signed display artifacts on an allowlisted HTTPS feed and target-specific signing verification, especially Linux/AppImage.
- The update command ack means the update check was accepted/started, not that an update downloaded or installed.

## Verification
- `pnpm --filter @vizora/middleware test -- --runTestsByPath src/modules/fleet/fleet.service.spec.ts src/modules/fleet/fleet.controller.spec.ts` — PASS, 2 suites / 45 tests.
- `pnpm --filter @vizora/realtime test -- --runInBand` — PASS, 13 suites / 287 tests.
- `pnpm --filter @vizora/display test -- --runInBand display-auto-updater device-client` — PASS, 2 suites / 63 tests.
- `pnpm --filter @vizora/display test:ci` — PASS, 8 suites / 145 tests.
- `pnpm --filter @vizora/display typecheck` — PASS.
- `pnpm --filter @vizora/display build` — PASS.
- `pnpm --filter @vizora/web test -- --runInBand` — PASS, 106 suites / 1115 tests, with pre-existing React act warnings.
- `npx nx build @vizora/web` with non-loopback production placeholder origins — PASS.
- `npx nx build @vizora/realtime` — PASS with existing webpack warnings.
- `npx nx build @vizora/middleware` — PASS with existing webpack warnings.
- `git diff --check` — PASS with CRLF warnings only.
- `pnpm security:no-hardcoded-jwts` — PASS.
- `$env:NODE_OPTIONS='--use-system-ca'; pnpm audit --prod --json` — completed and exits nonzero due existing workspace production dependency advisories; this PR does not claim to resolve global dependency audit.

## Review
- Claude Code CLI review: first pass NOT CLEAN due omitted untracked files and missing invariant tests; findings resolved.
- Claude Code CLI review: second pass CLEAN.
- Claude Code CLI final narrow delta review after packaged-client loopback hardening: CLEAN.