### PR TITLE
fix: S2 production-readiness (ops-lock crash-safety + Redis fallback + billing fail-closed)

### DIFF
--- a/middleware/src/modules/billing/billing.service.spec.ts
+++ b/middleware/src/modules/billing/billing.service.spec.ts
@@ -568,6 +568,29 @@ describe('BillingService', () => {
       });
     });
 
+    it('leaves subscriptionStatus unchanged on an unmapped status (fail-closed, audit S2-6)', async () => {
+      mockDatabaseService.organization.findFirst.mockResolvedValue(mockOrganization);
+      mockDatabaseService.organization.update.mockClear();
+      mockDatabaseService.organization.update.mockResolvedValue({});
+      mockStripeProvider.verifyWebhookSignature.mockReturnValue({
+        id: 'evt_paused',
+        type: 'customer.subscription.updated',
+        data: {
+          id: 'sub_paused',
+          customer: 'cus_stripe123',
+          // 'paused' is a real Stripe status we do not map. It must NOT coerce
+          // to 'active' (that would silently restore entitlement to a paused,
+          // non-paying subscription). Fail-closed: leave the org untouched.
+          status: 'paused',
+        },
+      });
+
+      const result = await service.handleWebhookEvent('stripe', { rawBody, signature });
+
+      expect(result).toEqual({ received: true });
+      expect(mockDatabaseService.organization.update).not.toHaveBeenCalled();
+    });
+
     it('should handle subscription.deleted and downgrade to free', async () => {
       mockDatabaseService.organization.findFirst.mockResolvedValue(mockOrganization);
       mockDatabaseService.organization.update.mockResolvedValue({});

--- a/middleware/src/modules/billing/billing.service.ts
+++ b/middleware/src/modules/billing/billing.service.ts
@@ -760,8 +760,17 @@ export class BillingService implements OnModuleInit {
       return;
     }
 
-    // Map status
+    // Map status. A missing/unmapped status returns null → leave the org's
+    // last-known subscriptionStatus untouched (fail-closed) rather than flip
+    // entitlement on a webhook we don't understand. (audit S2-6)
     const status = this.mapSubscriptionStatus(provider, data.status || data.subscription?.status);
+
+    if (status === null) {
+      this.logger.warn(
+        `Skipping subscriptionStatus update for org ${org.id}: unmapped/missing ${provider} status`,
+      );
+      return;
+    }
 
     await this.db.organization.update({
       where: { id: org.id },
@@ -986,8 +995,20 @@ export class BillingService implements OnModuleInit {
    */
   private mapSubscriptionStatus(
     provider: string,
-    status: string,
-  ): 'trial' | 'active' | 'past_due' | 'canceled' {
+    status: string | undefined,
+  ): 'trial' | 'active' | 'past_due' | 'canceled' | null {
+    // Fail CLOSED on entitlement: a missing or unrecognized status must NEVER
+    // coerce to 'active'. Silently granting entitlement to a paused/unknown
+    // subscription is revenue leakage that defaults the wrong way. Returning
+    // null tells the caller to leave the last-known status untouched and log,
+    // rather than flip entitlement in either direction on a webhook we don't
+    // understand. (audit S2-6)
+    if (!status) {
+      this.logger.warn(
+        `Subscription webhook for ${provider} had no status field; leaving subscriptionStatus unchanged`,
+      );
+      return null;
+    }
     if (provider === 'stripe') {
       const statusMap: Record<string, 'trial' | 'active' | 'past_due' | 'canceled'> = {
         trialing: 'trial',
@@ -998,7 +1019,12 @@ export class BillingService implements OnModuleInit {
         incomplete_expired: 'canceled',
         unpaid: 'past_due',
       };
-      return statusMap[status] || 'active';
+      const mapped = statusMap[status];
+      if (!mapped) {
+        this.logger.warn(`Unmapped Stripe subscription status "${status}"; leaving subscriptionStatus unchanged`);
+        return null;
+      }
+      return mapped;
     } else {
       const statusMap: Record<string, 'trial' | 'active' | 'past_due' | 'canceled'> = {
         created: 'trial',
@@ -1010,7 +1036,12 @@ export class BillingService implements OnModuleInit {
         completed: 'canceled',
         expired: 'canceled',
       };
-      return statusMap[status] || 'active';
+      const mapped = statusMap[status];
+      if (!mapped) {
+        this.logger.warn(`Unmapped ${provider} subscription status "${status}"; leaving subscriptionStatus unchanged`);
+        return null;
+      }
+      return mapped;
     }
   }
 }

--- a/middleware/src/modules/common/data-retention.service.spec.ts
+++ b/middleware/src/modules/common/data-retention.service.spec.ts
@@ -20,6 +20,8 @@ describe('DataRetentionService', () => {
             auditLog: { deleteMany: mockDeleteMany },
             notification: { deleteMany: mockDeleteMany },
             passwordResetToken: { deleteMany: mockDeleteMany },
+            mcpAuditLog: { deleteMany: mockDeleteMany },
+            adminAuditLog: { deleteMany: mockDeleteMany },
           },
         },
       ],
@@ -95,6 +97,24 @@ describe('DataRetentionService', () => {
       expect(call.where.expiresAt.lt).toBeInstanceOf(Date);
     });
 
+    it('should purge MCP and admin audit logs older than 90 days (audit S2-7)', async () => {
+      const mcpDeleteMany = jest.fn().mockResolvedValue({ count: 7 });
+      const adminDeleteMany = jest.fn().mockResolvedValue({ count: 4 });
+      (db.mcpAuditLog as any).deleteMany = mcpDeleteMany;
+      (db.adminAuditLog as any).deleteMany = adminDeleteMany;
+
+      await service.runRetentionPolicy();
+
+      expect(mcpDeleteMany).toHaveBeenCalledTimes(1);
+      expect(adminDeleteMany).toHaveBeenCalledTimes(1);
+      const ninetyDaysMs = 90 * 24 * 60 * 60 * 1000;
+      for (const fn of [mcpDeleteMany, adminDeleteMany]) {
+        const cutoff = fn.mock.calls[0][0].where.createdAt.lt as Date;
+        expect(cutoff).toBeInstanceOf(Date);
+        expect(Math.abs(Date.now() - cutoff.getTime() - ninetyDaysMs)).toBeLessThan(5000);
+      }
+    });
+
     it('should handle errors gracefully without throwing', async () => {
       (db.auditLog as any).deleteMany = jest.fn().mockRejectedValue(new Error('DB down'));
 
@@ -119,7 +139,8 @@ describe('DataRetentionService', () => {
       expect(logSpy).toHaveBeenCalledWith('Purged 3 read notifications older than 30 days');
       expect(logSpy).toHaveBeenCalledWith('Purged 2 expired password reset tokens');
       expect(logSpy).toHaveBeenCalledWith(
-        'Data retention cleanup complete: 10 audit logs, 8 notifications, 2 tokens',
+        'Data retention cleanup complete: 10 audit logs, 0 MCP audit logs, ' +
+          '0 admin audit logs, 8 notifications, 2 tokens',
       );
     });
   });

--- a/middleware/src/modules/common/data-retention.service.ts
+++ b/middleware/src/modules/common/data-retention.service.ts
@@ -16,6 +16,8 @@ export class DataRetentionService {
    * 2. Dismissed notifications older than 30 days
    * 3. Read (non-dismissed) notifications older than 30 days
    * 4. Expired password reset tokens
+   * 5. MCP audit logs older than 90 days
+   * 6. Admin audit logs older than 90 days
    *
    * Note: Content impressions are already cleaned up by AnalyticsService at 2 AM.
    * Note: Redis device commands have a 5-minute TTL and self-expire.
@@ -31,6 +33,8 @@ export class DataRetentionService {
     let auditCount = 0;
     let notifCount = 0;
     let tokenCount = 0;
+    let mcpAuditCount = 0;
+    let adminAuditCount = 0;
 
     // 1. Purge audit logs older than 90 days
     try {
@@ -82,8 +86,34 @@ export class DataRetentionService {
       this.logger.error(`Failed to purge expired tokens: ${err instanceof Error ? err.message : err}`);
     }
 
+    // 5. Purge MCP audit logs older than 90 days. mcp_audit_log is written on
+    // every MCP tool call (Hermes cron agents + future customer integrations)
+    // and had no retention — an unbounded pipeline-table growth surface (§12a).
+    try {
+      const result = await this.db.mcpAuditLog.deleteMany({
+        where: { createdAt: { lt: ninetyDaysAgo } },
+      });
+      mcpAuditCount = result.count;
+      this.logger.log(`Purged ${mcpAuditCount} MCP audit logs older than 90 days`);
+    } catch (err) {
+      this.logger.error(`Failed to purge MCP audit logs: ${err instanceof Error ? err.message : err}`);
+    }
+
+    // 6. Purge admin audit logs older than 90 days (lower volume, but likewise
+    // had no retention).
+    try {
+      const result = await this.db.adminAuditLog.deleteMany({
+        where: { createdAt: { lt: ninetyDaysAgo } },
+      });
+      adminAuditCount = result.count;
+      this.logger.log(`Purged ${adminAuditCount} admin audit logs older than 90 days`);
+    } catch (err) {
+      this.logger.error(`Failed to purge admin audit logs: ${err instanceof Error ? err.message : err}`);
+    }
+
     this.logger.log(
       `Data retention cleanup complete: ${auditCount} audit logs, ` +
+      `${mcpAuditCount} MCP audit logs, ${adminAuditCount} admin audit logs, ` +
       `${notifCount} notifications, ${tokenCount} tokens`,
     );
   }

--- a/realtime/src/gateways/device.gateway.spec.ts
+++ b/realtime/src/gateways/device.gateway.spec.ts
@@ -1196,16 +1196,24 @@ describe('DeviceGateway', () => {
       expect((gateway as any).lastHeartbeatDbWrites.has('device-1')).toBe(false);
     });
 
-    it('should return error response on failure', async () => {
+    it('gracefully degrades when Redis is down: heartbeat still succeeds via the Postgres fallback', async () => {
+      // Regression guard for the S2-2 fix: a Redis outage must NOT fail the
+      // heartbeat or disconnect the device. Before the fix, the unguarded
+      // setDeviceStatus throw returned an error ack AND skipped the DB write,
+      // so the middleware offline-scanner would mark the whole live fleet
+      // offline from a transient Redis blip. Now the gateway logs and continues
+      // to the durable Postgres write.
       mockRedisService.setDeviceStatus.mockRejectedValueOnce(new Error('Redis down'));
+      mockDatabaseService.display.updateMany.mockClear();
 
       const client = createMockSocket();
       const data = {};
 
       const result = await gateway.handleHeartbeat(client as any, data as any);
 
-      expect(result.success).toBe(false);
-      expect(result.error).toBeDefined();
+      expect(result.success).toBe(true);
+      // Fallback durability: the Postgres status refresh still ran despite Redis failing.
+      expect(mockDatabaseService.display.updateMany).toHaveBeenCalled();
     });
 
     it('should update metrics when device metrics are present', async () => {

--- a/realtime/src/gateways/device.gateway.ts
+++ b/realtime/src/gateways/device.gateway.ts
@@ -1026,13 +1026,24 @@ export class DeviceGateway
     // Join organization room
     await client.join(`org:${orgId}`);
 
-    // Update device status in Redis
-    await this.redisService.setDeviceStatus(deviceId, {
-      status: 'online',
-      lastHeartbeat: Date.now(),
-      socketId: client.id,
-      organizationId: orgId,
-    });
+    // Update device status in Redis. A Redis outage must NOT block the
+    // connect path: the DB write below is the durable source the dashboard
+    // and the offline-scanner read from. Without this guard, a rejected
+    // setex would propagate to handleConnection's catch → client.disconnect(),
+    // the device would never join rooms or get its playlist, and the DB
+    // status='online' write would never run — a Redis blip would take the
+    // whole fleet offline. Log and continue so Postgres is the real fallback.
+    try {
+      await this.redisService.setDeviceStatus(deviceId, {
+        status: 'online',
+        lastHeartbeat: Date.now(),
+        socketId: client.id,
+        organizationId: orgId,
+      });
+    } catch (redisError: unknown) {
+      const errorMessage = redisError instanceof Error ? redisError.message : 'Unknown error';
+      this.logger.warn(`Failed to set Redis status for device ${deviceId}, continuing to DB write: ${errorMessage}`);
+    }
 
     // 2.1: Only write to DB if status actually changed
     const previousStatus = this.deviceStatusCache.get(deviceId);
@@ -1311,13 +1322,20 @@ export class DeviceGateway
         this.deviceSockets.delete(deviceId);
         this.lastHeartbeatDbWrites.delete(deviceId);
 
-        // Update status in Redis
-        await this.redisService.setDeviceStatus(deviceId, {
-          status: 'offline',
-          lastHeartbeat: Date.now(),
-          socketId: null,
-          organizationId: client.data?.organizationId,
-        });
+        // Update status in Redis. Guarded so a Redis outage doesn't skip the
+        // durable DB offline write below (a disconnect must record offline in
+        // Postgres even if Redis is unavailable).
+        try {
+          await this.redisService.setDeviceStatus(deviceId, {
+            status: 'offline',
+            lastHeartbeat: Date.now(),
+            socketId: null,
+            organizationId: client.data?.organizationId,
+          });
+        } catch (redisError: unknown) {
+          const errorMessage = redisError instanceof Error ? redisError.message : 'Unknown error';
+          this.logger.warn(`Failed to set Redis offline status for device ${deviceId}, continuing to DB write: ${errorMessage}`);
+        }
 
         // 2.1: Update DB on disconnect (status transition) and clean up cache
         this.deviceStatusCache.delete(deviceId);
@@ -1402,20 +1420,30 @@ export class DeviceGateway
         });
       }
 
-      // Update heartbeat in Redis (cheap, always do this)
-      await this.redisService.setDeviceStatus(deviceId, {
-        status: 'online',
-        lastHeartbeat: Date.now(),
-        socketId: client.id,
-        organizationId: client.data.organizationId,
-        metrics: data.metrics,
-        currentContent: data.currentContent,
-        // Contract v1.1: surface dark-screen signals for the fleet view. A device
-        // that is connected but not (screenState=playing, playbackSource=live) is
-        // the "on but dark/stale" case the fleet view previously could not see.
-        screenState: data.screenState,
-        playbackSource: data.playbackSource,
-      });
+      // Update heartbeat in Redis (cheap, always do this). Guarded so a Redis
+      // outage does NOT skip the Postgres refresh below: if this threw, the
+      // handler's catch would return an error ack and the DB lastHeartbeat
+      // write would be skipped, and after HEARTBEAT_DB_REFRESH_INTERVAL_MS×… the
+      // middleware offline-scanner would mark the entire live fleet offline from
+      // a transient Redis blip. Log and continue so Postgres stays fresh.
+      try {
+        await this.redisService.setDeviceStatus(deviceId, {
+          status: 'online',
+          lastHeartbeat: Date.now(),
+          socketId: client.id,
+          organizationId: client.data.organizationId,
+          metrics: data.metrics,
+          currentContent: data.currentContent,
+          // Contract v1.1: surface dark-screen signals for the fleet view. A device
+          // that is connected but not (screenState=playing, playbackSource=live) is
+          // the "on but dark/stale" case the fleet view previously could not see.
+          screenState: data.screenState,
+          playbackSource: data.playbackSource,
+        });
+      } catch (redisError: unknown) {
+        const errorMessage = redisError instanceof Error ? redisError.message : 'Unknown error';
+        this.logger.warn(`Failed to set Redis heartbeat status for device ${deviceId}, continuing to DB refresh: ${errorMessage}`);
+      }
 
       // Keep Redis as the fast heartbeat path, but refresh Postgres often
       // enough that middleware's offline scanner does not see live devices as stale.

--- a/scripts/ops/fleet-manager.ts
+++ b/scripts/ops/fleet-manager.ts
@@ -23,6 +23,7 @@ import type { Incident, AgentResult, RemediationAction } from './lib/types.js';
 import { login, OpsApiClient } from './lib/api-client.js';
 import {
   readOpsState,
+  readOpsStateSnapshot,
   writeOpsState,
   recordAgentRun,
   addRemediation,
@@ -155,7 +156,11 @@ async function main(): Promise<void> {
       .map(s => s.displayId!),
   );
 
-  const state = readOpsState();
+  // Lock-free snapshot for dedup lookups (existing-incident attempt counts +
+  // detected timestamps) during the detection phase below, which does network
+  // I/O. The real locked read→merge→write happens at the very end, with no I/O
+  // under the lock. See scripts/ops/lib/state.ts.
+  const priorState = readOpsStateSnapshot();
   const incidents: Incident[] = [];
   const remediations: RemediationAction[] = [];
   let issuesFound = 0;
@@ -178,7 +183,7 @@ async function main(): Promise<void> {
       // Persistent offline (>1hr) — escalate
       issuesFound++;
       const incidentId = makeIncidentId(AGENT, 'display_offline_persistent', display.id);
-      const existing = state.incidents.find(i => i.id === incidentId);
+      const existing = priorState.incidents.find(i => i.id === incidentId);
 
       if (existing?.status === 'escalated') {
         incidents.push(existing);
@@ -205,7 +210,7 @@ async function main(): Promise<void> {
       // Recent offline (15min–1hr) — attempt ping/reconnect
       issuesFound++;
       const incidentId = makeIncidentId(AGENT, 'display_offline', display.id);
-      const existing = state.incidents.find(i => i.id === incidentId);
+      const existing = priorState.incidents.find(i => i.id === incidentId);
 
       log(AGENT, `${label}: offline for ${Math.round(mins)}min — attempting ping`);
 
@@ -266,7 +271,7 @@ async function main(): Promise<void> {
 
     const label = display.name || display.id;
     const incidentId = makeIncidentId(AGENT, 'display_error', display.id);
-    const existing = state.incidents.find(i => i.id === incidentId);
+    const existing = priorState.incidents.find(i => i.id === incidentId);
 
     issuesFound++;
     log(AGENT, `${label}: in error state (status=${display.status}, error=${display.error || display.errorState || 'none'}) — resetting to inactive`);
@@ -341,7 +346,7 @@ async function main(): Promise<void> {
     if (!allOffline) continue;
 
     const incidentId = makeIncidentId(AGENT, 'cluster_offline', orgId);
-    const existing = state.incidents.find(i => i.id === incidentId);
+    const existing = priorState.incidents.find(i => i.id === incidentId);
 
     issuesFound++;
     issuesEscalated++;
@@ -376,7 +381,7 @@ async function main(): Promise<void> {
 
     const label = display.name || display.id;
     const incidentId = makeIncidentId(AGENT, 'no_content', display.id);
-    const existing = state.incidents.find(i => i.id === incidentId);
+    const existing = priorState.incidents.find(i => i.id === incidentId);
 
     issuesFound++;
     log(AGENT, `${label}: online but has no playlist and no active schedule`);
@@ -401,7 +406,7 @@ async function main(): Promise<void> {
   // If a display was previously offline but is now back, resolve the incident
   const currentIncidentIds = new Set(incidents.map(i => i.id));
 
-  for (const existing of state.incidents) {
+  for (const existing of priorState.incidents) {
     if (existing.agent !== AGENT) continue;
     if (existing.status !== 'open') continue;
     if (currentIncidentIds.has(existing.id)) continue;
@@ -430,17 +435,23 @@ async function main(): Promise<void> {
     incidents,
   };
 
-  recordAgentRun(state, result);
+  // Brief locked read→merge→write with no I/O in between. recordAgentRun
+  // upserts our incidents by id, so any concurrent updates from other agents
+  // (their incident ids are namespaced by agent) are preserved.
+  const state = readOpsState();
+  try {
+    recordAgentRun(state, result);
 
-  // Add API client audit log entries as remediations
-  for (const r of api.auditLog) {
-    addRemediation(state, r);
+    // Add API client audit log entries as remediations
+    for (const r of api.auditLog) {
+      addRemediation(state, r);
+    }
+    for (const r of remediations) {
+      addRemediation(state, r);
+    }
+  } finally {
+    writeOpsState(state);
   }
-  for (const r of remediations) {
-    addRemediation(state, r);
-  }
-
-  writeOpsState(state);
 
   // ─── Summary ───────────────────────────────────────────────────────────
 

--- a/scripts/ops/health-guardian.ts
+++ b/scripts/ops/health-guardian.ts
@@ -25,6 +25,7 @@ import { execSync } from 'node:child_process';
 import type { Incident, AgentResult, RemediationAction } from './lib/types.js';
 import {
   readOpsState,
+  readOpsStateSnapshot,
   writeOpsState,
   recordAgentRun,
   addRemediation,
@@ -175,7 +176,11 @@ async function main(): Promise<void> {
   const startTime = Date.now();
   log(AGENT, 'Starting health check cycle');
 
-  const state = readOpsState();
+  // Lock-free snapshot for existing-incident lookups (attempt counts +
+  // detected timestamps) during detection, which does slow I/O: pm2 restarts,
+  // 30s restart cooldowns, health-endpoint fetches. The real locked
+  // read→merge→write is at the very end. See scripts/ops/lib/state.ts.
+  const priorState = readOpsStateSnapshot();
   const services = getServiceDefs();
   const incidents: Incident[] = [];
   const remediations: RemediationAction[] = [];
@@ -187,7 +192,7 @@ async function main(): Promise<void> {
 
   for (const svc of services) {
     const incidentId = makeIncidentId(AGENT, 'service-down', svc.name);
-    const existingIncident = state.incidents.find(i => i.id === incidentId);
+    const existingIncident = priorState.incidents.find(i => i.id === incidentId);
 
     log(AGENT, `Checking ${svc.name}: ${svc.healthUrl}`);
     const result = await checkEndpoint(svc.healthUrl);
@@ -352,7 +357,7 @@ async function main(): Promise<void> {
       if (status === 'errored' || status === 'stopped') {
         issuesFound++;
         const incidentId = makeIncidentId(AGENT, 'pm2-errored', procLabel);
-        const existingIncident = state.incidents.find(i => i.id === incidentId);
+        const existingIncident = priorState.incidents.find(i => i.id === incidentId);
         const previousAttempts = existingIncident?.attempts ?? 0;
 
         if (existingIncident?.status === 'escalated') {
@@ -506,13 +511,18 @@ async function main(): Promise<void> {
     incidents,
   };
 
-  recordAgentRun(state, result);
+  // Brief locked read→merge→write with no I/O in between. recordAgentRun
+  // upserts our incidents by id, preserving other agents' concurrent updates.
+  const state = readOpsState();
+  try {
+    recordAgentRun(state, result);
 
-  for (const r of remediations) {
-    addRemediation(state, r);
+    for (const r of remediations) {
+      addRemediation(state, r);
+    }
+  } finally {
+    writeOpsState(state);
   }
-
-  writeOpsState(state);
 
   // ─── 4. Summary ──────────────────────────────────────────────────────────
 

--- a/scripts/ops/lib/state.test.ts
+++ b/scripts/ops/lib/state.test.ts
@@ -1,0 +1,170 @@
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, test } from 'node:test';
+
+import {
+  readOpsState,
+  readOpsStateSnapshot,
+  writeOpsState,
+} from './state.js';
+import type { Incident, OpsState } from './types.js';
+
+// Each test runs against an isolated temp state file via the OPS_STATE_FILE
+// seam so the real logs/ops-state.json is never touched and cases don't
+// interfere with one another.
+let tmpDir: string;
+let stateFile: string;
+let lockFile: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'vizora-ops-state-'));
+  stateFile = join(tmpDir, 'ops-state.json');
+  lockFile = `${stateFile}.lock`;
+  process.env.OPS_STATE_FILE = stateFile;
+  delete process.env.OPS_LOCK_TIMEOUT_MS;
+});
+
+afterEach(() => {
+  delete process.env.OPS_STATE_FILE;
+  delete process.env.OPS_LOCK_TIMEOUT_MS;
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function sampleIncident(id: string): Incident {
+  return {
+    id,
+    agent: 'fleet-manager',
+    type: 'display_offline',
+    severity: 'critical',
+    target: 'display',
+    targetId: 'd1',
+    detected: new Date().toISOString(),
+    message: 'offline',
+    remediation: 'ping',
+    status: 'open',
+    attempts: 1,
+  };
+}
+
+function makeState(incidents: Incident[]): OpsState {
+  return {
+    systemStatus: incidents.some((i) => i.severity === 'critical') ? 'CRITICAL' : 'HEALTHY',
+    lastUpdated: new Date().toISOString(),
+    lastRun: {},
+    incidents,
+    recentRemediations: [],
+    agentResults: {},
+  };
+}
+
+test('acquire → write round-trip persists state and releases the lock', () => {
+  const state = readOpsState();
+  state.incidents.push(sampleIncident('fleet-manager:display_offline:d1'));
+  state.lastRun['fleet-manager'] = new Date().toISOString();
+  writeOpsState(state);
+
+  // If the lock were not released by writeOpsState, this second read would
+  // spin to timeout and throw — so a clean read proves release.
+  const readBack = readOpsState();
+  try {
+    assert.equal(readBack.incidents.length, 1);
+    assert.equal(readBack.incidents[0].id, 'fleet-manager:display_offline:d1');
+    assert.equal(readBack.lastRun['fleet-manager'], state.lastRun['fleet-manager']);
+  } finally {
+    writeOpsState(readBack);
+  }
+
+  assert.equal(existsSync(lockFile), false, 'lock file should be gone after release');
+});
+
+test('readOpsState THROWS on lock timeout instead of proceeding lock-less', () => {
+  process.env.OPS_LOCK_TIMEOUT_MS = '150';
+  // Another agent holds the lock: a fresh (non-stale) lock file.
+  writeFileSync(lockFile, 'other-agent:0:123');
+
+  assert.throws(() => readOpsState(), /lock timeout/);
+
+  // We never acquired it, so the foreign lock must be left untouched.
+  assert.equal(existsSync(lockFile), true);
+  assert.equal(readFileSync(lockFile, 'utf-8'), 'other-agent:0:123');
+});
+
+test('stale lock (>30s) left by a crashed agent is reclaimed', () => {
+  writeFileSync(stateFile, JSON.stringify(makeState([sampleIncident('fleet-manager:display_offline:d1')]), null, 2));
+  // A lock a crashed agent never released, backdated 60s so it reads as stale.
+  writeFileSync(lockFile, 'crashed-agent:0:1');
+  const backdated = new Date(Date.now() - 60_000);
+  utimesSync(lockFile, backdated, backdated);
+
+  const state = readOpsState();
+  try {
+    assert.equal(state.incidents.length, 1);
+    assert.equal(state.incidents[0].id, 'fleet-manager:display_offline:d1');
+  } finally {
+    writeOpsState(state);
+  }
+
+  assert.equal(existsSync(lockFile), false, 'reclaimed lock released after write');
+});
+
+test('release does NOT delete a lock owned by a different token', () => {
+  writeFileSync(stateFile, JSON.stringify(makeState([]), null, 2));
+
+  const state = readOpsState(); // acquires; our token is now in the lock file
+  // Simulate our lock being reclaimed as stale and re-acquired by another
+  // agent while we were still working.
+  writeFileSync(lockFile, 'foreign-agent:9:9');
+
+  writeOpsState(state); // release must compare-then-delete → token mismatch → keep
+
+  assert.equal(existsSync(lockFile), true, 'foreign lock must survive our release');
+  assert.equal(readFileSync(lockFile, 'utf-8'), 'foreign-agent:9:9');
+});
+
+test('corrupt state file is preserved as .corrupt and a later write does not wipe it', () => {
+  // Truncated JSON as a crash mid-write (pre-atomic) would leave. It carries
+  // real incident data whose silent loss is exactly what fix D prevents.
+  const corruptBytes = '{"systemStatus":"CRITICAL","incidents":[{"id":"fleet-manager:display_offline:d1"';
+  writeFileSync(stateFile, corruptBytes);
+
+  const recovered = readOpsState(); // parse fails → preserve corrupt + return empty
+  try {
+    assert.equal(recovered.systemStatus, 'HEALTHY');
+    assert.equal(recovered.incidents.length, 0);
+  } finally {
+    writeOpsState(recovered); // writes empty state atomically over STATE_FILE
+  }
+
+  const corruptFiles = readdirSync(tmpDir).filter((f) => f.includes('ops-state.json.corrupt-'));
+  assert.equal(corruptFiles.length, 1, 'exactly one preserved corrupt file');
+  assert.equal(
+    readFileSync(join(tmpDir, corruptFiles[0]), 'utf-8'),
+    corruptBytes,
+    'corrupt bytes must be retained verbatim — incident history preserved, not wiped',
+  );
+
+  const persisted = JSON.parse(readFileSync(stateFile, 'utf-8')) as OpsState;
+  assert.equal(persisted.systemStatus, 'HEALTHY');
+  assert.equal(persisted.incidents.length, 0);
+});
+
+test('readOpsStateSnapshot is lock-free — repeatable and leaves no lock', () => {
+  writeFileSync(stateFile, JSON.stringify(makeState([sampleIncident('a:b:c')]), null, 2));
+
+  const first = readOpsStateSnapshot();
+  const second = readOpsStateSnapshot(); // would deadlock if it took a lock
+
+  assert.equal(first.incidents.length, 1);
+  assert.equal(second.incidents.length, 1);
+  assert.equal(existsSync(lockFile), false, 'snapshot must never create a lock file');
+});

--- a/scripts/ops/lib/state.ts
+++ b/scripts/ops/lib/state.ts
@@ -6,15 +6,39 @@
  * remediations, and system status.
  *
  * Uses Windows-safe path resolution (same pattern as validate-monitor.ts).
+ *
+ * Concurrency model (7 PM2 cron agents share one file):
+ *   - `readOpsState()` acquires an exclusive advisory file lock and DOES NOT
+ *     release it. The paired `writeOpsState()` releases it. Hold the lock for
+ *     the shortest possible window — do detection I/O FIRST, then a brief
+ *     locked read→merge→write with NO network/subprocess I/O in between.
+ *   - `readOpsStateSnapshot()` is a lock-free read for the detection phase
+ *     (e.g. looking up prior incidents to compute attempt counts). It MUST NOT
+ *     be paired with `writeOpsState()`.
+ *   - The lock is owner-stamped: `acquireLock()` writes a per-acquisition token
+ *     into the lock file and `releaseLock()` only deletes the file when the
+ *     on-disk token still matches ours. A lock reclaimed as stale by another
+ *     agent is therefore never deleted out from under its new owner.
  */
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync, openSync, closeSync, unlinkSync, statSync } from 'node:fs';
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  openSync,
+  closeSync,
+  writeSync,
+  unlinkSync,
+  renameSync,
+  statSync,
+} from 'node:fs';
 import { join, dirname } from 'node:path';
+import { log } from './alerting.js';
 import type {
   OpsState,
   AgentResult,
   RemediationAction,
-  Incident,
   SystemStatus,
 } from './types.js';
 
@@ -22,57 +46,140 @@ import type {
 
 const MAX_INCIDENTS = 200;
 const MAX_REMEDIATIONS = 100;
-const LOCK_TIMEOUT_MS = 5_000;
+const DEFAULT_LOCK_TIMEOUT_MS = 5_000;
 const LOCK_RETRY_MS = 50;
+/** A lock file older than this is assumed abandoned (agent crashed) and reclaimed. */
+const LOCK_STALE_MS = 30_000;
 
 /**
  * State file path — resolves to `<project-root>/logs/ops-state.json`.
  * The regex handles Windows drive-letter paths from `import.meta.url`
  * (e.g., `/C:/projects/...` → `C:/projects/...`).
+ *
+ * Overridable via `OPS_STATE_FILE` — used by tests to point at a temp file and
+ * available to operators running a non-default layout. Resolved per-call so a
+ * test can vary it between cases.
  */
-const STATE_FILE = join(
+const DEFAULT_STATE_FILE = join(
   dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Z]:)/, '$1')),
   '..', '..', '..', 'logs', 'ops-state.json',
 );
 
-const LOCK_FILE = STATE_FILE + '.lock';
+function getStateFile(): string {
+  return process.env.OPS_STATE_FILE || DEFAULT_STATE_FILE;
+}
+
+function getLockFile(): string {
+  return getStateFile() + '.lock';
+}
+
+function getLockTimeoutMs(): number {
+  const override = Number(process.env.OPS_LOCK_TIMEOUT_MS);
+  return Number.isFinite(override) && override > 0 ? override : DEFAULT_LOCK_TIMEOUT_MS;
+}
 
 // ─── File Locking ───────────────────────────────────────────────────────────
 
 /**
- * Acquire an exclusive file lock using atomic `wx` flag.
- * Spins with short sleeps until the lock is acquired or timeout expires.
- * Stale locks (>30s old) are automatically removed.
+ * Token identifying the lock WE currently hold, or null. Set on a successful
+ * `acquireLock()`, cleared on `releaseLock()`. Because a single process runs
+ * its read→modify→write cycle sequentially, one module-level slot is enough.
  */
-function acquireLock(): void {
-  const deadline = Date.now() + LOCK_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    try {
-      const fd = openSync(LOCK_FILE, 'wx');
-      closeSync(fd);
-      return;
-    } catch {
-      // Check for stale lock (>30s old — agent probably crashed)
-      try {
-        if (existsSync(LOCK_FILE)) {
-          const { mtimeMs } = statSync(LOCK_FILE);
-          if (Date.now() - mtimeMs > 30_000) {
-            try { unlinkSync(LOCK_FILE); } catch { /* race with another agent */ }
-            continue;
-          }
-        }
-      } catch { /* lock file gone — retry will succeed */ }
+let heldToken: string | null = null;
 
-      // Busy wait with small random jitter
-      const waitEnd = Date.now() + LOCK_RETRY_MS + Math.random() * 50;
-      while (Date.now() < waitEnd) { /* spin */ }
-    }
-  }
-  // Timeout — proceed without lock (better than crashing)
+/** Monotonic per-process counter to make each acquisition's token unique. */
+let lockCounter = 0;
+
+/**
+ * Unique-per-acquisition owner token. `pid` distinguishes processes, the
+ * counter distinguishes acquisitions within a process, and hrtime adds
+ * monotonic entropy. `Math.random` is intentionally avoided.
+ */
+function makeOwnerToken(): string {
+  return `${process.pid}:${lockCounter++}:${process.hrtime.bigint()}`;
 }
 
+/**
+ * Synchronous sleep that parks the thread (no busy-wait / CPU burn) via
+ * `Atomics.wait`. `acquireLock` is synchronous — it cannot `await` — so this
+ * is how we back off between lock-acquisition attempts.
+ */
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * Acquire an exclusive file lock using the atomic `wx` open flag and stamp our
+ * owner token inside it. Retries with a short back-off until acquisition
+ * succeeds or the timeout expires; stale locks (> `LOCK_STALE_MS`) left by a
+ * crashed agent are reclaimed.
+ *
+ * THROWS on timeout — the caller must NOT proceed lock-less (doing so would
+ * allow concurrent read-modify-write races that silently lose updates).
+ */
+function acquireLock(): void {
+  const lockFile = getLockFile();
+  const token = makeOwnerToken();
+  const deadline = Date.now() + getLockTimeoutMs();
+
+  while (Date.now() < deadline) {
+    try {
+      const fd = openSync(lockFile, 'wx');
+      try {
+        writeSync(fd, token);
+      } finally {
+        closeSync(fd);
+      }
+      heldToken = token;
+      return;
+    } catch {
+      // Lock is held by someone else. Reclaim it if it looks abandoned.
+      try {
+        if (existsSync(lockFile)) {
+          const { mtimeMs } = statSync(lockFile);
+          if (Date.now() - mtimeMs > LOCK_STALE_MS) {
+            try { unlinkSync(lockFile); } catch { /* race with another reclaimer */ }
+            continue; // retry immediately
+          }
+        }
+      } catch { /* lock file vanished — the retry will succeed */ }
+
+      // Back off before retrying. Small pid-derived jitter decorrelates
+      // simultaneous agents without relying on Math.random.
+      sleepSync(LOCK_RETRY_MS + (process.pid % 25));
+    }
+  }
+
+  throw new Error(
+    `ops-state lock timeout after ${getLockTimeoutMs()}ms (lock file: ${lockFile})`,
+  );
+}
+
+/**
+ * Release the lock we hold. Compare-then-delete: only unlink the lock file if
+ * its on-disk token still matches ours. If it doesn't, another agent reclaimed
+ * our lock as stale and now owns it — we must NOT delete their live lock. Warn
+ * so the operator sees we ran long enough to be reclaimed.
+ */
 function releaseLock(): void {
-  try { unlinkSync(LOCK_FILE); } catch { /* ignore */ }
+  const token = heldToken;
+  heldToken = null;
+  if (token === null) return; // we never held it
+
+  const lockFile = getLockFile();
+  try {
+    const onDisk = readFileSync(lockFile, 'utf-8');
+    if (onDisk === token) {
+      unlinkSync(lockFile);
+    } else {
+      log(
+        'ops-state',
+        `WARNING: lock reclaimed by another agent before release (held too long); not deleting ${lockFile}`,
+      );
+    }
+  } catch {
+    // Lock file already gone (reclaimed then released elsewhere) — nothing to do.
+  }
 }
 
 // ─── Empty State ────────────────────────────────────────────────────────────
@@ -88,40 +195,35 @@ function emptyState(): OpsState {
   };
 }
 
-// ─── Read / Write ───────────────────────────────────────────────────────────
+// ─── Parsing (shared by locked and lock-free reads) ─────────────────────────
+
+/** Monotonic counter so concurrent corrupt-file rescues get distinct names. */
+let corruptCounter = 0;
 
 /**
- * Read the ops state file. Returns an empty state if the file does not
- * exist or cannot be parsed.
+ * Read and parse the state file, normalising missing fields. Does NOT touch
+ * the lock — callers own that.
  *
- * **LOCK CONTRACT (must read before calling):** This function acquires
- * an exclusive file lock and DOES NOT RELEASE IT. Every caller MUST
- * pair the read with a writeOpsState() to release the lock. The
- * canonical shape is:
- *
- * ```ts
- * const state = readOpsState();
- * try {
- *   // mutate state ...
- * } finally {
- *   writeOpsState(state);  // releases lock, even on throw above
- * }
- * ```
- *
- * Calling readOpsState() twice without a writeOpsState() between them
- * will deadlock on LOCK_TIMEOUT_MS (5s) and the second read will then
- * proceed without a lock — silently breaking the atomicity guarantee
- * for any concurrent agent. If you only need a snapshot for reporting,
- * call readOpsState() then immediately call writeOpsState(state)
- * unchanged to release the lock cleanly.
+ * On unparseable JSON (e.g. a truncated file from a pre-atomic-write crash) the
+ * corrupt file is PRESERVED — renamed to `<state>.corrupt-<pid>-<n>` and an
+ * ERROR is logged — before returning empty state. This is the critical safety
+ * property: without it, a subsequent write under the same lock would overwrite
+ * the corrupt file and silently erase all incident/remediation history.
  */
-export function readOpsState(): OpsState {
-  acquireLock();
+function parseStateFile(): OpsState {
+  const stateFile = getStateFile();
+  if (!existsSync(stateFile)) return emptyState();
+
+  let raw: string;
   try {
-    if (!existsSync(STATE_FILE)) return emptyState();
-    const raw = readFileSync(STATE_FILE, 'utf-8');
+    raw = readFileSync(stateFile, 'utf-8');
+  } catch {
+    // Transient read error (or a concurrent corrupt-rescue removed the file).
+    return emptyState();
+  }
+
+  try {
     const parsed = JSON.parse(raw) as OpsState;
-    // Ensure all required fields exist (guard against partial/corrupt files)
     return {
       systemStatus: parsed.systemStatus ?? 'HEALTHY',
       lastUpdated: parsed.lastUpdated ?? new Date().toISOString(),
@@ -131,21 +233,73 @@ export function readOpsState(): OpsState {
       agentResults: parsed.agentResults ?? {},
     };
   } catch {
+    const corruptPath = `${stateFile}.corrupt-${process.pid}-${corruptCounter++}`;
+    try {
+      renameSync(stateFile, corruptPath);
+      log('ops-state', `ERROR: corrupt ops-state file preserved at ${corruptPath} — starting from empty state`);
+    } catch (err) {
+      // Another agent may have already rescued/removed it. Still return empty.
+      log('ops-state', `ERROR: corrupt ops-state file could not be preserved: ${err instanceof Error ? err.message : err}`);
+    }
     return emptyState();
   }
-  // Note: lock is NOT released here — caller must call writeOpsState()
-  // to complete the atomic read-modify-write cycle.
+}
+
+// ─── Read / Write ───────────────────────────────────────────────────────────
+
+/**
+ * Acquire the lock and read the ops state. **DOES NOT RELEASE THE LOCK** — pair
+ * every call with `writeOpsState()` to release it (use try/finally):
+ *
+ * ```ts
+ * const state = readOpsState();
+ * try {
+ *   // mutate state ... (NO network / subprocess I/O here — keep it brief)
+ * } finally {
+ *   writeOpsState(state); // releases the lock, even if the block throws
+ * }
+ * ```
+ *
+ * THROWS `ops-state lock timeout` if the lock cannot be acquired within the
+ * timeout. Callers that must not abort (e.g. ops-watchdog recording its own
+ * run) should wrap this in try/catch. Never do slow I/O between this call and
+ * the paired `writeOpsState()` — read prior state with `readOpsStateSnapshot()`
+ * for that instead.
+ */
+export function readOpsState(): OpsState {
+  acquireLock();
+  try {
+    return parseStateFile();
+  } catch (err) {
+    // parseStateFile is defensive and shouldn't throw, but if it does we must
+    // release the lock rather than leak it, then propagate.
+    releaseLock();
+    throw err;
+  }
 }
 
 /**
- * Write ops state to disk and release the file lock. Trims incidents
+ * Lock-free snapshot read for the detection phase — e.g. looking up an agent's
+ * prior incidents to compute attempt counts / preserve `detected` timestamps
+ * while the agent is still doing network I/O. Does NOT acquire the lock and
+ * MUST NOT be paired with `writeOpsState()`. Do the real locked
+ * `readOpsState()`/`writeOpsState()` cycle at the very end, with no I/O in
+ * between, so the lock is held only briefly.
+ */
+export function readOpsStateSnapshot(): OpsState {
+  return parseStateFile();
+}
+
+/**
+ * Write ops state to disk atomically and release the file lock. Trims incidents
  * to MAX_INCIDENTS and remediations to MAX_REMEDIATIONS (keeping most recent).
  *
- * **Must be called after every readOpsState()**, including on the error
- * path, otherwise the lock leaks until the OS releases the .lock file's
- * mtime past LOCK_STALE_MS (30s) — during which window every other
- * agent's read silently degrades to a busy-wait. Pair the two calls
- * in a try/finally per the readOpsState() JSDoc example.
+ * The write is atomic: JSON is written to `<state>.tmp-<pid>` then `renameSync`d
+ * over the real file (atomic on the same filesystem). A crash mid-write can
+ * therefore never leave a truncated `ops-state.json` for the next reader.
+ *
+ * **Must be called after every `readOpsState()`**, including on the error path,
+ * so the lock is always released — pair the two in try/finally.
  */
 export function writeOpsState(state: OpsState): void {
   try {
@@ -154,9 +308,13 @@ export function writeOpsState(state: OpsState): void {
     state.recentRemediations = state.recentRemediations.slice(-MAX_REMEDIATIONS);
     state.lastUpdated = new Date().toISOString();
 
-    const dir = dirname(STATE_FILE);
+    const stateFile = getStateFile();
+    const dir = dirname(stateFile);
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-    writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+
+    const tmpFile = `${stateFile}.tmp-${process.pid}`;
+    writeFileSync(tmpFile, JSON.stringify(state, null, 2));
+    renameSync(tmpFile, stateFile);
   } finally {
     releaseLock();
   }

--- a/scripts/ops/ops-reporter.ts
+++ b/scripts/ops/ops-reporter.ts
@@ -27,6 +27,7 @@ import 'dotenv/config';
 import type { SystemStatus, Incident } from './lib/types.js';
 import {
   readOpsState,
+  readOpsStateSnapshot,
   writeOpsState,
   determineSystemStatus,
 } from './lib/state.js';
@@ -183,11 +184,11 @@ function pruneOldIncidents(incidents: Incident[]): { pruned: number; remaining: 
  * Remove remediations older than 24 hours.
  * Returns the number of remediations pruned.
  */
-function pruneOldRemediations(
-  remediations: { timestamp: string }[],
-): { pruned: number; remaining: typeof remediations } {
+function pruneOldRemediations<T extends { timestamp: string }>(
+  remediations: T[],
+): { pruned: number; remaining: T[] } {
   const cutoff = Date.now() - PRUNE_AGE_MS;
-  const remaining: typeof remediations = [];
+  const remaining: T[] = [];
   let pruned = 0;
 
   for (const r of remediations) {
@@ -207,40 +208,49 @@ async function main(): Promise<void> {
   const startTime = Date.now();
   log(AGENT, 'Starting ops reporting cycle');
 
-  // ─── 1. Read State ────────────────────────────────────────────────────────
+  // ─── 1. Read State (lock-free snapshot) ───────────────────────────────────
 
-  const state = readOpsState();
-  const previousStatus = state.systemStatus;
+  // ops-reporter does slow network I/O (Slack, email, login, dashboard) that
+  // must NOT run under the state lock. Phase 1 reads a lock-free snapshot to
+  // decide what to alert on; phase 2 does the I/O with no lock held; phase 3
+  // takes the lock briefly to persist the deterministic mutations (status
+  // recompute, prune, lastRun) against FRESH state.
+  const snapshot = readOpsStateSnapshot();
+  const previousStatus = snapshot.systemStatus;
 
-  log(AGENT, `Current state: status=${previousStatus}, incidents=${state.incidents.length}, remediations=${state.recentRemediations.length}`);
+  log(AGENT, `Current state: status=${previousStatus}, incidents=${snapshot.incidents.length}, remediations=${snapshot.recentRemediations.length}`);
 
   // ─── 2. Determine Status ──────────────────────────────────────────────────
 
-  const currentStatus = determineSystemStatus(state);
-  state.systemStatus = currentStatus;
+  const currentStatus = determineSystemStatus(snapshot);
+  snapshot.systemStatus = currentStatus; // for the dashboard payload below
 
   log(AGENT, `System status: ${previousStatus} -> ${currentStatus}`);
 
   // ─── 3. Agent Freshness Check ─────────────────────────────────────────────
 
   log(AGENT, 'Checking agent freshness');
-  checkAgentFreshness(state.lastRun);
+  checkAgentFreshness(snapshot.lastRun);
 
   // ─── 4. Alert Decision ────────────────────────────────────────────────────
 
   // Track last alert time in lastRun under our own agent name
-  const lastAlertIso = state.lastRun[`${AGENT}:last-alert`];
+  const lastAlertIso = snapshot.lastRun[`${AGENT}:last-alert`];
   const decision = shouldSendAlert(previousStatus, currentStatus, lastAlertIso);
 
   log(AGENT, `Alert decision: shouldAlert=${decision.shouldAlert}, reason="${decision.reason}"`);
 
-  // ─── 5. Send Alerts ───────────────────────────────────────────────────────
+  // ─── 5. Send Alerts (no lock held) ────────────────────────────────────────
 
-  const openIncidents = state.incidents.filter(i => i.status === 'open');
-  const fixedCount = Object.values(state.agentResults).reduce(
+  const openIncidents = snapshot.incidents.filter(i => i.status === 'open');
+  const fixedCount = Object.values(snapshot.agentResults).reduce(
     (sum, r) => sum + r.issuesFixed,
     0,
   );
+
+  // Captured for phase 3 so the suppression timestamp reflects when the alert
+  // actually went out.
+  let alertTimestamp: string | null = null;
 
   if (decision.shouldAlert) {
     if (decision.isRecovery) {
@@ -254,13 +264,13 @@ async function main(): Promise<void> {
       await sendEmailAlert(currentStatus, openIncidents, fixedCount);
     }
 
-    // Record alert timestamp for suppression tracking
-    state.lastRun[`${AGENT}:last-alert`] = new Date().toISOString();
+    // Record alert timestamp for suppression tracking (persisted in phase 3)
+    alertTimestamp = new Date().toISOString();
   } else {
     log(AGENT, 'Alert suppressed — no notification sent');
   }
 
-  // ─── 6. Update Dashboard ──────────────────────────────────────────────────
+  // ─── 6. Update Dashboard (no lock held) ───────────────────────────────────
 
   const dashEmail = process.env.OPS_EMAIL || process.env.VALIDATOR_EMAIL;
   const dashPassword = process.env.OPS_PASSWORD || process.env.VALIDATOR_PASSWORD;
@@ -270,7 +280,7 @@ async function main(): Promise<void> {
     log(AGENT, 'Updating dashboard');
     try {
       const token = await login(baseUrl, dashEmail, dashPassword);
-      await updateDashboard(state, token);
+      await updateDashboard(snapshot, token);
       log(AGENT, 'Dashboard updated successfully');
     } catch (err) {
       log(AGENT, `Dashboard update failed: ${err instanceof Error ? err.message : err}`);
@@ -287,42 +297,59 @@ async function main(): Promise<void> {
     );
   }
 
-  // ─── 7. Prune Old Data ────────────────────────────────────────────────────
+  // ─── 7. Persist: locked read → prune → write (no I/O in between) ──────────
 
-  const incidentPrune = pruneOldIncidents(state.incidents);
-  state.incidents = incidentPrune.remaining;
+  let finalStatus: SystemStatus = currentStatus;
+  let openCount = 0;
+  let criticalCount = 0;
+  let warningCount = 0;
 
-  const remediationPrune = pruneOldRemediations(state.recentRemediations);
-  state.recentRemediations = remediationPrune.remaining;
+  const state = readOpsState();
+  try {
+    // Recompute status from FRESH incidents — other agents may have added or
+    // resolved incidents during our I/O above.
+    finalStatus = determineSystemStatus(state);
+    state.systemStatus = finalStatus;
 
-  if (incidentPrune.pruned > 0 || remediationPrune.pruned > 0) {
-    log(AGENT, `Pruned: ${incidentPrune.pruned} old incidents, ${remediationPrune.pruned} old remediations`);
+    if (alertTimestamp) {
+      state.lastRun[`${AGENT}:last-alert`] = alertTimestamp;
+    }
+
+    const incidentPrune = pruneOldIncidents(state.incidents);
+    state.incidents = incidentPrune.remaining;
+
+    const remediationPrune = pruneOldRemediations(state.recentRemediations);
+    state.recentRemediations = remediationPrune.remaining;
+
+    if (incidentPrune.pruned > 0 || remediationPrune.pruned > 0) {
+      log(AGENT, `Pruned: ${incidentPrune.pruned} old incidents, ${remediationPrune.pruned} old remediations`);
+    }
+
+    state.lastRun[AGENT] = new Date().toISOString();
+
+    openCount = state.incidents.filter(i => i.status === 'open').length;
+    criticalCount = state.incidents.filter(
+      i => i.status === 'open' && i.severity === 'critical',
+    ).length;
+    warningCount = state.incidents.filter(
+      i => i.status === 'open' && i.severity === 'warning',
+    ).length;
+  } finally {
+    writeOpsState(state);
   }
-
-  // ─── 8. Save State ────────────────────────────────────────────────────────
-
-  state.lastRun[AGENT] = new Date().toISOString();
-  writeOpsState(state);
 
   // ─── Summary ──────────────────────────────────────────────────────────────
 
   const durationMs = Date.now() - startTime;
-  const openCount = state.incidents.filter(i => i.status === 'open').length;
-  const criticalCount = state.incidents.filter(
-    i => i.status === 'open' && i.severity === 'critical',
-  ).length;
-  const warningCount = state.incidents.filter(
-    i => i.status === 'open' && i.severity === 'warning',
-  ).length;
 
   log(
     AGENT,
-    `Cycle complete in ${durationMs}ms — status: ${currentStatus}, open: ${openCount} (${criticalCount} critical, ${warningCount} warning), alerted: ${decision.shouldAlert}`,
+    `Cycle complete in ${durationMs}ms — status: ${finalStatus}, open: ${openCount} (${criticalCount} critical, ${warningCount} warning), alerted: ${decision.shouldAlert}`,
   );
 
   // ─── Exit Code ────────────────────────────────────────────────────────────
 
-  if (currentStatus === 'HEALTHY') {
+  if (finalStatus === 'HEALTHY') {
     process.exitCode = 0;
   } else {
     process.exitCode = 1;

--- a/scripts/ops/ops-watchdog.ts
+++ b/scripts/ops/ops-watchdog.ts
@@ -33,7 +33,7 @@
 
 import 'dotenv/config';
 import type { Incident, AgentResult } from './lib/types.js';
-import { readOpsState, writeOpsState, recordAgentRun } from './lib/state.js';
+import { readOpsState, readOpsStateSnapshot, writeOpsState, recordAgentRun } from './lib/state.js';
 import { log, sendSlackAlert } from './lib/alerting.js';
 
 const AGENT = 'ops-watchdog';
@@ -113,120 +113,116 @@ async function main(): Promise<void> {
     log(AGENT, `invalid OPS_WATCHDOG_SLA_MINUTES=${process.env.OPS_WATCHDOG_SLA_MINUTES}; ignoring`);
   }
 
-  // readOpsState() acquires a file lock that MUST be released by the
-  // paired writeOpsState() — see scripts/ops/lib/state.ts:106-133. The
-  // try/finally below ensures we always release the lock, even when
-  // sendSlackAlert throws or when no stale agents are found and we
-  // exit early. Skipping the writeOpsState call would leak the lock
-  // for ~30 s (LOCK_STALE_MS) and block any other ops script that
-  // fires in that window.
-  let state: ReturnType<typeof readOpsState>;
+  // Phase 1: lock-free snapshot for staleness detection. The Slack alert in
+  // phase 2 is network I/O that must NOT run under the state lock, so the real
+  // locked read→merge→write (which also releases the lock) is deferred to
+  // phase 3. See scripts/ops/lib/state.ts.
+  let snapshot: ReturnType<typeof readOpsStateSnapshot>;
   try {
-    state = readOpsState();
+    snapshot = readOpsStateSnapshot();
   } catch (err) {
     log(AGENT, `FATAL: cannot read ops state: ${err instanceof Error ? err.message : err}`);
     process.exitCode = 2;
     return;
   }
 
-  let stale: StaleAgent[] = [];
+  const stale: StaleAgent[] = [];
   const healthyAgents = new Set<string>();
-  let durationMs = 0;
+  const lastRun: Record<string, string> = snapshot.lastRun ?? {};
+  const now = Date.now();
+
+  for (const [agent, slaDefault] of Object.entries(SLA_MINUTES_BY_AGENT)) {
+    const slaMinutes = (slaOverride && Number.isFinite(slaOverride) && slaOverride > 0)
+      ? slaOverride
+      : slaDefault;
+    const ts = lastRun[agent];
+    if (!ts) {
+      // No record at all — agent has never run, or state was wiped.
+      // Don't alert on first deploy; require the cron to have fired at
+      // least once. We'll catch persistent silence next tick.
+      log(AGENT, `${agent}: no lastRun record — skipping (first run after deploy?)`);
+      continue;
+    }
+    const ranAt = Date.parse(ts);
+    if (Number.isNaN(ranAt)) {
+      log(AGENT, `${agent}: malformed lastRun timestamp '${ts}'; skipping`);
+      continue;
+    }
+    const minsSinceRun = Math.floor((now - ranAt) / 60_000);
+    if (minsSinceRun > slaMinutes) {
+      stale.push({ agent, minsSinceRun, slaMinutes });
+    } else {
+      healthyAgents.add(agent);
+    }
+  }
+
+  const durationMs = Date.now() - startTime;
   let alertSent = false;
 
-  try {
-    const lastRun: Record<string, string> = state.lastRun ?? {};
-    const now = Date.now();
+  // Phase 2: alert I/O (no lock held).
+  if (stale.length === 0) {
+    log(AGENT, `all watched agents within SLA (${Object.keys(SLA_MINUTES_BY_AGENT).length} checked) in ${durationMs}ms`);
+    process.exitCode = 0;
+  } else {
+    const summary = stale
+      .map((s) => `${s.agent} silent ${s.minsSinceRun}m (sla=${s.slaMinutes}m)`)
+      .join(', ');
+    log(AGENT, `STALE: ${summary}`);
 
-    for (const [agent, slaDefault] of Object.entries(SLA_MINUTES_BY_AGENT)) {
-      const slaMinutes = (slaOverride && Number.isFinite(slaOverride) && slaOverride > 0)
-        ? slaOverride
-        : slaDefault;
-      const ts = lastRun[agent];
-      if (!ts) {
-        // No record at all — agent has never run, or state was wiped.
-        // Don't alert on first deploy; require the cron to have fired at
-        // least once. We'll catch persistent silence next tick.
-        log(AGENT, `${agent}: no lastRun record — skipping (first run after deploy?)`);
-        continue;
-      }
-      const ranAt = Date.parse(ts);
-      if (Number.isNaN(ranAt)) {
-        log(AGENT, `${agent}: malformed lastRun timestamp '${ts}'; skipping`);
-        continue;
-      }
-      const minsSinceRun = Math.floor((now - ranAt) / 60_000);
-      if (minsSinceRun > slaMinutes) {
-        stale.push({ agent, minsSinceRun, slaMinutes });
-      } else {
-        healthyAgents.add(agent);
-      }
-    }
+    const incidents = stale.map((s) => makeAgentSilentIncident(s, new Date(now).toISOString()));
 
-    durationMs = Date.now() - startTime;
-
-    if (stale.length === 0) {
-      log(AGENT, `all watched agents within SLA (${Object.keys(SLA_MINUTES_BY_AGENT).length} checked) in ${durationMs}ms`);
-      process.exitCode = 0;
-    } else {
-      const summary = stale
-        .map((s) => `${s.agent} silent ${s.minsSinceRun}m (sla=${s.slaMinutes}m)`)
-        .join(', ');
-      log(AGENT, `STALE: ${summary}`);
-
-      const incidents = stale.map((s) => makeAgentSilentIncident(s, new Date(now).toISOString()));
-
-      await sendSlackAlert(
-        'CRITICAL',
-        state.systemStatus ?? 'unknown',
-        incidents,
-        0,
-      );
-      alertSent = true;
-
-      log(AGENT, `alert sent for ${stale.length} stale agent(s) in ${durationMs}ms`);
-      process.exitCode = 1;
-    }
-  } finally {
-    // Record the watchdog's own run so that:
-    //   1. ops-state.json reflects ops-watchdog itself is alive (visible
-    //      via the dashboard / GET /api/v1/health/ops-status).
-    //   2. The lock acquired by readOpsState() is released — writeOpsState
-    //      always runs in a finally{} inside lib/state.ts.
-    // Mutations are limited to lastRun + agentResults + watchdog-owned
-    // incident updates, all driven through recordAgentRun for consistency.
-    const timestamp = new Date(startTime).toISOString();
-    const resolvedIncidents = resolveRecoveredAgentSilentIncidents(
-      state.incidents,
-      healthyAgents,
-      timestamp,
+    await sendSlackAlert(
+      'CRITICAL',
+      snapshot.systemStatus ?? 'unknown',
+      incidents,
+      0,
     );
-    const result: AgentResult = {
-      agent: AGENT,
-      timestamp,
-      durationMs: durationMs || (Date.now() - startTime),
-      issuesFound: stale.length,
-      // The watchdog doesn't remediate stale agents; resolved incidents
-      // mean watched agents recovered on a later run.
-      issuesFixed: resolvedIncidents.length,
-      issuesEscalated: alertSent ? stale.length : 0,
-      incidents: [
-        ...stale.map((s) => makeAgentSilentIncident(s, timestamp)),
-        ...resolvedIncidents,
-      ],
-    };
+    alertSent = true;
+
+    log(AGENT, `alert sent for ${stale.length} stale agent(s) in ${durationMs}ms`);
+    process.exitCode = 1;
+  }
+
+  // Phase 3: locked read→merge→write (no I/O in between). Records the
+  // watchdog's own run so ops-state.json reflects it is alive, resolves any
+  // now-recovered agent-silent incidents against FRESH state, and releases the
+  // lock (writeOpsState always releases in its finally). Mutations are limited
+  // to lastRun + agentResults + watchdog-owned incidents via recordAgentRun.
+  const timestamp = new Date(startTime).toISOString();
+  try {
+    const state = readOpsState();
     try {
+      const resolvedIncidents = resolveRecoveredAgentSilentIncidents(
+        state.incidents,
+        healthyAgents,
+        timestamp,
+      );
+      const result: AgentResult = {
+        agent: AGENT,
+        timestamp,
+        durationMs: durationMs || (Date.now() - startTime),
+        issuesFound: stale.length,
+        // The watchdog doesn't remediate stale agents; resolved incidents
+        // mean watched agents recovered on a later run.
+        issuesFixed: resolvedIncidents.length,
+        issuesEscalated: alertSent ? stale.length : 0,
+        incidents: [
+          ...stale.map((s) => makeAgentSilentIncident(s, timestamp)),
+          ...resolvedIncidents,
+        ],
+      };
       recordAgentRun(state, result);
+    } finally {
       writeOpsState(state);
-    } catch (err) {
-      // Lock release is the priority. Log but don't suppress — if state
-      // I/O is broken, the next run will surface it via health-guardian.
-      log(AGENT, `state write failed (lock may be held): ${err instanceof Error ? err.message : err}`);
-      // Surface as fatal IF we hadn't already set a non-zero exit code,
-      // so cron alerting picks it up.
-      if (process.exitCode === 0 || process.exitCode === undefined) {
-        process.exitCode = 2;
-      }
+    }
+  } catch (err) {
+    // Lock release is the priority. Log but don't suppress — if state I/O is
+    // broken, the next run will surface it via health-guardian.
+    log(AGENT, `state write failed (lock may be held): ${err instanceof Error ? err.message : err}`);
+    // Surface as fatal IF we hadn't already set a non-zero exit code, so cron
+    // alerting picks it up.
+    if (process.exitCode === 0 || process.exitCode === undefined) {
+      process.exitCode = 2;
     }
   }
 }

--- a/scripts/ops/schedule-doctor.ts
+++ b/scripts/ops/schedule-doctor.ts
@@ -112,7 +112,10 @@ async function main(): Promise<void> {
 
   log(AGENT, `Fetched ${schedules.length} schedules, ${displays.length} displays, ${playlists.length} playlists`);
 
-  const state = readOpsState();
+  // State is read at the very END (after all detection I/O), so the file lock
+  // is held only for the brief read→merge→write below — not across the
+  // api.patch / sendInlineAlert calls in the checks. This agent does no
+  // existing-incident dedup during detection, so no snapshot read is needed.
   const incidents: Incident[] = [];
   const remediations: RemediationAction[] = [];
   let issuesFound = 0;
@@ -327,13 +330,17 @@ async function main(): Promise<void> {
     incidents,
   };
 
-  recordAgentRun(state, result);
+  // Brief locked read→merge→write with no I/O in between.
+  const state = readOpsState();
+  try {
+    recordAgentRun(state, result);
 
-  for (const r of remediations) {
-    addRemediation(state, r);
+    for (const r of remediations) {
+      addRemediation(state, r);
+    }
+  } finally {
+    writeOpsState(state);
   }
-
-  writeOpsState(state);
 
   // ─── Summary ───────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## S2 production-readiness fixes (audit 2026-07-06)

Implements S2 findings from `docs/plans/2026-07-06-production-readiness-audit.md`.
Stacked on #222 (S1); base will retarget to `main` once #222 merges.

### Fixes in this PR

**S2-2 — Redis outage no longer takes the fleet offline** (`realtime/src/gateways/device.gateway.ts`)
`setDeviceStatus` (Redis `setex`) was awaited unguarded on the connect, heartbeat, and disconnect paths. A Redis failure disconnected the device (never joined rooms / got its playlist) and skipped the durable Postgres write; on heartbeat it skipped the DB `lastHeartbeat` refresh, so the offline-scanner marked the whole live fleet offline from a transient blip. All three calls are now guarded so control continues to the DB write — Postgres is the real fallback the design implies. The gateway spec's Redis-failure test asserted the old buggy behavior (Redis down → error ack); rewritten to assert graceful degradation + fallback durability. 305 realtime tests green.

**S2-6 — billing fails closed on unmapped subscription status** (`middleware/src/modules/billing/billing.service.ts`)
`mapSubscriptionStatus` returned `statusMap[status] || 'active'`, so a missing/unrecognized status (e.g. Stripe `paused`) silently coerced to `active` — a fail-open on entitlement (revenue leakage). Now returns `null` on missing/unmapped status and the caller skips the update (leaves last-known status untouched) with a warn log. New regression test: `paused` issues no `organization.update`. 203 billing tests green.

**S2-1 — ops shared-state lock corruption** (`scripts/ops/`)
The `logs/ops-state.json` file-lock shared by 7 PM2 cron agents had four compounding defects: the lock was held across network I/O; `acquireLock` proceeded lock-less on timeout (concurrent read-modify-write → lost updates); `releaseLock` unconditionally unlinked (stealing another agent's live lock); and a non-atomic write + `emptyState()`-on-parse-error could wipe all incident/remediation history and reset status to HEALTHY. Fixes in `lib/state.ts`: `acquireLock` now throws on timeout (fail-loud, no lock-less writes); the lock is owner-stamped with a per-acquisition token and `releaseLock` compare-then-deletes; `writeOpsState` writes to `.tmp-<pid>` then `renameSync` (atomic); a corrupt file is preserved as `.corrupt-<pid>-<n>` (not silently overwritten); new `readOpsStateSnapshot()` is a lock-free read for the detection phase. The five agents that held the lock across I/O (fleet-manager, health-guardian, schedule-doctor, ops-reporter, ops-watchdog) were restructured to detect-first (snapshot) → I/O with no lock → brief locked read→merge→write; content-lifecycle and db-maintainer already did no I/O under the lock. Correctness rests on incident IDs being agent-namespaced (`makeIncidentId`), so each agent only writes its own incidents and the snapshot→final-write split can't lose a cross-agent update. New `lib/state.test.ts` (6 hermetic cases via `OPS_STATE_FILE`): round-trip, timeout-throws, stale-reclaim, foreign-token-not-deleted, corrupt-preserved-not-wiped, snapshot-lock-free. `pnpm test:ops`: 20/20 pass (independently re-run). One in-scope type fix: `pruneOldRemediations` made generic to clear a latent TS2322.

**S2-7 — mcp_audit_log + admin_audit_logs unbounded growth** (`middleware/src/modules/common/data-retention.service.ts`)
`mcp_audit_log` is written on every MCP tool call and had no retention (§12a). Added 90-day `deleteMany` prunes for both tables (mirroring the auditLog block), plus a regression test. `data-retention` suite green (8 tests). Follow-up (needs a Prisma migration, not in this PR): add `@@index([createdAt])` to `McpAuditLog` so the prune stops full-scanning at scale.

### Verification
- realtime: 305 tests; billing: 203 tests; data-retention: 8 tests; ops: 20/20 (`pnpm test:ops`, incl. 6 new lock tests). All re-run independently.
- Each behavior change has a regression test asserting the corrected (not the old) behavior.

### Still pending (tracked, not in this PR)
S2-3 (playlist-push silent drop), S2-5 (billing webhook pending/completed distinction), the `McpAuditLog` createdAt index migration, S2-8..S2-13 (config/doc drift, Display.status authority, device-token dedup, CI coverage/lint expansion, @types/node), and the S3 tier. Branch protection on `main`, the tenant-guard enforce flip, and the Electron 28→39 upgrade remain maintainer decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Review
- **S2-1 ops-lock** — full independent re-review (read `state.ts`, fleet-manager diff, grep-verified no I/O under lock in all 7 agents, re-ran 20/20 tests) plus an adversarial subagent pass: "restructuring sound, ship it." Four low/cosmetic residuals disclosed (rare phase-3 timeout loses a cycle's audit — fail-loud trade-off; ops-reporter alert-vs-persist timing + dashboard staleness are pre-existing alerting weaknesses; two-concurrent-same-agent race precluded by PM2 `instances:1`).
- **S2-2 / S2-6** — verified against actual test output; each behavior change has a regression test asserting the corrected (not old) behavior.

> Stacked on #222. Base retargets to `main` after #222 merges.
