### PR TITLE
docs(runbook): align signup smoke with welcome email flow

### DIFF
--- a/docs/runbooks/first-customer-onboarding.md
+++ b/docs/runbooks/first-customer-onboarding.md
@@ -100,8 +100,8 @@ Run in this order:
 4. `bash scripts/smoke/api-critical-path.sh` (against localhost first; creates smoke-test rows)
 5. `ssh root@vizora.cloud 'cd /opt/vizora/app && API_BASE=https://vizora.cloud WEB_BASE=https://vizora.cloud bash scripts/smoke/api-critical-path.sh' > .ssh_go_live_smoke.txt 2>&1` (against prod API/web ingress from the VPS; creates smoke-test rows; realtime health remains local `RT_BASE=http://localhost:3002` and probes `/api/health`; read `.ssh_go_live_smoke.txt` as a separate step)
 6. Open `https://vizora.cloud` in a fresh incognito browser → verify landing page renders, all CTAs work
-7. Sign up with a NEW disposable email → verify welcome email lands within 60s
-8. Click email verify link → verify landed in dashboard
+7. Sign up with a NEW disposable email → verify dashboard access and welcome email delivery within 60s
+8. Email verification flow remains deferred (backlog B5); do not look for an email-confirmation link in the welcome email
 9. Generate pairing code, pair the SAME display from T-3 walkthrough → verify still online
 10. Push a NEW image → verify display swaps within 30s
 
@@ -276,7 +276,7 @@ If any tip → escalate to design review.
 ## Customer-1 scope (what's IN, what's OUT for launch day)
 
 ### IN scope
-- Sign up + email verify
+- Sign up + welcome email delivery
 - Login + 2FA NOT required (deferred)
 - Display pairing (single device)
 - Content upload (image, video, URL, HTML)

--- a/scripts/ops/release-readiness-gates.test.ts
+++ b/scripts/ops/release-readiness-gates.test.ts
@@ -174,6 +174,19 @@ test('first-customer C1 runbook verifies email app URL env', () => {
   assert.match(runbook, /email links do not point at localhost/i);
 });
 
+test('first-customer runbook does not require nonexistent email verification flow', () => {
+  const runbook = readRepoFile('docs/runbooks/first-customer-onboarding.md');
+  const schema = readRepoFile('packages/database/prisma/schema.prisma');
+
+  // This should trip when B5 eventually lands, forcing the launch runbook to be
+  // updated alongside the real email-verification schema/flow.
+  assert.doesNotMatch(schema, /emailVerified|emailVerifiedAt|verificationToken/);
+  assert.match(runbook, /welcome email/i);
+  assert.match(runbook, /Email verification flow remains deferred/i);
+  assert.doesNotMatch(runbook, /email verify/i);
+  assert.doesNotMatch(runbook, /verif\w*\s+link/i);
+});
+
 test('backlog uses current customer-1 C-series launch gate truth', () => {
   const backlog = readRepoFile('backlog.md');
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,62 @@
 # Vizora - Task Tracker
 
-## Active Workstream: External Heartbeat Docs Pass 76 (2026-06-03)
+## Active Workstream: First-Customer Email Verification Truth Pass 77 (2026-06-03)
+
+**Branch:** `fix/readiness-pass77`
+
+**Why now:** The live first-customer go-live runbook still instructed the
+operator to click an email verification link, but repo truth shows registration
+sends a welcome email and signs the user in; the email verification flow remains
+deferred as backlog B5. A launch runbook must not require a nonexistent flow
+during C4 smoke.
+
+**Drift-check:** `middleware/src/modules/auth/auth.service.ts` calls
+`MailService.sendWelcomeEmail()` after password and Google registration. Current
+`packages/database/prisma/schema.prisma` has no `emailVerified`,
+`emailVerifiedAt`, or verification-token field. `backlog.md` still records B5
+email verification as untouched/deferred.
+
+**New primitives introduced:** one static readiness-gate assertion. No runtime
+code, DB model/migration, public API, PM2 process, env var, MCP tool, Hermes
+skill, provider-spend path, production deploy, prod env edit, customer email
+send, payment setup, or hardware action is planned.
+
+**Hermes-first analysis:** not applicable. This is launch runbook truth and a
+static regression gate, not a business-agent, MCP, Hermes runtime, or
+AI/provider-spend path.
+
+**Plan**
+- [x] Add a failing readiness-gate test proving the first-customer runbook does
+      not require a nonexistent email verification flow.
+- [x] Update the runbook to require signup dashboard access + welcome email
+      delivery, while explicitly noting email verification is deferred.
+- [ ] Run focused ops test, broader ops tests, diff/secret checks, Claude Code
+      review, commit, PR, CI, and merge if green.
+
+**Evidence**
+- Red test:
+  - `node --import tsx --test scripts/ops/release-readiness-gates.test.ts`
+    failed 1/28 because the runbook still lacked "Email verification flow
+    remains deferred" and contained stale email verification instructions.
+- Green verification so far:
+  - `node --import tsx --test scripts/ops/release-readiness-gates.test.ts`:
+    28/28 tests passed.
+  - `pnpm test:ops`: 53/53 tests passed.
+  - `git diff --check`: passed with CRLF normalization warnings only.
+  - `pnpm security:no-hardcoded-jwts`: passed.
+- Claude Code review:
+  - CLEAN. Reviewer verified registration signs the user into a dashboard
+    session and sends a welcome email, the welcome email has no verification
+    link, the schema lacks email-verification fields, and B5 remains deferred.
+  - Applied reviewer-suggested low-risk robustness hardening: broadened the
+    stale-link guard to catch `verification link` wording and added a comment
+    that the schema assertion should trip when B5 eventually lands. Re-ran the
+    focused readiness-gate test (28/28), `pnpm test:ops` (53/53),
+    `git diff --check`, and `pnpm security:no-hardcoded-jwts` afterward.
+
+---
+
+## Completed Workstream: External Heartbeat Docs Pass 76 (2026-06-03)
 
 **Branch:** `fix/readiness-pass76`
 
@@ -28,7 +84,7 @@ AI/provider-spend path.
       external heartbeat `/fail` semantics.
 - [x] Update `.env.example` to explain success vs fail pings.
 - [x] Update the deferred review-polish backlog entry.
-- [ ] Run focused ops test, broader ops tests, diff/secret checks, Claude Code
+- [x] Run focused ops test, broader ops tests, diff/secret checks, Claude Code
       review, commit, PR, CI, and merge if green.
 
 **Evidence**
@@ -46,6 +102,11 @@ AI/provider-spend path.
     `scripts/ops/lib/alerting.ts` and `scripts/ops/health-guardian.ts`, the
     test guards the intended documentation contract, and operator setup remains
     explicitly not performed.
+- PR/CI/merge:
+  - Commit `39b46a3c` (`docs(ops): document healthchecks fail heartbeat`).
+  - PR #217 merged as `d5a1e45a`.
+  - GitHub checks passed before merge: audit, build, e2e, lint, security, and
+    test.
 
 ---
 


### PR DESCRIPTION
﻿## Summary
- Aligns the first-customer go-live runbook with current signup behavior: dashboard access + welcome email delivery, not a nonexistent email verification link.
- Adds a release-readiness gate proving the current schema has no email-verification fields and the runbook explicitly marks email verification deferred.
- Records pass76 merge evidence in the task tracker.

## Verification
- RED: `node --import tsx --test scripts/ops/release-readiness-gates.test.ts` failed 1/28 before the runbook fix due stale email-verification instructions.
- GREEN: `node --import tsx --test scripts/ops/release-readiness-gates.test.ts` => 28/28 tests passed
- `pnpm test:ops` => 53/53 tests passed
- `git diff --check` => passed with CRLF normalization warnings only
- `pnpm security:no-hardcoded-jwts` => passed
- Claude Code review: CLEAN

## Operator boundary
- No runtime code or schema migration.
- No production env edits, deploys, SMTP sends, customer emails, PM2 changes, or secrets.
- B5 email verification remains deferred; this PR makes the launch smoke truthful against shipped behavior.
