### PR TITLE
feat(smoke): add email readiness helper

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -1,11 +1,11 @@
 # Vizora Backlog
 
-**Last updated:** 2026-06-03 (main at `ab957a97`)
+**Last updated:** 2026-06-03 (main at `517ae30e`)
 **Production readiness:** repo-side foundation strongest on record; customer-1 launch remains operator-gated on C1-C4 below.
-**Tests:** Current merge evidence: PR #214 GitHub CI passed audit, build, e2e, lint, security, and test. That CI `e2e` job is the narrow middleware Jest gate, not the full Playwright browser suite. Local #211 verification included focused middleware fleet tests (2 suites / 45 tests), realtime tests (13 suites / 287 tests), display focused tests (2 suites / 63 tests), display CI tests (8 suites / 145 tests), display typecheck/build, web tests (106 suites / 1115 tests), web/realtime/middleware builds, diff hygiene, and secret scan. Pass71 re-verified admin web tests (8 suites / 80 tests) for stale K5 closure. Pass72/73 re-verified focused agent/ops gates around Hermes cost and audit fallback. Historical aggregate test report remains in `docs/plans/2026-05-09-test-results.md`; verify fresh counts before relying on older totals.
+**Tests:** Current merge evidence: PR #218 GitHub CI passed audit, build, e2e, lint, security, and test. That CI `e2e` job is the narrow middleware Jest gate, not the full Playwright browser suite. Local #211 verification included focused middleware fleet tests (2 suites / 45 tests), realtime tests (13 suites / 287 tests), display focused tests (2 suites / 63 tests), display CI tests (8 suites / 145 tests), display typecheck/build, web tests (106 suites / 1115 tests), web/realtime/middleware builds, diff hygiene, and secret scan. Pass71 re-verified admin web tests (8 suites / 80 tests) for stale K5 closure. Pass72/73 re-verified focused agent/ops gates around Hermes cost and audit fallback. Pass78 adds a repo-side no-send-by-default C1 email readiness helper; operator SMTP/Resend setup and any real test-send remain pending. Historical aggregate test report remains in `docs/plans/2026-05-09-test-results.md`; verify fresh counts before relying on older totals.
 **Customer-1 launch date:** operator-confirmed - do not use historical target dates until the operator confirms the actual launch window.
 
-**Security/realtime/readiness wave (#107-#214, merged through 2026-06-03, main `ab957a97`):** session invalidation now spans REST + WebSocket - password-change / account-deactivation force-logout across all devices (REST `#111`, WS connect-time `#112`, WS mid-session 60s sweep `#114`). Customer-1 smoke coverage is hardened (#116), M12 security alert emails are complete (#117), and the latest overnight readiness passes hardened health/readiness gates, validator reporting, admin readiness display, deploy verification, first-customer runbook truthfulness, public app URL precedence for email/reset/pairing/billing/lifecycle links (#209), repo-side display auto-update command plumbing (#211), Hermes runner balance-delta cost attribution (#213), and Hermes audit outcome fallback (#214). P1/P2 tables below reconciled to match.
+**Security/realtime/readiness wave (#107-#218, merged through 2026-06-03, main `517ae30e`):** session invalidation now spans REST + WebSocket - password-change / account-deactivation force-logout across all devices (REST `#111`, WS connect-time `#112`, WS mid-session 60s sweep `#114`). Customer-1 smoke coverage is hardened (#116), M12 security alert emails are complete (#117), and the latest overnight readiness passes hardened health/readiness gates, validator reporting, admin readiness display, deploy verification, first-customer runbook truthfulness (#218), public app URL precedence for email/reset/pairing/billing/lifecycle links (#209), repo-side display auto-update command plumbing (#211), Hermes runner balance-delta cost attribution (#213), Hermes audit outcome fallback (#214), and a no-send-by-default C1 email readiness helper (pass78). P1/P2 tables below reconciled to match.
 
 ---
 
@@ -61,6 +61,7 @@ Triggered by 2026-05-06 OpenRouter credit drain. PR #62 (merged `801b517` on 202
 | R11 | support-triage cross-tenant token design call — recommended kept-disabled for customer-1, Option 2 (platform-scope `support:*` tools) for week-2 | `docs/plans/2026-05-09-support-triage-cross-tenant-design.md` | 2026-05-09 |
 | R12 | CLAUDE.md test baseline refreshed (1700+ → 2335; carve-outs resolved) | `e80939d` | 2026-05-09 |
 | R13 | Customer-critical Playwright helper preflights local services and runs the launch-relevant browser subset; full suite remains T1 | `scripts/smoke/playwright-customer-critical.mjs` | 2026-06-03 |
+| R14 | C1 email readiness helper validates SMTP/app URL env offline by default; SMTP network verify and neutral test-send are separately flag-gated | `scripts/smoke/email-readiness.mjs` | 2026-06-03 |
 
 ### Earlier (carried over from prior backlog state)
 
@@ -112,7 +113,7 @@ Per current readiness reconciliation: the four operator-driven items below are t
 
 | # | Item | Owner | Effort | Status | Notes |
 |---|------|-------|--------|--------|-------|
-| **C1** | **SMTP / Resend on prod — domain `mail.vizora.cloud` verified (DKIM/SPF/DMARC), `SMTP_*`/`EMAIL_FROM` and public `APP_URL` or `WEB_URL` env set, test send works end-to-end** | Sri | 2h | TODO | Without this, customer registration emails + password resets don't send or link to the wrong host |
+| **C1** | **SMTP / Resend on prod — domain `mail.vizora.cloud` verified (DKIM/SPF/DMARC), `SMTP_*`/`EMAIL_FROM` and public `APP_URL` or `WEB_URL` env set, test send works end-to-end** | Sri | 2h | TODO | Repo-side helper: `pnpm smoke:email-readiness --production` checks config offline; `--verify-smtp` and `--send` require explicit operator flags. Operator still owns DNS/env/test-send. |
 | **C2** | **Customer-1 organization provisioned on prod** (skeleton, admin user invite, plan, quota) | Sri | 1h | TODO | Skip if customer self-registers |
 | **C3** | **Real-device walkthrough on customer hardware** (pair, push playlist, reboot, network-flap) | Sri + customer IT | 2h | TODO | Electron has 0% functional test coverage; this IS the test |
 | **C4** | **Final go-live smoke test on prod** | Claude Code (driven by Sri) | 3h | BLOCKED on C1-C3 | Operator-driven; document in `docs/runbooks/customer-1-go-live-smoke-{DATE}.md` |

--- a/docs/runbooks/first-customer-onboarding.md
+++ b/docs/runbooks/first-customer-onboarding.md
@@ -42,12 +42,18 @@ ssh root@vizora.cloud 'cd /opt/vizora/app && API_BASE=https://vizora.cloud WEB_B
 # RT_BASE=http://localhost:3002 and probes /api/health. Public WebSocket
 # ingress is covered by the real-device walkthrough below, not by direct :3002 HTTPS.
 #
-# Then trigger a real welcome email:
-curl -X POST https://vizora.cloud/api/v1/auth/register \
-  -H "Content-Type: application/json" \
-  -d '{"email":"<your-real-email>","password":"Test123!@#",
-       "firstName":"Smoke","lastName":"Test","organizationName":"smoke-final"}'
-# Within 30s, the configured EMAIL_FROM should land a welcome message in your inbox.
+# Offline C1 email config check; this does NOT contact SMTP and does NOT send email:
+ssh root@vizora.cloud 'cd /opt/vizora/app && pnpm smoke:email-readiness --production' > .ssh_email_readiness_check.txt 2>&1
+# Read .ssh_email_readiness_check.txt as a separate step.
+#
+# Optional SMTP credential handshake; this contacts SMTP but does NOT send email:
+ssh root@vizora.cloud 'cd /opt/vizora/app && EMAIL_READINESS_ALLOW_NETWORK=true pnpm smoke:email-readiness --production --verify-smtp' > .ssh_email_readiness_smtp.txt 2>&1
+# Read .ssh_email_readiness_smtp.txt as a separate step.
+#
+# Operator-approved test send; sends one neutral readiness email to the chosen inbox:
+ssh root@vizora.cloud 'cd /opt/vizora/app && EMAIL_READINESS_ALLOW_SEND=true pnpm smoke:email-readiness --production --send --to <your-real-email>' > .ssh_email_readiness_send.txt 2>&1
+# Read .ssh_email_readiness_send.txt as a separate step.
+# Within 30s, the configured EMAIL_FROM should land a readiness message in your inbox.
 ```
 
 ### 2. C2 — Customer-#1 organization provisioned

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "nx run-many --target=test --all",
     "test:ops": "node --import tsx --test \"scripts/ops/**/*.test.ts\"",
     "test:e2e": "pnpm --filter @vizora/middleware test:e2e",
+    "smoke:email-readiness": "node scripts/smoke/email-readiness.mjs",
     "e2e:customer-critical": "node scripts/smoke/playwright-customer-critical.mjs",
     "security:no-hardcoded-jwts": "node scripts/security/check-no-hardcoded-jwts.js",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint --ext .ts,.tsx middleware/src realtime/src",

--- a/scripts/ops/release-readiness-gates.test.ts
+++ b/scripts/ops/release-readiness-gates.test.ts
@@ -174,6 +174,123 @@ test('first-customer C1 runbook verifies email app URL env', () => {
   assert.match(runbook, /email links do not point at localhost/i);
 });
 
+test('email readiness helper validates C1 SMTP config without sending by default', async () => {
+  const helperSource = readRepoFile('scripts/smoke/email-readiness.mjs');
+  assert.match(helperSource, /import ['"]dotenv\/config['"]/);
+
+  const helper = (await import(
+    pathToFileURL(join(repoRoot, 'scripts/smoke/email-readiness.mjs')).href
+  )) as {
+    buildEmailReadinessPlan: (input: {
+      env: Record<string, string | undefined>;
+      args: string[];
+    }) => {
+      ok: boolean;
+      mode: 'check' | 'verify-smtp' | 'send';
+      errors: string[];
+      warnings: string[];
+      shouldSend: boolean;
+      shouldVerifySmtp: boolean;
+      to: string | null;
+    };
+  };
+
+  const env = {
+    NODE_ENV: 'production',
+    SMTP_HOST: 'smtp.resend.com',
+    SMTP_PORT: '587',
+    SMTP_USER: 'resend',
+    SMTP_PASS: 'secret',
+    EMAIL_FROM: 'Vizora <noreply@mail.vizora.cloud>',
+    APP_URL: 'https://vizora.cloud',
+    SMTP_TO: 'ops@example.com',
+  };
+
+  const checkOnly = helper.buildEmailReadinessPlan({ env, args: ['--production'] });
+  assert.equal(checkOnly.ok, true);
+  assert.equal(checkOnly.mode, 'check');
+  assert.equal(checkOnly.shouldSend, false);
+  assert.equal(checkOnly.shouldVerifySmtp, false);
+
+  const separatorCheck = helper.buildEmailReadinessPlan({ env, args: ['--', '--production'] });
+  assert.equal(separatorCheck.ok, true);
+  assert.equal(separatorCheck.mode, 'check');
+  assert.equal(separatorCheck.shouldSend, false);
+
+  const missing = helper.buildEmailReadinessPlan({
+    env: { NODE_ENV: 'production', SMTP_HOST: 'smtp.resend.com' },
+    args: ['--production'],
+  });
+  assert.equal(missing.ok, false);
+  assert.match(missing.errors.join('\n'), /SMTP_PASS/);
+  assert.match(missing.errors.join('\n'), /EMAIL_FROM/);
+  assert.match(missing.errors.join('\n'), /APP_URL or WEB_URL/);
+
+  const blockedSend = helper.buildEmailReadinessPlan({
+    env,
+    args: ['--production', '--send', '--to', 'ops@example.com'],
+  });
+  assert.equal(blockedSend.ok, false);
+  assert.equal(blockedSend.shouldSend, false);
+  assert.match(blockedSend.errors.join('\n'), /EMAIL_READINESS_ALLOW_SEND=true/);
+
+  const blockedNetworkVerify = helper.buildEmailReadinessPlan({
+    env,
+    args: ['--production', '--verify-smtp'],
+  });
+  assert.equal(blockedNetworkVerify.ok, false);
+  assert.equal(blockedNetworkVerify.shouldVerifySmtp, false);
+  assert.match(blockedNetworkVerify.errors.join('\n'), /EMAIL_READINESS_ALLOW_NETWORK=true/);
+
+  const localhostUrl = helper.buildEmailReadinessPlan({
+    env: { ...env, APP_URL: 'http://[::1]:3001' },
+    args: ['--production'],
+  });
+  assert.equal(localhostUrl.ok, false);
+  assert.match(localhostUrl.errors.join('\n'), /must use https in production/);
+  assert.match(localhostUrl.errors.join('\n'), /must not point at localhost in production/);
+
+  const deceptiveSender = helper.buildEmailReadinessPlan({
+    env: { ...env, EMAIL_FROM: 'Vizora <noreply@mail.vizora.cloud.evil.example>' },
+    args: ['--production'],
+  });
+  assert.equal(deceptiveSender.ok, true);
+  assert.match(deceptiveSender.warnings.join('\n'), /verified mail\.vizora\.cloud domain/);
+
+  const allowedSend = helper.buildEmailReadinessPlan({
+    env: { ...env, EMAIL_READINESS_ALLOW_SEND: 'true' },
+    args: ['--production', '--send', '--to', 'ops@example.com'],
+  });
+  assert.equal(allowedSend.ok, true);
+  assert.equal(allowedSend.mode, 'send');
+  assert.equal(allowedSend.shouldSend, true);
+  assert.equal(allowedSend.to, 'ops@example.com');
+});
+
+test('package.json exposes email readiness smoke helper', () => {
+  const pkg = JSON.parse(readRepoFile('package.json')) as {
+    scripts?: Record<string, string>;
+  };
+
+  assert.equal(
+    pkg.scripts?.['smoke:email-readiness'],
+    'node scripts/smoke/email-readiness.mjs',
+  );
+});
+
+test('first-customer C1 runbook uses explicit email readiness helper for test sends', () => {
+  const runbook = readRepoFile('docs/runbooks/first-customer-onboarding.md');
+
+  assert.match(runbook, /ssh root@vizora\.cloud 'cd \/opt\/vizora\/app && pnpm smoke:email-readiness --production'/);
+  assert.match(runbook, /EMAIL_READINESS_ALLOW_NETWORK=true pnpm smoke:email-readiness --production --verify-smtp/);
+  assert.match(runbook, /EMAIL_READINESS_ALLOW_SEND=true pnpm smoke:email-readiness --production --send --to <your-real-email>/);
+  assert.match(runbook, /\.ssh_email_readiness_check\.txt/);
+  assert.match(runbook, /\.ssh_email_readiness_smtp\.txt/);
+  assert.match(runbook, /\.ssh_email_readiness_send\.txt/);
+  assert.doesNotMatch(runbook, /smoke:email-readiness -- --/);
+  assert.doesNotMatch(runbook, /Then trigger a real welcome email/);
+});
+
 test('first-customer runbook does not require nonexistent email verification flow', () => {
   const runbook = readRepoFile('docs/runbooks/first-customer-onboarding.md');
   const schema = readRepoFile('packages/database/prisma/schema.prisma');

--- a/scripts/smoke/email-readiness.mjs
+++ b/scripts/smoke/email-readiness.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import { pathToFileURL } from 'node:url';
+
+function parseArgs(args) {
+  const parsed = {
+    production: false,
+    verifySmtp: false,
+    send: false,
+    to: null,
+    json: false,
+    help: false,
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--production') {
+      parsed.production = true;
+    } else if (arg === '--verify-smtp') {
+      parsed.verifySmtp = true;
+    } else if (arg === '--send') {
+      parsed.send = true;
+    } else if (arg === '--json') {
+      parsed.json = true;
+    } else if (arg === '--help' || arg === '-h') {
+      parsed.help = true;
+    } else if (arg === '--') {
+      continue;
+    } else if (arg === '--to') {
+      parsed.to = args[i + 1] ?? null;
+      i += 1;
+    } else if (arg.startsWith('--to=')) {
+      parsed.to = arg.slice('--to='.length);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function isLocalUrl(value) {
+  try {
+    const url = new URL(value);
+    return ['localhost', '127.0.0.1', '::1', '[::1]'].includes(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function isValidEmail(value) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+function hasValue(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function usesVerifiedSenderDomain(value) {
+  return /@mail\.vizora\.cloud(?:[>\s]|$)/i.test(value);
+}
+
+export function buildEmailReadinessPlan({ env, args }) {
+  let parsed;
+  const errors = [];
+  const warnings = [];
+
+  try {
+    parsed = parseArgs(args);
+  } catch (error) {
+    return {
+      ok: false,
+      mode: 'check',
+      errors: [error instanceof Error ? error.message : String(error)],
+      warnings,
+      shouldSend: false,
+      shouldVerifySmtp: false,
+      to: null,
+      config: {},
+    };
+  }
+
+  const production = parsed.production || env.NODE_ENV === 'production';
+  const smtpPass = env.SMTP_PASS || env.SMTP_PASSWORD;
+  const appUrl = env.APP_URL || env.WEB_URL;
+  const to = parsed.to || env.SMTP_TO || null;
+  const mode = parsed.send ? 'send' : parsed.verifySmtp ? 'verify-smtp' : 'check';
+
+  const required = [
+    ['SMTP_HOST', env.SMTP_HOST],
+    ['SMTP_PORT', env.SMTP_PORT],
+    ['SMTP_USER', env.SMTP_USER],
+    ['SMTP_PASS', smtpPass],
+    ['EMAIL_FROM', env.EMAIL_FROM],
+    ['APP_URL or WEB_URL', appUrl],
+  ];
+
+  for (const [name, value] of required) {
+    if (!hasValue(value)) {
+      errors.push(`${name} is required`);
+    }
+  }
+
+  const port = Number(env.SMTP_PORT);
+  if (hasValue(env.SMTP_PORT) && (!Number.isInteger(port) || port < 1 || port > 65535)) {
+    errors.push('SMTP_PORT must be an integer between 1 and 65535');
+  }
+
+  if (hasValue(appUrl)) {
+    try {
+      const parsedUrl = new URL(appUrl);
+      if (production && parsedUrl.protocol !== 'https:') {
+        errors.push('APP_URL or WEB_URL must use https in production');
+      }
+    } catch {
+      errors.push('APP_URL or WEB_URL must be a valid URL');
+    }
+
+    if (production && isLocalUrl(appUrl)) {
+      errors.push('APP_URL or WEB_URL must not point at localhost in production');
+    }
+  }
+
+  if (hasValue(env.EMAIL_FROM) && !usesVerifiedSenderDomain(env.EMAIL_FROM)) {
+    warnings.push('EMAIL_FROM should use the verified mail.vizora.cloud domain');
+  }
+
+  if (parsed.verifySmtp && env.EMAIL_READINESS_ALLOW_NETWORK !== 'true') {
+    errors.push('Set EMAIL_READINESS_ALLOW_NETWORK=true to run SMTP network verify');
+  }
+
+  if (parsed.send) {
+    if (env.EMAIL_READINESS_ALLOW_SEND !== 'true') {
+      errors.push('Set EMAIL_READINESS_ALLOW_SEND=true to send a readiness test email');
+    }
+    if (!hasValue(to)) {
+      errors.push('A test recipient is required via --to or SMTP_TO');
+    } else if (!isValidEmail(to)) {
+      errors.push('Test recipient must be a valid email address');
+    }
+  }
+
+  const ok = errors.length === 0;
+
+  return {
+    ok,
+    mode,
+    errors,
+    warnings,
+    shouldSend: ok && mode === 'send',
+    shouldVerifySmtp: ok && mode === 'verify-smtp',
+    to,
+    json: parsed.json,
+    config: {
+      production,
+      smtpHost: env.SMTP_HOST ?? null,
+      smtpPort: hasValue(env.SMTP_PORT) ? port : null,
+      smtpUser: env.SMTP_USER ?? null,
+      emailFrom: env.EMAIL_FROM ?? null,
+      appUrl: appUrl ?? null,
+      usesLegacySmtpPassword: !env.SMTP_PASS && hasValue(env.SMTP_PASSWORD),
+    },
+  };
+}
+
+function makeTransportConfig(env) {
+  const port = Number(env.SMTP_PORT);
+  return {
+    host: env.SMTP_HOST,
+    port,
+    secure: port === 465,
+    auth: {
+      user: env.SMTP_USER,
+      pass: env.SMTP_PASS || env.SMTP_PASSWORD,
+    },
+  };
+}
+
+async function verifySmtp(env) {
+  const nodemailer = await import('nodemailer');
+  const transporter = nodemailer.default.createTransport(makeTransportConfig(env));
+  await transporter.verify();
+}
+
+async function sendReadinessEmail(env, plan) {
+  const nodemailer = await import('nodemailer');
+  const transporter = nodemailer.default.createTransport(makeTransportConfig(env));
+  const appUrl = plan.config.appUrl;
+  await transporter.sendMail({
+    from: env.EMAIL_FROM,
+    to: plan.to,
+    subject: 'Vizora email readiness test',
+    text: [
+      'Vizora email readiness test.',
+      '',
+      `Public app URL: ${appUrl}`,
+      'If you received this message, SMTP authentication and delivery are working for this recipient.',
+    ].join('\n'),
+    html: [
+      '<p>Vizora email readiness test.</p>',
+      `<p><strong>Public app URL:</strong> ${appUrl}</p>`,
+      '<p>If you received this message, SMTP authentication and delivery are working for this recipient.</p>',
+    ].join(''),
+  });
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/smoke/email-readiness.mjs [options]
+
+Options:
+  --production       Enforce production URL checks even when NODE_ENV is not production
+  --verify-smtp      Verify SMTP credentials with nodemailer.verify()
+                     Requires EMAIL_READINESS_ALLOW_NETWORK=true
+  --send             Send one neutral readiness email
+                     Requires EMAIL_READINESS_ALLOW_SEND=true and --to or SMTP_TO
+  --to <email>       Recipient for --send
+  --json             Print JSON result
+
+Default mode performs offline env validation only. It does not contact SMTP and does not send email.`);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    printHelp();
+    return;
+  }
+
+  const plan = buildEmailReadinessPlan({ env: process.env, args });
+
+  if (plan.config.usesLegacySmtpPassword) {
+    plan.warnings.push('Using legacy SMTP_PASSWORD alias; prefer SMTP_PASS');
+  }
+
+  if (plan.json) {
+    console.log(JSON.stringify(plan, null, 2));
+  } else {
+    console.log(`[email-readiness] mode=${plan.mode}`);
+    for (const warning of plan.warnings) {
+      console.warn(`[email-readiness] warning: ${warning}`);
+    }
+    for (const error of plan.errors) {
+      console.error(`[email-readiness] error: ${error}`);
+    }
+  }
+
+  if (!plan.ok) {
+    process.exitCode = 1;
+    return;
+  }
+
+  if (plan.shouldVerifySmtp) {
+    await verifySmtp(process.env);
+    console.log('[email-readiness] SMTP verify succeeded');
+  } else if (plan.shouldSend) {
+    await sendReadinessEmail(process.env, plan);
+    console.log(`[email-readiness] test email sent to ${plan.to}`);
+  } else {
+    console.log('[email-readiness] offline config check passed; no SMTP connection and no email sent');
+  }
+}
+
+const directRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (directRun) {
+  main().catch((error) => {
+    console.error(`[email-readiness] fatal: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,84 @@
 # Vizora - Task Tracker
 
-## Active Workstream: First-Customer Email Verification Truth Pass 77 (2026-06-03)
+## Active Workstream: Email Readiness Smoke Helper Pass 78 (2026-06-03)
+
+**Branch:** `fix/readiness-pass78`
+
+**Why now:** C1 SMTP/Resend remains operator-gated, but the first-customer
+runbook still told the operator to create a real registration user just to
+prove email delivery. That sends customer-visible lifecycle mail and muddies
+the smoke result. A launch readiness check needs a safe repo-side helper:
+offline validation by default, optional SMTP credential verification only with
+an explicit network flag, and optional test-send only with an explicit send
+flag.
+
+**Drift-check:** `MailService` already sends welcome/reset/password/security
+emails through Nodemailer, and `StartupSelfTestService.checkEmail()` can verify
+SMTP when middleware starts. The residual C1 gap is operator ergonomics and
+safe evidence collection: runbook/test-send instructions should validate
+`SMTP_*`, `EMAIL_FROM`, and public `APP_URL`/`WEB_URL` without creating a
+real account or sending mail by default.
+
+**New primitives introduced:** one smoke helper script and static
+release-readiness assertions. No DB model/migration, public API, PM2 process,
+env var, MCP tool, Hermes skill, provider-spend path, production deploy, prod
+env edit, real customer registration, customer email send, payment setup, or
+hardware action is planned.
+
+**Hermes-first analysis:** not applicable. This is SMTP/runbook readiness
+validation, not a business-agent, MCP, Hermes runtime, or AI/provider-spend
+path.
+
+**Plan**
+- [x] Add failing release-readiness assertions for a no-send-by-default email
+      helper, package script exposure, and C1 runbook usage.
+- [x] Implement `scripts/smoke/email-readiness.mjs` with offline checks by
+      default, gated SMTP network verify, and gated neutral test-send.
+- [x] Update first-customer C1 runbook to use the helper instead of triggering
+      a real welcome email.
+- [ ] Run focused ops test, broader ops tests, diff/secret checks, Claude Code
+      review, commit, PR, CI, and merge if green.
+
+**Evidence so far**
+- Red test:
+  - `node --import tsx --test scripts/ops/release-readiness-gates.test.ts`
+    failed 3/31 because the helper file/package script did not exist and the
+    runbook still instructed "Then trigger a real welcome email".
+- Green verification so far:
+  - `node --check scripts/smoke/email-readiness.mjs`: passed.
+  - `node --import tsx --test scripts/ops/release-readiness-gates.test.ts`:
+    31/31 tests passed.
+  - `pnpm test:ops`: 56/56 tests passed.
+  - `git diff --check`: passed with CRLF normalization warnings only.
+  - `pnpm security:no-hardcoded-jwts`: passed.
+  - Synthetic production offline helper run:
+    `node scripts/smoke/email-readiness.mjs --production` printed
+    "offline config check passed; no SMTP connection and no email sent".
+  - `pnpm smoke:email-readiness --production` with synthetic production env:
+    passed and printed no SMTP/no email.
+  - `pnpm smoke:email-readiness -- --production --json` with synthetic
+    production env: passed, returned `ok: true`, and did not send or verify SMTP.
+- Claude Code review:
+  - First pass: NOT CLEAN. Medium finding that the helper did not load `.env`,
+    so a prod runbook invocation could miss `/opt/vizora/app/.env`. Fixed by
+    adding `import 'dotenv/config'` and a static regression assertion.
+  - Second pass: NOT CLEAN. Medium findings that documented pnpm commands used
+    the wrong `--` separator form and were not SSH-wrapped for prod execution.
+    Fixed by making the parser tolerate a bare `--`, documenting
+    `pnpm smoke:email-readiness --production`, wrapping C1 helper commands in
+    `ssh root@vizora.cloud 'cd /opt/vizora/app && ...'`, and adding static
+    assertions for the SSH output files and no `smoke:email-readiness -- --`
+    runbook drift.
+  - Third pass: CLEAN. Reviewer verified the dotenv, pnpm command, and
+    prod-SSH-wrapping findings are closed; no high/medium findings remain.
+- Operator boundary:
+  - No production env change, SMTP/Resend setup, network SMTP verify, real
+    email send, customer registration, deploy, or service restart was
+    performed.
+
+---
+
+## Completed Workstream: First-Customer Email Verification Truth Pass 77 (2026-06-03)
 
 **Branch:** `fix/readiness-pass77`
 
@@ -30,7 +108,7 @@ AI/provider-spend path.
       not require a nonexistent email verification flow.
 - [x] Update the runbook to require signup dashboard access + welcome email
       delivery, while explicitly noting email verification is deferred.
-- [ ] Run focused ops test, broader ops tests, diff/secret checks, Claude Code
+- [x] Run focused ops test, broader ops tests, diff/secret checks, Claude Code
       review, commit, PR, CI, and merge if green.
 
 **Evidence**
@@ -53,6 +131,11 @@ AI/provider-spend path.
     that the schema assertion should trip when B5 eventually lands. Re-ran the
     focused readiness-gate test (28/28), `pnpm test:ops` (53/53),
     `git diff --check`, and `pnpm security:no-hardcoded-jwts` afterward.
+- PR/CI/merge:
+  - Commit `a9fc2f83` (`docs(runbook): align signup smoke with welcome email flow`).
+  - PR #218 merged as `517ae30e`.
+  - GitHub checks passed before merge: audit, build, e2e, lint, security, and
+    test.
 
 ---
 


### PR DESCRIPTION
## Summary
- add `scripts/smoke/email-readiness.mjs` for C1 email readiness checks
- keep default mode offline/no-send/no-network; gate SMTP verify and neutral test-send behind explicit env flags
- update first-customer runbook/backlog to run the helper on prod via SSH output capture

## Verification
- `node --check scripts/smoke/email-readiness.mjs`
- `node --import tsx --test scripts/ops/release-readiness-gates.test.ts` (31/31)
- `pnpm smoke:email-readiness --production` with synthetic prod env (offline/no send)
- `pnpm smoke:email-readiness -- --production --json` with synthetic prod env (offline/no send)
- `pnpm test:ops` (56/56)
- `git diff --check` (CRLF normalization warnings only)
- `pnpm security:no-hardcoded-jwts`

## Review
- Claude Code review pass 1: NOT CLEAN; fixed `.env` loading with `dotenv/config`
- Claude Code review pass 2: NOT CLEAN; fixed pnpm command form and prod SSH wrapping
- Claude Code review pass 3: CLEAN; no high/medium findings

## Operator boundary
No production env changes, SMTP/Resend setup, SMTP network verify, real email send, customer registration, deploy, or service restart performed.