### PR TITLE
fix(agents): add Hermes audit outcome fallback

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -139,7 +139,7 @@ These are documented + non-blocking for customer-1. Investigations done; impleme
 |---|------|--------|---------|--------------|
 | T1 | Playwright suite refresh — close remaining ~26 failures (heaviest: 16-billing×10) | 6-8h | `docs/plans/2026-05-09-playwright-results.md` | Critical-path flows verified (8/10); 16-billing is OUT of customer-1 scope |
 | T2 | ✅ DONE - Per-firing cost attribution (Path A: balance-delta pre/post each firing) | ~1h | `docs/plans/2026-05-09-hermes-insights-investigation.md` | Pass72: runner samples post-flight OpenRouter balance and stores nonnegative delta as `agent_runs.costMicrodollars`; live rows require normal deploy, no prod firing performed |
-| T3 | agentRunId propagation runner→Hermes→MCP — Hermes 0.12.0 has no `--header` flag; needs upstream patch OR env-var config interpolation experiment | 2h-2d | `docs/plans/2026-05-09-agent-run-id-propagation-investigation.md` | Sidecar's audit-row join falls back to time-range; minor refinement degradation |
+| T3 | PARTIAL - agentRunId propagation runner→Hermes→MCP — Hermes 0.12.0 has no `--header` flag; needs upstream patch OR env-var config interpolation experiment | 2h-2d | `docs/plans/2026-05-09-agent-run-id-propagation-investigation.md` | Pass73: sidecar Path D fallback shipped (MCP audit `agentName` candidates + firing window when `agentRunId` rows are absent) and no longer false-refines empty audit evidence to `no_work`; precise per-run header propagation remains deferred |
 | T4 | support-triage cross-tenant token redesign — Option 2 (relax `support:*` tools to accept platform-scope) | 4-6h | `docs/plans/2026-05-09-support-triage-cross-tenant-design.md` | support-triage NOT enabled; operator handles tickets directly |
 
 ---

--- a/docs/plans/2026-05-09-agent-run-id-propagation-investigation.md
+++ b/docs/plans/2026-05-09-agent-run-id-propagation-investigation.md
@@ -83,15 +83,27 @@ Path A (upstream Hermes contribution) tracked in `tasks/feature-backlog.md` for 
 
 ## Implementation: enable the time-range fallback in the sidecar
 
-The sidecar at `scripts/agents/hermes/poll-insights.ts` currently joins `mcp_audit_log` ONLY by `agentRunId`. When that's NULL on every row (today's reality), the join finds 0 rows and the outcome refinement marks every successful firing as `no_work` — incorrect.
+The sidecar at `scripts/agents/hermes/poll-insights.ts` used to join `mcp_audit_log` ONLY by `agentRunId`. When that's NULL on every row (today's reality), the join found 0 rows and the outcome refinement marked every successful firing as `no_work` — incorrect.
 
-Add a fallback path: if `agentRunId` is consistently NULL for the firing's time window, fall back to a time-range + agentName join with a `confidence: 'low'` flag.
+Pass73 implemented Path D repo-side:
 
-(Implementation deferred — minor monitoring fix, not customer-blocking.)
+- `scripts/agents/hermes/outcome-refinement.ts` classifies audit status groups.
+- `poll-insights.ts` queries exact `agentRunId` groups first.
+- If exact groups are absent, it falls back to `agentRunId: null` + MCP audit
+  `agentName` candidates for the skill (for example
+  `vizora-customer-lifecycle` also checks `hermes-customer-lifecycle`) + the
+  firing's `startedAt`/`finishedAt` window with a small boundary pad.
+- Concrete audit-derived outcomes, including confirmed `success`, are PATCHed
+  through the existing internal endpoint so `enrichedAt` is set and valid runs
+  are not later orphan-swept as `runner_crash`.
+- If neither exact nor fallback rows exist, it leaves the provisional `success` row unrefined instead of writing `no_work`.
+
+There is no schema column for an explicit fallback confidence flag today, so the lower-confidence fallback is documented and covered by ops tests rather than persisted on the row.
 
 ## Status
 
 - Finding documented: ✅ this file
-- Sidecar Path D fallback: tracked in `tasks/feature-backlog.md` as P2
+- Sidecar Path D fallback: implemented repo-side in pass73
 - Path A upstream contribution: tracked as long-term feedback to Hermes maintainers
-- Customer #1 impact: NONE (cost defense intact, monitoring slightly degraded)
+- Remaining precise `agentRunId` propagation: deferred to Hermes upstream `--header` support or a verified env-var interpolation path
+- Customer #1 impact: NONE (cost defense intact, monitoring gracefully degrades when precise headers are unavailable)

--- a/docs/plans/2026-05-09-hermes-insights-investigation.md
+++ b/docs/plans/2026-05-09-hermes-insights-investigation.md
@@ -94,7 +94,7 @@ fi
 
 Pass `costMicrodollars=$(round_to_microdollars $COST_DELTA)` to the POST body. Middleware writes it directly into the `agent_runs` row alongside the metadata.
 
-The sidecar's role shrinks to: orphan-row sweep + outcome refinement (which still works via `mcp_audit_log` join — assuming Path B for `agentRunId` propagation also lands).
+The sidecar's role shrinks to: orphan-row sweep + outcome refinement. Pass73 keeps outcome refinement useful before precise `agentRunId` propagation lands by falling back to MCP audit `agentName` candidates for the skill plus the firing window when exact `agentRunId` rows are absent.
 
 ## Status
 
@@ -105,4 +105,8 @@ The sidecar's role shrinks to: orphan-row sweep + outcome refinement (which stil
   `costMicrodollars` on the initial `agent_runs` POST; middleware validates and
   persists that value. Production collection starts only after normal deploy; no
   prod firing or provider call was performed by this repo-side change.
+- Outcome fallback (Path D): implemented in pass73. Empty audit evidence no
+  longer false-refines successful firings to `no_work`; fallback audit rows are
+  grouped by MCP audit `agentName` candidates and firing window until precise
+  per-run MCP headers are available.
 - Long-term (Path B / C): backlog

--- a/docs/plans/2026-05-09-production-readiness-report.md
+++ b/docs/plans/2026-05-09-production-readiness-report.md
@@ -208,7 +208,7 @@ These are real but non-blocking for customer #1. Capture as P2 items, address po
 | # | Issue | Severity | Path forward |
 |---|---|---|---|
 | 1 | `hermes insights --source cli` returns "No sessions found" — sidecar can't enrich agent_runs with cost data | LOW (3 other cost-defense layers active) | Investigate Hermes session storage location; may need alternate insights query |
-| 2 | `agentRunId` not propagated runner→Hermes→MCP server. Sidecar's outcome refinement falls back to `no_work` for all rows | LOW (refinement is a quality signal, not a safety gate) | Implement runner env-var propagation in P3 |
+| 2 | `agentRunId` not propagated runner→Hermes→MCP server. Pass73 sidecar fallback now uses MCP audit `agentName` candidates + firing window when exact rows are absent, and leaves empty audit evidence unrefined instead of marking all rows `no_work` | LOW (refinement is a quality signal, not a safety gate) | Precise per-run propagation remains upstream/deferred; test Hermes env-var interpolation or `--header` support post-launch |
 | 3 | `hermes-vizora-support-triage` per-org token can only attribute its own org. Cross-org `log_shadow_row` writes get INVALID_INPUT | MEDIUM (support-triage NOT enabled today) | P2 design call: re-issue support-triage as platform-scope token + relax `support:*` tools to accept platform tokens |
 | 4 | `--max-tokens` is not a real Hermes 0.12.0 CLI flag (verified) — config setting is the only Layer 3 mechanism, unverified at OpenRouter request layer | MEDIUM | P0.0a smoke test once a long-tail firing happens with credits |
 | 5 | Tool allowlist (`-t` flag in ecosystem.config.js) currently empty — no model-side filtering | LOW (server-side scope check is the load-bearing backstop) | P0.0a smoke + P3 verification |

--- a/scripts/agents/hermes/outcome-refinement.ts
+++ b/scripts/agents/hermes/outcome-refinement.ts
@@ -1,0 +1,35 @@
+export type AuditStatusGroup = {
+  status: string;
+  count: number;
+};
+
+export type AuditOutcomeRefinement = 'success' | 'partial' | 'tool_error' | null;
+
+export function classifyAuditOutcome(groups: AuditStatusGroup[]): {
+  outcome: AuditOutcomeRefinement;
+  hasAuditEvidence: boolean;
+} {
+  const successes = groups.find((g) => g.status === 'success')?.count ?? 0;
+  const failures = groups
+    .filter((g) => g.status !== 'success')
+    .reduce((sum, g) => sum + g.count, 0);
+
+  if (successes === 0 && failures === 0) {
+    return { outcome: null, hasAuditEvidence: false };
+  }
+  if (successes === 0) {
+    return { outcome: 'tool_error', hasAuditEvidence: true };
+  }
+  if (failures > 0) {
+    return { outcome: 'partial', hasAuditEvidence: true };
+  }
+  return { outcome: 'success', hasAuditEvidence: true };
+}
+
+export function mcpAuditAgentNamesForSkill(skillName: string): string[] {
+  const names = new Set<string>([skillName]);
+  if (skillName.startsWith('vizora-')) {
+    names.add(`hermes-${skillName.slice('vizora-'.length)}`);
+  }
+  return [...names];
+}

--- a/scripts/agents/hermes/poll-insights.ts
+++ b/scripts/agents/hermes/poll-insights.ts
@@ -33,8 +33,13 @@
 // pattern used by scripts/ops/*.ts).
 import 'dotenv/config';
 import { execFileSync } from 'node:child_process';
-import { PrismaClient } from '@vizora/database';
+import { Prisma, PrismaClient } from '@vizora/database';
 import { parseHermesInsightsTable, type InsightsRow } from './insights-parser';
+import {
+  classifyAuditOutcome,
+  mcpAuditAgentNamesForSkill,
+  type AuditStatusGroup,
+} from './outcome-refinement';
 // Single source of truth for model rates (PR-review R1 I2: was duplicated).
 // The sidecar imports from middleware's schemas module by relative path —
 // tsx resolves it via the standard node module algorithm at runtime.
@@ -43,6 +48,7 @@ import { MODEL_RATES } from '../../../middleware/src/modules/agents/agent-runs.s
 const PRISMA = new PrismaClient();
 const MIDDLEWARE_URL = process.env.MIDDLEWARE_URL ?? 'http://localhost:3000';
 const INTERNAL_API_KEY = process.env.INTERNAL_API_SECRET ?? '';
+const AUDIT_FALLBACK_WINDOW_PADDING_MS = 5 * 1000;
 
 async function main(): Promise<void> {
   const insightsOutput = runHermesInsights();
@@ -246,14 +252,17 @@ async function sweepOrphans(): Promise<number> {
 }
 
 /**
- * Joins agent_runs to mcp_audit_log via agentRunId. Refines `success`
- * outcomes to `tool_error` / `partial` / `no_work` per ADL-3.
+ * Joins agent_runs to mcp_audit_log. Exact `agentRunId` rows win. Hermes
+ * 0.12.0 cannot yet propagate per-run headers, so current MCP audit rows can
+ * have null `agentRunId`; in that case we fall back to agentName + firing
+ * window and only refine when audit evidence exists.
  *
  * Mutually exclusive (Reviewer A D10):
  *   - success      = all calls succeeded
  *   - partial      = ≥1 success AND ≥1 failure
  *   - tool_error   = 0 successes AND ≥1 failure
- *   - no_work      = 0 calls at all (skill made no MCP calls)
+ *   - no_work      = not inferred from absent audit rows until precise
+ *                    per-run MCP headers exist.
  */
 async function refineOutcomesFromAuditLog(): Promise<number> {
   // Look at agent_runs with provisional `success` from the last hour
@@ -261,31 +270,74 @@ async function refineOutcomesFromAuditLog(): Promise<number> {
   // non-success state — outcome is otherwise immutable).
   const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
   const candidates = await PRISMA.agentRun.findMany({
-    where: { outcome: 'success', startedAt: { gte: oneHourAgo } },
-    select: { id: true },
+    where: {
+      outcome: 'success',
+      enrichedAt: null,
+      startedAt: { gte: oneHourAgo },
+    },
+    select: { id: true, skillName: true, startedAt: true, finishedAt: true },
   });
   let refined = 0;
-  for (const { id } of candidates) {
-    const groups = await PRISMA.mcpAuditLog.groupBy({
-      by: ['status'],
-      where: { agentRunId: id },
-      _count: { _all: true },
-    });
-    const successes = groups.find((g) => g.status === 'success')?._count._all ?? 0;
-    const failures = groups
-      .filter((g) => g.status !== 'success')
-      .reduce((sum, g) => sum + g._count._all, 0);
-    let next: 'success' | 'partial' | 'tool_error' | 'no_work' = 'success';
-    if (successes === 0 && failures === 0) next = 'no_work';
-    else if (successes === 0 && failures > 0) next = 'tool_error';
-    else if (successes > 0 && failures > 0) next = 'partial';
-    else next = 'success';
-    if (next !== 'success') {
-      const ok = await patchRun(id, { outcomeRefinement: next });
+  for (const row of candidates) {
+    const { groups } = await loadAuditStatusGroupsForRun(row);
+    const { outcome } = classifyAuditOutcome(groups);
+
+    // Patch confirmed `success` too: the middleware sets enrichedAt on PATCH,
+    // which prevents the orphan sweep from later misclassifying valid runs.
+    if (outcome) {
+      const ok = await patchRun(row.id, { outcomeRefinement: outcome });
       if (ok) refined++;
     }
   }
   return refined;
+}
+
+async function loadAuditStatusGroupsForRun(row: {
+  id: string;
+  skillName: string;
+  startedAt: Date;
+  finishedAt: Date | null;
+}): Promise<{
+  groups: AuditStatusGroup[];
+  source: 'agentRunId' | 'timeRange' | 'none';
+}> {
+  const exactGroups = await groupAuditStatuses({ agentRunId: row.id });
+  if (exactGroups.length > 0) {
+    return { groups: exactGroups, source: 'agentRunId' };
+  }
+
+  const fallbackStart = new Date(
+    row.startedAt.getTime() - AUDIT_FALLBACK_WINDOW_PADDING_MS,
+  );
+  const fallbackEndBase = row.finishedAt ?? row.startedAt;
+  const fallbackEnd = new Date(
+    fallbackEndBase.getTime() + AUDIT_FALLBACK_WINDOW_PADDING_MS,
+  );
+  const fallbackGroups = await groupAuditStatuses({
+    agentRunId: null,
+    agentName: { in: mcpAuditAgentNamesForSkill(row.skillName) },
+    createdAt: { gte: fallbackStart, lte: fallbackEnd },
+  });
+
+  if (fallbackGroups.length > 0) {
+    return { groups: fallbackGroups, source: 'timeRange' };
+  }
+  return { groups: [], source: 'none' };
+}
+
+async function groupAuditStatuses(
+  where: Prisma.McpAuditLogWhereInput,
+): Promise<AuditStatusGroup[]> {
+  const groups = await PRISMA.mcpAuditLog.groupBy({
+    by: ['status'],
+    where,
+    _count: { _all: true },
+  });
+
+  return groups.map((g) => ({
+    status: g.status,
+    count: g._count._all,
+  }));
 }
 
 main()

--- a/scripts/ops/hermes-outcome-refinement.test.ts
+++ b/scripts/ops/hermes-outcome-refinement.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  classifyAuditOutcome,
+  mcpAuditAgentNamesForSkill,
+} from '../agents/hermes/outcome-refinement';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function readRepoFile(path: string): string {
+  return readFileSync(join(repoRoot, path), 'utf8');
+}
+
+test('Hermes outcome classifier leaves empty audit evidence unrefined', () => {
+  assert.deepEqual(classifyAuditOutcome([]), {
+    outcome: null,
+    hasAuditEvidence: false,
+  });
+});
+
+test('Hermes outcome classifier keeps all-success audit rows successful', () => {
+  assert.deepEqual(classifyAuditOutcome([{ status: 'success', count: 3 }]), {
+    outcome: 'success',
+    hasAuditEvidence: true,
+  });
+});
+
+test('Hermes outcome classifier marks all-failure audit rows as tool_error', () => {
+  assert.deepEqual(classifyAuditOutcome([{ status: 'error', count: 2 }]), {
+    outcome: 'tool_error',
+    hasAuditEvidence: true,
+  });
+});
+
+test('Hermes outcome classifier marks mixed audit rows as partial', () => {
+  assert.deepEqual(
+    classifyAuditOutcome([
+      { status: 'success', count: 1 },
+      { status: 'error', count: 2 },
+    ]),
+    {
+      outcome: 'partial',
+      hasAuditEvidence: true,
+    },
+  );
+});
+
+test('Hermes audit fallback maps vizora skill names to MCP token agent names', () => {
+  assert.deepEqual(mcpAuditAgentNamesForSkill('vizora-customer-lifecycle'), [
+    'vizora-customer-lifecycle',
+    'hermes-customer-lifecycle',
+  ]);
+  assert.deepEqual(mcpAuditAgentNamesForSkill('vizora-support-triage'), [
+    'vizora-support-triage',
+    'hermes-support-triage',
+  ]);
+  assert.deepEqual(mcpAuditAgentNamesForSkill('custom-agent'), ['custom-agent']);
+});
+
+test('Hermes insights sidecar falls back to agentName and firing window when agentRunId is absent', () => {
+  const sidecar = readRepoFile('scripts/agents/hermes/poll-insights.ts');
+
+  assert.match(sidecar, /loadAuditStatusGroupsForRun/);
+  assert.match(sidecar, /where:\s*{\s*outcome:\s*'success',\s*enrichedAt:\s*null,\s*startedAt:/s);
+  assert.match(sidecar, /agentRunId:\s*null/);
+  assert.match(sidecar, /agentName:\s*{\s*in:\s*mcpAuditAgentNamesForSkill\(row\.skillName\)\s*}/s);
+  assert.match(sidecar, /createdAt:\s*{\s*gte:\s*fallbackStart,\s*lte:\s*fallbackEnd/s);
+  assert.match(sidecar, /if \(outcome\) {\s*const ok = await patchRun\(row\.id, { outcomeRefinement: outcome }\);/s);
+  assert.doesNotMatch(
+    sidecar,
+    /successes === 0 && failures === 0\)\s*next = 'no_work'/,
+  );
+  assert.doesNotMatch(sidecar, /agentName:\s*row\.skillName/);
+  assert.doesNotMatch(sidecar, /outcome !== 'success'/);
+});

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,93 @@
 # Vizora - Task Tracker
 
-## Active Workstream: Hermes Runner Cost Attribution Pass 72 (2026-06-03)
+## Active Workstream: Hermes Audit Outcome Fallback Pass 73 (2026-06-03)
+
+**Branch:** `fix/production-readiness-pass73`
+
+**Why now:** `backlog.md` T3 says the sidecar's `mcp_audit_log` join falls
+back to time range, but repo truth still joins only by `agentRunId`. The
+investigation doc records today's runtime constraint: Hermes 0.12.0 does not
+support per-invocation headers, so MCP audit rows can have null `agentRunId`.
+Current sidecar code then sees zero rows for each successful firing and marks
+it `no_work`, producing false monitoring evidence.
+
+**Drift-check:** existing primitives are already present: `AgentRun`,
+`McpAuditLog.agentName`, `McpAuditLog.createdAt`, the `@@index([agentName,
+createdAt])` Prisma index, and the `poll-insights.ts` sidecar refinement loop.
+The residual gap is specific: when exact `agentRunId` groups are absent, the
+sidecar does not use the documented MCP audit `agentName` candidates + firing
+window fallback and does not avoid false `no_work` refinements.
+
+**New primitives introduced:** one small pure TypeScript helper for classifying
+MCP audit status groups, plus fallback query logic in the existing sidecar. No
+DB model/migration, public API, PM2 process, env var, MCP tool, Hermes skill,
+provider-spend path, production deploy, prod env edit, customer email send,
+payment setup, or hardware action is planned.
+
+**Hermes-first analysis:** checked per project convention. Hermes is already
+the runtime/source for these agent firings; this pass does not add agent
+capability. No Hermes skill can classify Vizora's local `agent_runs` /
+`mcp_audit_log` rows because the data and response semantics are Vizora-native.
+
+| Domain | Hermes skill found? | Decision |
+|---|---|---|
+| Hermes per-run MCP header propagation | none in Hermes 0.12.0 CLI/config | keep upstream/Path B as deferred; do not invent header plumbing |
+| Agent-run outcome classification | none found | build small helper in existing sidecar path |
+| MCP audit fallback query | none found | use existing Prisma `McpAuditLog` indexes |
+
+Awesome-hermes-agent ecosystem check: no installable skill replaces this
+repo-local monitoring refinement.
+
+**Plan**
+- [x] Add failing ops tests proving empty audit evidence does not classify as
+      `no_work` and mixed/failure audit rows classify correctly.
+- [x] Implement the minimal sidecar fallback by MCP audit `agentName`
+      candidates + firing window when exact `agentRunId` rows are absent.
+- [x] Update backlog/investigation docs to reflect repo-side fallback shipped
+      while precise `agentRunId` propagation remains upstream/operator-gated.
+- [x] Run focused ops tests, full ops tests, type/build/diff/secret checks,
+      and Claude Code review.
+- [ ] Commit, PR, CI, and merge if green.
+
+**Evidence**
+- Red tests:
+  - `node --import tsx --test scripts/ops/hermes-outcome-refinement.test.ts`
+    initially failed because `outcome-refinement.ts` did not exist and
+    `poll-insights.ts` still joined only by `agentRunId`.
+  - Follow-up red after Claude review failed because the fallback still pinned
+    `agentName: row.skillName` and had no `mcpAuditAgentNamesForSkill()`.
+- Implementation:
+  - Added `scripts/agents/hermes/outcome-refinement.ts` with pure audit-status
+    classification and skill-name to MCP-audit-agent-name mapping
+    (`vizora-*` plus `hermes-*` candidate).
+  - `poll-insights.ts` now queries exact `agentRunId` groups first; if absent,
+    it queries `agentRunId: null`, `agentName IN mcpAuditAgentNamesForSkill()`,
+    and the firing window with a 5s boundary pad.
+  - Empty audit evidence leaves the provisional outcome untouched instead of
+    writing `no_work`; concrete audit-derived outcomes, including confirmed
+    `success`, PATCH through the existing internal endpoint so `enrichedAt`
+    prevents later orphan-sweep misclassification.
+  - Candidate refinement now filters `enrichedAt: null` to avoid redundant
+    PATCHes on already-confirmed success rows.
+- Verification:
+  - `node --import tsx --test scripts/ops/hermes-outcome-refinement.test.ts`:
+    6 tests passed.
+  - `pnpm test:ops`: 47 tests passed.
+  - `pnpm exec tsc --noEmit --module nodenext --moduleResolution nodenext --target es2022 --lib es2022 --skipLibCheck --strict --esModuleInterop scripts/agents/hermes/outcome-refinement.ts scripts/agents/hermes/poll-insights.ts`: passed.
+  - `pnpm --filter @vizora/middleware test -- --runTestsByPath src/modules/agents/agent-runs.schemas.spec.ts src/modules/agents/agent-runs.service.spec.ts --runInBand`: 2 suites / 26 tests passed.
+  - `npx nx build @vizora/middleware`: passed with existing webpack warnings.
+  - `git diff --check`: passed with CRLF warnings only.
+  - `pnpm security:no-hardcoded-jwts`: passed.
+- Claude Code review:
+  - Initial review found a high-severity phantom join: `agent_runs.skillName`
+    is `vizora-*`, while prod `mcp_audit_log.agentName` is `hermes-*`.
+  - Follow-up review returned `CLEAN`; remaining notes were low/non-blocking
+    around future dormant `hermes insights` enrichment coupling and regex
+    fallback tests.
+
+---
+
+## Completed Workstream: Hermes Runner Cost Attribution Pass 72 (2026-06-03)
 
 **Branch:** `fix/production-readiness-pass72`
 
@@ -46,7 +133,7 @@ repo-local runner/accounting change.
 - [x] Implement post-flight OpenRouter balance delta in the existing Hermes
       runner without changing cost guards or invoking providers in tests.
 - [x] Update backlog and investigation docs to close T2 repo-side.
-- [ ] Run focused middleware tests, ops gates, shell syntax check, diff hygiene,
+- [x] Run focused middleware tests, ops gates, shell syntax check, diff hygiene,
       secret scan, Claude Code review, commit, PR, CI, and merge if green.
 
 **Evidence**
@@ -72,6 +159,9 @@ repo-local runner/accounting change.
 - Claude Code review:
   - Local `claude.exe` review returned `CLEAN`, with no required edits.
   - Reviewer explicitly checked cost-preservation on sidecar outcome-only enrichment, shell decimal validation, cost-guard preservation, secret exposure, and docs truthfulness.
+- PR/CI/merge:
+  - PR #213 merged to `origin/main` at `e21ff71f373a43c5a6d40fa6cce2bbc2bb0875f6`.
+  - GitHub CI passed audit, build, e2e, lint, security, and test.
 
 ## Completed Workstream: Readiness Backlog Reconciliation Pass 71 (2026-06-03)
 


### PR DESCRIPTION
## Summary
- add a pure Hermes audit outcome classifier and skill-name to MCP-audit-agent-name mapping
- update `poll-insights.ts` to use exact `agentRunId` groups first, then fallback to MCP audit `agentName` candidates plus firing window
- stop false `no_work` refinements from empty audit evidence, PATCH confirmed successes so `enrichedAt` prevents orphan-sweep misclassification, and skip already-enriched rows
- reconcile T3/backlog/investigation docs; precise per-run `agentRunId` propagation remains deferred to Hermes/upstream

## Verification
- `node --import tsx --test scripts/ops/hermes-outcome-refinement.test.ts` — 6 tests passed
- `pnpm test:ops` — 47 tests passed
- `pnpm exec tsc --noEmit --module nodenext --moduleResolution nodenext --target es2022 --lib es2022 --skipLibCheck --strict --esModuleInterop scripts/agents/hermes/outcome-refinement.ts scripts/agents/hermes/poll-insights.ts` — passed
- `pnpm --filter @vizora/middleware test -- --runTestsByPath src/modules/agents/agent-runs.schemas.spec.ts src/modules/agents/agent-runs.service.spec.ts --runInBand` — 2 suites / 26 tests passed
- `npx nx build @vizora/middleware` — passed with existing webpack warnings
- `git diff --check` — passed with CRLF warnings only
- `pnpm security:no-hardcoded-jwts` — passed

## Review
- Claude Code initial review found the `vizora-*` skillName vs `hermes-*` MCP audit agentName mismatch.
- Fixed with `mcpAuditAgentNamesForSkill()` and follow-up Claude Code review returned CLEAN, with only low/non-blocking notes.

## Runtime / deploy
- No production deploy, env edit, customer email send, payment setup, or hardware action performed.