### PR TITLE
fix(redis): never give up reconnecting — stops the middleware crash-loop

### DIFF
--- a/middleware/src/modules/redis/redis.service.spec.ts
+++ b/middleware/src/modules/redis/redis.service.spec.ts
@@ -37,6 +37,25 @@ describe('RedisService', () => {
       await service.onModuleInit();
       expect(service.getClient()).not.toBeNull();
     });
+
+    it('uses a resilient retry strategy that never gives up (crash-loop regression)', async () => {
+      await service.onModuleInit();
+      const RedisMock = jest.requireMock('ioredis') as jest.Mock;
+      const opts = RedisMock.mock.calls[0][1];
+
+      // Raised from 3 so in-flight commands ride out a brief reconnect.
+      expect(opts.maxRetriesPerRequest).toBe(20);
+
+      // retryStrategy must NEVER return null: null fires 'end', after which every
+      // command fails and cascades into an unhandled rejection that crash-loops
+      // the process. It must always return a positive, capped backoff.
+      for (const times of [1, 5, 10, 11, 50, 500]) {
+        const delay = opts.retryStrategy(times);
+        expect(typeof delay).toBe('number');
+        expect(delay).toBeGreaterThan(0);
+        expect(delay).toBeLessThanOrEqual(5000);
+      }
+    });
   });
 
   describe('ping', () => {

--- a/middleware/src/modules/redis/redis.service.ts
+++ b/middleware/src/modules/redis/redis.service.ts
@@ -20,14 +20,23 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
 
     try {
       this.client = new Redis(redisUrl, {
-        maxRetriesPerRequest: 3,
+        // Redis is a critical dependency (auth cache, session revocation,
+        // rate-limit, device-refresh cooldown). Do NOT give up reconnecting:
+        // returning null from retryStrategy fires 'end', after which every
+        // command fails and cascades into an unhandled rejection that crash-loops
+        // the process — this drove 4500+ PM2 restarts in prod against a perfectly
+        // healthy Redis. Retry forever with capped backoff so the connection
+        // self-heals whenever Redis is reachable again. maxRetriesPerRequest is
+        // raised from 3 → 20 (ioredis default) so in-flight commands ride out a
+        // brief reconnect via the offline queue instead of failing fast.
+        maxRetriesPerRequest: 20,
         retryStrategy: (times) => {
-          if (times > 10) {
-            this.logger.error('Redis max retry attempts (10) exceeded');
-            return null; // Stop retrying — triggers 'end' event
-          }
           const delay = Math.min(times * 200, 5000); // Exponential backoff, max 5s
-          this.logger.warn(`Redis reconnecting in ${delay}ms (attempt ${times}/10)`);
+          // Surface the first few attempts, then only periodically, so a
+          // prolonged outage stays visible without flooding the logs.
+          if (times <= 5 || times % 30 === 0) {
+            this.logger.warn(`Redis reconnecting in ${delay}ms (attempt ${times})`);
+          }
           return delay;
         },
         lazyConnect: true, // Don't connect immediately


### PR DESCRIPTION
Found during the post-deploy prod investigation.

## Root cause
`vizora-middleware` had **4500+ PM2 restarts** against a **perfectly healthy Redis** (142-day uptime, 7 clients, 0 rejected connections, 1.7M/128M memory). The error log showed `Redis connection ended (max retries exceeded)` every ~5 min, each spawning a new pid.

`RedisService.retryStrategy` returned `null` after **10** reconnect attempts → fired `'end'` → the connection was then permanently dead → every Redis command (auth cache + session-revocation on the hot path, rate-limit, device-refresh cooldown) failed at `maxRetriesPerRequest: 3` → an unhandled rejection **crash-looped the process** → PM2 restart → repeat.

## Fix
Redis is a critical dependency, so the client must never stop trying to reconnect:
- `retryStrategy` now retries **forever** with a capped 5s backoff (logs the first few attempts, then periodically, so a real outage stays visible without flooding).
- `maxRetriesPerRequest` raised **3 → 20** so in-flight commands ride out a brief reconnect via the offline queue instead of failing fast.

Strictly more resilient — it only changes reconnect behaviour, never gives up.

## Test
`retryStrategy` never returns `null` (times 1…500) and always returns a positive, capped delay.
Verified: middleware `tsc` 0 · `redis.service` **27/27**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)