### PR TITLE
test(playwright): add customer critical readiness helper

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -1,11 +1,11 @@
 # Vizora Backlog
 
-**Last updated:** 2026-06-03 (main at `3494e025`)
+**Last updated:** 2026-06-03 (main at `ab957a97`)
 **Production readiness:** repo-side foundation strongest on record; customer-1 launch remains operator-gated on C1-C4 below.
-**Tests:** Current merge evidence: PR #211 GitHub CI passed audit, build, e2e, lint, security, and test. Local #211 verification included focused middleware fleet tests (2 suites / 45 tests), realtime tests (13 suites / 287 tests), display focused tests (2 suites / 63 tests), display CI tests (8 suites / 145 tests), display typecheck/build, web tests (106 suites / 1115 tests), web/realtime/middleware builds, diff hygiene, and secret scan. Pass71 re-verified admin web tests (8 suites / 80 tests) for stale K5 closure. Historical aggregate test report remains in `docs/plans/2026-05-09-test-results.md`; verify fresh counts before relying on older totals.
+**Tests:** Current merge evidence: PR #214 GitHub CI passed audit, build, e2e, lint, security, and test. That CI `e2e` job is the narrow middleware Jest gate, not the full Playwright browser suite. Local #211 verification included focused middleware fleet tests (2 suites / 45 tests), realtime tests (13 suites / 287 tests), display focused tests (2 suites / 63 tests), display CI tests (8 suites / 145 tests), display typecheck/build, web tests (106 suites / 1115 tests), web/realtime/middleware builds, diff hygiene, and secret scan. Pass71 re-verified admin web tests (8 suites / 80 tests) for stale K5 closure. Pass72/73 re-verified focused agent/ops gates around Hermes cost and audit fallback. Historical aggregate test report remains in `docs/plans/2026-05-09-test-results.md`; verify fresh counts before relying on older totals.
 **Customer-1 launch date:** operator-confirmed - do not use historical target dates until the operator confirms the actual launch window.
 
-**Security/realtime/readiness wave (#107-#211, merged through 2026-06-03, main `3494e025`):** session invalidation now spans REST + WebSocket - password-change / account-deactivation force-logout across all devices (REST `#111`, WS connect-time `#112`, WS mid-session 60s sweep `#114`). Customer-1 smoke coverage is hardened (#116), M12 security alert emails are complete (#117), and the latest overnight readiness passes hardened health/readiness gates, validator reporting, admin readiness display, deploy verification, first-customer runbook truthfulness, public app URL precedence for email/reset/pairing/billing/lifecycle links (#209), and repo-side display auto-update command plumbing (#211). P1/P2 tables below reconciled to match.
+**Security/realtime/readiness wave (#107-#214, merged through 2026-06-03, main `ab957a97`):** session invalidation now spans REST + WebSocket - password-change / account-deactivation force-logout across all devices (REST `#111`, WS connect-time `#112`, WS mid-session 60s sweep `#114`). Customer-1 smoke coverage is hardened (#116), M12 security alert emails are complete (#117), and the latest overnight readiness passes hardened health/readiness gates, validator reporting, admin readiness display, deploy verification, first-customer runbook truthfulness, public app URL precedence for email/reset/pairing/billing/lifecycle links (#209), repo-side display auto-update command plumbing (#211), Hermes runner balance-delta cost attribution (#213), and Hermes audit outcome fallback (#214). P1/P2 tables below reconciled to match.
 
 ---
 
@@ -60,6 +60,7 @@ Triggered by 2026-05-06 OpenRouter credit drain. PR #62 (merged `801b517` on 202
 | R10 | agentRunId propagation investigation — Hermes config supports static headers only, no `--header` flag in 0.12.0 | `docs/plans/2026-05-09-agent-run-id-propagation-investigation.md` | 2026-05-09 |
 | R11 | support-triage cross-tenant token design call — recommended kept-disabled for customer-1, Option 2 (platform-scope `support:*` tools) for week-2 | `docs/plans/2026-05-09-support-triage-cross-tenant-design.md` | 2026-05-09 |
 | R12 | CLAUDE.md test baseline refreshed (1700+ → 2335; carve-outs resolved) | `e80939d` | 2026-05-09 |
+| R13 | Customer-critical Playwright helper preflights local services and runs the launch-relevant browser subset; full suite remains T1 | `scripts/smoke/playwright-customer-critical.mjs` | 2026-06-03 |
 
 ### Earlier (carried over from prior backlog state)
 
@@ -137,7 +138,7 @@ These are documented + non-blocking for customer-1. Investigations done; impleme
 
 | # | Item | Effort | Pointer | Why deferred |
 |---|------|--------|---------|--------------|
-| T1 | Playwright suite refresh — close remaining ~26 failures (heaviest: 16-billing×10) | 6-8h | `docs/plans/2026-05-09-playwright-results.md` | Critical-path flows verified (8/10); 16-billing is OUT of customer-1 scope |
+| T1 | PARTIAL - Playwright suite refresh — close remaining ~26 failures (heaviest: 16-billing×10) | 6-8h | `docs/plans/2026-05-09-playwright-results.md`, `scripts/smoke/playwright-customer-critical.mjs` | Customer-critical helper now preflights middleware/web/realtime local ports and runs 01/03/04/05/06/15/21; full browser suite still needs a running stack and fresh result. 16-billing is OUT of customer-1 scope |
 | T2 | ✅ DONE - Per-firing cost attribution (Path A: balance-delta pre/post each firing) | ~1h | `docs/plans/2026-05-09-hermes-insights-investigation.md` | Pass72: runner samples post-flight OpenRouter balance and stores nonnegative delta as `agent_runs.costMicrodollars`; live rows require normal deploy, no prod firing performed |
 | T3 | PARTIAL - agentRunId propagation runner→Hermes→MCP — Hermes 0.12.0 has no `--header` flag; needs upstream patch OR env-var config interpolation experiment | 2h-2d | `docs/plans/2026-05-09-agent-run-id-propagation-investigation.md` | Pass73: sidecar Path D fallback shipped (MCP audit `agentName` candidates + firing window when `agentRunId` rows are absent) and no longer false-refines empty audit evidence to `no_work`; precise per-run header propagation remains deferred |
 | T4 | support-triage cross-tenant token redesign — Option 2 (relax `support:*` tools to accept platform-scope) | 4-6h | `docs/plans/2026-05-09-support-triage-cross-tenant-design.md` | support-triage NOT enabled; operator handles tickets directly |

--- a/docs/plans/2026-05-09-playwright-results.md
+++ b/docs/plans/2026-05-09-playwright-results.md
@@ -2,6 +2,15 @@
 
 > **TL;DR — post-fix improvement:** initial run 0/332 pass (100% bit-rot cascade). After mechanical refresh (mass `/api/` → `/api/v1/` + 4 h1 copy regexes in 01-auth), the re-run shows **only 26 failures across 9 of 19 specs that ran** (suite was killed at ~22 min before specs 20-24 completed) — estimated >90% pass rate on the new baseline. The two structural bugs the sub-agent identified ARE the dominant cause; remaining failures are per-test selector drift that needs targeted fixes.
 
+> **2026-06-03 update:** GitHub's `e2e` check is a narrow middleware Jest gate,
+> not this Playwright browser suite. Pass 74 added
+> `pnpm e2e:customer-critical`, which preflights middleware `:3000`, web
+> `:3001`, and realtime `:3002`, then runs the customer-critical browser subset
+> (01/03/04/05/06/15/21). No fresh full Playwright result was produced in pass
+> 74 because Docker Desktop was unavailable and local ports
+> 3000/3001/3002/5432/6379/9000 were closed. Treat the full-suite T1 refresh as
+> still pending until a real-stack run is recorded.
+
 ## Run 2 — Post-fix re-run (2026-05-09 20:09–20:31 UTC, killed before completion)
 
 | Spec | Failures | Pass status |
@@ -71,7 +80,8 @@ The 2 not verified (1 register flake, 21-notifications cut by suite kill) are ad
 
 **Playwright is now usable as a regression net for customer #1 launch.** The 26 remaining failures are localized + non-blocking; the critical path is verified. Operator can:
 
-- Run `npx playwright test e2e-tests/04-content.spec.ts e2e-tests/05-playlists.spec.ts e2e-tests/15-comprehensive-integration.spec.ts` to verify the most-critical 3 specs in <3 min before any deploy.
+- Run `pnpm e2e:customer-critical -- --reporter=list` to verify the
+  launch-relevant browser subset after the local stack is already listening.
 - Defer fixing 16-billing (10 failures) as week-1 tech-debt — billing is OUT of scope for customer #1 (free-tier launch).
 - Fix the singletons (06, 09, 18, 01, 03×2, 08×2) opportunistically.
 

--- a/docs/runbooks/first-customer-onboarding.md
+++ b/docs/runbooks/first-customer-onboarding.md
@@ -107,22 +107,35 @@ Run in this order:
 
 Record everything in `docs/runbooks/customer-1-go-live-smoke-{DATE}.md` with timestamps.
 
-### 2. Optional: Playwright suite refresh
-Per `2026-05-09-playwright-results.md`, the suite has bit-rot. Most stale paths fixed in commit `<TBD>`; remaining work is per-test selector updates.
+### 2. Optional: Playwright customer-critical browser smoke
+GitHub's `e2e` check is a narrow middleware Jest gate, not this browser
+suite. Run the preflighted helper only after the local Vizora stack is already
+up; it requires middleware :3000, web :3001, and realtime :3002. The helper
+does not start Docker, reload PM2, SSH to prod, or mutate services.
 
 ```bash
-# Bring up local stack
+# Bring up local stack first, for example:
 docker compose -f docker/docker-compose.yml up -d postgres redis minio
 pnpm --filter @vizora/middleware dev > /tmp/mw.log 2>&1 &
 pnpm --filter @vizora/realtime dev > /tmp/rt.log 2>&1 &
 pnpm --filter @vizora/web dev > /tmp/web.log 2>&1 &
 # Wait for "Ready in X" lines in each log (60-90s for web)
 
-# Run Playwright with full reporter
-npx playwright test --reporter=list 2>&1 | tee /tmp/pw.log
+# Run the customer-critical browser subset
+pnpm e2e:customer-critical -- --reporter=list
 ```
 
-If pass rate >80%, declare Playwright restored. If <80%, accept as week-1 tech-debt and move on (`api-critical-path.sh` is the substitute regression net for launch).
+If this fails at preflight, the local services are not up; fix that before
+interpreting Playwright output. If specs fail, record the failing spec names in
+`docs/runbooks/customer-1-go-live-smoke-{DATE}.md` and use
+`api-critical-path.sh` plus the real-device walkthrough as the launch-critical
+substitute until the browser drift is fixed.
+
+### 3. Broader Playwright suite refresh
+Per `2026-05-09-playwright-results.md`, the broad suite still has localized
+selector drift. Billing-heavy failures stay post-customer-1 because customer-1
+launches on the free tier. Do not declare the full Playwright suite restored
+until all 24 specs run against a real stack and the result is recorded.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "nx run-many --target=test --all",
     "test:ops": "node --import tsx --test \"scripts/ops/**/*.test.ts\"",
     "test:e2e": "pnpm --filter @vizora/middleware test:e2e",
+    "e2e:customer-critical": "node scripts/smoke/playwright-customer-critical.mjs",
     "security:no-hardcoded-jwts": "node scripts/security/check-no-hardcoded-jwts.js",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint --ext .ts,.tsx middleware/src realtime/src",
     "lint:web": "pnpm --filter @vizora/web exec next lint"

--- a/scripts/ops/release-readiness-gates.test.ts
+++ b/scripts/ops/release-readiness-gates.test.ts
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import test from 'node:test';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
@@ -27,6 +28,73 @@ test('critical-path smoke probes the realtime gateway prefixed health endpoint',
     /probe_status "Realtime health" "200" "\$RT_BASE\/api\/health"/,
   );
   assert.doesNotMatch(smokeScript, /\$RT_BASE\/health"/);
+});
+
+test('customer-critical Playwright helper preflights required local services', () => {
+  const helper = readRepoFile('scripts/smoke/playwright-customer-critical.mjs');
+
+  for (const port of [3000, 3001, 3002]) {
+    assert.match(helper, new RegExp(`requirePort\\([^\\)]*${port}`));
+  }
+
+  assert.match(helper, /e2e-tests\/01-auth\.spec\.ts/);
+  assert.match(helper, /e2e-tests\/03-displays\.spec\.ts/);
+  assert.match(helper, /e2e-tests\/04-content\.spec\.ts/);
+  assert.match(helper, /e2e-tests\/05-playlists\.spec\.ts/);
+  assert.match(helper, /e2e-tests\/06-schedules\.spec\.ts/);
+  assert.match(helper, /e2e-tests\/15-comprehensive-integration\.spec\.ts/);
+  assert.match(helper, /e2e-tests\/21-notifications\.spec\.ts/);
+  assert.doesNotMatch(helper, /e2e-tests\/16-billing\.spec\.ts/);
+  assert.doesNotMatch(helper, /docker compose|docker-compose|pm2 reload|ssh root@/);
+});
+
+test('customer-critical Playwright helper invokes Playwright without shell shims', async () => {
+  const helper = (await import(
+    pathToFileURL(join(repoRoot, 'scripts/smoke/playwright-customer-critical.mjs')).href
+  )) as {
+    buildPlaywrightCommand: (args: string[]) => {
+      executable: string;
+      args: string[];
+    };
+  };
+
+  const command = helper.buildPlaywrightCommand(['--reporter=list']);
+
+  assert.equal(command.executable, process.execPath);
+  assert.match(command.args[0], /@playwright[\\/]test[\\/]cli\.js$/);
+  assert.deepEqual(command.args.slice(1, 4), [
+    'test',
+    'e2e-tests/01-auth.spec.ts',
+    'e2e-tests/03-displays.spec.ts',
+  ]);
+  assert.equal(command.args.at(-1), '--reporter=list');
+  assert.doesNotMatch(command.executable, /bash|npx/i);
+  assert.doesNotMatch(command.args.join(' '), /npx\.cmd|bash scripts/);
+
+  const version = spawnSync(command.executable, [command.args[0], '--version'], {
+    encoding: 'utf8',
+  });
+  assert.equal(version.status, 0, version.stderr);
+  assert.match(version.stdout, /Version \d+\.\d+\.\d+/);
+});
+
+test('package.json exposes the customer-critical Playwright helper', () => {
+  const pkg = JSON.parse(readRepoFile('package.json')) as {
+    scripts?: Record<string, string>;
+  };
+
+  assert.equal(
+    pkg.scripts?.['e2e:customer-critical'],
+    'node scripts/smoke/playwright-customer-critical.mjs',
+  );
+});
+
+test('first-customer runbook points browser smoke at the preflighted Playwright helper', () => {
+  const runbook = readRepoFile('docs/runbooks/first-customer-onboarding.md');
+
+  assert.match(runbook, /pnpm e2e:customer-critical/);
+  assert.doesNotMatch(runbook, /npx playwright test --reporter=list/);
+  assert.match(runbook, /requires middleware :3000, web :3001, and realtime :3002/i);
 });
 
 test('first-customer runbook documents the realtime prefixed health endpoint', () => {

--- a/scripts/smoke/playwright-customer-critical.mjs
+++ b/scripts/smoke/playwright-customer-critical.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import net from 'node:net';
+import { pathToFileURL } from 'node:url';
+
+const require = createRequire(import.meta.url);
+
+export const customerCriticalSpecs = [
+  'e2e-tests/01-auth.spec.ts',
+  'e2e-tests/03-displays.spec.ts',
+  'e2e-tests/04-content.spec.ts',
+  'e2e-tests/05-playlists.spec.ts',
+  'e2e-tests/06-schedules.spec.ts',
+  'e2e-tests/15-comprehensive-integration.spec.ts',
+  'e2e-tests/21-notifications.spec.ts',
+];
+
+export function getPlaywrightCliPath() {
+  return require.resolve('@playwright/test/cli');
+}
+
+export function buildPlaywrightCommand(extraArgs = []) {
+  return {
+    executable: process.execPath,
+    args: [
+      getPlaywrightCliPath(),
+      'test',
+      ...customerCriticalSpecs,
+      ...extraArgs,
+    ],
+  };
+}
+
+export function requirePort(name, port, host = 'localhost') {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection({ host, port, timeout: 2000 });
+
+    socket.once('connect', () => {
+      socket.end();
+      resolve();
+    });
+
+    socket.once('timeout', () => {
+      socket.destroy();
+      reject(new Error(`${name} is not listening at ${host}:${port}`));
+    });
+
+    socket.once('error', () => {
+      reject(new Error(`${name} is not listening at ${host}:${port}`));
+    });
+  });
+}
+
+async function main() {
+  await requirePort('middleware', 3000);
+  await requirePort('web', 3001);
+  await requirePort('realtime', 3002);
+
+  const command = buildPlaywrightCommand(process.argv.slice(2));
+  const child = spawn(command.executable, command.args, { stdio: 'inherit' });
+
+  child.once('exit', (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+
+    process.exit(code ?? 1);
+  });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`[playwright-customer-critical] ${error.message}`);
+    console.error(
+      '[playwright-customer-critical] Start the local Vizora stack first; this helper only checks services and runs Playwright.',
+    );
+    process.exit(2);
+  });
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,100 @@
 # Vizora - Task Tracker
 
-## Active Workstream: Hermes Audit Outcome Fallback Pass 73 (2026-06-03)
+## Active Workstream: Playwright Readiness Truth Pass 74 (2026-06-03)
+
+**Branch:** `fix/playwright-readiness-pass74`
+
+**Why now:** PR #214 merged and GitHub CI is green, but the CI job named
+`e2e` is a narrow middleware Jest gate, not the full browser suite under
+`e2e-tests/`. `backlog.md` T1 still tracks Playwright suite refresh as a
+remaining production-readiness item. Local runtime truth matters here:
+Docker Desktop is not reachable, and ports 3000/3001/3002/5432/6379/9000 are
+closed in this environment, so a full real-stack Playwright proof cannot be
+honestly claimed from this worktree.
+
+**Drift-check:** `.github/workflows/ci.yml` explicitly says only
+`(agents|customer-critical-path)` middleware E2E suites are gated. The
+Playwright config has no `webServer` bootstrapping and expects already-running
+services at web `:3001` plus middleware `:3000`. The old Playwright report is
+stale, but T1 remains real until a fresh full browser run is executed against a
+running stack.
+
+**New primitives introduced:** a small repo-side Playwright readiness helper
+and tests/docs around it only. No DB model/migration, public API, PM2 process,
+env var, MCP tool, Hermes skill, provider-spend path, production deploy, prod
+env edit, customer email send, payment setup, or hardware action is planned.
+
+**Hermes-first analysis:** not applicable. This pass is browser-test readiness
+and local/operator runbook truth, not a business-agent, MCP, Hermes runtime, or
+AI/provider-spend path.
+
+**Plan**
+- [x] Add a failing ops/static test proving the customer-critical Playwright
+      command is documented and guarded by an explicit service preflight.
+- [x] Implement the minimal helper using existing Playwright specs and ports,
+      without starting or modifying production services.
+- [x] Update backlog/readiness docs to distinguish GitHub narrow E2E green from
+      full Playwright pending, with the exact local runtime blocker.
+- [x] Run focused tests, shell syntax/diff/secret checks, and Claude Code
+      review.
+- [ ] Commit, PR, CI, and merge if green.
+
+**Evidence**
+- Local runtime preflight:
+  - `docker info --format '{{.ServerVersion}}'` failed because Docker Desktop's
+    Linux engine pipe was unavailable.
+  - Ports 3000, 3001, 3002, 5432, 6379, and 9000 were not listening.
+- Red tests:
+  - `pnpm test:ops -- scripts/ops/release-readiness-gates.test.ts` failed
+    because `scripts/smoke/playwright-customer-critical.sh` did not exist,
+    `package.json` had no `e2e:customer-critical`, and the runbook still used an
+    ad hoc full-suite command.
+  - After testing the package command, `pnpm e2e:customer-critical --
+    --reporter=list` failed before preflight because Windows resolved `bash` to
+    the broken WSL shim (`/bin/bash` missing). The test contract was tightened
+    to require a Node runner, then failed until the Node runner and package
+    script existed.
+- Implementation:
+  - Added `scripts/smoke/playwright-customer-critical.mjs`, a cross-platform
+    Node preflight that checks middleware `:3000`, web `:3001`, realtime
+    `:3002`, then runs existing specs 01/03/04/05/06/15/21 via Playwright.
+    After Claude review, the Playwright invocation was changed to
+    `process.execPath` + resolved `@playwright/test/cli` instead of `npx.cmd`,
+    avoiding the Windows `.cmd` spawn failure class.
+  - Added `pnpm e2e:customer-critical`.
+  - Updated the first-customer runbook and Playwright results doc so browser
+    smoke uses the preflighted customer-critical subset and full Playwright
+    remains pending until a real-stack run is recorded.
+  - Updated `backlog.md` to current main `ab957a97`, PR #214 CI truth, and T1
+    partial state.
+- Verification:
+  - `node --import tsx --test scripts/ops/release-readiness-gates.test.ts`: 26
+    tests passed.
+  - `pnpm test:ops -- scripts/ops/release-readiness-gates.test.ts`: 51 tests
+    passed because the package script still globs all ops tests; retained as
+    an additional pre-review run, not the focused command.
+  - `pnpm test:ops`: 51 tests
+    passed.
+  - `node --check scripts/smoke/playwright-customer-critical.mjs`: passed.
+  - `pnpm e2e:customer-critical -- --reporter=list`: failed as expected at the
+    middleware `localhost:3000` preflight because local services are down; this
+    proves the package command reaches the helper instead of the broken Bash
+    path.
+  - `git diff --check`: passed with CRLF warnings only.
+  - `pnpm security:no-hardcoded-jwts`: passed.
+  - `rg -n "npx\.cmd|bash scripts/smoke/playwright-customer-critical|playwright-customer-critical\.sh" scripts\smoke scripts\ops package.json docs backlog.md`
+    returned no active source/doc/package matches.
+- Claude Code review:
+  - Initial review returned `NOT CLEAN`: high finding that Windows Node can
+    throw when spawning `npx.cmd` without shell, plus medium finding that tests
+    were only static and did not exercise the Playwright invocation path.
+  - Fix added an importable command builder and a behavioral test that spawns
+    the resolved Playwright CLI through `process.execPath --version`.
+  - Follow-up review returned `CLEAN`.
+
+---
+
+## Completed Workstream: Hermes Audit Outcome Fallback Pass 73 (2026-06-03)
 
 **Branch:** `fix/production-readiness-pass73`
 
@@ -47,7 +141,7 @@ repo-local monitoring refinement.
       while precise `agentRunId` propagation remains upstream/operator-gated.
 - [x] Run focused ops tests, full ops tests, type/build/diff/secret checks,
       and Claude Code review.
-- [ ] Commit, PR, CI, and merge if green.
+- [x] Commit, PR, CI, and merge if green.
 
 **Evidence**
 - Red tests:
@@ -84,6 +178,11 @@ repo-local monitoring refinement.
   - Follow-up review returned `CLEAN`; remaining notes were low/non-blocking
     around future dormant `hermes insights` enrichment coupling and regex
     fallback tests.
+- PR/CI/merge:
+  - Commit `2d3b5abb` (`fix(agents): add Hermes audit outcome fallback`).
+  - PR #214 merged as `ab957a97`.
+  - GitHub checks passed before merge: audit, build, e2e, lint, security, and
+    test.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `pnpm e2e:customer-critical`, a cross-platform Node helper that preflights middleware/web/realtime on localhost ports 3000/3001/3002 before running the customer-critical Playwright specs 01/03/04/05/06/15/21.
- Update release-readiness static tests so the helper is documented, excludes billing, respects operator boundaries, and invokes Playwright through `process.execPath` + the resolved `@playwright/test` CLI instead of Bash/npx shell shims.
- Reconcile docs/backlog truth: GitHub `e2e` is narrow middleware Jest, not full Playwright; full T1 browser-suite refresh remains pending until a real-stack run is recorded.

## Verification
- Red: `pnpm test:ops -- scripts/ops/release-readiness-gates.test.ts` initially failed for missing helper/package/runbook wiring.
- Red: `pnpm e2e:customer-critical -- --reporter=list` then exposed Windows `bash` resolution failure; test contract changed to require Node runner.
- Red: focused gate then failed because `buildPlaywrightCommand` did not exist.
- Green: `node --import tsx --test scripts/ops/release-readiness-gates.test.ts` -> 26 tests passed.
- Green: `pnpm test:ops` -> 51 tests passed.
- Green: `node --check scripts/smoke/playwright-customer-critical.mjs`.
- Expected local preflight block: `pnpm e2e:customer-critical -- --reporter=list` exits 2 at middleware `localhost:3000` because local services are down.
- Green: `git diff --check` (CRLF warnings only).
- Green: `pnpm security:no-hardcoded-jwts`.

## Review
- Claude Code initial review: NOT CLEAN, found Windows `.cmd` spawn issue and static-only test gap.
- Fixed by using `process.execPath` + resolved Playwright CLI and adding behavioral spawn coverage.
- Claude Code follow-up review: CLEAN.

## Runtime / Operator Notes
- No deploy, prod env edit, customer email send, payment setup, SSH mutation, or service restart performed.
- Docker Desktop is unavailable in this environment and ports 3000/3001/3002/5432/6379/9000 are closed, so no full real-stack Playwright result is claimed.