### PR TITLE
fix(billing): unwrap Razorpay webhook .entity; ack 200 on duplicate delivery (PR-7a)

### DIFF
--- a/middleware/src/modules/billing/providers/razorpay.provider.spec.ts
+++ b/middleware/src/modules/billing/providers/razorpay.provider.spec.ts
@@ -474,6 +474,36 @@ describe('RazorpayProvider', () => {
       expect(provider.verifyWebhookSignature(payload, expectedSignature).id).toBe(result.id);
     });
 
+    it('unwraps the real payload.<entity>.entity nesting so handlers read fields directly (billing #6)', () => {
+      // Real Razorpay webhook shape: each entity is nested under `.entity`.
+      const payload = Buffer.from(
+        JSON.stringify({
+          event: 'subscription.charged',
+          payload: {
+            subscription: { entity: { id: 'sub_1', customer_id: 'cust_9', status: 'active' } },
+            payment: { entity: { id: 'pay_1', amount: 379900, currency: 'INR' } },
+          },
+        }),
+      );
+      const signature = crypto
+        .createHmac('sha256', 'webhook_secret_123')
+        .update(payload)
+        .digest('hex');
+
+      const { data } = provider.verifyWebhookSignature(payload, signature) as unknown as {
+        data: {
+          subscription: { customer_id: string; status: string };
+          payment: { amount: number };
+        };
+      };
+
+      // The .entity layer is unwrapped: without this, data.subscription.customer_id
+      // and data.payment.amount would be undefined and the event silently dropped.
+      expect(data.subscription).toEqual({ id: 'sub_1', customer_id: 'cust_9', status: 'active' });
+      expect(data.subscription.customer_id).toBe('cust_9');
+      expect(data.payment.amount).toBe(379900);
+    });
+
     it('should throw on invalid signature', () => {
       const payload = Buffer.from(
         JSON.stringify({

--- a/middleware/src/modules/billing/providers/razorpay.provider.ts
+++ b/middleware/src/modules/billing/providers/razorpay.provider.ts
@@ -9,6 +9,7 @@ import {
   Subscription,
   Invoice,
   WebhookEvent,
+  WebhookEventData,
 } from './payment-provider.interface';
 import { CircuitBreakerService } from '../../common/services/circuit-breaker.service';
 
@@ -195,13 +196,27 @@ export class RazorpayProvider implements PaymentProvider {
     }
 
     const event = JSON.parse(payload.toString());
+    // Razorpay nests each entity under payload.<entity>.entity (e.g.
+    // payload.subscription.entity, payload.payment.entity, payload.invoice.entity),
+    // whereas the billing webhook handlers read data.subscription.customer_id /
+    // data.payment.amount / data.invoice.customer_id directly. Unwrap the .entity
+    // layer here — otherwise customerId/amount resolve to undefined and every
+    // Razorpay money event is silently dropped (billing #6).
+    const rawPayload: Record<string, unknown> = event.payload ?? {};
+    const data: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(rawPayload)) {
+      data[key] =
+        value && typeof value === 'object' && 'entity' in value
+          ? (value as { entity: unknown }).entity
+          : value;
+    }
     return {
       // Razorpay has no top-level event id in the body; derive a stable id from
       // the signed payload. Retries of the same event carry an identical body →
       // identical hash → deduped; genuinely different events differ → not deduped.
       id: `rzp_${crypto.createHash('sha256').update(payload).digest('hex').slice(0, 40)}`,
       type: event.event,
-      data: event.payload,
+      data: data as WebhookEventData,
     };
   }
 


### PR DESCRIPTION
**Batch PR-7a** of the 2026-07-10 backlog. Money-path. Closes **billing #6, #10**. Both **§9a-confirmed** (Razorpay webhook docs + prod state) before writing code.

## #6 — Razorpay webhook payload was mis-parsed → every money event silently dropped
`verifyWebhookSignature` returned `data: event.payload`, but Razorpay nests each entity under `payload.<entity>.entity` (`payload.subscription.entity`, `payload.payment.entity`, …). The provider-aware handlers read `data.subscription.customer_id` / `data.payment.amount` directly, so `customerId`/`amount` were `undefined` and every event hit the `if (!customerId) return` guard — **no transaction, no receipt, no ladder recovery**. The provider now unwraps the `.entity` layer. **Razorpay-only** — Stripe uses its own parser (verified: handlers branch on `provider`, and the Stripe paths use `data.customer`/`data.id` from Stripe's separate `verifyWebhookSignature`).

## #10 — duplicate delivery → infinite PSP retry loop
Both webhook controllers mapped any non-`ServiceUnavailable` error to **401 "invalid signature"**. A replayed payment hitting the unique `(provider, providerTransactionId)` constraint raises a Prisma **P2002 → 401 → the PSP retries forever**. A duplicate now **acks 200** (`{received, deduped}`).

## Tests
- Real nested-payload fixture proves the `.entity` unwrap (`data.subscription.customer_id`, `data.payment.amount` resolve).
- P2002 → 200 (not 401).
- Verified: middleware `tsc` 0 · billing/razorpay/webhook **281/281**.

## Note
The persistent `processed_webhook_events` table (backlog #10's durable-dedup half) is deferred — the P2002→200 fix stops the retry loop without a schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)