### PR TITLE
feat(display): eliminate blank/frozen-screen failure modes (PR-9)

### DIFF
--- a/display/src/electron/device-client.spec.ts
+++ b/display/src/electron/device-client.spec.ts
@@ -91,6 +91,9 @@ describe('DeviceClient', () => {
       onPlaylistUpdate: jest.fn(),
       onCommand: jest.fn(),
       onError: jest.fn(),
+      onOverride: jest.fn(),
+      onClearOverride: jest.fn(),
+      getRendererStatus: jest.fn().mockReturnValue({ screenState: 'playing', playbackSource: 'live' }),
     };
 
     mockStore = {
@@ -641,17 +644,9 @@ describe('DeviceClient', () => {
       });
     });
 
-    it('should append the device token before loading protected push_content URLs', async () => {
-      const electron = require('electron');
+    it('should overlay push_content via onOverride (not a top-level loadURL) with the device token attached', async () => {
       const logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
       try {
-        const mockWindow = {
-          webContents: {
-            getURL: jest.fn().mockReturnValue('file:///display/index.html'),
-          },
-          loadURL: jest.fn().mockResolvedValue(undefined),
-        };
-        electron.BrowserWindow.getAllWindows.mockReturnValue([mockWindow]);
         client.connect('device-token-123');
 
         const commandCall = mockSocket.on.mock.calls.find(
@@ -670,8 +665,14 @@ describe('DeviceClient', () => {
           },
         }, ack);
 
-        expect(mockWindow.loadURL).toHaveBeenCalledWith(
-          'http://localhost:3000/api/v1/device-content/content-1/file?token=device-token-123',
+        // Overlay model (realtime #9): the override is pushed to the renderer as
+        // an overlay, never navigated to at the top level.
+        expect(mockConfig.onOverride).toHaveBeenCalledWith(
+          expect.objectContaining({
+            content: expect.objectContaining({
+              url: 'http://localhost:3000/api/v1/device-content/content-1/file?token=device-token-123',
+            }),
+          }),
         );
         expect(logSpy.mock.calls.flat().join(' ')).not.toContain('device-token-123');
         expect(ack).toHaveBeenCalledWith({ ok: true });
@@ -680,15 +681,30 @@ describe('DeviceClient', () => {
       }
     });
 
-    it('should clear overrides in the main process even when the renderer command path is unavailable', async () => {
-      const electron = require('electron');
-      const mockWindow = {
-        webContents: {
-          getURL: jest.fn().mockReturnValue('file:///display/index.html'),
+    it('should negative-ack push_content when the overlay channel is unavailable', async () => {
+      mockConfig.onOverride = undefined;
+      client.connect('device-token-123');
+
+      const commandCall = mockSocket.on.mock.calls.find(
+        (call: any[]) => call[0] === 'command',
+      );
+      const ack = jest.fn();
+
+      await commandCall![1]({
+        type: 'push_content',
+        payload: {
+          content: { id: 'content-1', url: 'https://example.com/promo' },
+          duration: 1,
         },
-        loadURL: jest.fn().mockResolvedValue(undefined),
-      };
-      electron.BrowserWindow.getAllWindows.mockReturnValue([mockWindow]);
+      }, ack);
+
+      expect(ack).toHaveBeenCalledWith({
+        ok: false,
+        error: 'push_content overlay channel unavailable',
+      });
+    });
+
+    it('should clear overrides via onClearOverride even when the renderer command path is unavailable', async () => {
       mockConfig.onCommand.mockRejectedValue(new Error('renderer unavailable'));
       client.connect('device-token-123');
 
@@ -706,14 +722,104 @@ describe('DeviceClient', () => {
           duration: 1,
         },
       }, jest.fn());
-      mockWindow.loadURL.mockClear();
+
+      (mockConfig.onClearOverride as jest.Mock).mockClear();
 
       const ack = jest.fn();
       await commandCall![1]({ type: 'clear_override' }, ack);
 
       expect(mockConfig.onCommand).not.toHaveBeenCalled();
-      expect(mockWindow.loadURL).toHaveBeenCalledWith('file:///display/index.html');
+      expect(mockConfig.onClearOverride).toHaveBeenCalledTimes(1);
       expect(ack).toHaveBeenCalledWith({ ok: true });
+    });
+
+    it('auto-reverts the override via onClearOverride after the duration elapses', async () => {
+      client.connect('device-token-123');
+      const commandCall = mockSocket.on.mock.calls.find(
+        (call: any[]) => call[0] === 'command',
+      );
+
+      await commandCall![1]({
+        type: 'push_content',
+        payload: { content: { id: 'c1', url: 'https://example.com/promo' }, duration: 1 },
+      }, jest.fn());
+
+      expect(mockConfig.onOverride).toHaveBeenCalledTimes(1);
+      expect(mockConfig.onClearOverride).not.toHaveBeenCalled();
+
+      // duration is in minutes → 60_000ms
+      jest.advanceTimersByTime(60_000);
+      expect(mockConfig.onClearOverride).toHaveBeenCalledTimes(1);
+    });
+
+    it('applies last-writer-wins: a second push clears the first revert timer', async () => {
+      client.connect('device-token-123');
+      const commandCall = mockSocket.on.mock.calls.find(
+        (call: any[]) => call[0] === 'command',
+      );
+      const push = (id: string) => commandCall![1]({
+        type: 'push_content',
+        payload: { content: { id, url: `https://example.com/${id}` }, duration: 1 },
+      }, jest.fn());
+
+      await push('first');
+      await push('second');
+      expect(mockConfig.onOverride).toHaveBeenCalledTimes(2);
+
+      // Only the surviving (second) timer fires — a single revert, not two.
+      jest.advanceTimersByTime(60_000);
+      expect(mockConfig.onClearOverride).toHaveBeenCalledTimes(1);
+    });
+
+    it('folds renderer status (screenState/playbackSource) into the heartbeat', () => {
+      (mockConfig.getRendererStatus as jest.Mock).mockReturnValue({
+        screenState: 'recovering',
+        playbackSource: 'cached',
+      });
+      client.connect('test-token');
+
+      const connectCall = mockSocket.on.mock.calls.find((call: any[]) => call[0] === 'connect');
+      connectCall![1](); // triggers startHeartbeat → immediate heartbeat
+
+      const heartbeatEmit = mockSocket.emit.mock.calls.find(
+        (call: any[]) => call[0] === 'heartbeat',
+      );
+      expect(heartbeatEmit![1]).toEqual(
+        expect.objectContaining({ screenState: 'recovering', playbackSource: 'cached' }),
+      );
+    });
+
+    it('requests the current playlist on connect and applies a non-empty response', () => {
+      client.connect('test-token');
+      const connectCall = mockSocket.on.mock.calls.find((call: any[]) => call[0] === 'connect');
+      connectCall![1]();
+
+      const requestEmit = mockSocket.emit.mock.calls.find(
+        (call: any[]) => call[0] === 'playlist:request',
+      );
+      expect(requestEmit).toBeDefined();
+
+      // Server ack shape: createSuccessResponse({ playlist })
+      const ackCb = requestEmit![2];
+      ackCb({ data: { playlist: { items: [{ content: { id: 'x', type: 'image' } }] } } });
+
+      expect(mockConfig.onPlaylistUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ items: expect.any(Array) }),
+      );
+    });
+
+    it('ignores an empty playlist:request response so it never clobbers cached content', () => {
+      client.connect('test-token');
+      const connectCall = mockSocket.on.mock.calls.find((call: any[]) => call[0] === 'connect');
+      connectCall![1]();
+
+      const requestEmit = mockSocket.emit.mock.calls.find(
+        (call: any[]) => call[0] === 'playlist:request',
+      );
+      const ackCb = requestEmit![2];
+      ackCb({ data: { playlist: { items: [] } } });
+
+      expect(mockConfig.onPlaylistUpdate).not.toHaveBeenCalled();
     });
 
     it('should trigger display auto-update in the main process', async () => {

--- a/display/src/electron/device-client.ts
+++ b/display/src/electron/device-client.ts
@@ -9,6 +9,14 @@ interface DeviceClientConfig {
   onPlaylistUpdate: (playlist: any) => void | Promise<void>;
   onCommand: (command: any) => void | Promise<void>;
   onError: (error: any) => void;
+  // Emergency / push_content override rendered as an in-renderer overlay
+  // (realtime #9). `onOverride` shows it; `onClearOverride` reverts to the
+  // normal playlist. Both are wired to the renderer over IPC by the main process.
+  onOverride?: (override: { content: any; commandId?: string }) => void;
+  onClearOverride?: () => void;
+  // Renderer-liveness / playback-source signal folded into the heartbeat so a
+  // dead or frozen renderer is visible server-side, not just "online" (realtime #2).
+  getRendererStatus?: () => { screenState?: string; playbackSource?: string };
 }
 
 type SocketAck = (response?: { ok: boolean; error?: string }) => void;
@@ -48,7 +56,7 @@ export class DeviceClient {
   private readonly heartbeatIntervalMs = 15000; // 15 seconds
   private cachedDeviceIdentifier: string | null = null;
   private previousCpuTimes: { idle: number; total: number } | null = null;
-  private overrideState: { previousUrl?: string; revertTimer: any; commandId?: string } | null = null;
+  private overrideState: { content: any; revertTimer: any; commandId?: string; expiresAt?: number } | null = null;
   private deviceToken: string | null = null;
 
   private mainWindow: any = null;
@@ -72,18 +80,17 @@ export class DeviceClient {
       if (fs.existsSync(stateFile)) {
         const state = JSON.parse(fs.readFileSync(stateFile, 'utf-8'));
         const remaining = state.expiresAt - Date.now();
-        if (remaining > 0) {
-          // Override still active — set revert timer for remaining duration
+        // Overlay model (realtime #9): recovery re-shows the pushed content as an
+        // overlay for the remaining duration. Old-format files (pre-overlay, no
+        // `content`) can no longer be reconstructed — clean them up.
+        if (remaining > 0 && state.content?.url) {
           this.overrideState = {
-            previousUrl: state.previousUrl,
+            content: state.content,
             commandId: state.commandId,
+            expiresAt: state.expiresAt,
             revertTimer: setTimeout(() => {
               try {
-                const { BrowserWindow: BWRecover } = require('electron');
-                const win = BWRecover.getAllWindows()[0];
-                if (win && state.previousUrl) {
-                  win.loadURL(state.previousUrl);
-                }
+                this.config.onClearOverride?.();
                 this.overrideState = null;
                 try { fs.unlinkSync(stateFile); } catch {}
               } catch (err) {
@@ -91,9 +98,12 @@ export class DeviceClient {
               }
             }, remaining),
           };
+          // Re-show the overlay (the renderer is already loaded by the time the
+          // device client is constructed on boot).
+          this.config.onOverride?.({ content: state.content, commandId: state.commandId });
           console.log(`[DeviceClient] Recovered override state, ${Math.round(remaining / 1000)}s remaining`);
         } else {
-          // Override expired during crash — clean up
+          // Override expired during crash, or unrecoverable old format — clean up
           fs.unlinkSync(stateFile);
         }
       }
@@ -108,6 +118,18 @@ export class DeviceClient {
         fs.unlinkSync(stateFile);
       } catch {}
     }
+  }
+
+  /**
+   * Current active override, if any — used by the main process to re-show the
+   * overlay after a renderer reload (crash recovery / reload command) without
+   * tearing down the socket (realtime #9).
+   */
+  getActiveOverride(): { content: any; commandId?: string } | null {
+    if (!this.overrideState) {
+      return null;
+    }
+    return { content: this.overrideState.content, commandId: this.overrideState.commandId };
   }
 
   private clearTokenAndRequestPairing(reason: string): void {
@@ -305,6 +327,10 @@ export class DeviceClient {
     this.socket.on('connect', () => {
       console.log('[DeviceClient] Connected to realtime gateway');
       this.startHeartbeat();
+      // Backstop (realtime #3): a device that booted offline renders its cached
+      // last-known-good playlist immediately, but may never receive a fresh push
+      // if nothing changed server-side. Explicitly reconcile once connected.
+      this.requestCurrentPlaylist();
     });
 
     this.socket.on('disconnect', () => {
@@ -425,6 +451,30 @@ export class DeviceClient {
     }
   }
 
+  private requestCurrentPlaylist() {
+    if (!this.socket?.connected) {
+      return;
+    }
+
+    try {
+      this.socket.emit('playlist:request', { forceRefresh: false }, (response: any) => {
+        try {
+          const playlist = response?.data?.playlist ?? response?.playlist;
+          // Only reconcile when the server actually has content to serve — never
+          // clobber the cached last-known-good playlist with an empty response.
+          if (playlist && Array.isArray(playlist.items) && playlist.items.length > 0) {
+            const withTokens = this.attachDeviceTokenToProtectedUrls(playlist);
+            void this.config.onPlaylistUpdate(withTokens);
+          }
+        } catch (err) {
+          console.error('[DeviceClient] Failed to apply backstop playlist:', err);
+        }
+      });
+    } catch (err) {
+      console.warn('[DeviceClient] playlist:request backstop failed:', err);
+    }
+  }
+
   private reconnectForPendingDelivery() {
     if (!this.socket?.connected) {
       return;
@@ -462,7 +512,7 @@ export class DeviceClient {
     }
 
     try {
-      const heartbeatData = {
+      const heartbeatData: Record<string, unknown> = {
         timestamp: Date.now(),
         metrics: {
           cpuUsage: this.getCpuUsage(),
@@ -472,6 +522,19 @@ export class DeviceClient {
         currentContent: data.currentContent || null,
         status: 'online',
       };
+
+      // Contract v1.1 dark-screen fields (realtime #2): surface renderer liveness
+      // so a frozen / crashed renderer reads as on-but-dark instead of green.
+      // Explicit values on `data` win over the polled renderer status.
+      const rendererStatus = this.config.getRendererStatus?.() ?? {};
+      const screenState = data.screenState ?? rendererStatus.screenState;
+      const playbackSource = data.playbackSource ?? rendererStatus.playbackSource;
+      if (screenState) {
+        heartbeatData.screenState = screenState;
+      }
+      if (playbackSource) {
+        heartbeatData.playbackSource = playbackSource;
+      }
 
       this.socket.emit('heartbeat', heartbeatData, () => {});
     } catch (error) {
@@ -666,38 +729,33 @@ export class DeviceClient {
             throw new Error(`push_content invalid URL: ${content.url}`);
           }
 
+          // Overlay model (realtime #9): render the pushed content as an
+          // in-renderer overlay instead of a top-level loadURL. The socket + app
+          // survive, so the override + revert no longer thrash the connection.
+          if (!this.config.onOverride) {
+            throw new Error('push_content overlay channel unavailable');
+          }
+
           // Clear any existing override timer (last-writer-wins)
           if (this.overrideState?.revertTimer) {
             clearTimeout(this.overrideState.revertTimer);
           }
 
-          const { BrowserWindow: BWPush } = require('electron');
-          const pushWindow = BWPush.getAllWindows()[0];
-          if (!pushWindow) {
-            throw new Error('push_content no window found');
-          }
-
-          // Save current URL for revert (only if not already in an override)
-          const previousUrl = this.overrideState?.previousUrl || pushWindow.webContents.getURL();
-
-          // Load the pushed content
-          await pushWindow.loadURL(content.url);
-          console.log(`[DeviceClient] Override active: loading ${this.redactDeviceTokenFromUrl(content.url)} (commandId: ${commandId})`);
+          this.config.onOverride({ content, commandId });
+          console.log(`[DeviceClient] Override active: overlaying ${this.redactDeviceTokenFromUrl(content.url)} (commandId: ${commandId})`);
 
           // Set auto-revert timer (duration is in minutes)
           const durationMs = (duration || 60) * 60 * 1000;
+          const expiresAt = Date.now() + durationMs;
 
-          // Persist override state for crash recovery
+          // Persist override state for crash recovery (stores the overlay content
+          // so it can be re-shown for the remaining duration after a restart).
           const fs = require('fs');
           const path = require('path');
           const { app: appPush } = require('electron');
           const stateFile = path.join(appPush.getPath('userData'), 'override-state.json');
           try {
-            fs.writeFileSync(stateFile, JSON.stringify({
-              previousUrl,
-              commandId,
-              expiresAt: Date.now() + durationMs,
-            }));
+            fs.writeFileSync(stateFile, JSON.stringify({ content, commandId, expiresAt }));
           } catch (writeErr) {
             console.error('[DeviceClient] Failed to persist override state:', writeErr);
           }
@@ -705,11 +763,7 @@ export class DeviceClient {
           const revertTimer = setTimeout(() => {
             try {
               console.log(`[DeviceClient] Override expired — reverting to playlist`);
-              const { BrowserWindow: BWRevert } = require('electron');
-              const revertWindow = BWRevert.getAllWindows()[0];
-              if (revertWindow && previousUrl) {
-                revertWindow.loadURL(previousUrl);
-              }
+              this.config.onClearOverride?.();
               this.overrideState = null;
               // Clean up persisted state
               try { fs.unlinkSync(stateFile); } catch {}
@@ -718,7 +772,7 @@ export class DeviceClient {
             }
           }, durationMs);
 
-          this.overrideState = { previousUrl, revertTimer, commandId };
+          this.overrideState = { content, revertTimer, commandId, expiresAt };
         } catch (err) {
           console.error('[DeviceClient] push_content failed:', err);
           throw err;
@@ -733,17 +787,9 @@ export class DeviceClient {
               clearTimeout(this.overrideState.revertTimer);
             }
 
-            // Restore the previous URL
-            if (this.overrideState.previousUrl) {
-              const { BrowserWindow: BWClear } = require('electron');
-              const clearWindow = BWClear.getAllWindows()[0];
-              if (clearWindow) {
-                await clearWindow.loadURL(this.overrideState.previousUrl);
-                console.log(`[DeviceClient] Override cleared, restored ${this.overrideState.previousUrl}`);
-              } else {
-                throw new Error('clear_override no window found');
-              }
-            }
+            // Hide the overlay and revert to the normal playlist (realtime #9).
+            this.config.onClearOverride?.();
+            console.log('[DeviceClient] Override cleared, reverted to playlist');
 
             this.overrideState = null;
 

--- a/display/src/electron/main.spec.ts
+++ b/display/src/electron/main.spec.ts
@@ -21,7 +21,7 @@ jest.mock('./cache-manager', () => ({
 }));
 
 // Mock the device-client module
-const mockDeviceClient = {
+const mockDeviceClient: any = {
   connect: jest.fn(),
   disconnect: jest.fn(),
   requestPairingCode: jest.fn().mockResolvedValue({ code: 'ABC123', qrCode: 'qr-data' }),
@@ -29,10 +29,18 @@ const mockDeviceClient = {
   sendHeartbeat: jest.fn(),
   logImpression: jest.fn(),
   logError: jest.fn(),
+  getActiveOverride: jest.fn().mockReturnValue(null),
+  __config: undefined,
 };
 
 jest.mock('./device-client', () => ({
-  DeviceClient: jest.fn().mockImplementation(() => mockDeviceClient),
+  // Capture the config on the shared instance so tests can exercise the
+  // main-side wiring (persist / override bridge / renderer status) regardless of
+  // which module registry (isolateModules) main.ts was loaded in.
+  DeviceClient: jest.fn().mockImplementation((...args: any[]) => {
+    mockDeviceClient.__config = args[2];
+    return mockDeviceClient;
+  }),
 }));
 
 const mockMkdirSync = jest.fn();
@@ -77,6 +85,7 @@ const mockMainWindow = {
   setFullScreen: jest.fn(),
   isFullScreen: jest.fn().mockReturnValue(false),
   reload: jest.fn(),
+  isDestroyed: jest.fn().mockReturnValue(false),
 };
 
 const mockSetLoginItemSettings = jest.fn();
@@ -322,7 +331,7 @@ describe('main.ts - Electron main process', () => {
       expect(powerSaveBlocker.stop).toHaveBeenCalledWith(42);
     });
 
-    it('disconnects an existing device client before reinitializing after renderer reload', () => {
+    it('initializes the device client once and never tears down the socket on renderer reload', () => {
       jest.useFakeTimers();
       mockStoreGet.mockImplementation((key: string) => (key === 'deviceToken' ? 'device-token' : null));
 
@@ -336,9 +345,204 @@ describe('main.ts - Electron main process', () => {
       didFinishLoad();
       jest.advanceTimersByTime(500);
 
-      expect(mockDeviceClient.connect).toHaveBeenCalledTimes(2);
-      expect(mockDeviceClient.disconnect).toHaveBeenCalledTimes(1);
+      // Init-once (realtime #9): a reload must not reconnect or disconnect the
+      // live socket — the renderer's post-reload state is restored separately.
+      expect(mockDeviceClient.connect).toHaveBeenCalledTimes(1);
+      expect(mockDeviceClient.disconnect).not.toHaveBeenCalled();
       jest.useRealTimers();
+    });
+  });
+
+  describe('renderer crash recovery (realtime #2)', () => {
+    beforeEach(() => {
+      jest.isolateModules(() => {
+        require('./main');
+      });
+    });
+
+    function createWindowViaReady() {
+      const thenMock = (app.whenReady as jest.Mock).mock.results[0].value.then;
+      thenMock.mock.calls[0][0]();
+    }
+
+    it('reloads the renderer with a backoff delay on render-process-gone (not immediately)', () => {
+      jest.useFakeTimers();
+      createWindowViaReady();
+
+      const gone = webContentsListeners['render-process-gone'][0];
+      gone({}, { reason: 'crashed' });
+
+      // Scheduled, not immediate — avoids reloading into the same crash.
+      expect(mockMainWindow.reload).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(1000); // base delay
+      expect(mockMainWindow.reload).toHaveBeenCalledTimes(1);
+      jest.useRealTimers();
+    });
+
+    it('does not stack reloads and backs off exponentially instead of hot-looping', () => {
+      jest.useFakeTimers();
+      createWindowViaReady();
+      const gone = webContentsListeners['render-process-gone'][0];
+
+      // Two crashes before the first reload fires → only one reload scheduled.
+      gone({}, { reason: 'oom' });
+      gone({}, { reason: 'oom' });
+      jest.advanceTimersByTime(1000);
+      expect(mockMainWindow.reload).toHaveBeenCalledTimes(1);
+
+      // Next crash backs off to 2000ms (attempt 2), not another 1000ms.
+      gone({}, { reason: 'oom' });
+      jest.advanceTimersByTime(1000);
+      expect(mockMainWindow.reload).toHaveBeenCalledTimes(1);
+      jest.advanceTimersByTime(1000);
+      expect(mockMainWindow.reload).toHaveBeenCalledTimes(2);
+      jest.useRealTimers();
+    });
+
+    it('resets the backoff after a successful renderer load', () => {
+      jest.useFakeTimers();
+      mockStoreGet.mockImplementation((key: string) => (key === 'deviceToken' ? 'device-token' : null));
+      createWindowViaReady();
+      const gone = webContentsListeners['render-process-gone'][0];
+      const didFinishLoad = webContentsListeners['did-finish-load'][0];
+
+      gone({}, { reason: 'oom' });     // attempt 1 → delay 1000
+      jest.advanceTimersByTime(1000);  // reload #1
+      gone({}, { reason: 'oom' });     // attempt 2 → delay 2000
+      jest.advanceTimersByTime(2000);  // reload #2
+      didFinishLoad();                 // successful load resets backoff
+      jest.advanceTimersByTime(500);
+
+      (mockMainWindow.reload as jest.Mock).mockClear();
+      gone({}, { reason: 'oom' });     // attempt 1 again → delay 1000
+      jest.advanceTimersByTime(1000);
+      expect(mockMainWindow.reload).toHaveBeenCalledTimes(1);
+      jest.useRealTimers();
+    });
+
+    it('cancels a pending reload when the renderer becomes responsive again', () => {
+      jest.useFakeTimers();
+      createWindowViaReady();
+      const unresponsive = webContentsListeners['unresponsive'][0];
+      const responsive = webContentsListeners['responsive'][0];
+
+      unresponsive();
+      responsive(); // recovered on its own before the timer fired
+      jest.advanceTimersByTime(60000);
+      expect(mockMainWindow.reload).not.toHaveBeenCalled();
+      jest.useRealTimers();
+    });
+  });
+
+  describe('offline boot render + last-known-good playlist (realtime #3)', () => {
+    beforeEach(() => {
+      // Fake timers so the post-load 500ms device-client init timer never fires
+      // after the test — these tests only exercise the synchronous boot render.
+      jest.useFakeTimers();
+      jest.isolateModules(() => {
+        require('./main');
+      });
+    });
+
+    afterEach(() => {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    });
+
+    function createWindowViaReady() {
+      const thenMock = (app.whenReady as jest.Mock).mock.results[0].value.then;
+      thenMock.mock.calls[0][0]();
+    }
+
+    it('renders the cached playlist and paired state immediately on load', () => {
+      const cachedPlaylist = { id: 'p1', items: [{ content: { id: 'c1', type: 'image' } }] };
+      mockStoreGet.mockImplementation((key: string) => {
+        if (key === 'deviceToken') return 'device-token';
+        if (key === 'lastPlaylist') return cachedPlaylist;
+        return null;
+      });
+
+      createWindowViaReady();
+      const didFinishLoad = webContentsListeners['did-finish-load'][0];
+      didFinishLoad();
+
+      expect(mockWebContents.send).toHaveBeenCalledWith('paired', 'device-token');
+      expect(mockWebContents.send).toHaveBeenCalledWith('playlist-update', { playlist: cachedPlaylist });
+    });
+
+    it('shows pairing when no device token is stored', () => {
+      mockStoreGet.mockReturnValue(null);
+      createWindowViaReady();
+      const didFinishLoad = webContentsListeners['did-finish-load'][0];
+      didFinishLoad();
+      expect(mockWebContents.send).toHaveBeenCalledWith('pairing-required');
+    });
+
+    it('does not send a cached playlist when the store has none', () => {
+      mockStoreGet.mockImplementation((key: string) => (key === 'deviceToken' ? 'device-token' : null));
+      createWindowViaReady();
+      const didFinishLoad = webContentsListeners['did-finish-load'][0];
+      didFinishLoad();
+      const playlistSends = mockWebContents.send.mock.calls.filter((c: any[]) => c[0] === 'playlist-update');
+      expect(playlistSends).toHaveLength(0);
+    });
+  });
+
+  describe('device client wiring (realtime #2/#3/#9)', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      mockDeviceClient.__config = undefined;
+      jest.isolateModules(() => {
+        require('./main');
+      });
+    });
+
+    afterEach(() => {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    });
+
+    function initAndGetConfig() {
+      mockStoreGet.mockImplementation((key: string) => (key === 'deviceToken' ? 'device-token' : null));
+      const thenMock = (app.whenReady as jest.Mock).mock.results[0].value.then;
+      thenMock.mock.calls[0][0]();
+      const didFinishLoad = webContentsListeners['did-finish-load'][0];
+      didFinishLoad();
+      jest.advanceTimersByTime(500);
+      // Config captured on the shared mock instance by the DeviceClient factory.
+      return mockDeviceClient.__config;
+    }
+
+    it('persists a non-empty playlist to the store on receive', () => {
+      const config = initAndGetConfig();
+      const playlist = { id: 'p1', items: [{ content: { id: 'c1' } }] };
+      config.onPlaylistUpdate(playlist);
+      expect(mockStoreSet).toHaveBeenCalledWith('lastPlaylist', playlist);
+    });
+
+    it('does not persist an empty playlist (never clobbers the cache)', () => {
+      const config = initAndGetConfig();
+      mockStoreSet.mockClear();
+      config.onPlaylistUpdate({ id: 'p1', items: [] });
+      expect(mockStoreSet).not.toHaveBeenCalledWith('lastPlaylist', expect.anything());
+    });
+
+    it('bridges onOverride / onClearOverride to the renderer over IPC', () => {
+      const config = initAndGetConfig();
+      const override = { content: { url: 'https://example.com/promo' } };
+      config.onOverride(override);
+      expect(mockWebContents.send).toHaveBeenCalledWith('override', override);
+      config.onClearOverride();
+      expect(mockWebContents.send).toHaveBeenCalledWith('override', null);
+    });
+
+    it('reports renderer liveness via getRendererStatus (boot → playing after a paint ping)', () => {
+      const config = initAndGetConfig();
+      expect(config.getRendererStatus().screenState).toBe('boot');
+
+      const paintListener = ipcListeners['renderer-heartbeat'][0];
+      paintListener();
+      expect(config.getRendererStatus().screenState).toBe('playing');
     });
   });
 

--- a/display/src/electron/main.ts
+++ b/display/src/electron/main.ts
@@ -22,6 +22,23 @@ const COMMAND_RENDERER_ACK_TIMEOUT_MS = 5000;
 const LINUX_AUTOSTART_FILE = 'vizora-display.desktop';
 const PROCESS_ERROR_HANDLERS_REGISTERED = '__vizoraDisplayProcessErrorHandlersRegistered';
 
+// Renderer crash-recovery reload with capped exponential backoff (realtime #2).
+// The delay doubles per consecutive failure up to the cap and resets to 0 on a
+// successful load, and only one reload is ever scheduled at a time — so a
+// renderer that keeps dying backs off to 30s instead of hot-looping.
+const RENDERER_RELOAD_BASE_DELAY_MS = 1000;
+const RENDERER_RELOAD_MAX_DELAY_MS = 30000;
+// Renderer is considered dark/frozen if it has not posted a paint ping within
+// this window (it pings every ~2s; heartbeat cadence is 15s) (realtime #2).
+const RENDERER_LIVENESS_TIMEOUT_MS = 10000;
+const LAST_PLAYLIST_STORE_KEY = 'lastPlaylist';
+
+let deviceClientInitialized = false;
+let rendererReloadAttempts = 0;
+let rendererReloadTimer: NodeJS.Timeout | null = null;
+let lastRendererPaintAt = 0;
+let hasLivePlaylist = false;
+
 function shouldEnableRuntimeGuards(): boolean {
   return app.isPackaged;
 }
@@ -212,6 +229,102 @@ function sendCommandToRenderer(command: any): Promise<void> {
   });
 }
 
+function persistLastKnownGoodPlaylist(playlist: any): void {
+  // Persist the last non-empty playlist to disk so the screen can render content
+  // offline on the next boot, before the socket connects (realtime #3). Never
+  // overwrite a good cache with an empty playlist.
+  try {
+    if (playlist && Array.isArray(playlist.items) && playlist.items.length > 0) {
+      store.set(LAST_PLAYLIST_STORE_KEY, playlist);
+    }
+  } catch (error) {
+    console.error('[Main] Failed to persist last-known-good playlist:', error);
+  }
+}
+
+function getStoredDeviceToken(): string | undefined {
+  const stored = store.get('deviceToken') as string | undefined;
+  return stored || process.env.DEVICE_TOKEN || undefined;
+}
+
+function computeRendererStatus(): { screenState?: string; playbackSource?: string } {
+  // Fold renderer liveness into the heartbeat (realtime #2). A connected device
+  // whose renderer is not painting reads as on-but-dark (screenState != playing)
+  // instead of a false green.
+  const playbackSource = hasLivePlaylist ? 'live' : 'cached';
+  if (lastRendererPaintAt === 0) {
+    // Renderer has not yet reported a paint (early boot / pre-first-frame).
+    return { screenState: 'boot', playbackSource };
+  }
+  const stale = Date.now() - lastRendererPaintAt > RENDERER_LIVENESS_TIMEOUT_MS;
+  return { screenState: stale ? 'recovering' : 'playing', playbackSource };
+}
+
+function restoreRendererState(): void {
+  // Runs on every renderer load (first boot AND every reload). Renders the
+  // last-known-good playlist immediately from cache and restores the paired /
+  // pairing / override state, so a reloaded or offline-booted renderer never
+  // sits blank waiting for the socket (realtime #2 + #3).
+  if (!mainWindow) {
+    return;
+  }
+
+  const deviceToken = getStoredDeviceToken();
+  if (!deviceToken) {
+    mainWindow.webContents.send('pairing-required');
+    return;
+  }
+
+  mainWindow.webContents.send('paired', deviceToken);
+
+  const cached = store.get(LAST_PLAYLIST_STORE_KEY) as any;
+  if (cached && Array.isArray(cached.items) && cached.items.length > 0) {
+    // Fire-and-forget (no requestId): the renderer applies it without an ack.
+    mainWindow.webContents.send('playlist-update', { playlist: cached });
+  }
+
+  // Re-show an active override overlay after a renderer reload (realtime #9).
+  const activeOverride = deviceClient?.getActiveOverride?.();
+  if (activeOverride) {
+    mainWindow.webContents.send('override', activeOverride);
+  }
+}
+
+function cancelRendererReload(): void {
+  if (rendererReloadTimer) {
+    clearTimeout(rendererReloadTimer);
+    rendererReloadTimer = null;
+  }
+}
+
+function scheduleRendererReload(reason: string): void {
+  if (!mainWindow) {
+    return;
+  }
+  // Only one reload in flight — never stack timers (prevents hot-loop) (realtime #2).
+  if (rendererReloadTimer) {
+    return;
+  }
+
+  const delay = Math.min(
+    RENDERER_RELOAD_MAX_DELAY_MS,
+    RENDERER_RELOAD_BASE_DELAY_MS * Math.pow(2, rendererReloadAttempts),
+  );
+  rendererReloadAttempts++;
+  console.error(`[Main] Renderer ${reason} — reloading in ${delay}ms (attempt ${rendererReloadAttempts})`);
+
+  rendererReloadTimer = setTimeout(() => {
+    rendererReloadTimer = null;
+    try {
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.reload();
+      }
+    } catch (error) {
+      console.error('[Main] Renderer reload failed:', error);
+    }
+  }, delay);
+}
+
 function createWindow() {
   const primaryDisplay = screen.getPrimaryDisplay();
   const { width, height } = primaryDisplay.workAreaSize;
@@ -311,6 +424,21 @@ function createWindow() {
     mainWindow = null;
   });
 
+  // Renderer crash / hang recovery (realtime #2). An OOM, GPU crash or hung
+  // decode whites out the window with nothing to reload it — while the main
+  // process keeps heartbeating "online". Reload with capped backoff so a dead
+  // renderer comes back instead of staying blank forever.
+  mainWindow.webContents.on('render-process-gone', (_event, details) => {
+    scheduleRendererReload(`render-process-gone (${details?.reason ?? 'unknown'})`);
+  });
+  mainWindow.webContents.on('unresponsive', () => {
+    scheduleRendererReload('unresponsive');
+  });
+  mainWindow.webContents.on('responsive', () => {
+    // Renderer recovered on its own — cancel any pending reload.
+    cancelRendererReload();
+  });
+
   // Hide cursor in production
   if (process.env.NODE_ENV === 'production') {
     mainWindow.webContents.on('did-finish-load', () => {
@@ -318,20 +446,37 @@ function createWindow() {
     });
   }
 
-  // Wait for renderer to be ready before initializing device client
+  // On every renderer load (first boot AND crash-recovery reloads):
   mainWindow.webContents.on('did-finish-load', () => {
-    console.log('[Main] Renderer loaded, initializing device client...');
-    // Give renderer a moment to set up event listeners
-    setTimeout(() => {
-      initializeDeviceClient();
-    }, 500);
+    console.log('[Main] Renderer loaded');
+    // A successful load means the renderer is healthy again — reset crash backoff
+    // and renderer-liveness (the renderer will re-post paint pings) (realtime #2).
+    rendererReloadAttempts = 0;
+    cancelRendererReload();
+    lastRendererPaintAt = 0;
+
+    // Render last-known-good playlist + restore paired/pairing/override state
+    // immediately, before (and independent of) the socket (realtime #2/#3/#9).
+    restoreRendererState();
+
+    // Initialize the device client exactly once — NOT on every reload — so a
+    // renderer reload never tears down the live socket (realtime #9).
+    if (!deviceClientInitialized) {
+      deviceClientInitialized = true;
+      // Give renderer a moment to set up event listeners.
+      setTimeout(() => {
+        initializeDeviceClient();
+      }, 500);
+    }
   });
 }
 
 function initializeDeviceClient() {
+  // Init exactly once (realtime #9). A renderer reload must never tear down the
+  // live socket; the renderer's post-reload state is restored via
+  // restoreRendererState() instead.
   if (deviceClient) {
-    deviceClient.disconnect();
-    deviceClient = null;
+    return;
   }
 
   let deviceToken = store.get('deviceToken') as string | undefined;
@@ -363,6 +508,9 @@ function initializeDeviceClient() {
       mainWindow?.webContents.send('paired', token);
     },
     onPlaylistUpdate: (playlist) => {
+      // Persist the last-known-good playlist for offline boot (realtime #3).
+      persistLastKnownGoodPlaylist(playlist);
+      hasLivePlaylist = true;
       return sendPlaylistToRenderer(playlist);
     },
     onCommand: async (command) => {
@@ -374,21 +522,34 @@ function initializeDeviceClient() {
     onError: (error) => {
       mainWindow?.webContents.send('error', error);
     },
+    // Emergency / push_content override rendered as an in-renderer overlay,
+    // and cleared back to the playlist — no top-level navigation (realtime #9).
+    onOverride: (override) => {
+      mainWindow?.webContents.send('override', override);
+    },
+    onClearOverride: () => {
+      mainWindow?.webContents.send('override', null);
+    },
+    // Renderer-liveness folded into the heartbeat (realtime #2).
+    getRendererStatus: () => computeRendererStatus(),
   }, store);
 
   if (deviceToken) {
     console.log('[Main] Device token exists, connecting...');
     deviceClient.connect(deviceToken);
-    // Send paired event to renderer so it shows content screen instead of pairing
-    console.log('[Main] Sending paired event to renderer (existing token)');
-    mainWindow?.webContents.send('paired', deviceToken);
   } else {
-    // Request pairing
-    console.log('[Main] *** SENDING PAIRING-REQUIRED EVENT TO RENDERER ***');
-    mainWindow?.webContents.send('pairing-required');
-    console.log('[Main] pairing-required event sent');
+    // No token — the renderer was already told to show the pairing screen by
+    // restoreRendererState(); the device client is now ready to serve codes.
+    console.log('[Main] No device token — awaiting pairing');
   }
 }
+
+// Renderer liveness ping (realtime #2). The renderer posts this on a paint-gated
+// timer; the main process tracks the last paint time and folds it into the
+// heartbeat so a frozen renderer is visible server-side.
+ipcMain.on('renderer-heartbeat', () => {
+  lastRendererPaintAt = Date.now();
+});
 
 // IPC Handlers
 ipcMain.handle('get-pairing-code', async () => {

--- a/display/src/electron/preload.spec.ts
+++ b/display/src/electron/preload.spec.ts
@@ -59,6 +59,8 @@ describe('preload.ts', () => {
         'onPlaylistUpdate',
         'onCommand',
         'onError',
+        'onOverride',
+        'notifyRendererAlive',
         'removeListener',
       ];
 
@@ -214,6 +216,33 @@ describe('preload.ts', () => {
       const callback = jest.fn();
       exposedApi.onError(callback);
       expect(mockOn).toHaveBeenCalledWith('error', callback);
+    });
+
+    it('onOverride should register listener on override channel', () => {
+      const callback = jest.fn();
+      exposedApi.onOverride(callback);
+      expect(mockOn).toHaveBeenCalledWith('override', expect.any(Function));
+    });
+
+    it('onOverride should forward the override payload and normalize undefined to null', () => {
+      const callback = jest.fn();
+      exposedApi.onOverride(callback);
+      const listener = mockOn.mock.calls.find((call) => call[0] === 'override')?.[1];
+
+      const override = { content: { url: 'https://example.com/promo' } };
+      listener({}, override);
+      expect(callback).toHaveBeenCalledWith({}, override);
+
+      // A clear (undefined/null payload) is normalized to null.
+      listener({}, undefined);
+      expect(callback).toHaveBeenCalledWith({}, null);
+    });
+  });
+
+  describe('Renderer liveness', () => {
+    it('notifyRendererAlive should send a renderer-heartbeat ping', () => {
+      exposedApi.notifyRendererAlive();
+      expect(mockSend).toHaveBeenCalledWith('renderer-heartbeat');
     });
   });
 

--- a/display/src/electron/preload.ts
+++ b/display/src/electron/preload.ts
@@ -17,6 +17,10 @@ try {
   logImpression: (data: any) => ipcRenderer.invoke('log-impression', data),
   logError: (data: any) => ipcRenderer.invoke('log-error', data),
 
+  // Renderer liveness ping — proves the renderer is still painting so the main
+  // process can surface a dead / frozen renderer in the heartbeat (realtime #2).
+  notifyRendererAlive: () => ipcRenderer.send('renderer-heartbeat'),
+
   // Device info
   getDeviceInfo: () => ipcRenderer.invoke('get-device-info'),
 
@@ -74,6 +78,17 @@ try {
     }),
   onError: (callback: (event: any, error: any) => void) =>
     ipcRenderer.on('error', callback),
+
+  // Emergency / push_content override, rendered as an in-renderer overlay
+  // instead of a top-level navigation so the socket + app survive (realtime #9).
+  // A `null` payload clears the overlay and reverts to the normal playlist.
+  onOverride: (callback: (
+    event: any,
+    override: { content: any; commandId?: string } | null,
+  ) => void) =>
+    ipcRenderer.on('override', (event, payload) => {
+      callback(event, payload ?? null);
+    }),
 
   // Remove listeners
   removeListener: (channel: string, callback: any) =>

--- a/display/src/renderer/app.ts
+++ b/display/src/renderer/app.ts
@@ -5,6 +5,16 @@ import {
   shouldReadCachedContent,
   shouldPreloadContentType,
 } from './preload-policy';
+import { computeVideoSafetyTimeoutMs } from './video-safety';
+
+// Renderer liveness ping cadence (realtime #2). The renderer proves it is still
+// painting; the main process folds staleness into the heartbeat.
+const RENDERER_ALIVE_PING_INTERVAL_MS = 2000;
+// Advance watchdog (realtime #6): if rotation has not advanced within this window
+// while a multi-item / looping playlist is active, force a restart. Kept well
+// above the per-video safety ceiling so the two never fight.
+const ADVANCE_WATCHDOG_INTERVAL_MS = 30000;
+const ADVANCE_WATCHDOG_MAX_STALL_MS = 20 * 60 * 1000;
 
 declare global {
   interface Window {
@@ -34,6 +44,11 @@ declare global {
         ack?: (response?: { ok: boolean; error?: string }) => void,
       ) => void) => void;
       onError: (callback: (event: any, error: any) => void) => void;
+      onOverride?: (callback: (
+        event: any,
+        override: { content: any; commandId?: string } | null,
+      ) => void) => void;
+      notifyRendererAlive?: () => void;
       removeListener: (channel: string, callback: any) => void;
     };
   }
@@ -48,6 +63,14 @@ class DisplayApp {
   private contentStartTime: number = 0;
   private zoneTimers: Map<string, NodeJS.Timeout> = new Map();
   private zoneIndices: Map<string, number> = new Map();
+  // Reliability (realtime #6): per-video safety timer + a monotonic advance token
+  // that invalidates late timers/events from a superseded item (no double-advance).
+  private videoSafetyTimer: NodeJS.Timeout | null = null;
+  private advanceToken = 0;
+  private lastAdvanceAt = 0;
+  private advanceWatchdog: NodeJS.Timeout | null = null;
+  private playlistEnded = false;
+  private lastFrameAt = 0;
 
   constructor() {
     console.log('[App] Constructor: Creating DisplayApp instance');
@@ -123,9 +146,190 @@ class DisplayApp {
       this.showErrorScreen(error.message || 'Unknown error');
     });
 
+    // Emergency / push_content override rendered as an in-renderer overlay
+    // (realtime #9). A `null` payload clears the overlay and reveals the playlist.
+    window.electronAPI.onOverride?.((_, override) => {
+      try {
+        this.renderOverride(override);
+      } catch (error) {
+        console.error('[App] Failed to render override overlay:', error);
+      }
+    });
+
+    // Renderer liveness (realtime #2) + advance watchdog (realtime #6).
+    this.startRendererLivenessPing();
+    this.startAdvanceWatchdog();
+
     // Don't proactively show pairing screen - wait for main process to tell us
     // The main process will send 'pairing-required' if no token exists
     console.log('[App] Renderer ready, waiting for main process events...');
+  }
+
+  private startRendererLivenessPing() {
+    // Paint-gated liveness ping (realtime #2). requestAnimationFrame only fires
+    // while the compositor is actually painting, so if the renderer freezes the
+    // pings stop and the main process surfaces the device as on-but-dark. A hung
+    // renderer therefore reports staleness instead of a false "online".
+    const raf =
+      typeof requestAnimationFrame === 'function'
+        ? requestAnimationFrame
+        : (cb: FrameRequestCallback) => setTimeout(() => cb(Date.now()), 16) as unknown as number;
+
+    const frame = () => {
+      this.lastFrameAt = Date.now();
+      raf(frame);
+    };
+    frame();
+
+    setInterval(() => {
+      // Only ping if a frame painted recently — a frozen compositor stops raf,
+      // so we stop pinging and the device correctly reads as dark.
+      if (Date.now() - this.lastFrameAt < RENDERER_ALIVE_PING_INTERVAL_MS * 2) {
+        window.electronAPI.notifyRendererAlive?.();
+      }
+    }, RENDERER_ALIVE_PING_INTERVAL_MS);
+  }
+
+  private startAdvanceWatchdog() {
+    if (this.advanceWatchdog) {
+      clearInterval(this.advanceWatchdog);
+    }
+    this.advanceWatchdog = setInterval(
+      () => this.checkAdvanceWatchdog(),
+      ADVANCE_WATCHDOG_INTERVAL_MS,
+    );
+  }
+
+  private checkAdvanceWatchdog() {
+    // Backstop for a wedged rotation (realtime #6): if content has not advanced
+    // for far longer than any legitimate item duration while a rotating playlist
+    // is active, restart rotation. Skips a legitimately-ended non-looping playlist
+    // and single static holds so it never thrashes intended behavior.
+    if (this.playlistEnded) return;
+    const items = this.currentPlaylist?.items;
+    if (!Array.isArray(items) || items.length === 0) return;
+    if (items.length < 2 && !this.currentPlaylist.loopPlaylist) return;
+    if (this.lastAdvanceAt === 0) return;
+
+    if (Date.now() - this.lastAdvanceAt > ADVANCE_WATCHDOG_MAX_STALL_MS) {
+      console.warn('[App] Advance watchdog: rotation stalled — restarting');
+      this.clearVideoSafetyTimer();
+      if (this.playbackTimer) {
+        clearTimeout(this.playbackTimer);
+        this.playbackTimer = null;
+      }
+      this.nextContent();
+    }
+  }
+
+  private clearVideoSafetyTimer() {
+    if (this.videoSafetyTimer) {
+      clearTimeout(this.videoSafetyTimer);
+      this.videoSafetyTimer = null;
+    }
+  }
+
+  private armVideoSafetyTimer(item: any, token: number, probedDurationSec?: number) {
+    // Force-advance a stalled/hung video that fires neither `ended` nor `error`
+    // (realtime #6). Re-armed with the probed duration once metadata loads.
+    if (token !== this.advanceToken) return;
+    this.clearVideoSafetyTimer();
+    const timeoutMs = computeVideoSafetyTimeoutMs(
+      item?.duration ?? item?.content?.duration,
+      probedDurationSec,
+    );
+    this.videoSafetyTimer = setTimeout(() => {
+      console.warn('[App] Video safety timer fired — force-advancing (no ended/error)');
+      this.advance(token);
+    }, timeoutMs);
+  }
+
+  private advance(token: number) {
+    // Single guarded advance path (realtime #6). A late `ended`/`error`/safety
+    // timer from a superseded item carries a stale token and is ignored, so the
+    // playlist can never double-advance.
+    if (token !== this.advanceToken) return;
+    this.clearVideoSafetyTimer();
+    this.nextContent();
+  }
+
+  private renderOverride(override: { content?: any } | null) {
+    // In-renderer overlay for push_content / emergency overrides (realtime #9).
+    // Rendered above the playlist so the socket + app survive; a null payload
+    // removes it and reveals the still-running playlist underneath.
+    const existing = document.getElementById('override-overlay');
+
+    if (!override || !override.content) {
+      if (existing) {
+        existing.innerHTML = '';
+        existing.remove();
+      }
+      return;
+    }
+
+    const overlay = existing ?? document.createElement('div');
+    overlay.id = 'override-overlay';
+    overlay.style.position = 'fixed';
+    overlay.style.top = '0';
+    overlay.style.left = '0';
+    overlay.style.width = '100vw';
+    overlay.style.height = '100vh';
+    overlay.style.zIndex = '2000';
+    overlay.style.background = '#000';
+    overlay.style.display = 'flex';
+    overlay.style.alignItems = 'center';
+    overlay.style.justifyContent = 'center';
+    overlay.innerHTML = '';
+    if (!existing) {
+      document.body.appendChild(overlay);
+    }
+
+    const content = override.content;
+    const source = content.url || content.source;
+
+    switch (content.type) {
+      case 'image': {
+        const img = document.createElement('img');
+        img.src = source;
+        img.style.maxWidth = '100%';
+        img.style.maxHeight = '100%';
+        img.style.objectFit = 'contain';
+        overlay.appendChild(img);
+        break;
+      }
+      case 'video': {
+        const video = document.createElement('video');
+        video.src = source;
+        video.autoplay = true;
+        video.loop = true;
+        video.muted = false;
+        video.style.maxWidth = '100%';
+        video.style.maxHeight = '100%';
+        overlay.appendChild(video);
+        break;
+      }
+      case 'html':
+      case 'template': {
+        const htmlIframe = document.createElement('iframe');
+        htmlIframe.sandbox.add('allow-scripts');
+        htmlIframe.srcdoc = source;
+        htmlIframe.style.width = '100%';
+        htmlIframe.style.height = '100%';
+        htmlIframe.style.border = 'none';
+        overlay.appendChild(htmlIframe);
+        break;
+      }
+      default: {
+        // url / webpage / unspecified — load in an iframe.
+        const iframe = document.createElement('iframe');
+        iframe.src = source;
+        iframe.allow = 'autoplay';
+        iframe.style.width = '100%';
+        iframe.style.height = '100%';
+        iframe.style.border = 'none';
+        overlay.appendChild(iframe);
+      }
+    }
   }
 
   private async showPairingScreen() {
@@ -389,11 +593,16 @@ class DisplayApp {
   private updatePlaylist(playlist: any) {
     this.currentPlaylist = playlist;
     this.currentIndex = 0;
+    this.playlistEnded = false;
 
-    // Stop current playback
+    // Stop current playback (both the non-video rotation timer and the video
+    // safety timer) and invalidate any in-flight advance from the old item.
     if (this.playbackTimer) {
       clearTimeout(this.playbackTimer);
+      this.playbackTimer = null;
     }
+    this.clearVideoSafetyTimer();
+    this.advanceToken++;
 
     // Clear content container
     const container = document.getElementById('content-container');
@@ -426,6 +635,12 @@ class DisplayApp {
     if (!container || !currentItem) {
       return;
     }
+
+    // New item on the glass — invalidate any pending advance from the prior item
+    // and record the advance time for the watchdog (realtime #6).
+    const token = ++this.advanceToken;
+    this.clearVideoSafetyTimer();
+    this.lastAdvanceAt = Date.now();
 
     // Create content element
     const contentDiv = document.createElement('div');
@@ -467,15 +682,32 @@ class DisplayApp {
         contentDiv.appendChild(img);
         break;
 
-      case 'video':
+      case 'video': {
         const video = document.createElement('video');
         video.src = contentSource;
         video.autoplay = true;
         video.muted = false;
-        video.onerror = () => this.handleContentError(currentItem, 'Video load failed');
-        video.onended = () => this.nextContent();
+        // Guarded, single-advance handlers (realtime #6).
+        video.onerror = () => {
+          if (token !== this.advanceToken) return;
+          this.clearVideoSafetyTimer();
+          this.handleContentError(currentItem, 'Video load failed');
+        };
+        video.onended = () => this.advance(token);
+        // `stalled` / `waiting` are recoverable buffering signals — log only and
+        // let the safety timer escalate to a force-advance if playback never
+        // resumes. This avoids skipping content on a transient network hiccup.
+        video.onstalled = () => console.warn('[App] Video stalled (buffering)');
+        video.onwaiting = () => console.warn('[App] Video waiting (buffering)');
+        // Re-arm the safety timer with the true clip length once known.
+        video.onloadedmetadata = () =>
+          this.armVideoSafetyTimer(currentItem, token, video.duration);
         contentDiv.appendChild(video);
+        // Arm an initial safety timer immediately in case metadata never loads
+        // (a hung load fires neither loadedmetadata nor error).
+        this.armVideoSafetyTimer(currentItem, token, undefined);
         break;
+      }
 
       case 'webpage':
       case 'url':
@@ -535,7 +767,7 @@ class DisplayApp {
           timestamp: Date.now(),
         });
 
-        this.nextContent();
+        this.advance(token);
       }, expectedDuration);
     }
   }
@@ -568,7 +800,15 @@ class DisplayApp {
       if (this.currentPlaylist.loopPlaylist) {
         this.currentIndex = 0;
       } else {
-        // Stop playback
+        // Non-looping playlist finished — intentionally hold the last frame.
+        // Mark ended so the advance watchdog does not thrash it, and clear any
+        // pending timers so nothing fires against a stopped playlist (realtime #6).
+        this.playlistEnded = true;
+        this.clearVideoSafetyTimer();
+        if (this.playbackTimer) {
+          clearTimeout(this.playbackTimer);
+          this.playbackTimer = null;
+        }
         return;
       }
     }

--- a/display/src/renderer/video-safety.spec.ts
+++ b/display/src/renderer/video-safety.spec.ts
@@ -1,0 +1,38 @@
+import {
+  computeVideoSafetyTimeoutMs,
+  VIDEO_SAFETY_MARGIN_MS,
+  VIDEO_SAFETY_MIN_MS,
+  VIDEO_SAFETY_MAX_MS,
+} from './video-safety';
+
+describe('computeVideoSafetyTimeoutMs', () => {
+  it('uses the item duration plus a margin when no probed duration is available', () => {
+    // 60s clip → 60_000 + margin, comfortably above the floor.
+    expect(computeVideoSafetyTimeoutMs(60)).toBe(60_000 + VIDEO_SAFETY_MARGIN_MS);
+  });
+
+  it('prefers the probed media duration over the configured item duration', () => {
+    // Configured 10s but the real clip is 120s — trust the probe so a long clip
+    // is never cut off by the safety timer.
+    expect(computeVideoSafetyTimeoutMs(10, 120)).toBe(120_000 + VIDEO_SAFETY_MARGIN_MS);
+  });
+
+  it('falls back to the hard ceiling when neither duration is known (hung load)', () => {
+    expect(computeVideoSafetyTimeoutMs(undefined, undefined)).toBe(VIDEO_SAFETY_MAX_MS);
+    expect(computeVideoSafetyTimeoutMs(null)).toBe(VIDEO_SAFETY_MAX_MS);
+    expect(computeVideoSafetyTimeoutMs(0, NaN)).toBe(VIDEO_SAFETY_MAX_MS);
+  });
+
+  it('clamps a tiny duration up to the floor so it cannot hot-advance', () => {
+    expect(computeVideoSafetyTimeoutMs(1)).toBe(VIDEO_SAFETY_MIN_MS);
+  });
+
+  it('clamps a bogus huge duration down to the ceiling so it cannot wedge rotation', () => {
+    expect(computeVideoSafetyTimeoutMs(999999)).toBe(VIDEO_SAFETY_MAX_MS);
+  });
+
+  it('ignores non-finite / negative values and uses the next valid source', () => {
+    expect(computeVideoSafetyTimeoutMs(-5, 45)).toBe(45_000 + VIDEO_SAFETY_MARGIN_MS);
+    expect(computeVideoSafetyTimeoutMs(45, Infinity)).toBe(45_000 + VIDEO_SAFETY_MARGIN_MS);
+  });
+});

--- a/display/src/renderer/video-safety.ts
+++ b/display/src/renderer/video-safety.ts
@@ -1,0 +1,42 @@
+// Reliability helpers for video playback (backlog realtime #6).
+//
+// A stalled / hung <video> may never fire `ended` OR `error`. Without a
+// fallback the playlist freezes on a single frame forever while the device
+// still heartbeats "online". We arm a per-video safety timer that force-advances
+// if the natural events never arrive. The timeout is the item's known / probed
+// duration plus a margin, clamped between a floor (so a bogus 0s duration cannot
+// hot-advance) and a ceiling (so a bogus huge / missing duration cannot wedge
+// rotation forever).
+
+export const VIDEO_SAFETY_MARGIN_MS = 5000;
+export const VIDEO_SAFETY_MIN_MS = 15000;
+export const VIDEO_SAFETY_MAX_MS = 15 * 60 * 1000; // 15 min hard ceiling
+
+function firstFinitePositiveSeconds(...values: unknown[]): number | null {
+  for (const value of values) {
+    if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+      return value;
+    }
+  }
+  return null;
+}
+
+/**
+ * Compute the force-advance safety timeout (ms) for a video item.
+ *
+ * Prefers the probed media duration (from `loadedmetadata`) over the item's
+ * configured duration, since the probed value is the real length of the clip.
+ * When neither is known the video load itself may be hung, so we fall back to
+ * the hard ceiling rather than advancing early.
+ */
+export function computeVideoSafetyTimeoutMs(
+  itemDurationSec: unknown,
+  probedDurationSec?: unknown,
+): number {
+  const known = firstFinitePositiveSeconds(probedDurationSec, itemDurationSec);
+  if (known === null) {
+    return VIDEO_SAFETY_MAX_MS;
+  }
+  const withMargin = known * 1000 + VIDEO_SAFETY_MARGIN_MS;
+  return Math.min(VIDEO_SAFETY_MAX_MS, Math.max(VIDEO_SAFETY_MIN_MS, withMargin));
+}


### PR DESCRIPTION
**Batch PR-9** (P1 tier). Closes **realtime #2, #3, #6, #9** — the worst unattended failure modes: a screen goes blank/frozen while the backend still reports "online".

- **#2 renderer crash → permanent blank:** `webContents` `render-process-gone` / `unresponsive` handlers reload with **capped exponential backoff** (one reload scheduled at a time; resets on a successful load → never hot-loops). A `requestAnimationFrame`-gated renderer→main liveness ping (stops when the compositor freezes) surfaces renderer state in the heartbeat, so a dead renderer is visible server-side instead of green.
- **#3 blank on offline boot:** last non-empty playlist persisted to `electron-store`, rendered from cache **before the socket connects**; a connect-time `playlist:request` reconciles to live content. Screens now show cached content through a power-cut / router-down boot.
- **#6 stalled video / non-looping freeze:** per-video max-duration safety timer force-advances if `ended`/`error` never fire; a monotonic `advanceToken` invalidates late events (**no double-advance**); a 20-min advance watchdog restarts a wedged rotation (gated to skip legit non-looping / single-static holds).
- **#9 push_content override thrash:** overrides render as an **in-renderer overlay** (IPC) instead of a top-level `loadURL`, so the socket + app survive override+revert; the device client **initializes exactly once**, ending the reconnect loop.

## Verification (independently re-run)
- display `typecheck` 0 · `test:ci` **171/171** (+26) · `build` 0.

## Scope note
On-glass rendering (overlay elements, real `<video>` events, rAF cadence) awaits the **release real-device walkthrough** per the display release gate — the pure decision logic + all main/device/preload wiring is unit-tested. A **single video > 15 min** is force-advanced at 15 min (deliberate — the one freeze case the 20-min watchdog can't catch; rare for signage). This is the packaged Electron client; it ships to devices via the signed auto-update feed, not the VPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)