### PR TITLE
fix(agents): record runner balance-delta cost

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -133,12 +133,12 @@ Per current readiness reconciliation: the four operator-driven items below are t
 
 ## Tech-debt from 2026-05-09 readiness pass (post-launch sprint)
 
-These are documented + non-blocking for customer-1. Investigations done; implementations deferred.
+These are documented + non-blocking for customer-1. Investigations done; implementations deferred unless marked done.
 
 | # | Item | Effort | Pointer | Why deferred |
 |---|------|--------|---------|--------------|
 | T1 | Playwright suite refresh — close remaining ~26 failures (heaviest: 16-billing×10) | 6-8h | `docs/plans/2026-05-09-playwright-results.md` | Critical-path flows verified (8/10); 16-billing is OUT of customer-1 scope |
-| T2 | Per-firing cost attribution (Path A: balance-delta pre/post each firing) | ~1h | `docs/plans/2026-05-09-hermes-insights-investigation.md` | Cost defense intact (4 layers); attribution is monitoring-quality |
+| T2 | ✅ DONE - Per-firing cost attribution (Path A: balance-delta pre/post each firing) | ~1h | `docs/plans/2026-05-09-hermes-insights-investigation.md` | Pass72: runner samples post-flight OpenRouter balance and stores nonnegative delta as `agent_runs.costMicrodollars`; live rows require normal deploy, no prod firing performed |
 | T3 | agentRunId propagation runner→Hermes→MCP — Hermes 0.12.0 has no `--header` flag; needs upstream patch OR env-var config interpolation experiment | 2h-2d | `docs/plans/2026-05-09-agent-run-id-propagation-investigation.md` | Sidecar's audit-row join falls back to time-range; minor refinement degradation |
 | T4 | support-triage cross-tenant token redesign — Option 2 (relax `support:*` tools to accept platform-scope) | 4-6h | `docs/plans/2026-05-09-support-triage-cross-tenant-design.md` | support-triage NOT enabled; operator handles tickets directly |
 

--- a/docs/plans/2026-05-09-hermes-insights-investigation.md
+++ b/docs/plans/2026-05-09-hermes-insights-investigation.md
@@ -44,7 +44,9 @@ The sidecar's design (`scripts/agents/hermes/poll-insights.ts`) assumes `hermes 
 - L3 (Hermes `model.max_tokens=4096`): per-call output cap
 - L4 (cross-firing breaker, planned P4): NOT YET IMPLEMENTED
 
-What we lose: **per-firing cost attribution.** The `agent_runs` table has `costMicrodollars=NULL` for every row written today. Grafana's "cost per firing" panel is empty.
+What we lose before Path A lands: **per-firing cost attribution.** Existing
+pre-Path-A `agent_runs` rows have `costMicrodollars=NULL`; Grafana's "cost per
+firing" panel stays empty for those historical rows.
 
 ## Three fix paths (ranked by cost / complexity)
 
@@ -98,5 +100,9 @@ The sidecar's role shrinks to: orphan-row sweep + outcome refinement (which stil
 
 - Finding documented: ✅ this file
 - Sidecar fix: minimal — change `level: 'error'` to `level: 'info'` for the "No sessions found" case so it doesn't trip the parser-failure alert
-- Runner fix (Path A): tracked in `tasks/feature-backlog.md` as P2
+- Runner fix (Path A): implemented in pass72. `run-hermes-skill.sh` samples
+  post-flight OpenRouter balance and sends nonnegative balance deltas as
+  `costMicrodollars` on the initial `agent_runs` POST; middleware validates and
+  persists that value. Production collection starts only after normal deploy; no
+  prod firing or provider call was performed by this repo-side change.
 - Long-term (Path B / C): backlog

--- a/middleware/src/modules/agents/agent-runs.schemas.spec.ts
+++ b/middleware/src/modules/agents/agent-runs.schemas.spec.ts
@@ -1,0 +1,33 @@
+import { RecordRunInput } from './agent-runs.schemas';
+
+describe('RecordRunInput', () => {
+  const basePayload = {
+    skillName: 'vizora-customer-lifecycle',
+    startedAt: '2026-06-03T12:00:00.000Z',
+    finishedAt: '2026-06-03T12:00:30.000Z',
+    exitCode: 0,
+    outcome: 'success',
+  };
+
+  it('accepts runner-measured costMicrodollars as a nonnegative integer', () => {
+    const parsed = RecordRunInput.safeParse({
+      ...basePayload,
+      costMicrodollars: 2400,
+    });
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.data).toEqual(expect.objectContaining({ costMicrodollars: 2400 }));
+  });
+
+  it('rejects negative or fractional runner-measured costMicrodollars', () => {
+    expect(RecordRunInput.safeParse({
+      ...basePayload,
+      costMicrodollars: -1,
+    }).success).toBe(false);
+
+    expect(RecordRunInput.safeParse({
+      ...basePayload,
+      costMicrodollars: 12.5,
+    }).success).toBe(false);
+  });
+});

--- a/middleware/src/modules/agents/agent-runs.schemas.ts
+++ b/middleware/src/modules/agents/agent-runs.schemas.ts
@@ -4,8 +4,9 @@
  * See: docs/plans/2026-05-08-agent-platform-redesign-design.md §3.1
  *
  * The runner script POSTs RecordRunInput synchronously on firing exit.
- * The insights-poller sidecar PATCHes EnrichRunInput ~5 min later with
- * cost / token data extracted from `hermes insights`.
+ * The runner may include balance-delta cost on the initial row. The
+ * insights-poller sidecar PATCHes EnrichRunInput ~5 min later with token
+ * data, rate snapshots, and outcome refinements when available.
  *
  * Outcome taxonomy follows ADL-3 (mutually exclusive). The runner emits
  * only the 4-value subset it can detect from Hermes-visible signals; the
@@ -58,6 +59,9 @@ export type RunnerOutcomeT = z.infer<typeof RunnerOutcome>;
 /**
  * Body of POST /api/v1/internal/agent-runs.
  * Dates are ISO-8601 strings on the wire; service-side they become Date.
+ * `costMicrodollars` is optional runner-measured spend from pre/post
+ * OpenRouter balance deltas. Token-derived sidecar enrichment may remain null
+ * when Hermes one-shot mode does not persist sessions.
  */
 export const RecordRunInput = z.object({
   skillName: z.string().min(1).max(128),
@@ -70,6 +74,7 @@ export const RecordRunInput = z.object({
   errorExcerpt: z.string().max(1024).optional(),
   preflightBalanceUsd: z.number().optional(),
   preflightTodaySpendUsd: z.number().optional(),
+  costMicrodollars: z.number().int().nonnegative().optional(),
 });
 export type RecordRunInputT = z.infer<typeof RecordRunInput>;
 

--- a/middleware/src/modules/agents/agent-runs.service.spec.ts
+++ b/middleware/src/modules/agents/agent-runs.service.spec.ts
@@ -84,7 +84,7 @@ describe('AgentRunsService', () => {
       // Sanity: cost columns are absent from the create payload.
       const createArgs = db.agentRun.create.mock.calls[0][0].data;
       expect(createArgs.tokensIn).toBeUndefined();
-      expect(createArgs.costMicrodollars).toBeUndefined();
+      expect(createArgs.costMicrodollars).toBeNull();
     });
 
     it('truncates errorExcerpt to 1024 chars', async () => {
@@ -115,6 +115,27 @@ describe('AgentRunsService', () => {
         data: expect.objectContaining({
           outcome: 'budget_aborted',
           preflightBalanceUsd: 0.05,
+        }),
+        select: { id: true },
+      });
+    });
+
+    it('persists runner-measured costMicrodollars when supplied at record time', async () => {
+      db.agentRun.create.mockResolvedValue({ id: 'cuid_cost' });
+      await service.recordRun({
+        skillName: 'vizora-costed',
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date().toISOString(),
+        exitCode: 0,
+        outcome: 'success',
+        preflightBalanceUsd: 1.23456789,
+        costMicrodollars: 1800,
+      });
+
+      expect(db.agentRun.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          costMicrodollars: 1800,
+          preflightBalanceUsd: 1.23456789,
         }),
         select: { id: true },
       });
@@ -269,6 +290,23 @@ describe('AgentRunsService', () => {
       await service.enrichRun('r8', { tokensIn: 100, tokensOut: 50 });
       const dataArg = db.agentRun.updateMany.mock.calls[0][0].data;
       expect('outcome' in dataArg).toBe(false);
+    });
+
+    it('preserves runner-measured cost when sidecar has no token-derived cost', async () => {
+      const recent = new Date(Date.now() - 30 * 1000);
+      db.agentRun.findUnique.mockResolvedValue({
+        id: 'r-cost',
+        finishedAt: recent,
+        enrichedAt: null,
+        costMicrodollars: 1800,
+      });
+      db.agentRun.updateMany.mockResolvedValue({ count: 1 });
+
+      await service.enrichRun('r-cost', { outcomeRefinement: 'no_work' });
+
+      const dataArg = db.agentRun.updateMany.mock.calls[0][0].data;
+      expect('costMicrodollars' in dataArg).toBe(false);
+      expect(dataArg).toEqual(expect.objectContaining({ outcome: 'no_work' }));
     });
   });
 

--- a/middleware/src/modules/agents/agent-runs.service.ts
+++ b/middleware/src/modules/agents/agent-runs.service.ts
@@ -18,7 +18,7 @@ import {
  * Two-stage write pattern (design ADL-2):
  *   1. recordRun()  — synchronous, called by the runner POST endpoint
  *   2. enrichRun()  — asynchronous, called by the insights-poller sidecar
- *                     ~5 min later with cost + token data
+ *                     ~5 min later with token/rate data and refinements
  *
  * Cost is FROZEN at write (ADL-7). When MODEL_RATES changes, historical
  * rows preserve their snapshotted rateInUsdPerMt / rateOutUsdPerMt.
@@ -61,6 +61,7 @@ export class AgentRunsService {
         errorExcerpt: input.errorExcerpt?.slice(0, 1024) ?? null,
         preflightBalanceUsd: input.preflightBalanceUsd ?? null,
         preflightTodaySpendUsd: input.preflightTodaySpendUsd ?? null,
+        costMicrodollars: input.costMicrodollars ?? null,
         callerType: callerType ?? null,
       },
       select: { id: true },
@@ -82,7 +83,7 @@ export class AgentRunsService {
     // a sidecar bug from a benign late-tick (Reviewer A+B design review).
     const existing = await this.db.agentRun.findUnique({
       where: { id },
-      select: { id: true, finishedAt: true, enrichedAt: true },
+      select: { id: true, finishedAt: true, enrichedAt: true, costMicrodollars: true },
     });
     if (!existing) {
       throw new NotFoundException(`agent_runs row '${id}' not found`);
@@ -121,12 +122,14 @@ export class AgentRunsService {
     const data: Record<string, unknown> = {
       tokensIn: input.tokensIn ?? null,
       tokensOut: input.tokensOut ?? null,
-      costMicrodollars,
       rateInUsdPerMt: rateIn ?? null,
       rateOutUsdPerMt: rateOut ?? null,
       model: input.model ?? null,
       enrichedAt: new Date(),
     };
+    if (costMicrodollars != null || existing.costMicrodollars == null) {
+      data.costMicrodollars = costMicrodollars;
+    }
     if (input.outcomeRefinement != null) {
       data.outcome = input.outcomeRefinement;
     }

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -962,13 +962,14 @@ model McpAuditLog {
 
 /// Per-firing record for Hermes-driven agent invocations. Written in
 /// two stages: the runner script POSTs metadata synchronously on firing
-/// exit; the insights-poller sidecar PATCHes cost/token data ~5 min
-/// later by joining `hermes insights` output back to the row.
+/// exit, including optional balance-delta cost; the insights-poller sidecar
+/// PATCHes token/rate data and outcome refinements ~5 min later when
+/// `hermes insights` output is available.
 ///
 /// Cost columns are FROZEN at write — see ADL-7 in the design doc.
-/// `rateInUsdPerMt` and `rateOutUsdPerMt` capture the model rate USED
-/// at the moment of enrichment so historical queries stay accurate
-/// when MODEL_RATES changes.
+/// `rateInUsdPerMt` and `rateOutUsdPerMt` capture the model rate USED at
+/// the moment of sidecar enrichment so token-derived historical queries
+/// stay accurate when MODEL_RATES changes.
 ///
 /// Retention: 90 days (enforced by db-maintainer cron).
 model AgentRun {
@@ -993,8 +994,9 @@ model AgentRun {
   // Token usage from `hermes insights`. Null until sidecar enriches.
   tokensIn               Int?
   tokensOut              Int?
-  // Cost in microdollars (USD * 1e6) for integer arithmetic. Computed
-  // ONCE at enrichment time; never recomputed (ADL-7).
+  // Cost in microdollars (USD * 1e6) for integer arithmetic. Either
+  // runner-measured from pre/post balance delta or sidecar-computed from
+  // token usage; never recomputed after write (ADL-7).
   costMicrodollars       Int?
   // Rate used at enrichment time. Snapshotting these keeps historical
   // analyses correct when OpenRouter rates change.

--- a/scripts/agents/hermes/run-hermes-skill.sh
+++ b/scripts/agents/hermes/run-hermes-skill.sh
@@ -19,7 +19,8 @@
 #   3. Pre-flight check on Hermes version (refuse if HERMES_VERSION env
 #      is set and `hermes --version` returns a different value).
 #   4. Optional per-skill toolset filter via -t (P1.2).
-#   5. Post-flight POST /internal/agent-runs with run metadata.
+#   5. Post-flight OpenRouter balance-delta cost attribution.
+#   6. Post-flight POST /internal/agent-runs with run metadata.
 #
 # NOTE on max_tokens (PR-review R3 C1):
 #   `--max-tokens` is NOT a Hermes 0.12.0 CLI flag — argparse interprets
@@ -128,10 +129,12 @@ for arg in sys.argv[1:]:
     if v == "": continue
     # Numeric coercion for known number fields. Validate strictly so a
     # tampered env var cannot inject non-numeric content.
-    if k in ("exitCode", "pid"):
+    if k in ("exitCode", "pid", "costMicrodollars"):
         try:
             fields[k] = int(v)
         except ValueError:
+            sys.exit(1)
+        if fields[k] < 0:
             sys.exit(1)
     elif k in ("preflightBalanceUsd", "preflightTodaySpendUsd"):
         if not re.fullmatch(r"-?\d+(\.\d+)?", v):
@@ -231,6 +234,30 @@ RC=$?
 
 END=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
 
+# Path A cost attribution: sample OpenRouter balance after Hermes exits and
+# store the observed preflight-postflight delta on the initial agent_runs row.
+# Omit the value if either balance probe fails or a concurrent top-up/refund
+# makes the delta negative.
+POSTFLIGHT_BALANCE="$(openrouter_balance_usd 2>/dev/null || echo "")"
+COST_MICRODOLLARS=""
+if [[ -n "$PREFLIGHT_BALANCE" && -n "$POSTFLIGHT_BALANCE" ]] \
+    && [[ "$PREFLIGHT_BALANCE" =~ ^-?[0-9]+(\.[0-9]+)?$ ]] \
+    && [[ "$POSTFLIGHT_BALANCE" =~ ^-?[0-9]+(\.[0-9]+)?$ ]]; then
+  COST_DELTA_USD="$(echo "$PREFLIGHT_BALANCE - $POSTFLIGHT_BALANCE" | bc -l)"
+  if [[ "$COST_DELTA_USD" =~ ^-?([0-9]+(\.[0-9]+)?|\.[0-9]+)$ ]] \
+      && (( $(echo "$COST_DELTA_USD >= 0" | bc -l) )); then
+    COST_MICRODOLLARS="$(python3 -c '
+from decimal import Decimal, ROUND_HALF_UP
+import sys
+delta = Decimal(sys.argv[1])
+micros = int((delta * Decimal("1000000")).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+if micros < 0 or micros > 2147483647:
+    sys.exit(1)
+print(micros)
+' "$COST_DELTA_USD" 2>/dev/null || echo "")"
+  fi
+fi
+
 # Classify outcome from RC + stdout markers ONLY (Reviewer A I2 +
 # design ADL-3). FORBIDDEN/INVALID_INPUT live in mcp_audit_log, not
 # Hermes stdout — sidecar refines later.
@@ -271,6 +298,7 @@ POST_BODY="$(build_run_body \
   "outcome=$OUTCOME" \
   "preflightBalanceUsd=$PREFLIGHT_BALANCE" \
   "preflightTodaySpendUsd=$PREFLIGHT_TODAY_SPEND" \
+  "costMicrodollars=$COST_MICRODOLLARS" \
   "$EXCERPT_ARG")"
 
 RUN_ID="$(post_agent_run "$POST_BODY" \

--- a/scripts/ops/release-readiness-gates.test.ts
+++ b/scripts/ops/release-readiness-gates.test.ts
@@ -183,6 +183,15 @@ test('ops reporter summarizes active incidents instead of only open incidents', 
   assert.doesNotMatch(reporter, /filter\(i => i\.status === 'open'\)/);
 });
 
+test('Hermes runner records post-flight balance-delta cost attribution', () => {
+  const runner = readRepoFile('scripts/agents/hermes/run-hermes-skill.sh');
+
+  assert.match(runner, /POSTFLIGHT_BALANCE="\$\(openrouter_balance_usd/);
+  assert.match(runner, /COST_MICRODOLLARS=/);
+  assert.match(runner, /"costMicrodollars=\$COST_MICRODOLLARS"/);
+  assert.match(runner, /\$PREFLIGHT_BALANCE - \$POSTFLIGHT_BALANCE/);
+});
+
 test('ops alerting labels unresolved incident lists as active incidents', () => {
   const alerting = readRepoFile('scripts/ops/lib/alerting.ts');
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,79 @@
 # Vizora - Task Tracker
 
-## Active Workstream: Readiness Backlog Reconciliation Pass 71 (2026-06-03)
+## Active Workstream: Hermes Runner Cost Attribution Pass 72 (2026-06-03)
+
+**Branch:** `fix/production-readiness-pass72`
+
+**Why now:** `backlog.md` still tracks T2 per-firing cost attribution as open.
+The OpenRouter credit-drain incident is already mitigated by hard cost guards,
+but current `agent_runs.costMicrodollars` rows remain null because Hermes `-z`
+does not persist sessions for the sidecar to parse. The existing investigation
+recommends Path A: measure pre/post OpenRouter credit balance around each
+runner firing and store the delta.
+
+**Drift-check:** existing code already has `AgentRun.costMicrodollars`,
+`AgentRunsService.getTodaySpendUsd()`, runner pre-flight OpenRouter balance
+checks, and internal `POST /api/v1/internal/agent-runs`. The residual gap is
+specific: the runner does not capture post-flight balance or send a measured
+cost, and the initial record schema/service rejects/omits that value.
+
+**New primitives introduced:** one optional internal wire field,
+`costMicrodollars`, on `RecordRunInput`, plus a small runner-side calculation
+that converts an observed USD balance delta to integer microdollars. No DB
+model/migration, public API, PM2 process, env var, MCP tool, Hermes skill,
+provider-spend path, production deploy, prod env edit, customer email send,
+payment setup, or hardware action is planned.
+
+**Hermes-first analysis:** checked per project convention. The official Hermes
+skills catalog and awesome-hermes-agent ecosystem contain general Hermes setup,
+skills, PR, and workflow helpers, but no Vizora-specific internal
+`agent_runs`/OpenRouter-balance attribution primitive.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Hermes runner cost attribution | none found | build in existing `run-hermes-skill.sh` runner |
+| OpenRouter balance delta accounting | none found | reuse existing `openrouter-balance.sh` helper |
+| Vizora agent-run persistence | none found | extend existing NestJS internal `AgentRunsService` path |
+
+Awesome-hermes-agent ecosystem check: no installable skill replaces this
+repo-local runner/accounting change.
+
+**Plan**
+- [x] Add failing schema/service/static ops tests for runner-supplied
+      `costMicrodollars`.
+- [x] Implement minimal middleware schema/service persistence for measured
+      runner cost.
+- [x] Implement post-flight OpenRouter balance delta in the existing Hermes
+      runner without changing cost guards or invoking providers in tests.
+- [x] Update backlog and investigation docs to close T2 repo-side.
+- [ ] Run focused middleware tests, ops gates, shell syntax check, diff hygiene,
+      secret scan, Claude Code review, commit, PR, CI, and merge if green.
+
+**Evidence**
+- Red tests:
+  - `pnpm --filter @vizora/middleware test -- --runTestsByPath src/modules/agents/agent-runs.schemas.spec.ts src/modules/agents/agent-runs.service.spec.ts --runInBand` failed because `RecordRunInput` stripped `costMicrodollars` and `AgentRunsService.recordRun()` omitted it.
+  - `pnpm test:ops -- scripts/ops/release-readiness-gates.test.ts` failed because `run-hermes-skill.sh` had no post-flight balance attribution wiring.
+- Implementation:
+  - `RecordRunInput` now accepts optional nonnegative integer `costMicrodollars`.
+  - `AgentRunsService.recordRun()` persists runner-measured `costMicrodollars` on the initial row.
+  - `AgentRunsService.enrichRun()` preserves runner-measured cost when the sidecar has no token-derived cost, and only replaces it when token/rate data can compute a cost.
+  - `run-hermes-skill.sh` samples post-flight OpenRouter balance, computes a nonnegative preflight-postflight delta in microdollars, and includes it in the internal agent-run POST when both balance probes are valid.
+  - `backlog.md` and `docs/plans/2026-05-09-hermes-insights-investigation.md` now mark T2 Path A repo-fixed while keeping live collection deploy-gated.
+- Green verification so far:
+  - `pnpm --filter @vizora/middleware test -- --runTestsByPath src/modules/agents/agent-runs.schemas.spec.ts src/modules/agents/agent-runs.service.spec.ts --runInBand`: 2 suites / 25 tests passed.
+  - `pnpm --filter @vizora/middleware test -- --runTestsByPath src/modules/agents/agent-runs.service.spec.ts --runInBand`: 1 suite / 24 tests passed after adding the cost-preservation regression.
+  - `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern="modules/agents"`: 9 suites / 116 tests passed, with expected negative-path AgentState/Onboarding logs.
+  - `pnpm test:ops`: 41 tests passed.
+  - `C:\Program Files\Git\bin\bash.exe -n scripts/agents/hermes/run-hermes-skill.sh`: passed.
+  - `npx nx build @vizora/middleware`: passed with existing webpack warnings.
+  - `git diff --check`: passed with CRLF warnings only.
+  - `pnpm security:no-hardcoded-jwts`: passed.
+  - `bash -n scripts/agents/hermes/run-hermes-skill.sh` was not usable in this PowerShell environment because `bash` resolves to a broken WSL shim (`/bin/bash` missing); Git Bash was used explicitly instead.
+- Claude Code review:
+  - Local `claude.exe` review returned `CLEAN`, with no required edits.
+  - Reviewer explicitly checked cost-preservation on sidecar outcome-only enrichment, shell decimal validation, cost-guard preservation, secret exposure, and docs truthfulness.
+
+## Completed Workstream: Readiness Backlog Reconciliation Pass 71 (2026-06-03)
 
 **Branch:** `fix/production-readiness-pass71`
 
@@ -24,7 +97,7 @@ No business-agent or Hermes runtime behavior is being designed or changed.
 - [x] Drift-check K7 push-to-group against the fleet API/service path.
 - [x] Patch `tasks/todo.md`, `backlog.md`, and correction lessons with concrete
       evidence only.
-- [ ] Run docs diff hygiene, request Claude Code review, commit, PR, and merge
+- [x] Run docs diff hygiene, request Claude Code review, commit, PR, and merge
       if green.
 
 **Evidence**
@@ -47,6 +120,11 @@ No business-agent or Hermes runtime behavior is being designed or changed.
   - `pnpm security:no-hardcoded-jwts`: passed.
 - Claude Code review:
   - Local `claude` CLI reviewed the docs-only diff and returned `CLEAN`.
+- Commit/PR/CI:
+  - Commit `94f44371` (`docs: reconcile readiness backlog state`).
+  - PR #212 merged as `a2d0a96d`.
+  - GitHub checks passed before merge: audit, build, e2e, lint, security, and
+    test.
 
 ## Completed Workstream: Display Auto-Update Command Pass 70 (2026-06-03)
 


### PR DESCRIPTION
## Summary
- closes T2 Path A repo-side by recording Hermes runner balance-delta cost on `agent_runs`
- accepts optional nonnegative `costMicrodollars` on the internal runner POST and persists it at record time
- preserves runner-measured cost when sidecar outcome refinement has no token-derived cost, while still allowing token-derived cost to replace it when available
- updates backlog/investigation docs to mark T2 repo-fixed and deploy-gated for live collection

## Verification
- Red tests confirmed schema/service/static ops missing behavior before implementation
- `pnpm --filter @vizora/middleware test -- --runTestsByPath src/modules/agents/agent-runs.schemas.spec.ts src/modules/agents/agent-runs.service.spec.ts --runInBand` - 2 suites / 25 tests passed
- `pnpm --filter @vizora/middleware test -- --runTestsByPath src/modules/agents/agent-runs.service.spec.ts --runInBand` - 1 suite / 24 tests passed after cost-preservation regression
- `pnpm --filter @vizora/middleware test -- --runInBand --testPathPattern=modules/agents` - 9 suites / 116 tests passed, expected negative-path logs only
- `pnpm test:ops` - 41 tests passed
- `C:\Program Files\Git\bin\bash.exe -n scripts/agents/hermes/run-hermes-skill.sh` - passed
- `npx nx build @vizora/middleware` - passed with existing webpack warnings
- `git diff --check` - passed with CRLF warnings only
- `pnpm security:no-hardcoded-jwts` - passed
- Claude Code local CLI review - CLEAN

## Operator gates
No production deploy, env edit, provider call/firing, customer email, payment setup, hardware action, or DB migration was performed. Live cost rows start only after a normal reviewed deploy.