### PR TITLE
fix(storage): proxy content download + avatar through authenticated middleware (PR-7b)

### DIFF
--- a/middleware/src/modules/auth/auth.controller.spec.ts
+++ b/middleware/src/modules/auth/auth.controller.spec.ts
@@ -43,8 +43,8 @@ describe('AuthController', () => {
       resetPassword: jest.fn(),
       changePassword: jest.fn(),
       deleteAccount: jest.fn(),
-      getAvatarUrl: jest.fn().mockResolvedValue(null),
-      uploadAvatar: jest.fn(),
+      getAvatarStream: jest.fn().mockResolvedValue(null),
+      uploadAvatar: jest.fn().mockResolvedValue(undefined),
       deleteAvatar: jest.fn(),
     };
 
@@ -345,11 +345,38 @@ describe('AuthController', () => {
   });
 
   describe('getMe', () => {
-    it('should return current user data', async () => {
+    it('should return current user data with null avatarUrl when no avatar is set', async () => {
       const result = await controller.getMe(mockUser);
 
       expect(result.success).toBe(true);
       expect(result.data.user).toEqual({ ...mockUser, avatarUrl: null });
+    });
+
+    it('should return the stable proxied avatar URL when an avatar is set', async () => {
+      const result = await controller.getMe({
+        ...mockUser,
+        avatar: 'avatars/user-123.jpg',
+      } as any);
+
+      expect(result.data.user.avatarUrl).toBe('/api/v1/auth/me/avatar');
+    });
+  });
+
+  describe('uploadAvatar', () => {
+    it('should return a cache-busted proxied avatar URL', async () => {
+      const file = {
+        buffer: Buffer.from('img'),
+        mimetype: 'image/png',
+      } as Express.Multer.File;
+
+      const result = await controller.uploadAvatar('user-123', file);
+
+      expect(authService.uploadAvatar).toHaveBeenCalledWith('user-123', {
+        buffer: file.buffer,
+        mimetype: 'image/png',
+      });
+      expect(result.success).toBe(true);
+      expect(result.data.avatarUrl).toMatch(/^\/api\/v1\/auth\/me\/avatar\?v=\d+$/);
     });
   });
 

--- a/middleware/src/modules/auth/auth.controller.ts
+++ b/middleware/src/modules/auth/auth.controller.ts
@@ -1,6 +1,9 @@
-import { Controller, Post, Patch, Body, UseGuards, Get, Delete, Res, Req, HttpCode, HttpStatus, BadRequestException, UseInterceptors, UploadedFile } from '@nestjs/common';
+import { Controller, Post, Patch, Body, UseGuards, Get, Delete, Res, Req, HttpCode, HttpStatus, BadRequestException, NotFoundException, UseInterceptors, UploadedFile } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { Request, Response } from 'express';
+import { pipeline } from 'node:stream/promises';
+import { SkipEnvelope } from '../common/interceptors/response-envelope.interceptor';
+import { SkipOutputSanitize } from '../common/interceptors/sanitize.interceptor';
 import { Throttle } from '@nestjs/throttler';
 import {
   ApiTags,
@@ -39,6 +42,14 @@ const RATE_LIMIT_TTL_MS = 60_000;
 @Controller('auth')
 export class AuthController {
   constructor(private authService: AuthService) {}
+
+  /**
+   * Stable, browser-reachable avatar URL. Relative so it flows through the
+   * Next.js `/api/v1` rewrite proxy (same-origin cookies) and is served by the
+   * authenticated middleware proxy (GET /auth/me/avatar) — not a presigned
+   * MinIO URL, which is unreachable from the browser in prod (PR-7b).
+   */
+  private static readonly AVATAR_URL_PATH = '/api/v1/auth/me/avatar';
 
   /**
    * Set auth token as httpOnly cookie.
@@ -290,12 +301,43 @@ export class AuthController {
   @Get('me')
   async getMe(@CurrentUser() user: AuthenticatedUser) {
     const { passwordHash, password, ...safeUser } = user || {} as any;
-    // Resolve avatar storage key to a presigned URL
-    const avatarUrl = await this.authService.getAvatarUrl(safeUser.avatar || null);
+    // A stored avatar key resolves to the authenticated proxy URL; the actual
+    // bytes are streamed by GET /auth/me/avatar (PR-7b).
+    const avatarUrl = safeUser.avatar ? AuthController.AVATAR_URL_PATH : null;
     return {
       success: true,
       data: { user: { ...safeUser, avatarUrl } },
     };
+  }
+
+  @ApiOperation({ summary: 'Stream the authenticated user avatar image' })
+  @ApiBearerAuth('JWT-auth')
+  @ApiCookieAuth()
+  @ApiResponse({ status: 200, description: 'Avatar image stream.' })
+  @ApiResponse({ status: 404, description: 'No avatar set.' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @UseGuards(JwtAuthGuard)
+  @Get('me/avatar')
+  @SkipEnvelope()
+  @SkipOutputSanitize()
+  async getAvatar(
+    @CurrentUser('id') userId: string,
+    @Res() res: Response,
+  ): Promise<void> {
+    const avatar = await this.authService.getAvatarStream(userId);
+    if (!avatar) {
+      throw new NotFoundException('No avatar set');
+    }
+
+    res.set({
+      'Content-Type': avatar.contentType,
+      ...(avatar.contentLength ? { 'Content-Length': String(avatar.contentLength) } : {}),
+      // Same-origin (via the Next proxy); revalidate so a logged-out→logged-in
+      // switch on a shared browser can't show the previous user's avatar.
+      'Cache-Control': 'private, no-cache',
+    });
+
+    await pipeline(avatar.stream, res);
   }
 
   @ApiOperation({ summary: 'Update profile (name) for authenticated user' })
@@ -334,11 +376,14 @@ export class AuthController {
     if (!file) {
       throw new BadRequestException('No file provided');
     }
-    const result = await this.authService.uploadAvatar(userId, {
+    await this.authService.uploadAvatar(userId, {
       buffer: file.buffer,
       mimetype: file.mimetype,
     });
-    return { success: true, data: result };
+    // Cache-buster so the freshly-uploaded image reloads immediately even
+    // though the proxy URL path is stable.
+    const avatarUrl = `${AuthController.AVATAR_URL_PATH}?v=${Date.now()}`;
+    return { success: true, data: { avatarUrl } };
   }
 
   @ApiOperation({ summary: 'Delete avatar for authenticated user' })

--- a/middleware/src/modules/auth/auth.service.ts
+++ b/middleware/src/modules/auth/auth.service.ts
@@ -865,7 +865,7 @@ export class AuthService {
     return updated;
   }
 
-  async uploadAvatar(userId: string, file: { buffer: Buffer; mimetype: string }): Promise<{ avatarUrl: string }> {
+  async uploadAvatar(userId: string, file: { buffer: Buffer; mimetype: string }): Promise<void> {
     const allowedMimes = ['image/jpeg', 'image/png', 'image/webp'];
     if (!allowedMimes.includes(file.mimetype)) {
       throw new HttpException('Only JPEG, PNG, and WebP images are allowed', HttpStatus.BAD_REQUEST);
@@ -915,10 +915,11 @@ export class AuthService {
     // Invalidate user cache
     await this.redisService.del(`user_auth:${userId}`);
 
-    // Generate a presigned URL for immediate use
-    const avatarUrl = await this.storageService.getPresignedUrl(objectKey, 86400); // 24h
-
-    return { avatarUrl };
+    // The avatar is served through the authenticated middleware proxy
+    // (GET /auth/me/avatar), not a presigned MinIO URL — in prod MinIO is only
+    // reachable server-side, so a presigned localhost URL is dead in the
+    // browser. The controller builds the stable proxied URL from the stored
+    // object key (PR-7b).
   }
 
   async deleteAvatar(userId: string): Promise<void> {
@@ -944,14 +945,46 @@ export class AuthService {
     }
   }
 
-  async getAvatarUrl(avatarKey: string | null): Promise<string | null> {
-    if (!avatarKey) return null;
+  /**
+   * Open a readable stream for a user's avatar so it can be proxied through the
+   * authenticated middleware (GET /auth/me/avatar). Returns null when the user
+   * has no avatar, storage is unavailable, or the object is missing — the
+   * controller maps null to a 404.
+   *
+   * Replaces the old getAvatarUrl presigned-URL path: in prod MinIO is bound to
+   * localhost and not publicly reachable, so a presigned URL was dead in the
+   * browser (PR-7b).
+   */
+  async getAvatarStream(userId: string): Promise<{
+    stream: NodeJS.ReadableStream;
+    contentType: string;
+    contentLength?: number;
+  } | null> {
+    const user = await this.databaseService.user.findUnique({
+      where: { id: userId },
+      select: { avatar: true },
+    });
+
+    if (!user?.avatar) return null;
     if (!this.storageService.isMinioAvailable()) return null;
+
     try {
-      return await this.storageService.getPresignedUrl(avatarKey, 86400); // 24h
+      const metadata = await this.storageService.getFileMetadata(user.avatar);
+      const stream = await this.storageService.getObject(user.avatar);
+      return {
+        stream,
+        contentType: metadata?.contentType || this.inferAvatarContentType(user.avatar),
+        contentLength: metadata?.size,
+      };
     } catch {
       return null;
     }
+  }
+
+  private inferAvatarContentType(objectKey: string): string {
+    if (objectKey.endsWith('.png')) return 'image/png';
+    if (objectKey.endsWith('.webp')) return 'image/webp';
+    return 'image/jpeg';
   }
 
   async deleteAccount(userId: string, password: string): Promise<void> {

--- a/middleware/src/modules/content/content.controller.spec.ts
+++ b/middleware/src/modules/content/content.controller.spec.ts
@@ -7,7 +7,11 @@ jest.mock('isomorphic-dompurify', () => ({
 }));
 
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException } from '@nestjs/common';
+import {
+  BadRequestException,
+  NotFoundException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
 import { ContentController } from './content.controller';
 import { ContentService } from './content.service';
 import { ThumbnailService } from './thumbnail.service';
@@ -16,7 +20,7 @@ import { StorageService } from '../storage/storage.service';
 import { StorageQuotaService } from '../storage/storage-quota.service';
 import { SubscriptionActiveGuard } from '../billing/guards/subscription-active.guard';
 import { DatabaseService } from '../database/database.service';
-import { Readable } from 'stream';
+import { Readable, Writable } from 'stream';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -531,25 +535,55 @@ describe('ContentController', () => {
     });
   });
 
-  describe('getDownloadUrl', () => {
-    it('should generate a presigned URL for same-organization MinIO content', async () => {
+  describe('downloadContent', () => {
+    const createMockResponse = () => {
+      const chunks: Buffer[] = [];
+      let res: any;
+      res = new Writable({
+        write(chunk, _encoding, callback) {
+          res.headersSent = true;
+          chunks.push(Buffer.from(chunk));
+          callback();
+        },
+      });
+      res.headersSent = false;
+      res.set = jest.fn().mockReturnValue(res);
+      res.redirect = jest.fn();
+      res.removeHeader = jest.fn();
+      res.getBody = () => Buffer.concat(chunks);
+      return res;
+    };
+
+    it('should stream same-organization MinIO content as an attachment', async () => {
       mockContentService.findOne.mockResolvedValue({
         id: 'content-123',
+        name: 'My File.jpg',
         url: 'minio://org-123/uploads/file.jpg',
+        mimeType: 'image/jpeg',
       } as any);
       mockStorageService.isMinioAvailable.mockReturnValue(true);
-      mockStorageService.getPresignedUrl.mockResolvedValue('https://minio.example/signed');
-
-      const result = await controller.getDownloadUrl(organizationId, 'content-123');
-
-      expect(result).toEqual({
-        url: 'https://minio.example/signed',
-        expiresIn: 3600,
-      });
-      expect(mockStorageService.getPresignedUrl).toHaveBeenCalledWith(
-        'org-123/uploads/file.jpg',
-        3600,
+      mockStorageService.getFileMetadata.mockResolvedValue({
+        size: 5,
+        lastModified: new Date('2026-05-31T00:00:00.000Z'),
+        contentType: 'image/jpeg',
+      } as any);
+      mockStorageService.getObject.mockResolvedValue(
+        Readable.from([Buffer.from('image')]) as any,
       );
+
+      const res = createMockResponse();
+      await controller.downloadContent(organizationId, 'content-123', res);
+
+      expect(mockStorageService.getObject).toHaveBeenCalledWith('org-123/uploads/file.jpg');
+      expect(res.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'Content-Type': 'image/jpeg',
+          'Content-Disposition': 'attachment; filename="My File.jpg"',
+          'Content-Length': '5',
+          'Cache-Control': 'private, no-cache',
+        }),
+      );
+      expect(res.getBody().toString()).toBe('image');
     });
 
     it('should reject MinIO content whose object key is outside the organization prefix', async () => {
@@ -558,13 +592,53 @@ describe('ContentController', () => {
         url: 'minio://other-org/uploads/secret.jpg',
       } as any);
       mockStorageService.isMinioAvailable.mockReturnValue(true);
-      mockStorageService.getPresignedUrl.mockResolvedValue('https://minio.example/signed');
 
+      const res = createMockResponse();
       await expect(
-        controller.getDownloadUrl(organizationId, 'content-123'),
+        controller.downloadContent(organizationId, 'content-123', res),
       ).rejects.toThrow(BadRequestException);
 
-      expect(mockStorageService.getPresignedUrl).not.toHaveBeenCalled();
+      expect(mockStorageService.getObject).not.toHaveBeenCalled();
+    });
+
+    it('should redirect to local/external URLs instead of streaming', async () => {
+      mockContentService.findOne.mockResolvedValue({
+        id: 'content-123',
+        url: 'https://cdn.example/video.mp4',
+      } as any);
+
+      const res = createMockResponse();
+      await controller.downloadContent(organizationId, 'content-123', res);
+
+      expect(res.redirect).toHaveBeenCalledWith('https://cdn.example/video.mp4');
+      expect(mockStorageService.getObject).not.toHaveBeenCalled();
+    });
+
+    it('should 503 when MinIO is unavailable for MinIO-stored content', async () => {
+      mockContentService.findOne.mockResolvedValue({
+        id: 'content-123',
+        url: 'minio://org-123/uploads/file.jpg',
+      } as any);
+      mockStorageService.isMinioAvailable.mockReturnValue(false);
+
+      const res = createMockResponse();
+      await expect(
+        controller.downloadContent(organizationId, 'content-123', res),
+      ).rejects.toThrow(ServiceUnavailableException);
+
+      expect(mockStorageService.getObject).not.toHaveBeenCalled();
+    });
+
+    it('should 404 when content has no associated file', async () => {
+      mockContentService.findOne.mockResolvedValue({
+        id: 'content-123',
+        url: null,
+      } as any);
+
+      const res = createMockResponse();
+      await expect(
+        controller.downloadContent(organizationId, 'content-123', res),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 

--- a/middleware/src/modules/content/content.controller.ts
+++ b/middleware/src/modules/content/content.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   Delete,
   Query,
+  Res,
   HttpCode,
   HttpStatus,
   UploadedFile,
@@ -15,6 +16,7 @@ import {
   BadRequestException,
   NotFoundException,
   ServiceUnavailableException,
+  InternalServerErrorException,
   Logger,
 } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
@@ -43,6 +45,10 @@ import {
 import { ReviewContentDto } from './dto/review-content.dto';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { getOwnedMinioObjectKey, MINIO_URL_PREFIX } from '../storage/minio-object-key';
+import { SkipEnvelope } from '../common/interceptors/response-envelope.interceptor';
+import { SkipOutputSanitize } from '../common/interceptors/sanitize.interceptor';
+import type { Response } from 'express';
+import { pipeline } from 'node:stream/promises';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -398,47 +404,97 @@ export class ContentController {
   }
 
   /**
-   * Get a download URL for content
-   * For MinIO-stored content, generates a presigned URL
-   * For local content, returns the direct URL
+   * Download a content file.
+   *
+   * MinIO-stored content is proxied through the middleware: the object is
+   * fetched server-side (MinIO is only reachable from the server — in prod its
+   * endpoint is bound to localhost and not publicly exposed) and streamed to
+   * the caller as an attachment. This replaces the previous presigned-URL
+   * response, which handed the browser an unreachable
+   * `http://localhost:9000/...` URL in production (PR-7b).
+   *
+   * Local (`/uploads`) and external URLs are already browser-reachable, so we
+   * redirect to them instead of streaming.
+   *
+   * Auth + org-scoping are enforced by the controller-level RolesGuard /
+   * @RequiresSubscription plus the org-prefixed object-key check
+   * (getOwnedMinioObjectKey throws if the key is outside the caller's org).
    */
   @Get(':id/download')
-  async getDownloadUrl(
+  @SkipEnvelope()
+  @SkipOutputSanitize()
+  async downloadContent(
     @CurrentUser('organizationId') organizationId: string,
     @Param('id', ParseIdPipe) id: string,
-    @Query('expirySeconds') expirySeconds?: string,
-  ): Promise<{ url: string; expiresIn: number }> {
+    @Res() res: Response,
+  ): Promise<void> {
     const content = await this.contentService.findOne(organizationId, id);
 
     if (!content.url) {
       throw new NotFoundException('Content has no associated file');
     }
 
+    // Throws BadRequestException if the object key is outside the caller's org.
     const objectKey = getOwnedMinioObjectKey(organizationId, content.url);
-    if (objectKey) {
-      const expiry = Math.min(parseInt(expirySeconds, 10) || 3600, 86400);
 
-      if (!this.storageService.isMinioAvailable()) {
-        throw new BadRequestException('Storage service is currently unavailable');
-      }
-
-      try {
-        const presignedUrl = await this.storageService.getPresignedUrl(objectKey, expiry);
-        return {
-          url: presignedUrl,
-          expiresIn: expiry,
-        };
-      } catch (error) {
-        this.logger.error(`Failed to generate presigned URL for ${id}: ${error}`);
-        throw new BadRequestException('Failed to generate download URL');
-      }
+    if (!objectKey) {
+      // Local (/uploads) or external URL — reachable by the browser directly.
+      res.redirect(content.url);
+      return;
     }
 
-    // For local/external URLs, return directly (no expiration)
-    return {
-      url: content.url,
-      expiresIn: 0, // 0 indicates no expiration
-    };
+    if (!this.storageService.isMinioAvailable()) {
+      throw new ServiceUnavailableException('Storage service is currently unavailable');
+    }
+
+    const metadata = await this.storageService.getFileMetadata(objectKey);
+    if (!metadata) {
+      throw new NotFoundException('Content file not found');
+    }
+
+    const stream = await this.storageService.getObject(objectKey);
+
+    res.set({
+      'Content-Type': content.mimeType || metadata.contentType || 'application/octet-stream',
+      'Content-Disposition': `attachment; filename="${this.buildDownloadFilename(content.name)}"`,
+      'Content-Length': String(metadata.size),
+      'Cache-Control': 'private, no-cache',
+    });
+
+    await this.streamToResponse(stream, res, id);
+  }
+
+  /**
+   * Build a header-safe filename for Content-Disposition. Strips quotes,
+   * backslashes, and CR/LF so a caller-controlled content name cannot inject
+   * response headers.
+   */
+  private buildDownloadFilename(name?: string | null): string {
+    const cleaned = (name || 'download').replace(/[\r\n"\\]/g, '').trim();
+    return cleaned.length > 0 ? cleaned : 'download';
+  }
+
+  private async streamToResponse(
+    stream: NodeJS.ReadableStream,
+    res: Response,
+    contentId: string,
+  ): Promise<void> {
+    try {
+      await pipeline(stream, res);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'unknown stream error';
+      this.logger.error(`Failed to stream content ${contentId}: ${message}`);
+
+      if (!res.headersSent) {
+        res.removeHeader('Content-Type');
+        res.removeHeader('Content-Disposition');
+        res.removeHeader('Content-Length');
+        res.removeHeader('Cache-Control');
+        throw new InternalServerErrorException('Failed to stream content file');
+      }
+
+      res.destroy(error instanceof Error ? error : undefined);
+    }
   }
 
   @Patch(':id')


### PR DESCRIPTION
**Batch PR-7b** of the 2026-07-10 backlog. Closes **content-streaming #5**. **§9a-confirmed** against prod before writing code.

## Problem (confirmed on prod)
`MINIO_ENDPOINT=localhost`, MinIO bound to `127.0.0.1:9000` only, no nginx storage vhost, `NODE_ENV=production` → `getPresignedUrl()` returns `http://localhost:9000/...`, **unreachable from the admin browser**. Content download + avatar display were **silently broken in prod** (contradicting the backlog's "avatar DONE via presigned").

## Fix (code-only, no prod infra change)
Stream the two **low-volume** browser paths through the authenticated middleware (MinIO is reachable server-side). The high-volume device per-loop media path and `getPresignedUrl` are **untouched**.

- **`GET /content/:id/download`** now streams the MinIO object as an attachment — **org-scoped** (`getOwnedMinioObjectKey` throws if the key is outside the caller's org), header-injection-safe filename (strips CR/LF/quotes/backslash), 503 on storage-down, 404 on missing, pipeline error handling. Local/external URLs redirect as before.
- **`GET /auth/me/avatar`** (new) streams the authenticated user's **own** avatar — **self-scoped** via `@CurrentUser('id')` (no path param → no IDOR). `getMe`/`uploadAvatar` return the stable relative proxy URL instead of a presigned URL; same-origin through the Next `/api/v1` rewrite, so avatar consumers use it verbatim as `<img src>` (**no web change needed**).
- Reuses `StorageService.getObject` + `getFileMetadata` (same pattern as `device-content`); no new storage method. Binary responses carry `@SkipEnvelope` + `@SkipOutputSanitize`.

## Verification (independently re-run)
- middleware `tsc` 0 · content/auth/storage **344/344** · `eslint` 0 errors.
- Security reviewed: self-scoped avatar (no IDOR), org-scoped download, header-injection-safe filename, cache-control `private, no-cache`.

## Note
The web `getContentDownloadUrl` client method has **zero consumers** today; if resurrected it must navigate the browser directly to the endpoint (now streams binary, not JSON). Flagged, not fixed (dead code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)