### PR TITLE
fix(silent-failure): deletion email, unaudited-MCP-write alert, /backlog leak, agent-message sanitize (PR-5)

### DIFF
--- a/middleware/src/modules/auth/auth.service.ts
+++ b/middleware/src/modules/auth/auth.service.ts
@@ -1113,7 +1113,7 @@ export class AuthService {
 
     // 7. Send confirmation email (best-effort)
     try {
-      await this.mailService.sendAccountDeletionEmail?.(originalEmail, user.firstName);
+      await this.mailService.sendAccountDeletionEmail(originalEmail, user.firstName);
     } catch (err) {
       this.logger.warn(`Failed to send account deletion email to ${originalEmail}: ${err instanceof Error ? err.message : 'Unknown'}`);
     }

--- a/middleware/src/modules/mail/mail.service.ts
+++ b/middleware/src/modules/mail/mail.service.ts
@@ -504,6 +504,30 @@ export class MailService {
   }
 
   /**
+   * Confirmation sent after a user deletes their Vizora account. Contains no
+   * secrets — only the display name + static copy confirming the deletion, plus
+   * a support contact for anyone who didn't initiate it. firstName is
+   * user-controlled, so it's escaped before interpolation. Non-critical: a
+   * failed confirmation must never roll back the deletion that already happened.
+   */
+  async sendAccountDeletionEmail(to: string, firstName: string): Promise<void> {
+    const subject = 'Your Vizora account has been deleted';
+    const html = this.wrapInTemplate(`
+          <h1 style="color:#F0ECE8;font-size:22px;font-weight:700;margin:0 0 8px 0;">Your account has been deleted</h1>
+          <p style="color:#8A9BA3;font-size:14px;line-height:1.6;margin:0 0 24px 0;">
+            Hi ${MailService.escapeHtml(firstName)},<br><br>
+            This is a confirmation that your Vizora account and its associated data have been deleted.
+            We're sorry to see you go.
+          </p>
+          <p style="color:#5A6B73;font-size:12px;line-height:1.5;margin:16px 0 0 0;">
+            If you did <strong style="color:#F0ECE8;">not</strong> request this, contact support@vizora.cloud
+            immediately — your account may have been compromised.
+          </p>
+    `);
+    await this.sendMail(to, subject, html, 'Account deletion', 'auth');
+  }
+
+  /**
    * Security notification sent after a successful login from a new context.
    * This is intentionally framed as "new login context" rather than a durable
    * trusted-device system: IPs and browser User-Agent strings can legitimately

--- a/middleware/src/modules/mcp/audit/mcp-audit.service.ts
+++ b/middleware/src/modules/mcp/audit/mcp-audit.service.ts
@@ -24,6 +24,7 @@ export class McpAuditService {
     agentName: string;
     organizationId: string | null;
     tool: string | null;
+    scope?: string;
     paramsRaw: unknown;
     status: 'success' | 'error';
     errorCode?: string;
@@ -43,9 +44,61 @@ export class McpAuditService {
         },
       });
     } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
       this.logger.error(
-        `Failed to write MCP audit row (agent=${entry.agentName} tool=${entry.tool}): ${err instanceof Error ? err.message : err}`,
+        `Failed to write MCP audit row (agent=${entry.agentName} tool=${entry.tool}): ${message}`,
       );
+      // §12b: a WRITE tool just mutated state (a lifecycle tool may have
+      // sent a real customer email) and now has NO durable audit row.
+      // That must not be silent — fire an out-of-band operator alert at
+      // the write site. Read-tool audit-write failures stay log-only:
+      // no mutation was lost, so there's nothing to reconcile.
+      if (entry.scope?.endsWith(':write')) {
+        this.alertWriteAuditFailure(entry, message);
+      }
+    }
+  }
+
+  /**
+   * Out-of-band operator alert for a WRITE-tool audit-log write failure.
+   * Routes through Sentry (already wired in middleware; it fans out to
+   * whichever channels ops configured on the project — Slack/PagerDuty/
+   * email) so a mutation with no durable audit row can't pass unnoticed.
+   *
+   * Lazy-require Sentry so unit tests don't need the module mocked
+   * (mirrors CircuitBreakerService's write-site alert).
+   */
+  private alertWriteAuditFailure(
+    entry: {
+      agentName: string;
+      tool: string | null;
+      scope?: string;
+      organizationId: string | null;
+    },
+    errorMessage: string,
+  ): void {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const Sentry = require('@sentry/nestjs');
+      Sentry.captureMessage(
+        `MCP write-tool mutation not audited — audit write failed (tool=${entry.tool} scope=${entry.scope})`,
+        {
+          level: 'error',
+          tags: {
+            event: 'mcp_audit_write_failed',
+            tool: entry.tool ?? 'unknown',
+            scope: entry.scope ?? 'unknown',
+          },
+          extra: {
+            agentName: entry.agentName,
+            organizationId: entry.organizationId,
+            errorMessage,
+          },
+        },
+      );
+    } catch {
+      /* Sentry not loaded in this context (e.g. unit tests) — the
+         logger.error above is the fallback signal. */
     }
   }
 }

--- a/middleware/src/modules/mcp/mcp.service.ts
+++ b/middleware/src/modules/mcp/mcp.service.ts
@@ -205,6 +205,7 @@ export class McpService implements OnModuleInit {
     tool: {
       name: string;
       description: string;
+      scope: string;
       inputSchema: { shape: Record<string, unknown> };
       handler: (
         input: TIn,
@@ -235,6 +236,7 @@ export class McpService implements OnModuleInit {
             agentName: context.agentName,
             organizationId: context.organizationId,
             tool: tool.name,
+            scope: tool.scope,
             paramsRaw: input,
             status: 'success',
             latencyMs: Date.now() - startedAt,
@@ -250,6 +252,7 @@ export class McpService implements OnModuleInit {
             agentName: context.agentName,
             organizationId: context.organizationId,
             tool: tool.name,
+            scope: tool.scope,
             paramsRaw: input,
             status: 'error',
             errorCode: mapped.code,

--- a/middleware/src/modules/mcp/tools/support.tools.ts
+++ b/middleware/src/modules/mcp/tools/support.tools.ts
@@ -1,4 +1,5 @@
 import { ForbiddenException } from '@nestjs/common';
+import sanitizeHtml from 'sanitize-html';
 import { SupportService } from '../../support/support.service';
 import {
   hasScope,
@@ -220,10 +221,21 @@ export async function createSupportMessageTool(
   const input = CreateSupportMessageInput.parse(
     rawInput,
   ) as CreateSupportMessageInputT;
+  // MCP endpoints carry @SkipInputSanitize() (the JSON-RPC envelope must not
+  // be HTML-mangled), so the global SanitizeInterceptor never touches this
+  // content. This message is later rendered in the support thread, so strip
+  // HTML here with the SAME config the interceptor uses for plain string
+  // fields — stored-XSS defense at the one write site that bypasses the
+  // interceptor. Only `content` is sanitized; request_id is not user prose.
+  const sanitizedContent = sanitizeHtml(input.content, {
+    allowedTags: [],
+    allowedAttributes: {},
+    disallowedTagsMode: 'discard',
+  });
   const created = await supportService.createAgentMessage(
     orgId,
     input.request_id,
-    input.content,
+    sanitizedContent,
   );
   return CreateSupportMessageResult.parse({
     request_id: input.request_id,

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,8 +1,11 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
-// Pages that don't require authentication
-const publicPaths = ['/login', '/register', '/', '/display', '/backlog'];
+// Pages that don't require authentication.
+// NOTE: /backlog is intentionally NOT public — it renders the same internal
+// roadmap component as the superadmin-only /admin/backlog page (launch gates,
+// budget notes, competitor gaps) and is gated below like an /admin route.
+const publicPaths = ['/login', '/register', '/', '/display'];
 
 function base64UrlDecode(str: string): string {
   // Convert Base64url to standard Base64
@@ -62,17 +65,31 @@ export function middleware(request: NextRequest) {
   const tokenFromHeader = request.headers.get('authorization')?.replace('Bearer ', '');
   const token = tokenFromCookie || tokenFromHeader;
 
-  // Redirect to login if no valid token and trying to access protected route
-  if ((!token || !isValidJwtFormat(token)) && (pathname.startsWith('/dashboard') || pathname.startsWith('/admin'))) {
+  // Redirect to login if no valid token and trying to access protected route.
+  // /backlog is treated as a protected superadmin route (see publicPaths note).
+  if (
+    (!token || !isValidJwtFormat(token)) &&
+    (pathname.startsWith('/dashboard') ||
+      pathname.startsWith('/admin') ||
+      pathname === '/backlog' ||
+      pathname.startsWith('/backlog/'))
+  ) {
     const loginUrl = new URL('/login', request.url);
     loginUrl.searchParams.set('redirect', pathname);
     return NextResponse.redirect(loginUrl);
   }
 
-  // Defense-in-depth: block non-superadmin users from accessing /admin routes.
-  // This decodes the JWT payload (without signature verification) to check for
-  // superadmin privileges. Actual auth verification happens at the API level.
-  if (token && (pathname === '/admin' || pathname.startsWith('/admin/'))) {
+  // Defense-in-depth: block non-superadmin users from accessing /admin routes
+  // (and the equivalent internal /backlog roadmap). This decodes the JWT
+  // payload (without signature verification) to check for superadmin
+  // privileges. Actual auth verification happens at the API level.
+  if (
+    token &&
+    (pathname === '/admin' ||
+      pathname.startsWith('/admin/') ||
+      pathname === '/backlog' ||
+      pathname.startsWith('/backlog/'))
+  ) {
     const payload = decodeJwtPayload(token);
     if (!payload || !isSuperAdminFromPayload(payload)) {
       const dashboardUrl = new URL('/dashboard', request.url);


### PR DESCRIPTION
**Batch PR-5** of the 2026-07-10 improvement backlog. Closes **notifications #10, mcp #4, web #15, mcp #14** — four independent silent-failure / info-leak fixes.

- **notifications #10 — silent no-op deletion email.** `auth.service.ts` called `this.mailService.sendAccountDeletionEmail?.(…)` on a method that **never existed**; the `?.` swallowed it, so the deletion confirmation silently never sent. Implemented the method (`mail.service.ts`, escaped display name, non-critical) and dropped the `?.` so a future rename fails at compile time.
- **mcp #4 (§12b) — unaudited write mutation.** When an MCP **write** tool's audit row fails to write, the mutation (which may be a real lifecycle **customer email**) previously succeeded with only a `logger.error`. Now it fires an **out-of-band Sentry alert** at the write site (established §12b channel — `CircuitBreakerService` precedent), gated on `:write` scope; the read path stays log-only.
- **web #15 — public roadmap leak.** `/backlog` (launch gates, budget notes, competitor gaps) was in `publicPaths` → served with no auth. Removed it **and** gated `/backlog` like `/admin` (superadmin-only). Removal alone would NOT have closed it — the auth gate only fires for `/dashboard` + `/admin` prefixes, so a bare removal still fell through to `NextResponse.next()`. (`app/backlog/page.tsx` is a pure duplicate of the superadmin `/admin/backlog`.)
- **mcp #14 — stored-XSS.** `create_support_message` content bypassed the global `SanitizeInterceptor` (`@SkipInputSanitize()` on the MCP tree); now sanitized server-side with the interceptor's own config before it's stored + rendered in the support thread.

## Verification (independently re-run)
- middleware `tsc` 0 · web `tsc` 0 · `mail|mcp|auth` **391/391** · `eslint` 0 errors.

## Follow-ups (noted, not in this batch)
The §12b alert has no dedup (one Sentry event per failed write-tool call if the audit DB is down under load) — acceptable for a conservative fix, worth a rate-limit if noisy. Dedicated regression tests for the sanitize + `/backlog` gating are candidates for a later test-hardening pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)