### PR TITLE
fix(db): correct table name in entitlementStateSince migration

### DIFF
--- a/packages/database/prisma/migrations/20260702000000_add_entitlement_state_since/migration.sql
+++ b/packages/database/prisma/migrations/20260702000000_add_entitlement_state_since/migration.sql
@@ -1,10 +1,10 @@
 -- B3 entitlement ladder: track when the org entered its current entitlement rung.
 -- The ladder job keys grace windows on this column instead of updatedAt, so an
 -- unrelated org write no longer silently resets the grace clock.
-ALTER TABLE "Organization" ADD COLUMN "entitlementStateSince" TIMESTAMP(3);
+ALTER TABLE "organizations" ADD COLUMN "entitlementStateSince" TIMESTAMP(3);
 
 -- Backfill existing past_due orgs so the ladder has a defined start; use updatedAt
 -- as the best available approximation of when they entered the rung.
-UPDATE "Organization" SET "entitlementStateSince" = "updatedAt"
+UPDATE "organizations" SET "entitlementStateSince" = "updatedAt"
   WHERE "subscriptionStatus" IN ('past_due', 'publish_locked', 'suspended')
     AND "entitlementStateSince" IS NULL;


### PR DESCRIPTION
The `20260702000000_add_entitlement_state_since` migration used `"Organization"` (Prisma model name) instead of the mapped table `"organizations"`, so it failed on prod with P3018 (`relation "Organization" does not exist`). Only the table name was wrong; columns are correct. Fixed both occurrences.

CI seeds its DB with `prisma db push` (schema-direct), so it never executes migration SQL files — this class of bug is invisible to the current pipeline. Found during the prod deploy of b125fa88; prod DB was unchanged (clean rollback), app stayed on the old build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)