### PR TITLE
fix(monitoring): correct realtime Prometheus scrape path (/api/internal/metrics)

### DIFF
--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -8,6 +8,10 @@ scrape_configs:
     static_configs:
       - targets: ['host.docker.internal:3000']
   - job_name: 'realtime'
-    metrics_path: '/internal/metrics'
+    # Realtime sets a global prefix of `api`, which prepends to the
+    # @willsoto PrometheusModule path `/internal/metrics` → served at
+    # `/api/internal/metrics` (verified against the running service). The
+    # middleware prefix is `/api/v1`; realtime's is only `/api`.
+    metrics_path: '/api/internal/metrics'
     static_configs:
       - targets: ['host.docker.internal:3002']


### PR DESCRIPTION
Follow-up to PR-3 (#232), found during the prod deploy smoke-test. PR-3 fixed the **middleware** scrape path but set **realtime's** to `/internal/metrics`. Verified against the running realtime service on prod:

- `localhost:3002/api/internal/metrics` → **200** (real metrics)
- `localhost:3002/internal/metrics` → **404**

Realtime's global prefix is `api` (middleware's is `api/v1`), which prepends to the `@willsoto` PrometheusModule path `/internal/metrics` → actually served at `/api/internal/metrics`. Without this, realtime stays blind whenever Prometheus is running.

Config-only; **no Prometheus runs on prod today**, so nothing live is affected — this just makes the scrape config correct for when it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)