### PR TITLE
fix(t2): make content version monotonic on in-place item edits (reorder/add/remove/duration)

### DIFF
--- a/middleware/src/modules/playlists/playlists.service.spec.ts
+++ b/middleware/src/modules/playlists/playlists.service.spec.ts
@@ -343,6 +343,20 @@ describe('PlaylistsService', () => {
         }),
       );
     });
+
+    it('should bump parent Playlist.updatedAt to keep device version monotonic', async () => {
+      mockDatabaseService.playlist.findFirst.mockResolvedValue(mockPlaylist);
+      mockDatabaseService.content.findFirst.mockResolvedValue({ id: 'content-123' });
+      mockDatabaseService.playlistItem.findFirst.mockResolvedValue({ order: 0 });
+      mockDatabaseService.playlistItem.create.mockResolvedValue(mockPlaylistItem);
+
+      await service.addItem('org-123', 'playlist-123', 'content-123', 10);
+
+      expect(mockDatabaseService.playlist.updateMany).toHaveBeenCalledWith({
+        where: { id: 'playlist-123', organizationId: 'org-123' },
+        data: { updatedAt: expect.any(Date) },
+      });
+    });
   });
 
   describe('updateItem', () => {
@@ -370,6 +384,20 @@ describe('PlaylistsService', () => {
         service.updateItem('org-123', 'playlist-123', 'item-999', { duration: 60 }),
       ).rejects.toThrow(NotFoundException);
     });
+
+    it('should bump parent Playlist.updatedAt to keep device version monotonic', async () => {
+      mockDatabaseService.playlist.findFirst.mockResolvedValue(mockPlaylist);
+      mockDatabaseService.playlistItem.updateMany.mockResolvedValue({ count: 1 });
+      mockDatabaseService.playlistItem.findFirst.mockResolvedValue({ id: 'item-123', duration: 60, content: {} });
+      mockDatabaseService.playlist.findUnique.mockResolvedValue(mockPlaylist);
+
+      await service.updateItem('org-123', 'playlist-123', 'item-123', { duration: 60 });
+
+      expect(mockDatabaseService.playlist.updateMany).toHaveBeenCalledWith({
+        where: { id: 'playlist-123', organizationId: 'org-123' },
+        data: { updatedAt: expect.any(Date) },
+      });
+    });
   });
 
   describe('removeItem', () => {
@@ -382,6 +410,20 @@ describe('PlaylistsService', () => {
       expect(result).toEqual({ id: 'item-123', playlistId: 'playlist-123' });
       expect(mockDatabaseService.playlistItem.deleteMany).toHaveBeenCalledWith({
         where: { id: 'item-123', playlistId: 'playlist-123' },
+      });
+    });
+
+    it('should bump parent Playlist.updatedAt to keep device version monotonic', async () => {
+      mockDatabaseService.playlist.findFirst.mockResolvedValue(mockPlaylist);
+      mockDatabaseService.playlistItem.deleteMany.mockResolvedValue({ count: 1 });
+
+      await service.removeItem('org-123', 'playlist-123', 'item-123');
+
+      // A deleted item can't refresh itself, so the parent touch is the only
+      // thing that moves the device content version on removal.
+      expect(mockDatabaseService.playlist.updateMany).toHaveBeenCalledWith({
+        where: { id: 'playlist-123', organizationId: 'org-123' },
+        data: { updatedAt: expect.any(Date) },
       });
     });
   });
@@ -599,6 +641,33 @@ describe('PlaylistsService', () => {
       await expect(
         service.reorder('org-123', 'nonexistent', ['item-1'])
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should bump parent Playlist.updatedAt inside the transaction to keep device version monotonic', async () => {
+      const playlistWithItems = {
+        ...mockPlaylist,
+        items: [
+          { id: 'item-1', contentId: 'c-1', order: 0, duration: 10, content: null },
+          { id: 'item-2', contentId: 'c-2', order: 1, duration: 20, content: null },
+        ],
+        itemCount: 2,
+        totalDuration: 30,
+        totalSize: 0,
+      };
+
+      mockDatabaseService.playlist.findFirst
+        .mockResolvedValueOnce(playlistWithItems)
+        .mockResolvedValueOnce(playlistWithItems);
+
+      // tx client is the mock itself, so tx.playlist.updateMany is the same spy.
+      mockDatabaseService.$transaction.mockImplementation(async (fn) => fn(mockDatabaseService));
+
+      await service.reorder('org-123', 'playlist-123', ['item-2', 'item-1']);
+
+      expect(mockDatabaseService.playlist.updateMany).toHaveBeenCalledWith({
+        where: { id: 'playlist-123', organizationId: 'org-123' },
+        data: { updatedAt: expect.any(Date) },
+      });
     });
   });
 

--- a/middleware/src/modules/playlists/playlists.service.ts
+++ b/middleware/src/modules/playlists/playlists.service.ts
@@ -304,6 +304,14 @@ export class PlaylistsService {
       },
     });
 
+    // Touch the parent Playlist row so the device content `version` stays
+    // monotonic on in-place item edits — contentVersion reads playlist.updatedAt,
+    // and PlaylistItem has no updatedAt of its own.
+    await this.db.playlist.updateMany({
+      where: { id: playlistId, organizationId },
+      data: { updatedAt: new Date() },
+    });
+
     // Notify displays about the playlist change
     this.notifyPlaylistChangeAfterItemUpdate(organizationId, playlistId);
 
@@ -321,6 +329,14 @@ export class PlaylistsService {
     if (result.count === 0) {
       throw new NotFoundException('Playlist item not found');
     }
+
+    // Touch the parent Playlist row so the device content `version` stays
+    // monotonic on in-place item edits — contentVersion reads playlist.updatedAt,
+    // and PlaylistItem has no updatedAt of its own.
+    await this.db.playlist.updateMany({
+      where: { id: playlistId, organizationId },
+      data: { updatedAt: new Date() },
+    });
 
     const updatedItem = await this.db.playlistItem.findFirst({
       where: { id: itemId, playlistId },
@@ -343,6 +359,15 @@ export class PlaylistsService {
     if (result.count === 0) {
       throw new NotFoundException('Playlist item not found');
     }
+
+    // Touch the parent Playlist row so the device content `version` stays
+    // monotonic — a deleted item can't refresh itself, so this parent bump is the
+    // ONLY thing that moves the version on removal (contentVersion reads
+    // playlist.updatedAt).
+    await this.db.playlist.updateMany({
+      where: { id: playlistId, organizationId },
+      data: { updatedAt: new Date() },
+    });
 
     const deletedItem = { id: itemId, playlistId };
 
@@ -411,6 +436,15 @@ export class PlaylistsService {
           data: { order: i },
         });
       }
+
+      // Touch the parent Playlist row so the device content `version` stays
+      // monotonic on reorder (contentVersion reads playlist.updatedAt). Kept
+      // inside the transaction with the item writes so the version and the new
+      // order commit atomically.
+      await tx.playlist.updateMany({
+        where: { id: playlistId, organizationId },
+        data: { updatedAt: new Date() },
+      });
     });
 
     // Return updated playlist


### PR DESCRIPTION
## What this fixes

On the T2 content-coherence branch, the device content `version` (`contentVersion`, `packages/database/src/lib/effective-content.ts:178-211`) does **not** rise when an assigned playlist is edited in place — for 4 of the common edit types. The device's version-wins gate (`shouldApplyContent`, strict `>`) then silently rejects those edits as stale duplicates, so a reconnecting/restarting display keeps stale content.

**Root cause:** `contentVersion` maxes over `playlist.updatedAt`, `scheduleUpdatedAt`, and each `item.content?.updatedAt`. It also reads `item.updatedAt`, but `PlaylistItem` has **no `updatedAt` column** (`schema.prisma:288-303`) — that read is dead. The granular item endpoints (`reorder` / `addItem` / `updateItem` / `removeItem`) write only `PlaylistItem` rows and never touch the `Playlist` row, so nothing `contentVersion` reads moves.

| in-place edit (same playlist id) | version bumps (before) | after this PR |
|---|:---:|:---:|
| reorder | ❌ | ✅ |
| add item | ❌ | ✅ |
| remove item | ❌ | ✅ |
| duration change | ❌ | ✅ |
| content edit (rename/re-upload) | ✅ | ✅ |
| reassignment (different playlist) | ✅ | ✅ |

## The change (1 commit, `483d2a35`)

Bump `Playlist.updatedAt` in the four methods (`middleware/src/modules/playlists/playlists.service.ts`) — `contentVersion` already reads `playlist.updatedAt`, so all four holes close together:

- `reorder`: inside the existing `$transaction` (version + order commit atomically)
- `addItem` / `updateItem` / `removeItem`: after the item mutation — for `removeItem` the parent bump is the **only** version-mover, since a deleted row can't refresh itself
- + 4 unit tests asserting the parent `updateMany` per method (org-scoped `{ id, organizationId }`, `updatedAt` touch)

## ⚠️ Verify before merge (the mocked tests can't prove this)

Drafted in a partial-install worktree — **not run through tsc/jest here; CI is the authoritative gate.** The added unit tests assert the parent-update *call* is made; please also add **one integration assertion** that an edit actually raises `contentVersion` (i.e. that Prisma `updateMany` advances `@updatedAt` at runtime). Separately, `packages/database/tests/effective-content.test.ts` (~lines 22-28) mocks a nonexistent `PlaylistItem.updatedAt` and has no reorder/add/remove case — replace it with real per-edit-type coverage.

## Why it matters

vizora-tv PR #9 (Finding-2 offline-boot pull) persists `{playlistId, version}` across restart and is **safe only if `version` is monotonic on in-place edits** — which it isn't without this. #9 is held until this lands and the T2 branch ships.

Note on the base branch: `fix/t2-effective-content-resolver` was not on origin (local-only); I published it at `4a5f0f11` (this PR's base) so this could be a clean 1-commit diff. If your local T2 head is ahead, force-update the base and rebase `483d2a35` onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
