### PR TITLE
fix(billing): enforce entitlement ladder; keep paid access on cancel; preserve interval (PR-6)

### DIFF
--- a/middleware/src/modules/billing/billing.service.spec.ts
+++ b/middleware/src/modules/billing/billing.service.spec.ts
@@ -67,6 +67,7 @@ describe('BillingService', () => {
     currentPeriodEnd: new Date('2024-02-01'),
     cancelAtPeriodEnd: false,
     priceId: 'price_basic',
+    interval: 'monthly' as const,
   };
 
   const mockInvoices = [
@@ -93,6 +94,9 @@ describe('BillingService', () => {
       billingTransaction: {
         create: jest.fn(),
       },
+      // updateSubscription wraps its local write in $transaction — run the
+      // callback against the same mock so tx.organization.update is captured.
+      $transaction: jest.fn(async (cb: any) => cb(mockDatabaseService)),
     };
 
     mockStripeProvider = {
@@ -491,7 +495,10 @@ describe('BillingService', () => {
   });
 
   describe('cancelSubscription', () => {
-    it('should cancel subscription at period end', async () => {
+    it('cancel-at-period-end (Stripe) does NOT revoke paid access — status stays active', async () => {
+      // Fix #3: Stripe keeps the sub active through the paid period
+      // (cancel_at_period_end=true). We must NOT flip local status to 'canceled'
+      // or SubscriptionActiveGuard would block writes the customer paid for.
       mockDatabaseService.organization.findUnique.mockResolvedValue(mockOrganization);
       mockStripeProvider.cancelSubscription.mockResolvedValue(undefined);
       mockDatabaseService.organization.update.mockResolvedValue({});
@@ -503,11 +510,36 @@ describe('BillingService', () => {
       const result = await service.cancelSubscription('org-123', false);
 
       expect(mockStripeProvider.cancelSubscription).toHaveBeenCalledWith('sub_stripe123', false);
+      // No local status write on the Stripe grace path — status is untouched.
+      expect(mockDatabaseService.organization.update).not.toHaveBeenCalled();
+      // getSubscriptionStatus reflects the still-active sub + cancelAtPeriodEnd.
+      expect(result.subscriptionStatus).toBe('active');
+      expect(result.cancelAtPeriodEnd).toBe(true);
+    });
+
+    it('cancel-at-period-end (Razorpay) finalizes immediately — provider cancels now, no grace', async () => {
+      // Razorpay's cancel(id, false) cancels IMMEDIATELY, so we mirror the
+      // provider by finalizing local status to 'canceled' (documented behavior).
+      const razorpayOrg = {
+        ...mockOrganization,
+        stripeCustomerId: null,
+        stripeSubscriptionId: null,
+        razorpayCustomerId: 'cust_razorpay123',
+        razorpaySubscriptionId: 'sub_razorpay123',
+        paymentProvider: 'razorpay',
+      };
+      mockDatabaseService.organization.findUnique.mockResolvedValue(razorpayOrg);
+      mockRazorpayProvider.cancelSubscription.mockResolvedValue(undefined);
+      mockRazorpayProvider.getSubscription.mockResolvedValue(null);
+      mockDatabaseService.organization.update.mockResolvedValue({});
+
+      await service.cancelSubscription('org-123', false);
+
+      expect(mockRazorpayProvider.cancelSubscription).toHaveBeenCalledWith('sub_razorpay123', false);
       expect(mockDatabaseService.organization.update).toHaveBeenCalledWith({
         where: { id: 'org-123' },
         data: { subscriptionStatus: 'canceled' },
       });
-      expect(result).toBeDefined();
     });
 
     it('should cancel subscription immediately and downgrade to free', async () => {
@@ -538,6 +570,88 @@ describe('BillingService', () => {
       });
 
       await expect(service.cancelSubscription('org-123')).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('updateSubscription', () => {
+    it('preserves a YEARLY subscriber interval on plan change (no silent monthly re-bill)', async () => {
+      // Fix #4: a yearly subscriber changing plans must stay yearly. The interval
+      // is read from the live Stripe subscription, not hardcoded to monthly.
+      mockDatabaseService.organization.findUnique.mockResolvedValue(mockOrganization);
+      mockStripeProvider.getSubscription.mockResolvedValue({
+        ...mockSubscription,
+        interval: 'yearly',
+      });
+      mockStripeProvider.updateSubscription.mockResolvedValue({
+        ...mockSubscription,
+        interval: 'yearly',
+      });
+      mockDatabaseService.organization.update.mockResolvedValue({});
+
+      await service.updateSubscription('org-123', { planId: 'pro' });
+
+      // STRIPE_PRO_YEARLY_PRICE_ID = 'price_pro_yearly' (set in beforeAll).
+      expect(mockStripeProvider.updateSubscription).toHaveBeenCalledWith(
+        'sub_stripe123',
+        'price_pro_yearly',
+      );
+    });
+
+    it('keeps a MONTHLY subscriber on monthly', async () => {
+      mockDatabaseService.organization.findUnique.mockResolvedValue(mockOrganization);
+      mockStripeProvider.getSubscription.mockResolvedValue({
+        ...mockSubscription,
+        interval: 'monthly',
+      });
+      mockStripeProvider.updateSubscription.mockResolvedValue({
+        ...mockSubscription,
+        interval: 'monthly',
+      });
+      mockDatabaseService.organization.update.mockResolvedValue({});
+
+      await service.updateSubscription('org-123', { planId: 'pro' });
+
+      expect(mockStripeProvider.updateSubscription).toHaveBeenCalledWith(
+        'sub_stripe123',
+        'price_pro_monthly',
+      );
+    });
+
+    it('refuses the plan change when the current interval cannot be determined (no wrong charge)', async () => {
+      mockDatabaseService.organization.findUnique.mockResolvedValue(mockOrganization);
+      // Live sub exposes no monthly/yearly interval (e.g. week/day price or a
+      // failed provider fetch). Must fail loudly rather than default to monthly.
+      mockStripeProvider.getSubscription.mockResolvedValue({
+        ...mockSubscription,
+        interval: undefined,
+      });
+
+      await expect(
+        service.updateSubscription('org-123', { planId: 'pro' }),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockStripeProvider.updateSubscription).not.toHaveBeenCalled();
+    });
+
+    it('uses the interval-agnostic Razorpay plan id on plan change', async () => {
+      const razorpayOrg = {
+        ...mockOrganization,
+        stripeSubscriptionId: null,
+        razorpaySubscriptionId: 'sub_razorpay123',
+        razorpayCustomerId: 'cust_razorpay123',
+        paymentProvider: 'razorpay',
+      };
+      mockDatabaseService.organization.findUnique.mockResolvedValue(razorpayOrg);
+      mockRazorpayProvider.updateSubscription.mockResolvedValue({});
+      mockRazorpayProvider.getSubscription.mockResolvedValue(null);
+      mockDatabaseService.organization.update.mockResolvedValue({});
+
+      await service.updateSubscription('org-123', { planId: 'pro' });
+
+      // RAZORPAY_PRO_PLAN_ID = 'plan_pro_inr' (set in beforeAll); no interval dimension.
+      expect(mockRazorpayProvider.updateSubscription).toHaveBeenCalledWith(
+        'sub_razorpay123',
+        'plan_pro_inr',
+      );
     });
   });
 

--- a/middleware/src/modules/billing/billing.service.ts
+++ b/middleware/src/modules/billing/billing.service.ts
@@ -338,11 +338,30 @@ export class BillingService implements OnModuleInit {
         throw new BadRequestException('Invalid plan');
       }
 
-      // Get price ID from environment at runtime
-      const priceId =
-        org.paymentProvider === 'stripe'
-          ? getStripePriceId(dto.planId, 'monthly') // Default to monthly for upgrades
-          : getRazorpayPlanId(dto.planId);
+      // Resolve the new price ID, preserving the subscriber's CURRENT billing
+      // interval. A yearly subscriber changing plans must stay yearly —
+      // hardcoding 'monthly' here silently re-bills them at the wrong amount and
+      // cadence. The interval isn't stored locally, so read it from the live
+      // provider subscription (Stripe price recurring.interval).
+      let priceId: string | undefined;
+      if (org.paymentProvider === 'stripe') {
+        const currentSub = await provider.getSubscription(subscriptionId);
+        const interval = currentSub?.interval;
+        if (!interval) {
+          // Never fall back to a concrete interval on a re-bill path: an unknown
+          // interval must fail loudly rather than risk an incorrect charge.
+          throw new BadRequestException(
+            'Unable to determine the current billing interval for this subscription; ' +
+              'refusing to change plans to avoid an incorrect charge.',
+          );
+        }
+        priceId = getStripePriceId(dto.planId, interval);
+      } else {
+        // Razorpay plan IDs are interval-agnostic (getRazorpayPlanId resolves one
+        // plan id per tier, with no monthly/yearly dimension), so there is no
+        // interval to preserve on this path.
+        priceId = getRazorpayPlanId(dto.planId);
+      }
 
       if (!priceId) {
         throw new BadRequestException(`Price not configured for ${dto.planId}`);
@@ -433,8 +452,21 @@ export class BillingService implements OnModuleInit {
             org.paymentProvider === 'razorpay' ? null : org.razorpaySubscriptionId,
         },
       });
+    } else if (org.paymentProvider === 'stripe') {
+      // "Cancel at period end": provider.cancelSubscription(id, false) set
+      // Stripe's cancel_at_period_end=true and the subscription stays ACTIVE
+      // through the paid period. Do NOT flip the local status to 'canceled' —
+      // that would revoke dashboard write access the customer already paid for.
+      // Leave subscriptionStatus untouched; getSubscriptionStatus derives
+      // cancelAtPeriodEnd from the live sub, so the UI shows "access until
+      // {periodEnd}" + a Reactivate action. Finalization to free/canceled happens
+      // on the customer.subscription.deleted webhook (handleSubscriptionCanceled)
+      // when Stripe actually ends the subscription at period end.
     } else {
-      // Mark as pending cancellation
+      // Razorpay: provider.cancelSubscription(id, false) maps to the SDK's
+      // cancel_at_cycle_end=false, which cancels the subscription IMMEDIATELY —
+      // there is no period-end grace to honor. Finalize locally to match the
+      // provider rather than fake a grace it won't keep. (Existing behavior.)
       await this.db.organization.update({
         where: { id: organizationId },
         data: {

--- a/middleware/src/modules/billing/entitlement.service.spec.ts
+++ b/middleware/src/modules/billing/entitlement.service.spec.ts
@@ -63,7 +63,30 @@ describe('EntitlementService (B3 ladder)', () => {
     );
     const { advanced } = await service.advanceLadder(NOW);
     expect(advanced).toBe(0);
-    expect(db.organization.updateMany).not.toHaveBeenCalled();
+    // No RUNG ADVANCE (a status flip). The unconditional heal updateMany
+    // (data: { entitlementStateSince }) may run; assert only that no status
+    // transition happened.
+    expect(db.organization.updateMany).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ subscriptionStatus: expect.anything() }),
+      }),
+    );
+  });
+
+  it('heals an un-stamped dunning org so it is never invisible to the ladder', async () => {
+    // Regression for the webhook-ordering leak: an org set to past_due via
+    // handleSubscriptionUpdated (out-of-order Stripe events) has
+    // entitlementStateSince=null and would otherwise never be advanced —
+    // holding full access forever. advanceLadder stamps it from first-sight.
+    db.organization.findMany.mockResolvedValue([]);
+    await service.advanceLadder(NOW);
+    expect(db.organization.updateMany).toHaveBeenCalledWith({
+      where: {
+        subscriptionStatus: { in: ['past_due', 'publish_locked', 'suspended'] },
+        entitlementStateSince: null,
+      },
+      data: { entitlementStateSince: NOW },
+    });
   });
 
   it('advances past_due → publish_locked at exactly day 7, and emits NO device signal', async () => {

--- a/middleware/src/modules/billing/entitlement.service.ts
+++ b/middleware/src/modules/billing/entitlement.service.ts
@@ -113,6 +113,25 @@ export class EntitlementService {
   async advanceLadder(now = new Date()): Promise<{ advanced: number }> {
     let advanced = 0;
 
+    // Heal un-stamped dunning orgs. An org can enter a dunning rung via a path
+    // that never stamps the episode clock: handleSubscriptionUpdated writes
+    // subscriptionStatus directly (billing.service), and Stripe does not
+    // guarantee webhook ordering — a `customer.subscription.updated(past_due)`
+    // can land BEFORE `invoice.payment_failed` runs beginPastDue, whose
+    // updateMany is guarded on status IN (active,trial) and so no-ops once the
+    // status is already past_due. Result: entitlementStateSince stays null, and
+    // advanceRung's `entitlementStateSince: { not: null }` filter never sees the
+    // org → it holds full (post-#6 SubscriptionActiveGuard) access in the rung
+    // FOREVER, and dunning never enforces. Stamp any un-stamped dunning org from
+    // first-sight (fail-closed; the grace clock simply starts now).
+    await this.db.organization.updateMany({
+      where: {
+        subscriptionStatus: { in: ['past_due', 'publish_locked', 'suspended'] },
+        entitlementStateSince: null,
+      },
+      data: { entitlementStateSince: now },
+    });
+
     // Rung 1: past_due → publish_locked (screens still play; no device signal)
     advanced += await this.advanceRung(
       'past_due',

--- a/middleware/src/modules/billing/guards/entitlement-publish.guard.spec.ts
+++ b/middleware/src/modules/billing/guards/entitlement-publish.guard.spec.ts
@@ -4,8 +4,8 @@ import { EntitlementPublishGuard } from './entitlement-publish.guard';
 /** B3 — publish-lock gate. Blocks NEW publishing at publish_locked/suspended;
  *  allows everything else; fails OPEN on infra error (dunning tool, not security). */
 describe('EntitlementPublishGuard', () => {
-  const makeCtx = (organizationId?: string) => ({
-    switchToHttp: () => ({ getRequest: () => ({ user: { organizationId } }) }),
+  const makeCtx = (organizationId?: string, body?: Record<string, unknown>) => ({
+    switchToHttp: () => ({ getRequest: () => ({ user: { organizationId }, body }) }),
   }) as any;
 
   const guard = (status: string | null, throwOnRead = false) => {
@@ -41,5 +41,25 @@ describe('EntitlementPublishGuard', () => {
 
   it('defers to the auth guard when there is no organization on the request', async () => {
     expect(await guard('publish_locked').canActivate(makeCtx(undefined))).toBe(true);
+  });
+
+  // Fleet command carve-out: POST /fleet/commands multiplexes device commands.
+  // Only `push_content` is a publish; the rest stay available while locked.
+  it('allows a non-publish fleet command (reboot) even when publish_locked', async () => {
+    expect(
+      await guard('publish_locked').canActivate(makeCtx('o1', { command: 'reboot' })),
+    ).toBe(true);
+  });
+
+  it('BLOCKS the fleet push_content command when publish_locked', async () => {
+    await expect(
+      guard('publish_locked').canActivate(makeCtx('o1', { command: 'push_content' })),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('allows the fleet push_content command when active', async () => {
+    expect(
+      await guard('active').canActivate(makeCtx('o1', { command: 'push_content' })),
+    ).toBe(true);
   });
 });

--- a/middleware/src/modules/billing/guards/entitlement-publish.guard.ts
+++ b/middleware/src/modules/billing/guards/entitlement-publish.guard.ts
@@ -20,12 +20,29 @@ import { DatabaseService } from '../../database/database.service';
  */
 const PUBLISH_BLOCKED_STATUSES = new Set(['publish_locked', 'suspended']);
 
+// The fleet command endpoint (POST /fleet/commands) multiplexes several device
+// commands through a single handler. Only `push_content` publishes NEW content
+// to a screen; the others (reload/restart/reboot/clear_cache/update) are device
+// management that must stay available at the publish_locked rung. When this guard
+// runs on a request carrying a fleet command envelope, it enforces ONLY for the
+// publish command. Requests to the dedicated push/assign endpoints carry no
+// `command` field, so this carve-out never affects them.
+const FLEET_PUBLISH_COMMAND = 'push_content';
+
 @Injectable()
 export class EntitlementPublishGuard implements CanActivate {
   constructor(private readonly db: DatabaseService) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
+
+    // Fleet carve-out: a non-publish fleet command is not a "publish" and stays
+    // allowed while publishing is locked. Only `push_content` is gated.
+    const command = request.body?.command;
+    if (typeof command === 'string' && command !== FLEET_PUBLISH_COMMAND) {
+      return true;
+    }
+
     const organizationId = request.user?.organizationId;
     if (!organizationId) return true; // auth guard owns the unauthenticated case
 

--- a/middleware/src/modules/billing/guards/subscription-active.guard.spec.ts
+++ b/middleware/src/modules/billing/guards/subscription-active.guard.spec.ts
@@ -201,10 +201,35 @@ describe('SubscriptionActiveGuard', () => {
       });
     });
 
-    describe('when subscription is past_due', () => {
-      it('should deny access', async () => {
+    describe('entitlement ladder (B3) — dunning rungs keep dashboard writes', () => {
+      it('should ALLOW past_due writes (7-day grace; one failed card must not lock the dashboard)', async () => {
+        mockRequest.method = 'POST';
         mockDatabaseService.organization.findUnique.mockResolvedValue({
           subscriptionStatus: 'past_due',
+          trialEndsAt: null,
+        } as any);
+
+        const result = await guard.canActivate(mockExecutionContext);
+
+        expect(result).toBe(true);
+      });
+
+      it('should ALLOW publish_locked writes (publishing is gated separately by EntitlementPublishGuard)', async () => {
+        mockRequest.method = 'POST';
+        mockDatabaseService.organization.findUnique.mockResolvedValue({
+          subscriptionStatus: 'publish_locked',
+          trialEndsAt: null,
+        } as any);
+
+        const result = await guard.canActivate(mockExecutionContext);
+
+        expect(result).toBe(true);
+      });
+
+      it('should BLOCK suspended writes (screens keep playing via tenant:suspended device signal)', async () => {
+        mockRequest.method = 'POST';
+        mockDatabaseService.organization.findUnique.mockResolvedValue({
+          subscriptionStatus: 'suspended',
           trialEndsAt: null,
         } as any);
 

--- a/middleware/src/modules/billing/guards/subscription-active.guard.ts
+++ b/middleware/src/modules/billing/guards/subscription-active.guard.ts
@@ -15,6 +15,18 @@ import { IS_PUBLIC_KEY } from '../../auth/decorators/public.decorator';
  * Free tier: Users whose trial has expired retain limited write access for core
  * operations (device pairing, content push, content upload within quota).
  * The free tier is subject to quota limits enforced separately by QuotaGuard.
+ *
+ * Entitlement ladder (B3) — dashboard WRITE access per subscription rung:
+ *   active / trial (not expired) / free → FULL write access.
+ *   past_due       → FULL write access (7-day dunning grace; banner only, no
+ *                    enforcement — one failed card must NOT lock the dashboard).
+ *   publish_locked → FULL write access EXCEPT publishing NEW content, which is
+ *                    gated separately by EntitlementPublishGuard on the
+ *                    push/assign endpoints. Screens keep playing.
+ *   suspended      → all writes blocked (screens keep playing via the separate
+ *                    tenant:suspended device signal).
+ *   canceled / any other inactive state → all writes blocked.
+ * Publishing itself is NOT gated here — that is EntitlementPublishGuard's job.
  */
 @Injectable()
 export class SubscriptionActiveGuard implements CanActivate {
@@ -76,6 +88,21 @@ export class SubscriptionActiveGuard implements CanActivate {
     // basic operations like pairing devices, pushing content, and uploading
     // within their quota limits. Premium features are gated separately.
     if (org.subscriptionTier === 'free') {
+      return true;
+    }
+
+    // Dunning rungs that KEEP dashboard write access (B3 ladder):
+    //   past_due       → 7-day grace; a single failed charge must not lock the
+    //                    dashboard. Banner-only; no write enforcement yet.
+    //   publish_locked → general dashboard writes stay allowed; only publishing
+    //                    NEW content to screens is blocked, and that is enforced
+    //                    by EntitlementPublishGuard on the publish/assign/push
+    //                    endpoints — NOT here.
+    // suspended / canceled / any other inactive state fall through to the throw.
+    if (
+      org.subscriptionStatus === 'past_due' ||
+      org.subscriptionStatus === 'publish_locked'
+    ) {
       return true;
     }
 

--- a/middleware/src/modules/billing/providers/payment-provider.interface.ts
+++ b/middleware/src/modules/billing/providers/payment-provider.interface.ts
@@ -21,6 +21,15 @@ export interface Subscription {
   currentPeriodEnd: Date;
   cancelAtPeriodEnd: boolean;
   priceId: string;
+  /**
+   * Normalized billing interval of the subscription's price
+   * (Stripe price `recurring.interval`: month → 'monthly', year → 'yearly').
+   * Undefined when the provider does not expose it or the interval is neither
+   * monthly nor yearly. Consumers must NOT default a missing interval to a
+   * concrete value on a re-bill path — an unknown interval means "refuse and
+   * surface" rather than "assume monthly".
+   */
+  interval?: 'monthly' | 'yearly';
   metadata?: Record<string, unknown>;
 }
 

--- a/middleware/src/modules/billing/providers/stripe.provider.ts
+++ b/middleware/src/modules/billing/providers/stripe.provider.ts
@@ -242,7 +242,21 @@ export class StripeProvider implements PaymentProvider {
       currentPeriodEnd: new Date(sub.current_period_end * 1000),
       cancelAtPeriodEnd: sub.cancel_at_period_end,
       priceId: sub.items.data[0]?.price.id || '',
+      interval: this.mapInterval(sub.items.data[0]?.price.recurring?.interval),
       metadata: sub.metadata,
     };
+  }
+
+  /**
+   * Normalize Stripe's price `recurring.interval` to our plan interval. Only
+   * month/year map; anything else (week/day/absent) returns undefined so callers
+   * on a re-bill path refuse rather than silently pick a wrong cadence.
+   */
+  private mapInterval(
+    interval: Stripe.Price.Recurring.Interval | undefined,
+  ): 'monthly' | 'yearly' | undefined {
+    if (interval === 'month') return 'monthly';
+    if (interval === 'year') return 'yearly';
+    return undefined;
   }
 }

--- a/middleware/src/modules/displays/displays.controller.ts
+++ b/middleware/src/modules/displays/displays.controller.ts
@@ -20,6 +20,7 @@ import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CheckQuota } from '../billing/decorators/check-quota.decorator';
 import { RequiresSubscription } from '../billing/decorators/requires-subscription.decorator';
+import { EntitlementPublishGuard } from '../billing/guards/entitlement-publish.guard';
 import { DisplaysService } from './displays.service';
 import { CreateDisplayDto } from './dto/create-display.dto';
 import { UpdateDisplayDto } from './dto/update-display.dto';
@@ -74,8 +75,12 @@ export class DisplaysController {
     return this.displaysService.bulkDelete(organizationId, dto.displayIds);
   }
 
+  // Publishing NEW content to screens (assigning a playlist to displays) is
+  // gated at the publish_locked/suspended rungs — screens keep playing their
+  // current playlist, but a past-due tenant can't push new playlists out.
   @Post('bulk/assign-playlist')
   @Roles('admin', 'manager')
+  @UseGuards(EntitlementPublishGuard)
   bulkAssignPlaylist(
     @CurrentUser('organizationId') organizationId: string,
     @Body() dto: BulkAssignPlaylistDto,
@@ -189,8 +194,11 @@ export class DisplaysController {
     return this.displaysService.enableDevice(id, organizationId);
   }
 
+  // Pushing NEW content to a display is a publish action — gated at
+  // publish_locked/suspended. The screen keeps playing its current content.
   @Post(':id/push-content')
   @Roles('admin', 'manager')
+  @UseGuards(EntitlementPublishGuard)
   pushContent(
     @CurrentUser('organizationId') organizationId: string,
     @Param('id', ParseUUIDPipe) id: string,

--- a/middleware/src/modules/fleet/fleet.controller.ts
+++ b/middleware/src/modules/fleet/fleet.controller.ts
@@ -12,6 +12,7 @@ import {
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { RequiresSubscription } from '../billing/decorators/requires-subscription.decorator';
+import { EntitlementPublishGuard } from '../billing/guards/entitlement-publish.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { FleetService } from './fleet.service';
 import { SendCommandDto } from './dto/send-command.dto';
@@ -22,8 +23,13 @@ import { SendCommandDto } from './dto/send-command.dto';
 export class FleetController {
   constructor(private readonly fleetService: FleetService) {}
 
+  // This endpoint multiplexes device commands. EntitlementPublishGuard enforces
+  // ONLY the `push_content` command at the publish_locked/suspended rungs (its
+  // fleet carve-out lets reload/restart/reboot/clear_cache/update through, since
+  // those are device management, not publishing NEW content).
   @Post('commands')
   @Roles('admin', 'manager')
+  @UseGuards(EntitlementPublishGuard)
   async sendCommand(
     @CurrentUser() user: any,
     @CurrentUser('organizationId') orgId: string,


### PR DESCRIPTION
**Batch PR-6** of the 2026-07-10 improvement backlog. **Money-critical.** Closes **billing #1, #3, #4**. Under 3-vector adversarial review (correctness / money-math / tenant-scope) before merge.

## #1 — the entitlement ladder was collapsed
`EntitlementPublishGuard` (the purpose-built publish lock) was wired to **zero** controllers, and `SubscriptionActiveGuard` blocked **all** non-GET writes the instant status left `active`/`trial` — so one failed card (`past_due`) immediately killed the whole dashboard.
- `SubscriptionActiveGuard` now allows `past_due` (full — 7-day dunning grace) and `publish_locked` (non-publish writes); `suspended`/`canceled` still blocked.
- `EntitlementPublishGuard` wired onto the genuine publish/push endpoints: `POST /displays/:id/push-content`, `POST /displays/bulk/assign-playlist`, and the **`push_content`** fleet command (via a body-`command` carve-out so reload/restart/etc. pass through). Plain edits, uploads, folder ops, and group-membership are intentionally **not** guarded.

**Resulting ladder:** active/trial/free/`past_due` = full · `publish_locked` = everything except publishing · `suspended`/`canceled` = writes blocked (screens keep playing).

## #3 — "cancel at period end" no longer revokes paid access
Stripe non-immediate cancel keeps `status = active` (Stripe holds `cancel_at_period_end`, derived live by `getSubscriptionStatus`); the `customer.subscription.deleted` webhook (`handleSubscriptionCanceled`) finalizes downgrade + `canceled` at period end. Razorpay cancels immediately (verified against the SDK), so it keeps its local finalize.

## #4 — plan change no longer silently re-bills yearly as monthly
`updateSubscription` carries the current interval from the live Stripe subscription (`price.recurring.interval`, now surfaced on the mapped `Subscription`) instead of hardcoding `'monthly'`; **throws `BadRequest` if the interval can't be determined** rather than sending a wrong charge.

## Verification (independently re-run)
- middleware `tsc` 0 · billing + guards **215/215** · `eslint` 0 errors.

## Known / flagged
- No `interval` dimension exists for Razorpay plan ids (one env var per tier) — Fix #4 is Stripe-only; Razorpay path left interval-agnostic.
- Pre-existing Razorpay `cancelAtCycleEnd` semantic inversion noted (not changed here).
- Whether `past_due` escalates to `publish_locked` after the 7-day grace (an escalation cron) is being checked by the money-math review — a follow-up if absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)