### PR TITLE
fix(crons): cluster-safe leader lock — @Cron jobs fire once, not once-per-instance

### DIFF
--- a/middleware/src/modules/analytics/analytics.service.ts
+++ b/middleware/src/modules/analytics/analytics.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { DatabaseService } from '../database/database.service';
+import { CronLeaderService } from '../common/services/cron-leader.service';
 import type {
   DeviceMetricDataPoint,
   ContentPerformanceItem,
@@ -19,7 +20,10 @@ import type {
 export class AnalyticsService {
   private readonly logger = new Logger(AnalyticsService.name);
 
-  constructor(private readonly db: DatabaseService) {}
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly cronLeader: CronLeaderService,
+  ) {}
 
   private getRangeDays(range: string): number {
     switch (range) {
@@ -509,35 +513,37 @@ export class AnalyticsService {
    */
   @Cron('0 2 * * *')
   async cleanupOldImpressions() {
-    const ninetyDaysAgo = new Date();
-    ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
+    await this.cronLeader.runExclusive('analytics-daily', async () => {
+      const ninetyDaysAgo = new Date();
+      ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
 
-    try {
-      const batchSize = 10000;
-      let totalDeleted = 0;
-      let batchDeleted: number;
+      try {
+        const batchSize = 10000;
+        let totalDeleted = 0;
+        let batchDeleted: number;
 
-      do {
-        // Find IDs to delete in batches to avoid long-running transactions
-        const batch = await this.db.contentImpression.findMany({
-          where: { timestamp: { lt: ninetyDaysAgo } },
-          select: { id: true },
-          take: batchSize,
-        });
+        do {
+          // Find IDs to delete in batches to avoid long-running transactions
+          const batch = await this.db.contentImpression.findMany({
+            where: { timestamp: { lt: ninetyDaysAgo } },
+            select: { id: true },
+            take: batchSize,
+          });
 
-        if (batch.length === 0) break;
+          if (batch.length === 0) break;
 
-        const result = await this.db.contentImpression.deleteMany({
-          where: { id: { in: batch.map(b => b.id) } },
-        });
-        batchDeleted = result.count;
-        totalDeleted += batchDeleted;
-      } while (batchDeleted === batchSize);
+          const result = await this.db.contentImpression.deleteMany({
+            where: { id: { in: batch.map(b => b.id) } },
+          });
+          batchDeleted = result.count;
+          totalDeleted += batchDeleted;
+        } while (batchDeleted === batchSize);
 
-      this.logger.log(`Cleaned up ${totalDeleted} old impressions`);
-    } catch (error) {
-      this.logger.error('Failed to cleanup old impressions:', error);
-    }
+        this.logger.log(`Cleaned up ${totalDeleted} old impressions`);
+      } catch (error) {
+        this.logger.error('Failed to cleanup old impressions:', error);
+      }
+    });
   }
 
   /**

--- a/middleware/src/modules/billing/billing-lifecycle.service.ts
+++ b/middleware/src/modules/billing/billing-lifecycle.service.ts
@@ -4,6 +4,7 @@ import { DatabaseService } from '../database/database.service';
 import { MailService } from '../mail/mail.service';
 import { PLAN_TIERS } from './constants/plans';
 import { EntitlementService } from './entitlement.service';
+import { CronLeaderService } from '../common/services/cron-leader.service';
 
 @Injectable()
 export class BillingLifecycleService {
@@ -13,6 +14,7 @@ export class BillingLifecycleService {
     private readonly db: DatabaseService,
     private readonly mailService: MailService,
     private readonly entitlementService: EntitlementService,
+    private readonly cronLeader: CronLeaderService,
   ) {}
 
   /**
@@ -38,16 +40,21 @@ export class BillingLifecycleService {
    */
   @Cron('0 8 * * *')
   async handleTrialLifecycle(): Promise<void> {
-    this.logger.log('Running trial lifecycle check...');
+    // Cluster-safe: without this, both PM2 instances run it and every trial
+    // reminder / expiry email goes out twice (expireTrials + sendTrialReminders
+    // have no dedup of their own — unlike the B3 ladder).
+    await this.cronLeader.runExclusive('billing-trial-lifecycle', async () => {
+      this.logger.log('Running trial lifecycle check...');
 
-    await Promise.allSettled([
-      this.expireTrials(),
-      this.sendTrialReminders(10),
-      this.sendTrialReminders(5),
-      this.sendTrialReminders(2),
-    ]);
+      await Promise.allSettled([
+        this.expireTrials(),
+        this.sendTrialReminders(10),
+        this.sendTrialReminders(5),
+        this.sendTrialReminders(2),
+      ]);
 
-    this.logger.log('Trial lifecycle check complete');
+      this.logger.log('Trial lifecycle check complete');
+    });
   }
 
   /**
@@ -167,14 +174,20 @@ export class BillingLifecycleService {
     // (past_due → publish_locked → suspended → canceled) keyed on
     // entitlementStateSince in UTC days — NOT the old updatedAt cutoff (B8), and
     // NOT a binary suspend-at-7-days. The ladder writes its own run heartbeat.
-    try {
-      const { advanced } = await this.entitlementService.advanceLadder();
-      this.logger.log(`Entitlement ladder run complete (${advanced} advanced)`);
-    } catch (error) {
-      // A dead ladder job must be observable — surface as error-level so alerting
-      // fires, and let the next run retry (the ladder is idempotent).
-      this.logger.error(`Entitlement ladder run FAILED: ${error}`);
-    }
+    //
+    // Cluster-safe leader lock. advanceLadder is already idempotent (status-guarded
+    // CAS + SET NX dunning claim), so this is belt-and-suspenders for the ladder —
+    // but it keeps the run (and its logs/heartbeat) to a single instance.
+    await this.cronLeader.runExclusive('billing-grace-period-expiry', async () => {
+      try {
+        const { advanced } = await this.entitlementService.advanceLadder();
+        this.logger.log(`Entitlement ladder run complete (${advanced} advanced)`);
+      } catch (error) {
+        // A dead ladder job must be observable — surface as error-level so alerting
+        // fires, and let the next run retry (the ladder is idempotent).
+        this.logger.error(`Entitlement ladder run FAILED: ${error}`);
+      }
+    });
   }
 
   /**
@@ -184,11 +197,16 @@ export class BillingLifecycleService {
    */
   @Cron(CronExpression.EVERY_HOUR)
   async checkLadderFreshness(): Promise<void> {
-    if (await this.entitlementService.isLadderStale()) {
-      this.logger.error(
-        'ENTITLEMENT LADDER STALE: the daily rung-advancement job has not run within its ' +
-          'staleness window. Rungs are not advancing — investigate the billing cron.',
-      );
-    }
+    // Leader-guarded so a stale ladder logs ONCE per hour, not once per instance
+    // (the double STALE line — one per PID — was the tell that crons fan out
+    // across the cluster).
+    await this.cronLeader.runExclusive('billing-ladder-freshness-watchdog', async () => {
+      if (await this.entitlementService.isLadderStale()) {
+        this.logger.error(
+          'ENTITLEMENT LADDER STALE: the daily rung-advancement job has not run within its ' +
+            'staleness window. Rungs are not advancing — investigate the billing cron.',
+        );
+      }
+    });
   }
 }

--- a/middleware/src/modules/billing/subscription-write-gates.spec.ts
+++ b/middleware/src/modules/billing/subscription-write-gates.spec.ts
@@ -10,6 +10,7 @@ import { SubscriptionActiveGuard } from './guards/subscription-active.guard';
 import { DatabaseService } from '../database/database.service';
 import { MailModule } from '../mail/mail.module';
 import { RedisModule } from '../redis/redis.module';
+import { CommonModule } from '../common/common.module';
 import { DisplayGroupsModule } from '../display-groups/display-groups.module';
 import { DisplayGroupsController } from '../display-groups/display-groups.controller';
 import { FoldersModule } from '../folders/folders.module';
@@ -114,7 +115,7 @@ describe('dashboard subscription write gates', () => {
       };
 
       const moduleRef = await Test.createTestingModule({
-        imports: [MailModule, RedisModule, moduleType],
+        imports: [CommonModule, MailModule, RedisModule, moduleType],
       })
         .overrideProvider(DatabaseService)
         .useValue(databaseService)

--- a/middleware/src/modules/common/common.module.ts
+++ b/middleware/src/modules/common/common.module.ts
@@ -1,6 +1,7 @@
 import { Global, Module } from '@nestjs/common';
 import { CircuitBreakerService } from './services/circuit-breaker.service';
 import { GeoService } from './services/geo.service';
+import { CronLeaderService } from './services/cron-leader.service';
 import { DataRetentionService } from './data-retention.service';
 
 /**
@@ -9,7 +10,7 @@ import { DataRetentionService } from './data-retention.service';
  */
 @Global()
 @Module({
-  providers: [CircuitBreakerService, GeoService, DataRetentionService],
-  exports: [CircuitBreakerService, GeoService],
+  providers: [CircuitBreakerService, GeoService, CronLeaderService, DataRetentionService],
+  exports: [CircuitBreakerService, GeoService, CronLeaderService],
 })
 export class CommonModule {}

--- a/middleware/src/modules/common/data-retention.service.spec.ts
+++ b/middleware/src/modules/common/data-retention.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { DataRetentionService } from './data-retention.service';
 import { DatabaseService } from '../database/database.service';
+import { CronLeaderService } from './services/cron-leader.service';
 
 describe('DataRetentionService', () => {
   let service: DataRetentionService;
@@ -14,6 +15,10 @@ describe('DataRetentionService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DataRetentionService,
+        {
+          provide: CronLeaderService,
+          useValue: { runExclusive: (_n: string, fn: () => Promise<void>) => fn() },
+        },
         {
           provide: DatabaseService,
           useValue: {

--- a/middleware/src/modules/common/data-retention.service.ts
+++ b/middleware/src/modules/common/data-retention.service.ts
@@ -1,12 +1,16 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { DatabaseService } from '../database/database.service';
+import { CronLeaderService } from './services/cron-leader.service';
 
 @Injectable()
 export class DataRetentionService {
   private readonly logger = new Logger(DataRetentionService.name);
 
-  constructor(private readonly db: DatabaseService) {}
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly cronLeader: CronLeaderService,
+  ) {}
 
   /**
    * Daily data retention policy — runs at 3 AM (after analytics cleanup at 2 AM).
@@ -24,97 +28,99 @@ export class DataRetentionService {
    */
   @Cron('0 3 * * *')
   async runRetentionPolicy() {
-    this.logger.log('Starting daily data retention cleanup...');
+    await this.cronLeader.runExclusive('data-retention-prune', async () => {
+      this.logger.log('Starting daily data retention cleanup...');
 
-    const now = new Date();
-    const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
-    const ninetyDaysAgo = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000);
+      const now = new Date();
+      const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+      const ninetyDaysAgo = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000);
 
-    let auditCount = 0;
-    let notifCount = 0;
-    let tokenCount = 0;
-    let mcpAuditCount = 0;
-    let adminAuditCount = 0;
+      let auditCount = 0;
+      let notifCount = 0;
+      let tokenCount = 0;
+      let mcpAuditCount = 0;
+      let adminAuditCount = 0;
 
-    // 1. Purge audit logs older than 90 days
-    try {
-      const result = await this.db.auditLog.deleteMany({
-        where: { createdAt: { lt: ninetyDaysAgo } },
-      });
-      auditCount = result.count;
-      this.logger.log(`Purged ${auditCount} audit logs older than 90 days`);
-    } catch (err) {
-      this.logger.error(`Failed to purge audit logs: ${err instanceof Error ? err.message : err}`);
-    }
+      // 1. Purge audit logs older than 90 days
+      try {
+        const result = await this.db.auditLog.deleteMany({
+          where: { createdAt: { lt: ninetyDaysAgo } },
+        });
+        auditCount = result.count;
+        this.logger.log(`Purged ${auditCount} audit logs older than 90 days`);
+      } catch (err) {
+        this.logger.error(`Failed to purge audit logs: ${err instanceof Error ? err.message : err}`);
+      }
 
-    // 2. Purge dismissed notifications older than 30 days
-    try {
-      const deletedDismissed = await this.db.notification.deleteMany({
-        where: {
-          dismissedAt: { not: null, lt: thirtyDaysAgo },
-        },
-      });
-      notifCount += deletedDismissed.count;
-      this.logger.log(`Purged ${deletedDismissed.count} dismissed notifications older than 30 days`);
-    } catch (err) {
-      this.logger.error(`Failed to purge dismissed notifications: ${err instanceof Error ? err.message : err}`);
-    }
+      // 2. Purge dismissed notifications older than 30 days
+      try {
+        const deletedDismissed = await this.db.notification.deleteMany({
+          where: {
+            dismissedAt: { not: null, lt: thirtyDaysAgo },
+          },
+        });
+        notifCount += deletedDismissed.count;
+        this.logger.log(`Purged ${deletedDismissed.count} dismissed notifications older than 30 days`);
+      } catch (err) {
+        this.logger.error(`Failed to purge dismissed notifications: ${err instanceof Error ? err.message : err}`);
+      }
 
-    // 3. Purge read (non-dismissed) notifications older than 30 days
-    try {
-      const deletedRead = await this.db.notification.deleteMany({
-        where: {
-          read: true,
-          dismissedAt: null,
-          createdAt: { lt: thirtyDaysAgo },
-        },
-      });
-      notifCount += deletedRead.count;
-      this.logger.log(`Purged ${deletedRead.count} read notifications older than 30 days`);
-    } catch (err) {
-      this.logger.error(`Failed to purge read notifications: ${err instanceof Error ? err.message : err}`);
-    }
+      // 3. Purge read (non-dismissed) notifications older than 30 days
+      try {
+        const deletedRead = await this.db.notification.deleteMany({
+          where: {
+            read: true,
+            dismissedAt: null,
+            createdAt: { lt: thirtyDaysAgo },
+          },
+        });
+        notifCount += deletedRead.count;
+        this.logger.log(`Purged ${deletedRead.count} read notifications older than 30 days`);
+      } catch (err) {
+        this.logger.error(`Failed to purge read notifications: ${err instanceof Error ? err.message : err}`);
+      }
 
-    // 4. Delete expired password reset tokens
-    try {
-      const result = await this.db.passwordResetToken.deleteMany({
-        where: { expiresAt: { lt: now } },
-      });
-      tokenCount = result.count;
-      this.logger.log(`Purged ${tokenCount} expired password reset tokens`);
-    } catch (err) {
-      this.logger.error(`Failed to purge expired tokens: ${err instanceof Error ? err.message : err}`);
-    }
+      // 4. Delete expired password reset tokens
+      try {
+        const result = await this.db.passwordResetToken.deleteMany({
+          where: { expiresAt: { lt: now } },
+        });
+        tokenCount = result.count;
+        this.logger.log(`Purged ${tokenCount} expired password reset tokens`);
+      } catch (err) {
+        this.logger.error(`Failed to purge expired tokens: ${err instanceof Error ? err.message : err}`);
+      }
 
-    // 5. Purge MCP audit logs older than 90 days. mcp_audit_log is written on
-    // every MCP tool call (Hermes cron agents + future customer integrations)
-    // and had no retention — an unbounded pipeline-table growth surface (§12a).
-    try {
-      const result = await this.db.mcpAuditLog.deleteMany({
-        where: { createdAt: { lt: ninetyDaysAgo } },
-      });
-      mcpAuditCount = result.count;
-      this.logger.log(`Purged ${mcpAuditCount} MCP audit logs older than 90 days`);
-    } catch (err) {
-      this.logger.error(`Failed to purge MCP audit logs: ${err instanceof Error ? err.message : err}`);
-    }
+      // 5. Purge MCP audit logs older than 90 days. mcp_audit_log is written on
+      // every MCP tool call (Hermes cron agents + future customer integrations)
+      // and had no retention — an unbounded pipeline-table growth surface (§12a).
+      try {
+        const result = await this.db.mcpAuditLog.deleteMany({
+          where: { createdAt: { lt: ninetyDaysAgo } },
+        });
+        mcpAuditCount = result.count;
+        this.logger.log(`Purged ${mcpAuditCount} MCP audit logs older than 90 days`);
+      } catch (err) {
+        this.logger.error(`Failed to purge MCP audit logs: ${err instanceof Error ? err.message : err}`);
+      }
 
-    // 6. Purge admin audit logs older than 90 days (lower volume, but likewise
-    // had no retention).
-    try {
-      const result = await this.db.adminAuditLog.deleteMany({
-        where: { createdAt: { lt: ninetyDaysAgo } },
-      });
-      adminAuditCount = result.count;
-      this.logger.log(`Purged ${adminAuditCount} admin audit logs older than 90 days`);
-    } catch (err) {
-      this.logger.error(`Failed to purge admin audit logs: ${err instanceof Error ? err.message : err}`);
-    }
+      // 6. Purge admin audit logs older than 90 days (lower volume, but likewise
+      // had no retention).
+      try {
+        const result = await this.db.adminAuditLog.deleteMany({
+          where: { createdAt: { lt: ninetyDaysAgo } },
+        });
+        adminAuditCount = result.count;
+        this.logger.log(`Purged ${adminAuditCount} admin audit logs older than 90 days`);
+      } catch (err) {
+        this.logger.error(`Failed to purge admin audit logs: ${err instanceof Error ? err.message : err}`);
+      }
 
-    this.logger.log(
-      `Data retention cleanup complete: ${auditCount} audit logs, ` +
-      `${mcpAuditCount} MCP audit logs, ${adminAuditCount} admin audit logs, ` +
-      `${notifCount} notifications, ${tokenCount} tokens`,
-    );
+      this.logger.log(
+        `Data retention cleanup complete: ${auditCount} audit logs, ` +
+        `${mcpAuditCount} MCP audit logs, ${adminAuditCount} admin audit logs, ` +
+        `${notifCount} notifications, ${tokenCount} tokens`,
+      );
+    });
   }
 }

--- a/middleware/src/modules/common/services/cron-leader.service.spec.ts
+++ b/middleware/src/modules/common/services/cron-leader.service.spec.ts
@@ -1,0 +1,102 @@
+import { CronLeaderService } from './cron-leader.service';
+import { RedisService } from '../../redis/redis.service';
+
+describe('CronLeaderService', () => {
+  let service: CronLeaderService;
+  let mockClient: { set: jest.Mock };
+  let mockRedis: { getClient: jest.Mock };
+
+  beforeEach(() => {
+    mockClient = { set: jest.fn() };
+    mockRedis = { getClient: jest.fn().mockReturnValue(mockClient) };
+    service = new CronLeaderService(mockRedis as unknown as RedisService);
+  });
+
+  it('runs the body when it wins the lock (SET NX → OK) with the right key/args', async () => {
+    mockClient.set.mockResolvedValue('OK');
+    const fn = jest.fn().mockResolvedValue(undefined);
+
+    await service.runExclusive('job-a', fn);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(mockClient.set).toHaveBeenCalledWith(
+      'cron:leader:job-a',
+      expect.any(String),
+      'EX',
+      50,
+      'NX',
+    );
+  });
+
+  it('does NOT run the body when another instance holds the lock (SET NX → null)', async () => {
+    mockClient.set.mockResolvedValue(null);
+    const fn = jest.fn().mockResolvedValue(undefined);
+
+    await service.runExclusive('job-a', fn);
+
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('across the cluster, exactly ONE of two racing instances runs the body', async () => {
+    // Simulate a shared Redis: the first SET NX wins, every later one loses until
+    // the key expires. Two CronLeaderService instances (= two PM2 workers) race.
+    let held = false;
+    const set = jest.fn().mockImplementation(async () => {
+      if (held) return null;
+      held = true;
+      return 'OK';
+    });
+    const sharedRedis = { getClient: () => ({ set }) } as unknown as RedisService;
+
+    const instanceA = new CronLeaderService(sharedRedis);
+    const instanceB = new CronLeaderService(sharedRedis);
+    const fnA = jest.fn().mockResolvedValue(undefined);
+    const fnB = jest.fn().mockResolvedValue(undefined);
+
+    await Promise.all([
+      instanceA.runExclusive('shared-job', fnA),
+      instanceB.runExclusive('shared-job', fnB),
+    ]);
+
+    expect(fnA.mock.calls.length + fnB.mock.calls.length).toBe(1);
+  });
+
+  it('fail-open: runs the body when Redis is unavailable (getClient → null)', async () => {
+    mockRedis.getClient.mockReturnValue(null);
+    const fn = jest.fn().mockResolvedValue(undefined);
+
+    await service.runExclusive('job-a', fn);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('fail-open: runs the body when the SET NX call throws', async () => {
+    mockClient.set.mockRejectedValue(new Error('redis down'));
+    const fn = jest.fn().mockResolvedValue(undefined);
+
+    await service.runExclusive('job-a', fn);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates errors from the body (does not swallow them)', async () => {
+    mockClient.set.mockResolvedValue('OK');
+    const fn = jest.fn().mockRejectedValue(new Error('boom'));
+
+    await expect(service.runExclusive('job-a', fn)).rejects.toThrow('boom');
+  });
+
+  it('honors a custom ttl', async () => {
+    mockClient.set.mockResolvedValue('OK');
+
+    await service.runExclusive('job-a', jest.fn().mockResolvedValue(undefined), 55);
+
+    expect(mockClient.set).toHaveBeenCalledWith(
+      'cron:leader:job-a',
+      expect.any(String),
+      'EX',
+      55,
+      'NX',
+    );
+  });
+});

--- a/middleware/src/modules/common/services/cron-leader.service.ts
+++ b/middleware/src/modules/common/services/cron-leader.service.ts
@@ -1,0 +1,89 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { RedisService } from '../../redis/redis.service';
+
+/**
+ * Cluster-safe cron leader election.
+ *
+ * PM2 runs the middleware in cluster mode (multiple instances) and
+ * `@nestjs/schedule` fires every `@Cron` in EVERY instance — so, uncoordinated,
+ * a cron runs once per instance per tick. That double-advances state and
+ * double-sends email (e.g. duplicate trial reminders, and — but for the B3
+ * ladder's own idempotency — double dunning). This wraps a cron body in a
+ * per-cron Redis lock so exactly ONE instance runs it per window.
+ *
+ * Design:
+ *  - Redis `SET NX EX`. The lock is LEFT TO EXPIRE (never explicitly released):
+ *    the winner claims for `ttlSeconds`, every other instance's `SET NX` fails
+ *    and it skips. TTL is set below the shortest cron period (default 50s <
+ *    EVERY_MINUTE's 60s) so the next tick can re-acquire; PM2 cluster instances
+ *    share the host clock, so both fire within milliseconds and 50s easily
+ *    covers that race. If the winner crashes mid-run the lock expires and the
+ *    next window retries.
+ *  - FAIL-OPEN: if Redis is unavailable (or the SET errors) the body runs
+ *    anyway. A *skipped* cron — above all the entitlement ladder, where a missed
+ *    day delays every dunning escalation — is worse than a rare double-fire, and
+ *    the money-path crons (B3 ladder) are additionally idempotent by construction
+ *    (status-guarded CAS + SET NX dunning claim), so a fail-open double-fire is
+ *    absorbed there.
+ *  - A per-cron lock (vs. an `NODE_APP_INSTANCE === '0'` guard) survives a single
+ *    instance being down: whichever instance is alive fires, wins the lock, and
+ *    runs. An instance-0-only guard would skip the run entirely whenever instance
+ *    0 is the one restarting.
+ */
+@Injectable()
+export class CronLeaderService {
+  private readonly logger = new Logger(CronLeaderService.name);
+
+  constructor(private readonly redis: RedisService) {}
+
+  /**
+   * Run `fn` only on the instance that wins the leader lock for `name` this tick.
+   *
+   * @param name  stable per-cron identifier (the Redis key suffix). Must be unique
+   *              per cron across the app.
+   * @param fn    the cron body. Its own errors propagate (this wrapper never
+   *              swallows them) — keep the caller's existing try/catch.
+   * @param ttlSeconds  lock lifetime; MUST be < the cron's period. Default 50s is
+   *              correct for every current cron (all fire at most once/minute).
+   *              Only override for a faster cron.
+   */
+  async runExclusive(
+    name: string,
+    fn: () => Promise<void>,
+    ttlSeconds = 50,
+  ): Promise<void> {
+    const client = this.redis.getClient();
+    if (!client) {
+      this.logger.warn(
+        `Redis unavailable — running cron "${name}" fail-open (no leader lock; possible double-run in cluster).`,
+      );
+      await fn();
+      return;
+    }
+
+    let acquired: 'OK' | null;
+    try {
+      acquired = await client.set(`cron:leader:${name}`, this.token(), 'EX', ttlSeconds, 'NX');
+    } catch (err) {
+      this.logger.warn(
+        `Leader lock for "${name}" errored (${err instanceof Error ? err.message : String(err)}) — running fail-open.`,
+      );
+      await fn();
+      return;
+    }
+
+    if (acquired !== 'OK') {
+      // Expected path for every instance except the winner — debug-level to avoid
+      // N-1 log lines per tick.
+      this.logger.debug(`Cron "${name}" skipped — another instance holds the leader lock.`);
+      return;
+    }
+
+    await fn();
+  }
+
+  /** Identifies the winning instance in the lock value (debug/forensics only). */
+  private token(): string {
+    return `${process.env.NODE_APP_INSTANCE ?? '0'}:${process.pid}`;
+  }
+}

--- a/middleware/src/modules/content/content.service.spec.ts
+++ b/middleware/src/modules/content/content.service.spec.ts
@@ -9,6 +9,7 @@ jest.mock('isomorphic-dompurify', () => ({
 import { NotFoundException, BadRequestException, BadGatewayException } from '@nestjs/common';
 import { ContentService, TemplateMetadata } from './content.service';
 import { DatabaseService } from '../database/database.service';
+import { CronLeaderService } from '../common/services/cron-leader.service';
 import { TemplateRenderingService } from './template-rendering.service';
 import { DataSourceRegistryService } from './data-source-registry.service';
 import { StorageQuotaService } from '../storage/storage-quota.service';
@@ -142,6 +143,7 @@ describe('ContentService', () => {
       mockStorageService,
       mockEventEmitter as any,
       mockNotificationsService as any,
+      { runExclusive: (_n: string, fn: () => Promise<void>) => fn() } as unknown as CronLeaderService,
     );
   });
 

--- a/middleware/src/modules/content/content.service.ts
+++ b/middleware/src/modules/content/content.service.ts
@@ -2,6 +2,7 @@ import { Injectable, NotFoundException, BadRequestException, Logger, ServiceUnav
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Prisma } from '@vizora/database';
 import { DatabaseService } from '../database/database.service';
+import { CronLeaderService } from '../common/services/cron-leader.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { CreateContentDto } from './dto/create-content.dto';
 import { UpdateContentDto } from './dto/update-content.dto';
@@ -83,6 +84,7 @@ export class ContentService {
     private readonly storageService: StorageService,
     private readonly eventEmitter: EventEmitter2,
     private readonly notificationsService: NotificationsService,
+    private readonly cronLeader: CronLeaderService,
   ) {}
 
   // Map database content to API response format
@@ -625,108 +627,117 @@ export class ContentService {
 
   @Cron(CronExpression.EVERY_HOUR)
   async checkExpiredContent() {
-    const now = new Date();
+    let result: { processed: number; playlistsRefreshed: number } = {
+      processed: 0,
+      playlistsRefreshed: 0,
+    };
 
-    // Find all expired content that is still active
-    const expiredContent = await this.db.content.findMany({
-      where: {
-        expiresAt: { lte: now },
-        status: 'active',
-      },
-    });
+    await this.cronLeader.runExclusive('content-expiration', async () => {
+      const now = new Date();
 
-    // Collect (playlistId, organizationId) pairs that need a device-fleet
-    // push after the transaction commits — without this, device clients
-    // continue serving the expired content (or the now-deleted playlist
-    // slot) until they reconnect, sometimes hours later.
-    const affectedPlaylists: Array<{ playlistId: string; organizationId: string }> = [];
+      // Find all expired content that is still active
+      const expiredContent = await this.db.content.findMany({
+        where: {
+          expiresAt: { lte: now },
+          status: 'active',
+        },
+      });
 
-    for (const content of expiredContent) {
-      await this.db.$transaction(async (tx) => {
-        // Snapshot playlistIds BEFORE the updateMany / deleteMany — we
-        // can't read them after the contentId rewrite or row deletion.
-        const items = await tx.playlistItem.findMany({
-          where: { contentId: content.id },
-          select: { playlistId: true },
-        });
-        const distinctPlaylistIds = Array.from(new Set(items.map((i) => i.playlistId)));
+      // Collect (playlistId, organizationId) pairs that need a device-fleet
+      // push after the transaction commits — without this, device clients
+      // continue serving the expired content (or the now-deleted playlist
+      // slot) until they reconnect, sometimes hours later.
+      const affectedPlaylists: Array<{ playlistId: string; organizationId: string }> = [];
 
-        if (content.replacementContentId) {
-          // Validate the replacement is (a) same-organization AND (b) itself
-          // still servable — status 'active' and not itself expired. Without the
-          // status/expiry guard, an expired or archived replacement would be
-          // repointed onto devices, defeating the expiration entirely (a
-          // replacement chain could push already-dead content). A non-servable
-          // replacement falls through to the delete-items branch, exactly as if
-          // no replacement had been configured.
-          const replacement = await tx.content.findFirst({
-            where: {
-              id: content.replacementContentId,
-              organizationId: content.organizationId,
-              status: 'active',
-              OR: [{ expiresAt: null }, { expiresAt: { gt: now } }],
-            },
+      for (const content of expiredContent) {
+        await this.db.$transaction(async (tx) => {
+          // Snapshot playlistIds BEFORE the updateMany / deleteMany — we
+          // can't read them after the contentId rewrite or row deletion.
+          const items = await tx.playlistItem.findMany({
+            where: { contentId: content.id },
+            select: { playlistId: true },
           });
+          const distinctPlaylistIds = Array.from(new Set(items.map((i) => i.playlistId)));
 
-          if (replacement) {
-            await tx.playlistItem.updateMany({
-              where: { contentId: content.id },
-              data: { contentId: content.replacementContentId },
+          if (content.replacementContentId) {
+            // Validate the replacement is (a) same-organization AND (b) itself
+            // still servable — status 'active' and not itself expired. Without the
+            // status/expiry guard, an expired or archived replacement would be
+            // repointed onto devices, defeating the expiration entirely (a
+            // replacement chain could push already-dead content). A non-servable
+            // replacement falls through to the delete-items branch, exactly as if
+            // no replacement had been configured.
+            const replacement = await tx.content.findFirst({
+              where: {
+                id: content.replacementContentId,
+                organizationId: content.organizationId,
+                status: 'active',
+                OR: [{ expiresAt: null }, { expiresAt: { gt: now } }],
+              },
             });
+
+            if (replacement) {
+              await tx.playlistItem.updateMany({
+                where: { contentId: content.id },
+                data: { contentId: content.replacementContentId },
+              });
+            } else {
+              // Cross-org, missing, or not-itself-active replacement -- remove
+              // playlist items rather than serve stale content.
+              this.logger.warn(
+                `Expired content ${content.id} has unusable replacementContentId ${content.replacementContentId} (org mismatch, not found, or itself expired/archived). Removing playlist items.`,
+              );
+              await tx.playlistItem.deleteMany({
+                where: { contentId: content.id },
+              });
+            }
           } else {
-            // Cross-org, missing, or not-itself-active replacement -- remove
-            // playlist items rather than serve stale content.
-            this.logger.warn(
-              `Expired content ${content.id} has unusable replacementContentId ${content.replacementContentId} (org mismatch, not found, or itself expired/archived). Removing playlist items.`,
-            );
             await tx.playlistItem.deleteMany({
               where: { contentId: content.id },
             });
           }
-        } else {
-          await tx.playlistItem.deleteMany({
-            where: { contentId: content.id },
-          });
-        }
 
-        await tx.content.update({
-          where: { id: content.id },
-          data: { status: 'expired' },
+          await tx.content.update({
+            where: { id: content.id },
+            data: { status: 'expired' },
+          });
+
+          for (const playlistId of distinctPlaylistIds) {
+            affectedPlaylists.push({
+              playlistId,
+              organizationId: content.organizationId,
+            });
+          }
         });
+      }
 
-        for (const playlistId of distinctPlaylistIds) {
-          affectedPlaylists.push({
-            playlistId,
-            organizationId: content.organizationId,
-          });
-        }
-      });
-    }
+      // Notify device fleet AFTER the transactions commit so the realtime
+      // gateway pushes the up-to-date playlist (with replacement content
+      // swapped in OR with the expired slot removed). De-dup by playlistId
+      // — a single playlist with N expired items only needs one push.
+      const distinctAffected = new Map<string, string>();
+      for (const a of affectedPlaylists) {
+        distinctAffected.set(a.playlistId, a.organizationId);
+      }
+      for (const [playlistId, organizationId] of distinctAffected) {
+        // playlist.updated is already listened-to by PlaylistsService's
+        // notifyDisplaysOfPlaylistUpdate plumbing (via the @OnEvent
+        // handler that triggers off this event), so the device push
+        // pipeline is reused exactly. action='expired_content_replaced'
+        // tags the event so downstream consumers (audit log, ops
+        // dashboards) can distinguish a system-driven push from an
+        // operator-driven edit.
+        this.eventEmitter.emit('playlist.updated', {
+          entityId: playlistId,
+          organizationId,
+          action: 'expired_content_replaced',
+        });
+      }
 
-    // Notify device fleet AFTER the transactions commit so the realtime
-    // gateway pushes the up-to-date playlist (with replacement content
-    // swapped in OR with the expired slot removed). De-dup by playlistId
-    // — a single playlist with N expired items only needs one push.
-    const distinctAffected = new Map<string, string>();
-    for (const a of affectedPlaylists) {
-      distinctAffected.set(a.playlistId, a.organizationId);
-    }
-    for (const [playlistId, organizationId] of distinctAffected) {
-      // playlist.updated is already listened-to by PlaylistsService's
-      // notifyDisplaysOfPlaylistUpdate plumbing (via the @OnEvent
-      // handler that triggers off this event), so the device push
-      // pipeline is reused exactly. action='expired_content_replaced'
-      // tags the event so downstream consumers (audit log, ops
-      // dashboards) can distinguish a system-driven push from an
-      // operator-driven edit.
-      this.eventEmitter.emit('playlist.updated', {
-        entityId: playlistId,
-        organizationId,
-        action: 'expired_content_replaced',
-      });
-    }
+      result = { processed: expiredContent.length, playlistsRefreshed: distinctAffected.size };
+    });
 
-    return { processed: expiredContent.length, playlistsRefreshed: distinctAffected.size };
+    return result;
   }
 
 

--- a/middleware/src/modules/content/template-refresh.service.spec.ts
+++ b/middleware/src/modules/content/template-refresh.service.spec.ts
@@ -9,6 +9,7 @@ jest.mock('isomorphic-dompurify', () => ({
 import { TemplateRefreshService } from './template-refresh.service';
 import { TemplateRenderingService } from './template-rendering.service';
 import { DatabaseService } from '../database/database.service';
+import { CronLeaderService } from '../common/services/cron-leader.service';
 import { TemplateMetadata } from './content.service';
 
 describe('TemplateRefreshService', () => {
@@ -60,6 +61,7 @@ describe('TemplateRefreshService', () => {
     service = new TemplateRefreshService(
       mockDb as DatabaseService,
       mockTemplateRendering,
+      { runExclusive: (_n: string, fn: () => Promise<void>) => fn() } as unknown as CronLeaderService,
     );
   });
 

--- a/middleware/src/modules/content/template-refresh.service.ts
+++ b/middleware/src/modules/content/template-refresh.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Prisma } from '@vizora/database';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { DatabaseService } from '../database/database.service';
+import { CronLeaderService } from '../common/services/cron-leader.service';
 import { TemplateRenderingService } from './template-rendering.service';
 import { TemplateMetadata } from './content.service';
 
@@ -15,6 +16,7 @@ export class TemplateRefreshService {
   constructor(
     private readonly db: DatabaseService,
     private readonly templateRendering: TemplateRenderingService,
+    private readonly cronLeader: CronLeaderService,
   ) {}
 
   /**
@@ -22,56 +24,59 @@ export class TemplateRefreshService {
    */
   @Cron(CronExpression.EVERY_MINUTE)
   async processTemplateRefresh(): Promise<{ processed: number; errors: number }> {
-    const now = new Date();
     let processed = 0;
     let errors = 0;
 
-    try {
-      // Find all template content with refresh enabled
-      const templates = await this.db.content.findMany({
-        where: {
-          type: 'template',
-          status: 'active',
-        },
-      });
+    await this.cronLeader.runExclusive('content-template-refresh', async () => {
+      const now = new Date();
 
-      for (const template of templates) {
-        const metadata = template.metadata as TemplateMetadata | null;
+      try {
+        // Find all template content with refresh enabled
+        const templates = await this.db.content.findMany({
+          where: {
+            type: 'template',
+            status: 'active',
+          },
+        });
 
-        if (!metadata || !metadata.refreshConfig?.enabled) {
-          continue;
-        }
+        for (const template of templates) {
+          const metadata = template.metadata as TemplateMetadata | null;
 
-        // Check if refresh is due
-        const lastRefresh = metadata.refreshConfig.lastRefresh
-          ? new Date(metadata.refreshConfig.lastRefresh)
-          : null;
+          if (!metadata || !metadata.refreshConfig?.enabled) {
+            continue;
+          }
 
-        const intervalMs = metadata.refreshConfig.intervalMinutes * 60 * 1000;
-        const nextRefresh = lastRefresh
-          ? new Date(lastRefresh.getTime() + intervalMs)
-          : new Date(0); // If never refreshed, refresh now
+          // Check if refresh is due
+          const lastRefresh = metadata.refreshConfig.lastRefresh
+            ? new Date(metadata.refreshConfig.lastRefresh)
+            : null;
 
-        if (now >= nextRefresh) {
-          try {
-            await this.refreshTemplate(template.id, template);
-            processed++;
-            this.logger.debug(`Refreshed template: ${template.name} (${template.id})`);
-          } catch (error) {
-            errors++;
-            const message = error instanceof Error ? error.message : 'Unknown error';
-            this.logger.error(`Failed to refresh template ${template.id}: ${message}`);
+          const intervalMs = metadata.refreshConfig.intervalMinutes * 60 * 1000;
+          const nextRefresh = lastRefresh
+            ? new Date(lastRefresh.getTime() + intervalMs)
+            : new Date(0); // If never refreshed, refresh now
+
+          if (now >= nextRefresh) {
+            try {
+              await this.refreshTemplate(template.id, template);
+              processed++;
+              this.logger.debug(`Refreshed template: ${template.name} (${template.id})`);
+            } catch (error) {
+              errors++;
+              const message = error instanceof Error ? error.message : 'Unknown error';
+              this.logger.error(`Failed to refresh template ${template.id}: ${message}`);
+            }
           }
         }
-      }
 
-      if (processed > 0 || errors > 0) {
-        this.logger.log(`Template refresh completed: ${processed} processed, ${errors} errors`);
+        if (processed > 0 || errors > 0) {
+          this.logger.log(`Template refresh completed: ${processed} processed, ${errors} errors`);
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        this.logger.error(`Template refresh job failed: ${message}`);
       }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown error';
-      this.logger.error(`Template refresh job failed: ${message}`);
-    }
+    });
 
     return { processed, errors };
   }

--- a/middleware/src/modules/displays/displays.service.spec.ts
+++ b/middleware/src/modules/displays/displays.service.spec.ts
@@ -7,6 +7,7 @@ import { createHash } from 'node:crypto';
 import { DisplaysService } from './displays.service';
 import { DatabaseService } from '../database/database.service';
 import { CircuitBreakerService, CircuitState } from '../common/services/circuit-breaker.service';
+import { CronLeaderService } from '../common/services/cron-leader.service';
 import { StorageService } from '../storage/storage.service';
 import {
   NotFoundException,
@@ -150,6 +151,10 @@ describe('DisplaysService', () => {
         {
           provide: EventEmitter2,
           useValue: { emit: jest.fn() },
+        },
+        {
+          provide: CronLeaderService,
+          useValue: { runExclusive: (_n: string, fn: () => Promise<void>) => fn() },
         },
       ],
     }).compile();
@@ -1148,6 +1153,7 @@ describe('DisplaysService', () => {
           resolveUrl: jest.fn().mockImplementation((url) => url),
         } as any,
         { emit: jest.fn() } as any,
+        { runExclusive: (_n: string, fn: () => Promise<void>) => fn() } as unknown as CronLeaderService,
       );
 
       httpService.post.mockReturnValue(

--- a/middleware/src/modules/displays/displays.service.ts
+++ b/middleware/src/modules/displays/displays.service.ts
@@ -16,6 +16,7 @@ import { firstValueFrom } from 'rxjs';
 import * as crypto from 'crypto';
 import { DatabaseService } from '../database/database.service';
 import { CircuitBreakerService } from '../common/services/circuit-breaker.service';
+import { CronLeaderService } from '../common/services/cron-leader.service';
 import { StorageService } from '../storage/storage.service';
 import { CreateDisplayDto } from './dto/create-display.dto';
 import { UpdateDisplayDto } from './dto/update-display.dto';
@@ -55,6 +56,7 @@ export class DisplaysService {
     private readonly circuitBreaker: CircuitBreakerService,
     private readonly storageService: StorageService,
     private readonly eventEmitter: EventEmitter2,
+    private readonly cronLeader: CronLeaderService,
   ) {}
 
   /** Returns internal API secret headers, or null if secret is not configured */
@@ -303,31 +305,33 @@ export class DisplaysService {
    */
   @Cron(CronExpression.EVERY_MINUTE)
   async detectOfflineDevices(): Promise<void> {
-    const threshold = new Date(Date.now() - 2 * 60 * 1000); // 2 minutes ago
-    const staleDevices = await this.db.display.findMany({
-      where: {
-        status: 'online',
-        lastHeartbeat: { lt: threshold },
-      },
-      select: { id: true, nickname: true, deviceIdentifier: true, organizationId: true },
-    });
-
-    if (staleDevices.length === 0) return;
-
-    await this.db.display.updateMany({
-      where: { id: { in: staleDevices.map(d => d.id) } },
-      data: { status: 'offline' },
-    });
-
-    for (const device of staleDevices) {
-      this.eventEmitter.emit('device.offline', {
-        deviceId: device.id,
-        deviceName: device.nickname || device.deviceIdentifier,
-        organizationId: device.organizationId,
+    await this.cronLeader.runExclusive('displays-detect-offline', async () => {
+      const threshold = new Date(Date.now() - 2 * 60 * 1000); // 2 minutes ago
+      const staleDevices = await this.db.display.findMany({
+        where: {
+          status: 'online',
+          lastHeartbeat: { lt: threshold },
+        },
+        select: { id: true, nickname: true, deviceIdentifier: true, organizationId: true },
       });
-    }
 
-    this.logger.log(`Marked ${staleDevices.length} device(s) as offline (stale heartbeat)`);
+      if (staleDevices.length === 0) return;
+
+      await this.db.display.updateMany({
+        where: { id: { in: staleDevices.map(d => d.id) } },
+        data: { status: 'offline' },
+      });
+
+      for (const device of staleDevices) {
+        this.eventEmitter.emit('device.offline', {
+          deviceId: device.id,
+          deviceName: device.nickname || device.deviceIdentifier,
+          organizationId: device.organizationId,
+        });
+      }
+
+      this.logger.log(`Marked ${staleDevices.length} device(s) as offline (stale heartbeat)`);
+    });
   }
 
   /**
@@ -350,28 +354,30 @@ export class DisplaysService {
    */
   @Cron(CronExpression.EVERY_HOUR)
   async resetStalePairingDevices(): Promise<void> {
-    const threshold = new Date(Date.now() - 30 * 60 * 1000); // 30 minutes ago
-    const stale = await this.db.display.findMany({
-      where: {
-        status: 'pairing',
-        // Use updatedAt — that's when generatePairingToken touched the row.
-        // lastHeartbeat is the wrong field here because a pairing-state
-        // device by definition has never heartbeated.
-        updatedAt: { lt: threshold },
-      },
-      select: { id: true, nickname: true, deviceIdentifier: true, organizationId: true },
+    await this.cronLeader.runExclusive('displays-hourly', async () => {
+      const threshold = new Date(Date.now() - 30 * 60 * 1000); // 30 minutes ago
+      const stale = await this.db.display.findMany({
+        where: {
+          status: 'pairing',
+          // Use updatedAt — that's when generatePairingToken touched the row.
+          // lastHeartbeat is the wrong field here because a pairing-state
+          // device by definition has never heartbeated.
+          updatedAt: { lt: threshold },
+        },
+        select: { id: true, nickname: true, deviceIdentifier: true, organizationId: true },
+      });
+
+      if (stale.length === 0) return;
+
+      await this.db.display.updateMany({
+        where: { id: { in: stale.map((d) => d.id) } },
+        data: { status: 'offline' },
+      });
+
+      this.logger.log(
+        `Reset ${stale.length} stale 'pairing'-state device(s) to 'offline' (>30min in pairing)`,
+      );
     });
-
-    if (stale.length === 0) return;
-
-    await this.db.display.updateMany({
-      where: { id: { in: stale.map((d) => d.id) } },
-      data: { status: 'offline' },
-    });
-
-    this.logger.log(
-      `Reset ${stale.length} stale 'pairing'-state device(s) to 'offline' (>30min in pairing)`,
-    );
   }
 
   async generatePairingToken(organizationId: string, id: string) {

--- a/middleware/src/modules/health/validation-monitor.service.ts
+++ b/middleware/src/modules/health/validation-monitor.service.ts
@@ -3,6 +3,7 @@ import { OnEvent } from '@nestjs/event-emitter';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { RedisService } from '../redis/redis.service';
 import { DatabaseService } from '../database/database.service';
+import { CronLeaderService } from '../common/services/cron-leader.service';
 
 /**
  * Tier 2 — Event-Driven Validation Monitor
@@ -56,6 +57,7 @@ export class ValidationMonitorService {
 
   constructor(
     private readonly db: DatabaseService,
+    private readonly cronLeader: CronLeaderService,
     @Optional() private readonly redis?: RedisService,
   ) {}
 
@@ -85,20 +87,22 @@ export class ValidationMonitorService {
 
   @Cron(CronExpression.EVERY_HOUR)
   async handleHourlyValidation() {
-    this.logger.log('Running hourly full validation scan');
-    try {
-      // Get all orgs with active content
-      const orgs = await this.db.organization.findMany({
-        select: { id: true },
-        where: { subscriptionStatus: { not: 'canceled' } },
-        take: 50,
-      });
-      for (const org of orgs) {
-        await this.runValidation(org.id, 'scheduled.hourly');
+    await this.cronLeader.runExclusive('health-validation-monitor', async () => {
+      this.logger.log('Running hourly full validation scan');
+      try {
+        // Get all orgs with active content
+        const orgs = await this.db.organization.findMany({
+          select: { id: true },
+          where: { subscriptionStatus: { not: 'canceled' } },
+          take: 50,
+        });
+        for (const org of orgs) {
+          await this.runValidation(org.id, 'scheduled.hourly');
+        }
+      } catch (err) {
+        this.logger.error(`Hourly validation failed: ${err instanceof Error ? err.message : err}`);
       }
-    } catch (err) {
-      this.logger.error(`Hourly validation failed: ${err instanceof Error ? err.message : err}`);
-    }
+    });
   }
 
   // ─── Debounced Trigger ───────────────────────────────────────────────────

--- a/middleware/src/modules/notifications/alert-rules/alert-rules.service.spec.ts
+++ b/middleware/src/modules/notifications/alert-rules/alert-rules.service.spec.ts
@@ -1,6 +1,7 @@
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { AlertRulesService } from './alert-rules.service';
 import { DatabaseService } from '../../database/database.service';
+import { CronLeaderService } from '../../common/services/cron-leader.service';
 import { DEDUP_WINDOW_MS, MIN_OFFLINE_SEC_FLOOR } from './alert-rule.types';
 
 describe('AlertRulesService', () => {
@@ -42,7 +43,10 @@ describe('AlertRulesService', () => {
         findFirst: jest.fn(),
       },
     };
-    service = new AlertRulesService(db as unknown as DatabaseService);
+    service = new AlertRulesService(
+      db as unknown as DatabaseService,
+      { runExclusive: (_n: string, fn: () => Promise<void>) => fn() } as unknown as CronLeaderService,
+    );
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/middleware/src/modules/notifications/alert-rules/alert-rules.service.ts
+++ b/middleware/src/modules/notifications/alert-rules/alert-rules.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { DatabaseService } from '../../database/database.service';
+import { CronLeaderService } from '../../common/services/cron-leader.service';
 import { CreateAlertRuleDto } from './dto/create-alert-rule.dto';
 import { UpdateAlertRuleDto } from './dto/update-alert-rule.dto';
 import { CreateRecipientDto } from './dto/create-recipient.dto';
@@ -34,7 +35,10 @@ import {
 export class AlertRulesService {
   private readonly logger = new Logger(AlertRulesService.name);
 
-  constructor(private readonly db: DatabaseService) {}
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly cronLeader: CronLeaderService,
+  ) {}
 
   // ---------------------------------------------------------------------------
   // CRUD
@@ -310,66 +314,68 @@ export class AlertRulesService {
    */
   @Cron(CronExpression.EVERY_HOUR)
   async healMissingDefaultRules(): Promise<void> {
-    // R10 alert-rules scout: page through orgs in batches instead of
-    // loading the entire set into memory. At a few thousand orgs the
-    // unpaginated findMany would spike memory + force a long-running
-    // transaction; at tens of thousands it's an OOM risk every hour.
-    // Per-batch processing also lets us interleave Prisma + heal work
-    // so a single bad org doesn't gate the rest.
-    const PAGE_SIZE = 100;
-    let cursor: string | undefined;
-    let healed = 0;
-    let failed = 0;
-    let totalSeen = 0;
+    await this.cronLeader.runExclusive('alert-rules-heal-defaults', async () => {
+      // R10 alert-rules scout: page through orgs in batches instead of
+      // loading the entire set into memory. At a few thousand orgs the
+      // unpaginated findMany would spike memory + force a long-running
+      // transaction; at tens of thousands it's an OOM risk every hour.
+      // Per-batch processing also lets us interleave Prisma + heal work
+      // so a single bad org doesn't gate the rest.
+      const PAGE_SIZE = 100;
+      let cursor: string | undefined;
+      let healed = 0;
+      let failed = 0;
+      let totalSeen = 0;
 
-    /* eslint-disable no-constant-condition */
-    while (true) {
-      const orgsNeedingRule = await this.db.organization.findMany({
-        where: {
-          alertRules: {
-            none: { name: 'Default offline alert (auto-migrated)' },
+      /* eslint-disable no-constant-condition */
+      while (true) {
+        const orgsNeedingRule = await this.db.organization.findMany({
+          where: {
+            alertRules: {
+              none: { name: 'Default offline alert (auto-migrated)' },
+            },
           },
-        },
-        select: { id: true, name: true },
-        orderBy: { id: 'asc' },
-        take: PAGE_SIZE,
-        ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
-      });
+          select: { id: true, name: true },
+          orderBy: { id: 'asc' },
+          take: PAGE_SIZE,
+          ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+        });
 
-      if (orgsNeedingRule.length === 0) break;
-      totalSeen += orgsNeedingRule.length;
+        if (orgsNeedingRule.length === 0) break;
+        totalSeen += orgsNeedingRule.length;
 
-      for (const org of orgsNeedingRule) {
-        try {
-          const admins = await this.db.user.findMany({
-            where: { organizationId: org.id, role: 'admin' },
-            select: { id: true },
-          });
-          await this.seedDefaultRuleForOrg(
-            org.id,
-            admins.map((a) => a.id),
-          );
-          healed++;
-        } catch (err) {
-          failed++;
-          this.logger.error(
-            `Heal cron: failed to seed default alert rule for org ${org.id}: ${err instanceof Error ? err.message : err}`,
-          );
+        for (const org of orgsNeedingRule) {
+          try {
+            const admins = await this.db.user.findMany({
+              where: { organizationId: org.id, role: 'admin' },
+              select: { id: true },
+            });
+            await this.seedDefaultRuleForOrg(
+              org.id,
+              admins.map((a) => a.id),
+            );
+            healed++;
+          } catch (err) {
+            failed++;
+            this.logger.error(
+              `Heal cron: failed to seed default alert rule for org ${org.id}: ${err instanceof Error ? err.message : err}`,
+            );
+          }
         }
+
+        cursor = orgsNeedingRule[orgsNeedingRule.length - 1].id;
+        if (orgsNeedingRule.length < PAGE_SIZE) break;
       }
+      /* eslint-enable no-constant-condition */
 
-      cursor = orgsNeedingRule[orgsNeedingRule.length - 1].id;
-      if (orgsNeedingRule.length < PAGE_SIZE) break;
-    }
-    /* eslint-enable no-constant-condition */
-
-    if (totalSeen === 0) {
-      this.logger.debug('Heal cron: all orgs have the default downtime alert rule');
-      return;
-    }
-    this.logger.log(
-      `Heal cron: healed ${healed}, failed ${failed} of ${totalSeen} orgs needing default downtime alert rule`,
-    );
+      if (totalSeen === 0) {
+        this.logger.debug('Heal cron: all orgs have the default downtime alert rule');
+        return;
+      }
+      this.logger.log(
+        `Heal cron: healed ${healed}, failed ${failed} of ${totalSeen} orgs needing default downtime alert rule`,
+      );
+    });
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
PM2 runs middleware in cluster mode (2 instances) and `@nestjs/schedule` fires every `@Cron` in **every** instance, so uncoordinated crons run twice a day. Proven in the 2026-07-10 prod deploy logs — the entitlement-ladder watchdog logged `ENTITLEMENT LADDER STALE` **twice at 04:00:00, one line per middleware PID**.

The B3 ladder absorbs its own double-fire (status-guarded CAS + `SET NX` dunning claim), but the sibling **trial-lifecycle cron does not** — trial reminder/expiry emails were going out **twice** in the cluster. This resolves the audit's open *"duplicate @Cron in cluster mode"* question.

## Fix — structural, not per-cron discipline
- **`CronLeaderService.runExclusive(name, fn, ttl=50s)`** — Redis `SET NX` per-cron lock, let-expire, so exactly one instance runs each tick.
  - **Fail-open** (runs anyway if Redis is down): a skipped ladder day delays every dunning escalation — worse than a rare double-fire — and the money-path crons are idempotent underneath.
  - **Per-cron lock (not `NODE_APP_INSTANCE===0`)**: survives a single instance being down — whichever instance is alive wins the lock and runs.
  - 7 unit tests incl. a two-instance race → exactly-one-runs, plus both fail-open paths.
- Provided/exported by the `@Global` `CommonModule` (zero per-module import churn).
- **11 crons wrapped** across 8 services: billing (trial-lifecycle, grace-period ladder, watchdog), analytics, template-refresh, content-expiration, alert-rules, displays (×2), validation-monitor, data-retention.

## Deliberately NOT wrapped
`continuous-health-monitor.runHealthCheck` populates **per-instance** in-memory state (`_latest` / history ring buffer) that `health.controller` serves via `getHistory()/getLatest()/getStats()` from a load-balanced endpoint — guarding it would blank the dashboard on the non-leader instance. Its double-fire is harmless (idempotent checks, Redis last-writer-wins), so it stays per-instance by design.

## Tests
6 specs updated with a pass-through `CronLeaderService` mock (so existing assertions hold). `tsc` clean; middleware **3179/3179** unit tests pass locally.

## Follow-up (not in this PR)
CI `migrate deploy`-against-scratch-DB step remains the top CI gap (ranked above this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)