### PR TITLE
docs: reconcile readiness backlog state

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -1,11 +1,11 @@
 # Vizora Backlog
 
-**Last updated:** 2026-06-03 (main at `5d15fff3`)
+**Last updated:** 2026-06-03 (main at `3494e025`)
 **Production readiness:** repo-side foundation strongest on record; customer-1 launch remains operator-gated on C1-C4 below.
-**Tests:** Current merge evidence: PR #209 GitHub CI passed audit, build, e2e, lint, security, and test. Local #209 verification included middleware unit tests (149 suites / 3055 tests), ops tests (40/40), release-readiness gates (21/21), middleware build, ESLint, and secret scan. Historical aggregate test report remains in `docs/plans/2026-05-09-test-results.md`; verify fresh counts before relying on older totals.
+**Tests:** Current merge evidence: PR #211 GitHub CI passed audit, build, e2e, lint, security, and test. Local #211 verification included focused middleware fleet tests (2 suites / 45 tests), realtime tests (13 suites / 287 tests), display focused tests (2 suites / 63 tests), display CI tests (8 suites / 145 tests), display typecheck/build, web tests (106 suites / 1115 tests), web/realtime/middleware builds, diff hygiene, and secret scan. Pass71 re-verified admin web tests (8 suites / 80 tests) for stale K5 closure. Historical aggregate test report remains in `docs/plans/2026-05-09-test-results.md`; verify fresh counts before relying on older totals.
 **Customer-1 launch date:** operator-confirmed - do not use historical target dates until the operator confirms the actual launch window.
 
-**Security/realtime/readiness wave (#107-#209, merged through 2026-06-03, main `5d15fff3`):** session invalidation now spans REST + WebSocket - password-change / account-deactivation force-logout across all devices (REST `#111`, WS connect-time `#112`, WS mid-session 60s sweep `#114`). Customer-1 smoke coverage is hardened (#116), M12 security alert emails are complete (#117), and the latest overnight readiness passes hardened health/readiness gates, validator reporting, admin readiness display, deploy verification, first-customer runbook truthfulness, and public app URL precedence for email/reset/pairing/billing/lifecycle links (#209). P1/P2 tables below reconciled to match.
+**Security/realtime/readiness wave (#107-#211, merged through 2026-06-03, main `3494e025`):** session invalidation now spans REST + WebSocket - password-change / account-deactivation force-logout across all devices (REST `#111`, WS connect-time `#112`, WS mid-session 60s sweep `#114`). Customer-1 smoke coverage is hardened (#116), M12 security alert emails are complete (#117), and the latest overnight readiness passes hardened health/readiness gates, validator reporting, admin readiness display, deploy verification, first-customer runbook truthfulness, public app URL precedence for email/reset/pairing/billing/lifecycle links (#209), and repo-side display auto-update command plumbing (#211). P1/P2 tables below reconciled to match.
 
 ---
 
@@ -258,9 +258,9 @@ Items the audit listed but we are NOT pursuing live (Engage/kiosk, live remote v
 | K2 | Electron powerSaveBlocker not enabled | Low | FIXED | Packaged display clients start `prevent-display-sleep` and stop it on quit |
 | K3 | Electron auto-update not configured | Low | REPO-FIXED / OPERATOR-GATED | Admin-only `update` fleet command now reaches packaged display clients through `electron-updater` with backend + client feed allowlist checks; live rollout still requires signed artifacts on an allowlisted HTTPS feed and target-specific signing verification |
 | K4 | Display client has 0 test coverage | Medium | FIXED | Electron display Jest suite, typecheck, and build are CI-gated; real-device walkthrough still required |
-| K5 | 3 pre-existing RSC admin test failures | Low | TODO | React Server Component edge cases |
+| K5 | 3 pre-existing RSC admin test failures | Low | FIXED | Historical RSC-admin failure is stale. Pass71 verified all current admin web tests: 8 suites / 80 tests passed; known React `act(...)` warning noise remains non-failing |
 | K6 | AI Designer returns "launching soon" stub | Info | TODO | Intentional — needs API budget |
-| K7 | Push-to-group iterates client-side | Low | TODO | No server-side batch endpoint |
+| K7 | Push-to-group iterates client-side | Low | FIXED | Generalized fleet command endpoint accepts `target.type = group`; `fleet.service` resolves display-group members server-side and fans out through the existing gateway broadcast path |
 | K8 | Playlist loop UI not fully wired | Low | FIXED | Fixed in unblocked tasks sprint |
 
 ---

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,10 @@
 # Vizora - Lessons Learned
 
+## Session: 2026-06-03 - Runtime Assumption Correction
+
+### SMTP / Email State
+- When the operator says SMTP used to work, do not infer "SMTP unconfigured" from stale backlog gates alone. Separate repo-side email-link/config validation from runtime SMTP truth, and verify current env/runtime/test-send evidence before reporting email as broken. Customer-visible sends still require explicit operator approval.
+
 ## Session: 2026-05-31 - Autonomous Builder Correction
 
 ### Session Coordination

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,54 @@
 # Vizora - Task Tracker
 
-## Active Workstream: Display Auto-Update Command Pass 70 (2026-06-03)
+## Active Workstream: Readiness Backlog Reconciliation Pass 71 (2026-06-03)
+
+**Branch:** `fix/production-readiness-pass71`
+
+**Why now:** PR #211 merged the repo-side display auto-update command work,
+but the readiness handoff still has stale open checklist/docs items. Backlog
+also still lists two known issues as TODO even though current code/test
+evidence shows they are no longer true: admin RSC tests are green, and fleet
+commands already support server-side group targeting.
+
+**New primitives introduced:** none. This is source-of-truth reconciliation
+only; no production env change, deploy, email send, payment setup, display
+release publish, hardware action, DB migration, PM2 process, MCP tool, Hermes
+skill, or provider-spend path is planned.
+
+**Hermes-first analysis:** not applicable to a docs-only backlog reconciliation.
+No business-agent or Hermes runtime behavior is being designed or changed.
+
+**Plan**
+- [x] Verify current branch/head and confirm pass70 merged on `origin/main`.
+- [x] Re-run focused admin web tests to prove the stale K5 RSC-test claim.
+- [x] Drift-check K7 push-to-group against the fleet API/service path.
+- [x] Patch `tasks/todo.md`, `backlog.md`, and correction lessons with concrete
+      evidence only.
+- [ ] Run docs diff hygiene, request Claude Code review, commit, PR, and merge
+      if green.
+
+**Evidence**
+- Current branch: `fix/production-readiness-pass71`.
+- Base/head: `3494e025` (`origin/main`) after PR #211 merge.
+- Admin test verification:
+  - `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/admin/__tests__/admin-dashboard.test.tsx src/app/admin/__tests__/organizations-page.test.tsx src/app/admin/__tests__/plans-page.test.tsx src/app/admin/analytics/__tests__/analytics-page.test.tsx src/app/admin/backlog/__tests__/backlog-page.test.tsx src/app/admin/health/__tests__/health-page.test.tsx src/app/admin/support/__tests__/support-dashboard.test.tsx src/app/admin/users/__tests__/users-page.test.tsx`
+  - Result: 8 suites / 80 tests passed; known React `act(...)` warnings in
+    `AdminAnalyticsClient` remain non-failing.
+- K7 drift-check evidence:
+  - `middleware/src/modules/fleet/dto/send-command.dto.ts` accepts
+    `target.type` values `device`, `group`, `organization`, and `tag`.
+  - `middleware/src/modules/fleet/fleet.service.ts` resolves `group` targets by
+    loading `displayGroupMember` rows, then fans out through the existing
+    gateway broadcast path once per command.
+  - `web/src/lib/api/fleet.ts` sends a single `POST /fleet/commands` request for
+    arbitrary fleet targets.
+- Verification:
+  - `git diff --check`: passed with CRLF warnings only.
+  - `pnpm security:no-hardcoded-jwts`: passed.
+- Claude Code review:
+  - Local `claude` CLI reviewed the docs-only diff and returned `CLEAN`.
+
+## Completed Workstream: Display Auto-Update Command Pass 70 (2026-06-03)
 
 **Branch:** `fix/production-readiness-pass70`
 
@@ -43,13 +91,15 @@ Electron update delivery.
 - [x] Run focused middleware/display tests, display typecheck/build,
       relevant realtime checks, diff hygiene, and secret scan.
 - [x] Request Claude Code review and resolve findings.
-- [ ] Commit, PR, CI, and merge if green.
+- [x] Commit, PR, CI, and merge if green.
 - [x] Do not publish display releases, deploy, edit production env, send real
       emails, touch payment setup, or run hardware commands.
 
 **Evidence**
 - Branch: `fix/production-readiness-pass70`.
 - Plan commit: `bb32194e` (`docs: plan display auto-update command`).
+- Implementation commit: `ce800cbc` (`fix(display): wire admin auto-update command`).
+- PR: #211, merged into `main` as `3494e025`; GitHub checks green before merge.
 - Red tests:
   - Middleware focused fleet tests failed before implementation because manager
     update was not forbidden and update `feedUrl` validation/payload sanitizing


### PR DESCRIPTION
## Summary
- marks the display auto-update pass70 workstream as merged via PR #211 / main 3494e025
- updates backlog current-state evidence through PR #211
- closes stale K5/K7 known-issue rows using current admin test and fleet-targeting evidence
- records the SMTP runtime-assumption lesson from the operator correction without claiming SMTP is currently green

## Verification
- `pnpm --filter @vizora/web test -- --runInBand --runTestsByPath src/app/admin/__tests__/admin-dashboard.test.tsx src/app/admin/__tests__/organizations-page.test.tsx src/app/admin/__tests__/plans-page.test.tsx src/app/admin/analytics/__tests__/analytics-page.test.tsx src/app/admin/backlog/__tests__/backlog-page.test.tsx src/app/admin/health/__tests__/health-page.test.tsx src/app/admin/support/__tests__/support-dashboard.test.tsx src/app/admin/users/__tests__/users-page.test.tsx` - 8 suites / 80 tests passed, known React act warnings only
- `git diff --check` - passed with CRLF warnings only
- `pnpm security:no-hardcoded-jwts` - passed
- Claude Code local CLI review - CLEAN

## Operator gates
No production deploy, env edit, SMTP test send, DNS change, payment setup, display release publish, DB migration, or hardware command.