### PR TITLE
fix(observability): un-blind Prometheus/Grafana + wire error-rate health signal (PR-3)

### DIFF
--- a/docker/grafana/provisioning/alerting/alerts.yml
+++ b/docker/grafana/provisioning/alerting/alerts.yml
@@ -31,42 +31,12 @@ groups:
     folder: Vizora
     interval: 1m
     rules:
-      # Device offline for more than 5 minutes
-      - uid: device-offline
-        title: Device Offline > 5 minutes
-        condition: C
-        data:
-          - refId: A
-            relativeTimeRange:
-              from: 600
-              to: 0
-            datasourceUid: prometheus
-            model:
-              expr: 'time() - vizora_device_last_heartbeat_timestamp > 300'
-              intervalMs: 60000
-              maxDataPoints: 43200
-          - refId: C
-            relativeTimeRange:
-              from: 0
-              to: 0
-            datasourceUid: '-100'
-            model:
-              conditions:
-                - evaluator:
-                    type: gt
-                    params: [0]
-                  operator:
-                    type: and
-                  query:
-                    params: [A]
-              type: classic_conditions
-        noDataState: OK
-        execErrState: Alerting
-        for: 5m
-        annotations:
-          summary: 'A display device has been offline for more than 5 minutes'
-        labels:
-          severity: warning
+      # NOTE: The "Device Offline > 5 minutes" rule was removed. Its expr
+      # referenced `vizora_device_last_heartbeat_timestamp`, a metric no
+      # service exports, so the rule could never fire (dead alert). Device-
+      # offline paging is owned by the in-app O7 alert-rules evaluator
+      # (event-driven, per-tenant), NOT by Prometheus. Do not re-add a
+      # Prometheus device-offline rule unless that metric is actually exported.
 
       # Error rate spike > 5% over 5 minute window
       - uid: error-rate-spike

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -4,10 +4,10 @@ global:
 
 scrape_configs:
   - job_name: 'middleware'
-    metrics_path: '/api/internal/metrics'
+    metrics_path: '/api/v1/internal/metrics'
     static_configs:
       - targets: ['host.docker.internal:3000']
   - job_name: 'realtime'
-    metrics_path: '/metrics'
+    metrics_path: '/internal/metrics'
     static_configs:
       - targets: ['host.docker.internal:3002']

--- a/middleware/src/modules/metrics/metrics-auth.middleware.ts
+++ b/middleware/src/modules/metrics/metrics-auth.middleware.ts
@@ -1,0 +1,53 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import * as crypto from 'crypto';
+
+/**
+ * Restricts access to /api/v1/internal/metrics to localhost or requests with
+ * a valid METRICS_TOKEN bearer token. In production, Prometheus/Grafana
+ * should scrape from localhost or a private network.
+ *
+ * The metrics route is marked @Public() so it bypasses the global JwtAuthGuard
+ * (Prometheus has no JWT); this middleware is what keeps the now-public endpoint
+ * from being world-readable.
+ */
+@Injectable()
+export class MetricsAuthMiddleware implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction) {
+    // Allow localhost access (Prometheus scraping from same host)
+    const remoteIp = req.ip || req.socket.remoteAddress || '';
+    const isLocalhost =
+      remoteIp === '127.0.0.1' ||
+      remoteIp === '::1' ||
+      remoteIp === '::ffff:127.0.0.1';
+
+    if (isLocalhost) {
+      return next();
+    }
+
+    // Allow access with bearer token if METRICS_TOKEN is configured
+    const metricsToken = process.env.METRICS_TOKEN;
+    if (metricsToken) {
+      const authHeader = req.headers.authorization;
+      const expected = `Bearer ${metricsToken}`;
+      if (
+        authHeader &&
+        authHeader.length === expected.length &&
+        crypto.timingSafeEqual(Buffer.from(authHeader), Buffer.from(expected))
+      ) {
+        return next();
+      }
+    }
+
+    // In development, allow all access for convenience
+    if (process.env.NODE_ENV !== 'production') {
+      return next();
+    }
+
+    res.status(403).json({
+      statusCode: 403,
+      message: 'Metrics access denied',
+      error: 'Forbidden',
+    });
+  }
+}

--- a/middleware/src/modules/metrics/metrics.controller.ts
+++ b/middleware/src/modules/metrics/metrics.controller.ts
@@ -1,12 +1,17 @@
 import { Controller, Get, Res } from '@nestjs/common';
 import type { Response } from 'express';
 import { MetricsService } from './metrics.service';
+import { Public } from '../auth/decorators/public.decorator';
 
 @Controller('internal')
 export class MetricsController {
   constructor(private readonly metricsService: MetricsService) {}
 
-  // Requires JWT auth. For Prometheus scraping, use network-level access control or an API key.
+  // @Public() opts this route out of the global JwtAuthGuard so Prometheus
+  // (which has no JWT) can scrape it. Access is instead gated by
+  // MetricsAuthMiddleware (localhost or METRICS_TOKEN bearer) — wired in
+  // MetricsModule.configure().
+  @Public()
   @Get('metrics')
   async getMetrics(@Res() res: Response) {
     const metrics = await this.metricsService.getMetrics();

--- a/middleware/src/modules/metrics/metrics.interceptor.ts
+++ b/middleware/src/modules/metrics/metrics.interceptor.ts
@@ -3,15 +3,26 @@ import {
   NestInterceptor,
   ExecutionContext,
   CallHandler,
+  Optional,
 } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import type { Request, Response } from 'express';
 import { MetricsService } from './metrics.service';
+import { ContinuousHealthMonitorService } from '../health/continuous-health-monitor.service';
 
 @Injectable()
 export class MetricsInterceptor implements NestInterceptor {
-  constructor(private readonly metricsService: MetricsService) {}
+  constructor(
+    private readonly metricsService: MetricsService,
+    // Optional so unit tests that construct the interceptor directly (and the
+    // DI graph) never hard-fail if the health monitor is unavailable. When
+    // present, 5xx responses feed the continuous-health error-rate check —
+    // without this wiring recordError() was never called, so checkErrorRate()
+    // always saw 0 5xx.
+    @Optional()
+    private readonly healthMonitor?: ContinuousHealthMonitorService,
+  ) {}
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
     const request = context.switchToHttp().getRequest<Request>();
@@ -34,14 +45,21 @@ export class MetricsInterceptor implements NestInterceptor {
           if (response.statusCode >= 400) {
             this.metricsService.httpErrorsTotal.inc({ method, path, status });
           }
+          if (response.statusCode >= 500) {
+            this.healthMonitor?.recordError(response.statusCode);
+          }
         },
         error: (error) => {
-          const status = String(error.status || 500);
+          const statusCode = error.status || 500;
+          const status = String(statusCode);
           const duration = (Date.now() - startTime) / 1000;
 
           this.metricsService.httpRequestsTotal.inc({ method, path, status });
           this.metricsService.httpRequestDuration.observe({ method, path, status }, duration);
           this.metricsService.httpErrorsTotal.inc({ method, path, status });
+          if (statusCode >= 500) {
+            this.healthMonitor?.recordError(statusCode);
+          }
         },
       }),
     );

--- a/middleware/src/modules/metrics/metrics.module.ts
+++ b/middleware/src/modules/metrics/metrics.module.ts
@@ -1,11 +1,23 @@
-import { Module, Global } from '@nestjs/common';
+import {
+  Module,
+  Global,
+  NestModule,
+  MiddlewareConsumer,
+} from '@nestjs/common';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { MetricsService } from './metrics.service';
 import { MetricsController } from './metrics.controller';
 import { MetricsInterceptor } from './metrics.interceptor';
+import { MetricsAuthMiddleware } from './metrics-auth.middleware';
+import { HealthModule } from '../health/health.module';
 
 @Global()
 @Module({
+  // HealthModule exports ContinuousHealthMonitorService, which MetricsInterceptor
+  // (registered here as APP_INTERCEPTOR) injects to feed 5xx counts into the
+  // continuous-health error-rate check. No cycle: HealthModule does not depend
+  // on MetricsModule.
+  imports: [HealthModule],
   controllers: [MetricsController],
   providers: [
     MetricsService,
@@ -16,4 +28,11 @@ import { MetricsInterceptor } from './metrics.interceptor';
   ],
   exports: [MetricsService],
 })
-export class MetricsModule {}
+export class MetricsModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    // Gate the (now @Public) /api/v1/internal/metrics endpoint behind
+    // localhost/METRICS_TOKEN. The global prefix is prepended to this route
+    // string by Nest, so it matches the served /api/v1/internal/metrics path.
+    consumer.apply(MetricsAuthMiddleware).forRoutes('internal/metrics');
+  }
+}

--- a/realtime/src/gateways/device.gateway.spec.ts
+++ b/realtime/src/gateways/device.gateway.spec.ts
@@ -83,6 +83,7 @@ describe('DeviceGateway', () => {
     recordImpression: jest.fn(),
     recordContentError: jest.fn(),
     updateDeviceMetrics: jest.fn(),
+    reconcileDevicesOnline: jest.fn(),
   };
 
   const mockDatabaseService = {

--- a/realtime/src/gateways/device.gateway.ts
+++ b/realtime/src/gateways/device.gateway.ts
@@ -531,6 +531,31 @@ export class DeviceGateway
     // Periodically tear down dashboard sockets whose session was invalidated
     // mid-connection (password change / deactivation) — see sweepInvalidatedSessions.
     this.cleanupIntervals.push(setInterval(() => this.sweepInvalidatedSessions(), 60000));
+    // Periodically reconcile the devices_online metric from the authoritative
+    // presence map (deviceSockets). The inc/dec in MetricsService drifts after a
+    // missed disconnect; this snapshot re-syncs it. Realtime runs single-instance
+    // (PM2 instances:1) so a plain setInterval is safe — no leader election.
+    this.cleanupIntervals.push(setInterval(() => this.reconcileDeviceMetrics(), 60000));
+  }
+
+  /**
+   * Reconcile the devices_online gauge from the in-memory presence map.
+   * deviceSockets (deviceId -> active socketId) is the authoritative set of
+   * currently-connected devices; each socket carries its organizationId on
+   * socket.data. Tally per org and hand the snapshot to MetricsService, which
+   * reset()s and set()s the gauge. Sockets missing from the server (already
+   * gone) are skipped so a stale map entry never inflates the count.
+   */
+  private reconcileDeviceMetrics(): void {
+    const countsByOrg = new Map<string, number>();
+    for (const socketId of this.deviceSockets.values()) {
+      const socket = this.server?.sockets?.sockets?.get(socketId);
+      const orgId = socket?.data?.organizationId;
+      if (typeof orgId === 'string' && orgId) {
+        countsByOrg.set(orgId, (countsByOrg.get(orgId) ?? 0) + 1);
+      }
+    }
+    this.metricsService.reconcileDevicesOnline(countsByOrg);
   }
 
   async onModuleDestroy() {

--- a/realtime/src/metrics/metrics.service.spec.ts
+++ b/realtime/src/metrics/metrics.service.spec.ts
@@ -5,7 +5,7 @@ describe('MetricsService', () => {
 
   // Factory functions to create fresh mock instances per test
   const createCounter = () => ({ inc: jest.fn() });
-  const createGauge = () => ({ inc: jest.fn(), dec: jest.fn(), set: jest.fn() });
+  const createGauge = () => ({ inc: jest.fn(), dec: jest.fn(), set: jest.fn(), reset: jest.fn() });
   const createHistogram = () => ({ observe: jest.fn() });
 
   beforeEach(() => {
@@ -134,6 +134,28 @@ describe('MetricsService', () => {
       expect(service.devicesOnline.dec).toHaveBeenCalledWith({
         organization_id: 'org-1',
       });
+    });
+  });
+
+  describe('reconcileDevicesOnline', () => {
+    it('should reset the gauge and set per-org counts from the snapshot', () => {
+      service.reconcileDevicesOnline(
+        new Map([
+          ['org-1', 3],
+          ['org-2', 1],
+        ]),
+      );
+
+      expect(service.devicesOnline.reset).toHaveBeenCalled();
+      expect(service.devicesOnline.set).toHaveBeenCalledWith({ organization_id: 'org-1' }, 3);
+      expect(service.devicesOnline.set).toHaveBeenCalledWith({ organization_id: 'org-2' }, 1);
+    });
+
+    it('should reset the gauge even when the snapshot is empty', () => {
+      service.reconcileDevicesOnline(new Map());
+
+      expect(service.devicesOnline.reset).toHaveBeenCalled();
+      expect(service.devicesOnline.set).not.toHaveBeenCalled();
     });
   });
 

--- a/realtime/src/metrics/metrics.service.ts
+++ b/realtime/src/metrics/metrics.service.ts
@@ -119,6 +119,23 @@ export class MetricsService {
   }
 
   /**
+   * Reconcile the devices_online gauge from an authoritative snapshot of the
+   * currently-connected devices, counted per organization.
+   *
+   * updateDeviceStatus inc/dec's this gauge, which drifts after a process
+   * restart or a missed disconnect (dec never fires). Periodically set()-ing
+   * the gauge from the gateway's in-memory presence map is the source of truth.
+   * reset() first so organizations that dropped to zero disappear instead of
+   * retaining a stale count.
+   */
+  reconcileDevicesOnline(onlineCountsByOrg: Map<string, number>) {
+    this.devicesOnline.reset();
+    for (const [organizationId, count] of onlineCountsByOrg) {
+      this.devicesOnline.set({ organization_id: organizationId }, count);
+    }
+  }
+
+  /**
    * Update device metrics - aggregated per organization
    */
   updateDeviceMetrics(organizationId: string, cpuUsage: number, memoryUsage: number) {


### PR DESCRIPTION
**Batch PR-3** of the 2026-07-10 improvement backlog. Closes **analytics #1, #4, #5, #6, #13**. Monitoring was silently blind — panels looked healthy because they had no data at all.

- **#1 scrape paths (both services)** — Prometheus scraped `/api/internal/metrics` (middleware serves `/api/v1/internal/metrics`) and `/metrics` (realtime serves `/internal/metrics`). Every Grafana panel + alert was empty. Fixed both in `docker/prometheus/prometheus.yml`.
- **#6 middleware scrape-auth** — `/internal/metrics` sat behind the global `JwtAuthGuard` (confirmed `APP_GUARD` in `auth.module.ts`), so even a corrected scrape would 401. Added `@Public()` + a `MetricsAuthMiddleware` (localhost / `METRICS_TOKEN` bearer via `timingSafeEqual`), ported from realtime's existing middleware.
- **#4 phantom Grafana alert** — the "Device Offline > 5min" rule keyed off `vizora_device_last_heartbeat_timestamp`, which nothing exports → could never fire. Removed with a comment noting device-offline paging is owned by the in-app O7 evaluator.
- **#5 dead error-rate signal** — `ContinuousHealthMonitor.recordError()` was never called, so `checkErrorRate()` always saw 0 5xx and reported healthy. Wired from `MetricsInterceptor` on `>= 500` (both `next` and `error` taps; mutually exclusive → no double-count). 4xx left unfed by design to avoid 404-probe noise.
- **#13 devices_online drift** — the gauge inc/dec drifts after a restart or missed disconnect. Added a 60s reconcile that `set()`s it from the gateway's authoritative `deviceSockets` presence map (realtime is single-instance, so a plain interval is safe).

## Verification (independently re-run)
- middleware `tsc` 0 · metrics+health **122/122**
- realtime `tsc` 0 · metrics+gateway **135/135**
- `eslint` **0 errors**
- DI checked acyclic: `MetricsModule → HealthModule → {Database,Redis,Storage}`; `HealthModule` never imports `MetricsModule`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)