### PR TITLE
fix(auth): email normalization + unified password policy (PR-2)

### DIFF
--- a/middleware/src/modules/auth/auth.service.ts
+++ b/middleware/src/modules/auth/auth.service.ts
@@ -628,8 +628,12 @@ export class AuthService {
   }
 
   async forgotPassword(email: string): Promise<void> {
+    // Normalize so a case-variant address can't bypass the per-email rate limit
+    // or miss the (lowercased) stored account. Defense-in-depth alongside the
+    // DTO @Transform, for any non-HTTP caller.
+    const normalizedEmail = email.toLowerCase().trim();
     // Rate limit: 3 per hour per email
-    const rateLimitKey = `password_reset:${email}`;
+    const rateLimitKey = `password_reset:${normalizedEmail}`;
     const attempts = await this.redisService.get(rateLimitKey);
     if (attempts && parseInt(attempts, 10) >= 3) {
       // Don't throw — always return success to prevent enumeration
@@ -644,7 +648,7 @@ export class AuthService {
 
     // Find user
     const user = await this.databaseService.user.findUnique({
-      where: { email },
+      where: { email: normalizedEmail },
     });
 
     if (!user || !user.isActive) {

--- a/middleware/src/modules/auth/dto/change-password.dto.ts
+++ b/middleware/src/modules/auth/dto/change-password.dto.ts
@@ -1,5 +1,6 @@
-import { IsString, MinLength, Matches } from 'class-validator';
+import { IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { StrongPassword } from './password.validation';
 
 export class ChangePasswordDto {
   @ApiProperty({ description: 'Current password' })
@@ -7,10 +8,6 @@ export class ChangePasswordDto {
   currentPassword: string;
 
   @ApiProperty({ description: 'New password (min 8 characters, must contain uppercase, lowercase, and number or special character)' })
-  @IsString()
-  @MinLength(8)
-  @Matches(/((?=.*\d)|(?=.*\W+))(?![.\n])(?=.*[A-Z])(?=.*[a-z]).*$/, {
-    message: 'Password must contain uppercase, lowercase, and number or special character',
-  })
+  @StrongPassword()
   newPassword: string;
 }

--- a/middleware/src/modules/auth/dto/email-normalization.spec.ts
+++ b/middleware/src/modules/auth/dto/email-normalization.spec.ts
@@ -1,0 +1,31 @@
+import { plainToInstance } from 'class-transformer';
+import { ForgotPasswordDto } from './forgot-password.dto';
+import { InviteUserDto } from '../../users/dto/invite-user.dto';
+
+/**
+ * Regression for auth #5: login/register already normalized email, but
+ * forgot-password and invite did not — so a mixed-case forgot-password silently
+ * sent nothing (and rotated case bypassed the 3/hr cap), and a mixed-case invite
+ * created an account that later (lowercased) logins could never match.
+ */
+describe('email normalization (@Transform)', () => {
+  it('ForgotPasswordDto lowercases and trims the email', () => {
+    const dto = plainToInstance(ForgotPasswordDto, { email: '  John@Example.COM ' });
+    expect(dto.email).toBe('john@example.com');
+  });
+
+  it('InviteUserDto lowercases and trims the email', () => {
+    const dto = plainToInstance(InviteUserDto, {
+      email: '  Jane@Example.COM ',
+      firstName: 'Jane',
+      lastName: 'Doe',
+      role: 'viewer',
+    });
+    expect(dto.email).toBe('jane@example.com');
+  });
+
+  it('leaves a non-string email untouched (validation reports the type error)', () => {
+    const dto = plainToInstance(ForgotPasswordDto, { email: 123 as unknown as string });
+    expect(dto.email).toBe(123);
+  });
+});

--- a/middleware/src/modules/auth/dto/forgot-password.dto.ts
+++ b/middleware/src/modules/auth/dto/forgot-password.dto.ts
@@ -1,8 +1,14 @@
 import { IsEmail, IsNotEmpty } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class ForgotPasswordDto {
   @ApiProperty({ example: 'user@example.com' })
+  // Normalize before validation so a case-variant address hits the same
+  // per-email rate-limit bucket and resolves the (lowercased) stored account.
+  @Transform(({ value }) =>
+    typeof value === 'string' ? value.toLowerCase().trim() : value,
+  )
   @IsEmail({}, { message: 'Please enter a valid email address' })
   @IsNotEmpty({ message: 'Email is required' })
   email: string;

--- a/middleware/src/modules/auth/dto/password.validation.spec.ts
+++ b/middleware/src/modules/auth/dto/password.validation.spec.ts
@@ -1,0 +1,48 @@
+import { validate } from 'class-validator';
+import { StrongPassword, PASSWORD_MAX_BYTES } from './password.validation';
+
+class PwHolder {
+  @StrongPassword()
+  password!: string;
+}
+
+async function constraintsFor(pw: string): Promise<Record<string, string> | undefined> {
+  const holder = new PwHolder();
+  holder.password = pw;
+  const errors = await validate(holder);
+  return errors.length ? errors[0].constraints : undefined;
+}
+
+describe('StrongPassword', () => {
+  it('accepts a strong password', async () => {
+    expect(await constraintsFor('SecurePass123!')).toBeUndefined();
+  });
+
+  it('rejects a password with no lowercase (the old reset-password gap)', async () => {
+    const c = await constraintsFor('PASSWORD123!');
+    expect(c).toBeDefined();
+    expect(Object.keys(c!)).toContain('matches');
+  });
+
+  it('rejects a password shorter than 8 characters', async () => {
+    expect(await constraintsFor('Ab1!')).toBeDefined();
+  });
+
+  it('rejects a password longer than 72 bytes (bcrypt truncation cap)', async () => {
+    const pw = 'Aa1!' + 'a'.repeat(70); // 74 bytes
+    expect(Buffer.byteLength(pw, 'utf8')).toBeGreaterThan(PASSWORD_MAX_BYTES);
+    const c = await constraintsFor(pw);
+    expect(c).toBeDefined();
+    expect(Object.keys(c!)).toContain('maxBytes');
+  });
+
+  it('counts BYTES not characters — a multibyte password over 72 bytes is rejected', async () => {
+    // 'Aa1!' (4 bytes) + 24 × '你' (3 bytes each = 72) = 76 bytes, but only 28 chars.
+    const pw = 'Aa1!' + '你'.repeat(24);
+    expect(pw.length).toBeLessThanOrEqual(PASSWORD_MAX_BYTES); // char count is under the cap...
+    expect(Buffer.byteLength(pw, 'utf8')).toBeGreaterThan(PASSWORD_MAX_BYTES); // ...byte count is not
+    const c = await constraintsFor(pw);
+    expect(c).toBeDefined();
+    expect(Object.keys(c!)).toContain('maxBytes');
+  });
+});

--- a/middleware/src/modules/auth/dto/password.validation.ts
+++ b/middleware/src/modules/auth/dto/password.validation.ts
@@ -1,0 +1,73 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  IsString,
+  MinLength,
+  Matches,
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+} from 'class-validator';
+
+/**
+ * Shared password policy for register / change-password / reset-password.
+ *
+ * These three paths had drifted: reset required only uppercase + a digit (no
+ * lowercase), so a user could reset to a password that register would reject;
+ * reset and change had no maximum length at all. bcrypt silently truncates the
+ * input at 72 BYTES, so an un-capped field lets a long passphrase be silently
+ * shortened (and two passwords sharing a 72-byte prefix authenticate
+ * interchangeably). Centralising the rule here means the three paths can never
+ * diverge again.
+ */
+export const PASSWORD_MIN_LENGTH = 8;
+export const PASSWORD_MAX_BYTES = 72;
+
+// Upper + lower + (digit OR special).
+const PASSWORD_PATTERN = /((?=.*\d)|(?=.*\W+))(?![.\n])(?=.*[A-Z])(?=.*[a-z]).*$/;
+const PASSWORD_MESSAGE =
+  'Password must contain at least 1 uppercase letter, 1 lowercase letter, and 1 number or special character';
+
+/**
+ * Rejects a string whose UTF-8 byte length exceeds `max`. This is a BYTE cap,
+ * not a character cap — class-validator's MaxLength counts UTF-16 code units,
+ * which under-counts multibyte input and would let a >72-byte password through
+ * to bcrypt's silent truncation.
+ */
+export function MaxBytes(
+  max: number,
+  validationOptions?: ValidationOptions,
+): PropertyDecorator {
+  return (object: object, propertyName: string | symbol) => {
+    registerDecorator({
+      name: 'maxBytes',
+      target: object.constructor,
+      propertyName: propertyName as string,
+      constraints: [max],
+      options: validationOptions,
+      validator: {
+        validate(value: unknown, args: ValidationArguments) {
+          if (typeof value !== 'string') return true; // @IsString owns type errors
+          return Buffer.byteLength(value, 'utf8') <= (args.constraints[0] as number);
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `Password must be at most ${args.constraints[0]} bytes`;
+        },
+      },
+    });
+  };
+}
+
+/**
+ * Composed password validator: string, >= 8 chars, <= 72 bytes, and containing
+ * an uppercase letter, a lowercase letter, and a digit or special character.
+ */
+export function StrongPassword(): PropertyDecorator {
+  return applyDecorators(
+    IsString(),
+    MinLength(PASSWORD_MIN_LENGTH, {
+      message: `Password must be at least ${PASSWORD_MIN_LENGTH} characters`,
+    }),
+    MaxBytes(PASSWORD_MAX_BYTES),
+    Matches(PASSWORD_PATTERN, { message: PASSWORD_MESSAGE }),
+  );
+}

--- a/middleware/src/modules/auth/dto/register.dto.ts
+++ b/middleware/src/modules/auth/dto/register.dto.ts
@@ -1,6 +1,7 @@
 import { IsEmail, IsString, MinLength, MaxLength, Matches, IsOptional } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { StrongPassword } from './password.validation';
 
 export class RegisterDto {
   @ApiProperty({
@@ -22,12 +23,7 @@ export class RegisterDto {
     minLength: 8,
     maxLength: 100,
   })
-  @IsString()
-  @MinLength(8)
-  @MaxLength(100)
-  @Matches(/((?=.*\d)|(?=.*\W+))(?![.\n])(?=.*[A-Z])(?=.*[a-z]).*$/, {
-    message: 'Password must contain at least 1 uppercase letter, 1 lowercase letter, and 1 number or special character',
-  })
+  @StrongPassword()
   password: string;
 
   @ApiProperty({

--- a/middleware/src/modules/auth/dto/reset-password.dto.ts
+++ b/middleware/src/modules/auth/dto/reset-password.dto.ts
@@ -1,5 +1,6 @@
-import { IsNotEmpty, IsString, MinLength, Matches } from 'class-validator';
+import { IsNotEmpty, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { StrongPassword } from './password.validation';
 
 export class ResetPasswordDto {
   @ApiProperty({ example: 'abc123...' })
@@ -8,10 +9,6 @@ export class ResetPasswordDto {
   token: string;
 
   @ApiProperty({ example: 'NewStr0ngP@ss!' })
-  @IsString()
-  @IsNotEmpty({ message: 'Password is required' })
-  @MinLength(8, { message: 'Password must be at least 8 characters' })
-  @Matches(/[A-Z]/, { message: 'Password must contain at least one uppercase letter' })
-  @Matches(/[0-9]/, { message: 'Password must contain at least one number' })
+  @StrongPassword()
   newPassword: string;
 }

--- a/middleware/src/modules/users/dto/invite-user.dto.ts
+++ b/middleware/src/modules/users/dto/invite-user.dto.ts
@@ -1,6 +1,13 @@
 import { IsEmail, IsString, IsIn, MinLength, MaxLength } from 'class-validator';
+import { Transform } from 'class-transformer';
 
 export class InviteUserDto {
+  // Normalize so a mixed-case invite creates an account that later logins
+  // (which lowercase the address) can actually match, and so the duplicate
+  // check catches case-variants of an existing member.
+  @Transform(({ value }) =>
+    typeof value === 'string' ? value.toLowerCase().trim() : value,
+  )
   @IsEmail()
   email: string;
 

--- a/middleware/src/modules/users/users.service.ts
+++ b/middleware/src/modules/users/users.service.ts
@@ -80,9 +80,13 @@ export class UsersService {
   }
 
   async invite(organizationId: string, dto: InviteUserDto, invitedByUserId: string) {
+    // Normalize so a mixed-case invite can't create an account that later
+    // (lowercased) logins never match, and so the duplicate check catches
+    // case-variants. Defense-in-depth alongside the DTO @Transform.
+    const email = dto.email.toLowerCase().trim();
     // Check if email already exists
     const existingUser = await this.db.user.findUnique({
-      where: { email: dto.email },
+      where: { email },
     });
 
     if (existingUser) {
@@ -96,7 +100,7 @@ export class UsersService {
 
     const user = await this.db.user.create({
       data: {
-        email: dto.email,
+        email,
         firstName: dto.firstName,
         lastName: dto.lastName,
         role: dto.role,


### PR DESCRIPTION
**Batch PR-2** of the 2026-07-10 improvement backlog. Closes **auth #5, auth #9**.

## Email normalization (auth #5)
Login/register already lowercase+trim email, but two paths didn't:
- **ForgotPasswordDto** — a mixed-case address built a different `password_reset:` rate-limit key and missed the (lowercased) stored account → the reset email **silently never sent**, and rotating case bypassed the 3/hr cap.
- **InviteUserDto** — a mixed-case invite created an account that later (lowercased) logins could **never match**, and the duplicate check missed case-variants.

Fix: `@Transform` lowercase+trim on both DTOs, plus defense-in-depth normalization in `AuthService.forgotPassword` and `UsersService.invite` for non-HTTP callers.

## Password policy (auth #9)
`reset-password` required only uppercase + a digit (**no lowercase**) — a user could reset to a password `register` rejects; reset and change had **no maximum**, and bcrypt **silently truncates at 72 bytes**.

Fix: a shared `StrongPassword()` decorator — upper + lower + (digit or special), ≥8 chars, **≤72 bytes via a real byte-length validator** (not a char cap, which under-counts multibyte) — applied to register/change/reset so the three paths can't diverge again.

## Tests
- `StrongPassword` accepts a valid password; rejects no-lowercase, too-short, >72 ASCII bytes, and a **multibyte** password that is <72 chars but >72 bytes.
- DTO `@Transform` lowercases+trims both emails.

## Verification
- middleware auth + users specs: **258/258** pass · `tsc --noEmit` exit 0 · `eslint` 0 errors.

## Note
The register max moved from `MaxLength(100)` chars to a 72-byte cap — chars beyond byte 72 were silently ignored by bcrypt anyway, so this removes a false sense that they mattered. The invite **email** (currently returns a plaintext temp password) is a separate concern tracked in **PR-22**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)