### PR TITLE
feat(analytics): durable device time-series in ClickHouse → real uptime (PR-10)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -300,3 +300,24 @@ VALIDATOR_BASE_URL=http://localhost:3000
 # duplicate entry up top is the canonical one. Uncomment + set to enable.)
 # =============================================================================
 # SENTRY_DSN=https://your-dsn@sentry.io/project-id
+
+# =============================================================================
+# ClickHouse — durable device time-series (REAL uptime) + analytics
+# =============================================================================
+# The realtime gateway batches device-health samples into ClickHouse
+# (device_health_samples table) and the middleware reads them for real uptime.
+# FAIL-OPEN: if ClickHouse is unreachable the app runs exactly as before, minus
+# history — uptime endpoints then honestly report "insufficient data" rather
+# than a fabricated percentage. Never hard-fails boot.
+#
+# Defaults below match the docker-compose `analytics` profile (published on
+# 127.0.0.1:8123, user `default`, no password, database `default`).
+# CLICKHOUSE_URL=http://localhost:8123     # or set CLICKHOUSE_HOST + CLICKHOUSE_PORT
+CLICKHOUSE_HOST=localhost
+CLICKHOUSE_PORT=8123
+CLICKHOUSE_DATABASE=default
+CLICKHOUSE_USER=default
+CLICKHOUSE_PASSWORD=
+# Set to false to fully disable ClickHouse (e.g. dev without the analytics
+# profile) — the writer/reader become no-ops instead of logging retry warnings.
+# CLICKHOUSE_ENABLED=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,8 @@ Playwright runs sequentially (1 worker) to avoid DB race conditions. Retries: 2 
 
 **Dual persistence for device status**: Device online/offline status writes to both Redis (fast reads) and PostgreSQL (persistence/dashboard queries).
 
+**Durable device time-series (ClickHouse)**: ClickHouse is now wired (was provisioned-but-dark). The realtime gateway batches a `device_health_samples` row on every heartbeat via `ClickHouseService` (`realtime/src/services/clickhouse.service.ts`) — buffered, async, fire-and-forget, **fail-open** (a ClickHouse outage never touches the heartbeat path). The middleware reads it (`middleware/src/modules/clickhouse/`) for **real** uptime: `AnalyticsService.getDeviceUptime`/`getUptimeSummary` compute uptime as the fraction of 5-min buckets holding ≥1 sample, and return a clearly-labelled `insufficient_data` (`uptimePercent: null`, `measured: false`) when there is no history or ClickHouse is unreachable — never a fabricated number. A `ClickHouseWatchdogService` @Cron (§12a) alerts via Sentry when displays are active but samples stop arriving. Config is `CLICKHOUSE_*` (see `.env.example`); reads/writes fail-open and never hard-fail boot. Canonical DDL: `docker/clickhouse/init.sql` (app also creates it idempotently on startup).
+
 **Content system**: Supports image/video/url/html types. Template rendering via Handlebars. File validation with magic number verification to prevent MIME spoofing. Expiration system with automatic replacement content.
 
 **Response envelope**: Global `ResponseEnvelopeInterceptor` wraps all responses in `{ success, data, meta }`. Skip with `@SkipEnvelope()` decorator on individual endpoints.

--- a/docker/clickhouse/init.sql
+++ b/docker/clickhouse/init.sql
@@ -1,6 +1,25 @@
 -- ClickHouse initialization script for Vizora Analytics
 
--- Heartbeats table - Device health metrics
+-- Device health samples - durable device time-series powering REAL uptime.
+-- Written by the realtime gateway on every heartbeat (batched, fail-open) and
+-- read by the middleware AnalyticsService (uptime = fraction of 5-min buckets
+-- that hold >=1 sample). The app also creates this idempotently on startup
+-- (ClickHouseService.ensureSchema); this file is the canonical DDL for a fresh
+-- stack. Keep the two in sync.
+CREATE TABLE IF NOT EXISTS device_health_samples (
+  deviceId String,
+  organizationId String,
+  cpu Float32,
+  memory Float32,
+  temperature Nullable(Float32),
+  status String,
+  event_time DateTime
+) ENGINE = MergeTree()
+PARTITION BY toYYYYMM(event_time)
+ORDER BY (organizationId, deviceId, event_time)
+TTL event_time + INTERVAL 90 DAY DELETE;
+
+-- Heartbeats table - Device health metrics (legacy; not yet wired to the app)
 CREATE TABLE IF NOT EXISTS heartbeats (
   timestamp DateTime64(3),
   device_id String,

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -95,6 +95,7 @@
     }
   },
   "dependencies": {
+    "@clickhouse/client": "^1.23.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@nestjs/axios": "^4.0.0",
     "@nestjs/common": "^11.0.0",

--- a/middleware/src/app/app.module.ts
+++ b/middleware/src/app/app.module.ts
@@ -7,6 +7,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ConfigModule } from '../modules/config/config.module';
 import { DatabaseModule } from '../modules/database/database.module';
+import { ClickHouseModule } from '../modules/clickhouse/clickhouse.module';
 import { RedisModule } from '../modules/redis/redis.module';
 import { CommonModule } from '../modules/common/common.module';
 import { AuthModule } from '../modules/auth/auth.module';
@@ -119,6 +120,7 @@ import { CsrfMiddleware } from '../modules/common/middleware/csrf.middleware';
     StorageModule,
     MailModule,
     DatabaseModule,
+    ClickHouseModule,
     RedisModule,
     AuthModule,
     OrganizationsModule,

--- a/middleware/src/modules/analytics/analytics.service.spec.ts
+++ b/middleware/src/modules/analytics/analytics.service.spec.ts
@@ -5,8 +5,19 @@ import { DatabaseService } from '../database/database.service';
 describe('AnalyticsService', () => {
   let service: AnalyticsService;
   let mockDb: any;
+  let mockClickhouse: any;
 
   beforeEach(() => {
+    mockClickhouse = {
+      // Default: ClickHouse has no history → uptime reads are "insufficient data".
+      getDeviceUptimeAggregate: jest.fn().mockResolvedValue(null),
+      getOrgUptimeAggregates: jest.fn().mockResolvedValue(null),
+      getLatestSampleTime: jest.fn().mockResolvedValue({ available: false, lastSample: null }),
+      isHealthy: jest.fn().mockResolvedValue(false),
+      ensureSchema: jest.fn().mockResolvedValue(undefined),
+      isEnabled: true,
+    };
+
     mockDb = {
       display: {
         findMany: jest.fn().mockResolvedValue([]),
@@ -34,7 +45,7 @@ describe('AnalyticsService', () => {
       $queryRaw: jest.fn().mockResolvedValue([]),
     };
 
-    service = new AnalyticsService(mockDb as DatabaseService);
+    service = new AnalyticsService(mockDb as DatabaseService, mockClickhouse);
   });
 
   it('should be defined', () => {
@@ -443,24 +454,88 @@ describe('AnalyticsService', () => {
   });
 
   describe('getDeviceUptime', () => {
-    it('should return uptime data for a device', async () => {
+    // A device online for the whole window: a sample in (nearly) every 5-min
+    // bucket. ~30 days ⇒ ~8640 buckets; giving firstSample=windowStart and
+    // upBuckets≈totalBuckets yields ~100% measured uptime.
+    const fullCoverageAggregate = (deviceId: string, days: number, upFraction = 1) => {
+      const now = Date.now();
+      const firstSample = new Date(now - days * 24 * 60 * 60 * 1000);
+      const totalBuckets = Math.ceil((days * 24 * 60 * 60 * 1000) / (5 * 60 * 1000));
+      return {
+        deviceId,
+        upBuckets: Math.round(totalBuckets * upFraction),
+        sampleCount: Math.round(totalBuckets * upFraction),
+        firstSample,
+        lastSample: new Date(now),
+      };
+    };
+
+    it('returns a REAL measured uptime when ClickHouse has samples', async () => {
       const now = new Date();
-      mockDb.display.findFirst.mockResolvedValue({
-        id: 'device-123',
-        nickname: 'Test Device',
-        status: 'online',
-        lastHeartbeat: now,
-      });
+      mockDb.display.findFirst.mockResolvedValue({ id: 'device-123', lastHeartbeat: now });
+      mockClickhouse.getDeviceUptimeAggregate.mockResolvedValue(
+        fullCoverageAggregate('device-123', 30, 1),
+      );
 
       const result = await service.getDeviceUptime('org-123', 'device-123', 30);
 
       expect(result.deviceId).toBe('device-123');
-      expect(result.uptimePercent).toBe(95); // Online device gets 95%
-      expect(result.isEstimated).toBe(true);
-      expect(result.metricSource).toBe('heartbeat_status_heuristic');
-      expect(result.totalOnlineMinutes).toBeGreaterThan(0);
-      expect(result.totalOfflineMinutes).toBeGreaterThan(0);
-      expect(result.lastHeartbeat).toEqual(now);
+      expect(result.measured).toBe(true);
+      expect(result.metricSource).toBe('clickhouse_health_samples');
+      expect(result.uptimePercent).not.toBeNull();
+      expect(result.uptimePercent).toBeGreaterThan(95);
+      expect(result.uptimePercent).toBeLessThanOrEqual(100);
+      expect(result.sampleCount).toBeGreaterThan(0);
+      expect(result.totalOnlineMinutes! + result.totalOfflineMinutes!).toBeGreaterThan(0);
+      expect(mockClickhouse.getDeviceUptimeAggregate).toHaveBeenCalledWith(
+        'org-123',
+        'device-123',
+        expect.any(Date),
+      );
+    });
+
+    it('measures ~50% uptime when only half the buckets have samples', async () => {
+      mockDb.display.findFirst.mockResolvedValue({ id: 'device-123', lastHeartbeat: new Date() });
+      mockClickhouse.getDeviceUptimeAggregate.mockResolvedValue(
+        fullCoverageAggregate('device-123', 30, 0.5),
+      );
+
+      const result = await service.getDeviceUptime('org-123', 'device-123', 30);
+
+      expect(result.measured).toBe(true);
+      expect(result.uptimePercent).toBeGreaterThan(45);
+      expect(result.uptimePercent).toBeLessThan(55);
+    });
+
+    it('returns INSUFFICIENT DATA (null %, not a fabricated number) when no samples exist', async () => {
+      mockDb.display.findFirst.mockResolvedValue({ id: 'device-123', lastHeartbeat: null });
+      mockClickhouse.getDeviceUptimeAggregate.mockResolvedValue({
+        deviceId: 'device-123',
+        upBuckets: 0,
+        sampleCount: 0,
+        firstSample: new Date(),
+        lastSample: new Date(),
+      });
+
+      const result = await service.getDeviceUptime('org-123', 'device-123', 30);
+
+      expect(result.measured).toBe(false);
+      expect(result.uptimePercent).toBeNull();
+      expect(result.totalOnlineMinutes).toBeNull();
+      expect(result.totalOfflineMinutes).toBeNull();
+      expect(result.sampleCount).toBe(0);
+      expect(result.metricSource).toBe('insufficient_data');
+    });
+
+    it('returns INSUFFICIENT DATA when ClickHouse is unavailable (query returns null)', async () => {
+      mockDb.display.findFirst.mockResolvedValue({ id: 'device-123', lastHeartbeat: null });
+      mockClickhouse.getDeviceUptimeAggregate.mockResolvedValue(null);
+
+      const result = await service.getDeviceUptime('org-123', 'device-123', 30);
+
+      expect(result.measured).toBe(false);
+      expect(result.uptimePercent).toBeNull();
+      expect(result.metricSource).toBe('insufficient_data');
     });
 
     it('should throw NotFoundException for invalid device', async () => {
@@ -470,69 +545,75 @@ describe('AnalyticsService', () => {
         NotFoundException,
       );
     });
-
-    it('should calculate lower uptime for offline devices', async () => {
-      const staleHeartbeat = new Date(Date.now() - 10 * 60 * 1000); // 10 minutes ago
-      mockDb.display.findFirst.mockResolvedValue({
-        id: 'device-123',
-        nickname: 'Test Device',
-        status: 'offline',
-        lastHeartbeat: staleHeartbeat,
-      });
-
-      const result = await service.getDeviceUptime('org-123', 'device-123', 30);
-
-      expect(result.uptimePercent).toBe(20); // Offline device gets 20%
-    });
-
-    it('should calculate medium uptime for device with online status but stale heartbeat', async () => {
-      const staleHeartbeat = new Date(Date.now() - 10 * 60 * 1000); // 10 minutes ago
-      mockDb.display.findFirst.mockResolvedValue({
-        id: 'device-123',
-        nickname: 'Test Device',
-        status: 'online',
-        lastHeartbeat: staleHeartbeat,
-      });
-
-      const result = await service.getDeviceUptime('org-123', 'device-123', 30);
-
-      expect(result.uptimePercent).toBe(80); // Online status but stale heartbeat gets 80%
-    });
-
-    it('should use correct days parameter for calculations', async () => {
-      const now = new Date();
-      mockDb.display.findFirst.mockResolvedValue({
-        id: 'device-123',
-        nickname: 'Test Device',
-        status: 'online',
-        lastHeartbeat: now,
-      });
-
-      const result7Days = await service.getDeviceUptime('org-123', 'device-123', 7);
-      const result30Days = await service.getDeviceUptime('org-123', 'device-123', 30);
-
-      // Both have 95% uptime, but total minutes differ based on days
-      expect(result7Days.totalOnlineMinutes + result7Days.totalOfflineMinutes).toBe(7 * 24 * 60);
-      expect(result30Days.totalOnlineMinutes + result30Days.totalOfflineMinutes).toBe(30 * 24 * 60);
-    });
   });
 
   describe('getUptimeSummary', () => {
-    it('should return aggregated uptime data for all devices', async () => {
-      const now = new Date();
+    const coverageAggregate = (deviceId: string, upFraction: number, days = 30) => {
+      const now = Date.now();
+      const totalBuckets = Math.ceil((days * 24 * 60 * 60 * 1000) / (5 * 60 * 1000));
+      return {
+        deviceId,
+        upBuckets: Math.round(totalBuckets * upFraction),
+        sampleCount: Math.round(totalBuckets * upFraction),
+        firstSample: new Date(now - days * 24 * 60 * 60 * 1000),
+        lastSample: new Date(now),
+      };
+    };
+
+    it('measures uptime per device and averages over MEASURED devices only', async () => {
       mockDb.display.findMany.mockResolvedValue([
-        { id: 'd1', nickname: 'Device 1', status: 'online', lastHeartbeat: now },
-        { id: 'd2', nickname: 'Device 2', status: 'offline', lastHeartbeat: null },
+        { id: 'd1', nickname: 'Device 1', status: 'online' },
+        { id: 'd2', nickname: 'Device 2', status: 'offline' },
       ]);
+      // d1 has ~100% coverage; d2 has NO samples (absent from aggregates).
+      mockClickhouse.getOrgUptimeAggregates.mockResolvedValue([coverageAggregate('d1', 1)]);
 
       const result = await service.getUptimeSummary('org-123', 30);
 
       expect(result.deviceCount).toBe(2);
       expect(result.onlineCount).toBe(1);
       expect(result.offlineCount).toBe(1);
-      expect(result.isEstimated).toBe(true);
-      expect(result.metricSource).toBe('heartbeat_status_heuristic');
-      expect(result.devices).toHaveLength(2);
+      expect(result.measured).toBe(true);
+      expect(result.measuredDeviceCount).toBe(1);
+      expect(result.metricSource).toBe('clickhouse_health_samples');
+
+      const d1 = result.devices.find((d) => d.id === 'd1');
+      const d2 = result.devices.find((d) => d.id === 'd2');
+      expect(d1?.measured).toBe(true);
+      expect(d1?.uptimePercent).toBeGreaterThan(95);
+      // d2 has no samples → insufficient data, NOT a fabricated number.
+      expect(d2?.measured).toBe(false);
+      expect(d2?.uptimePercent).toBeNull();
+      // Average is over the single measured device (d1), not diluted by d2.
+      expect(result.avgUptimePercent).toBe(d1?.uptimePercent);
+    });
+
+    it('returns INSUFFICIENT DATA for the org when no device has samples', async () => {
+      mockDb.display.findMany.mockResolvedValue([
+        { id: 'd1', nickname: 'Device 1', status: 'online' },
+      ]);
+      mockClickhouse.getOrgUptimeAggregates.mockResolvedValue([]); // reachable, no rows
+
+      const result = await service.getUptimeSummary('org-123', 30);
+
+      expect(result.measured).toBe(false);
+      expect(result.measuredDeviceCount).toBe(0);
+      expect(result.avgUptimePercent).toBeNull();
+      expect(result.metricSource).toBe('insufficient_data');
+      expect(result.devices[0].uptimePercent).toBeNull();
+    });
+
+    it('returns INSUFFICIENT DATA when ClickHouse is unavailable', async () => {
+      mockDb.display.findMany.mockResolvedValue([
+        { id: 'd1', nickname: 'Device 1', status: 'online' },
+      ]);
+      mockClickhouse.getOrgUptimeAggregates.mockResolvedValue(null); // CH down
+
+      const result = await service.getUptimeSummary('org-123', 30);
+
+      expect(result.measured).toBe(false);
+      expect(result.avgUptimePercent).toBeNull();
+      expect(result.metricSource).toBe('insufficient_data');
     });
 
     it('should handle empty device list', async () => {
@@ -543,49 +624,19 @@ describe('AnalyticsService', () => {
       expect(result.deviceCount).toBe(0);
       expect(result.onlineCount).toBe(0);
       expect(result.offlineCount).toBe(0);
-      expect(result.avgUptimePercent).toBe(0);
+      expect(result.avgUptimePercent).toBeNull();
+      expect(result.measured).toBe(false);
       expect(result.devices).toEqual([]);
     });
 
-    it('should calculate correct average uptime', async () => {
-      const now = new Date();
-      const staleHeartbeat = new Date(Date.now() - 10 * 60 * 1000);
-      mockDb.display.findMany.mockResolvedValue([
-        { id: 'd1', nickname: 'Online Device', status: 'online', lastHeartbeat: now }, // 95%
-        { id: 'd2', nickname: 'Offline Device', status: 'offline', lastHeartbeat: staleHeartbeat }, // 20%
-      ]);
-
-      const result = await service.getUptimeSummary('org-123', 30);
-
-      // Average of 95 and 20 = 57.5
-      expect(result.avgUptimePercent).toBe(57.5);
-    });
-
     it('should use "Unnamed Device" for null nicknames', async () => {
-      const now = new Date();
       mockDb.display.findMany.mockResolvedValue([
-        { id: 'd1', nickname: null, status: 'online', lastHeartbeat: now },
+        { id: 'd1', nickname: null, status: 'online' },
       ]);
 
       const result = await service.getUptimeSummary('org-123', 30);
 
       expect(result.devices[0].nickname).toBe('Unnamed Device');
-    });
-
-    it('should return per-device uptime percentages', async () => {
-      const now = new Date();
-      mockDb.display.findMany.mockResolvedValue([
-        { id: 'd1', nickname: 'Device 1', status: 'online', lastHeartbeat: now },
-        { id: 'd2', nickname: 'Device 2', status: 'offline', lastHeartbeat: null },
-      ]);
-
-      const result = await service.getUptimeSummary('org-123', 30);
-
-      const device1 = result.devices.find((d) => d.id === 'd1');
-      const device2 = result.devices.find((d) => d.id === 'd2');
-
-      expect(device1?.uptimePercent).toBe(95);
-      expect(device2?.uptimePercent).toBe(20);
     });
   });
 

--- a/middleware/src/modules/analytics/analytics.service.ts
+++ b/middleware/src/modules/analytics/analytics.service.ts
@@ -1,6 +1,11 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { DatabaseService } from '../database/database.service';
+import {
+  ClickHouseService,
+  type DeviceHealthUptimeAggregate,
+} from '../clickhouse/clickhouse.service';
+import { UPTIME_BUCKET_MS } from '../clickhouse/clickhouse.constants';
 import type {
   DeviceMetricDataPoint,
   ContentPerformanceItem,
@@ -12,6 +17,7 @@ import type {
   ContentMetrics,
   DeviceUptimeResult,
   UptimeSummaryResult,
+  UptimeSummaryDevice,
   ExportAnalyticsResult,
 } from './dto/analytics-response.dto';
 
@@ -19,7 +25,10 @@ import type {
 export class AnalyticsService {
   private readonly logger = new Logger(AnalyticsService.name);
 
-  constructor(private readonly db: DatabaseService) {}
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly clickhouse: ClickHouseService,
+  ) {}
 
   private getRangeDays(range: string): number {
     switch (range) {
@@ -418,90 +427,148 @@ export class AnalyticsService {
   }
 
   /**
-   * Device uptime for a specific device
-   * Returns uptime percentage and online/offline minutes
+   * Real device uptime, measured over the durable ClickHouse
+   * `device_health_samples` time-series (a device's heartbeats mark the
+   * time-buckets it was online). When ClickHouse has no history for the device
+   * — freshly wired, device idle, or ClickHouse unreachable — this returns a
+   * clearly-labelled "insufficient data" result (`uptimePercent: null`,
+   * `measured: false`), NEVER a fabricated percentage.
    */
   async getDeviceUptime(
     organizationId: string,
     deviceId: string,
     days: number = 30,
   ): Promise<DeviceUptimeResult> {
-    // Get device from DB
     const device = await this.db.display.findFirst({
       where: { id: deviceId, organizationId },
+      select: { id: true, lastHeartbeat: true },
     });
 
     if (!device) {
       throw new NotFoundException('Device not found');
     }
 
-    // Simple calculation based on current status and lastHeartbeat
-    // For now, if device has heartbeat within last 5 minutes, consider it online
     const now = new Date();
-    const fiveMinutesAgo = new Date(now.getTime() - 5 * 60 * 1000);
-    const isOnline = device.lastHeartbeat && device.lastHeartbeat > fiveMinutesAgo;
+    const since = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+    const aggregate = await this.clickhouse.getDeviceUptimeAggregate(
+      organizationId,
+      deviceId,
+      since,
+    );
 
-    // For a more realistic calculation, we'd query audit logs or a heartbeat history table
-    // For now, return a simplified response based on current state
-    const totalMinutes = days * 24 * 60;
-    const uptimePercent = isOnline ? 95 : device.status === 'online' ? 80 : 20;
+    const computed = this.computeUptime(aggregate, since, now);
+
+    if (!computed) {
+      // No samples (or ClickHouse unavailable) → honest "insufficient data".
+      return {
+        deviceId,
+        measured: false,
+        uptimePercent: null,
+        sampleCount: aggregate?.sampleCount ?? 0,
+        totalOnlineMinutes: null,
+        totalOfflineMinutes: null,
+        lastHeartbeat: device.lastHeartbeat,
+        windowDays: days,
+        metricSource: 'insufficient_data',
+      };
+    }
 
     return {
       deviceId,
-      uptimePercent,
-      totalOnlineMinutes: Math.round((totalMinutes * uptimePercent) / 100),
-      totalOfflineMinutes: Math.round((totalMinutes * (100 - uptimePercent)) / 100),
+      measured: true,
+      uptimePercent: computed.uptimePercent,
+      sampleCount: aggregate!.sampleCount,
+      totalOnlineMinutes: computed.onlineMinutes,
+      totalOfflineMinutes: computed.offlineMinutes,
       lastHeartbeat: device.lastHeartbeat,
-      isEstimated: true,
-      metricSource: 'heartbeat_status_heuristic',
+      windowDays: days,
+      metricSource: 'clickhouse_health_samples',
     };
   }
 
   /**
-   * Uptime summary across all devices in an organization
+   * Uptime summary across all devices in an organization, measured over the
+   * ClickHouse time-series. Devices without samples are returned with
+   * `measured: false` / `uptimePercent: null`; the org average is taken over
+   * measured devices only (and is `null` when none have data). `onlineCount`
+   * remains a real live-status count from the Display table.
    */
   async getUptimeSummary(
     organizationId: string,
-    _days: number = 30,
+    days: number = 30,
   ): Promise<UptimeSummaryResult> {
     const devices = await this.db.display.findMany({
       where: { organizationId },
-      select: { id: true, nickname: true, status: true, lastHeartbeat: true },
+      select: { id: true, nickname: true, status: true },
     });
 
     const now = new Date();
-    const fiveMinutesAgo = new Date(now.getTime() - 5 * 60 * 1000);
+    const since = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+    const aggregates = await this.clickhouse.getOrgUptimeAggregates(organizationId, since);
+    const aggregateByDevice = new Map<string, DeviceHealthUptimeAggregate>(
+      (aggregates ?? []).map((a) => [a.deviceId, a]),
+    );
 
-    const deviceUptimes = devices.map((device) => {
-      const isOnline = device.lastHeartbeat && device.lastHeartbeat > fiveMinutesAgo;
-      const uptimePercent = isOnline ? 95 : device.status === 'online' ? 80 : 20;
+    const deviceResults: UptimeSummaryDevice[] = devices.map((device) => {
+      const computed = this.computeUptime(aggregateByDevice.get(device.id), since, now);
       return {
         id: device.id,
         nickname: device.nickname || 'Unnamed Device',
-        uptimePercent,
-        isOnline,
+        measured: computed !== null,
+        uptimePercent: computed ? computed.uptimePercent : null,
+        sampleCount: aggregateByDevice.get(device.id)?.sampleCount ?? 0,
       };
     });
 
-    const onlineCount = deviceUptimes.filter((d) => d.isOnline).length;
+    const measured = deviceResults.filter((d) => d.measured);
     const avgUptimePercent =
-      deviceUptimes.length > 0
-        ? deviceUptimes.reduce((sum, d) => sum + d.uptimePercent, 0) / deviceUptimes.length
-        : 0;
+      measured.length > 0
+        ? Math.round(
+            (measured.reduce((sum, d) => sum + (d.uptimePercent ?? 0), 0) / measured.length) * 10,
+          ) / 10
+        : null;
+
+    const onlineCount = devices.filter((d) => d.status === 'online').length;
 
     return {
-      avgUptimePercent: Math.round(avgUptimePercent * 10) / 10,
+      measured: measured.length > 0,
+      avgUptimePercent,
       deviceCount: devices.length,
+      measuredDeviceCount: measured.length,
       onlineCount,
       offlineCount: devices.length - onlineCount,
-      devices: deviceUptimes.map(({ id, nickname, uptimePercent }) => ({
-        id,
-        nickname,
-        uptimePercent,
-      })),
-      isEstimated: true,
-      metricSource: 'heartbeat_status_heuristic',
+      devices: deviceResults,
+      windowDays: days,
+      metricSource: measured.length > 0 ? 'clickhouse_health_samples' : 'insufficient_data',
     };
+  }
+
+  /**
+   * Turn a ClickHouse uptime aggregate into a percentage + online/offline
+   * minutes. Uptime% = up-buckets / total-buckets, where a bucket is "up" if it
+   * held ≥1 heartbeat sample. The observation window starts at the later of the
+   * requested window start and the device's first sample, so a device that
+   * only recently began reporting isn't unfairly scored against time before it
+   * existed. Returns null when there is no measurable history (0 samples or a
+   * null aggregate — the ClickHouse-unavailable case).
+   */
+  private computeUptime(
+    aggregate: DeviceHealthUptimeAggregate | null | undefined,
+    windowStart: Date,
+    now: Date,
+  ): { uptimePercent: number; onlineMinutes: number; offlineMinutes: number } | null {
+    if (!aggregate || aggregate.sampleCount === 0) return null;
+
+    const observedStartMs = Math.max(windowStart.getTime(), aggregate.firstSample.getTime());
+    const observedMs = Math.max(UPTIME_BUCKET_MS, now.getTime() - observedStartMs);
+    const totalBuckets = Math.max(1, Math.ceil(observedMs / UPTIME_BUCKET_MS));
+
+    const uptimePercent = Math.min(100, Math.round((aggregate.upBuckets / totalBuckets) * 1000) / 10);
+    const windowMinutes = observedMs / 60000;
+    const onlineMinutes = Math.round((windowMinutes * uptimePercent) / 100);
+    const offlineMinutes = Math.max(0, Math.round(windowMinutes) - onlineMinutes);
+
+    return { uptimePercent, onlineMinutes, offlineMinutes };
   }
 
   /**

--- a/middleware/src/modules/analytics/dto/analytics-response.dto.ts
+++ b/middleware/src/modules/analytics/dto/analytics-response.dto.ts
@@ -92,24 +92,52 @@ export interface ContentMetrics {
   topDevices: Array<{ deviceId: string; deviceName: string; views: number }>;
 }
 
+/**
+ * Uptime source markers. `clickhouse_health_samples` = a real measurement over
+ * the durable device-health time-series. `insufficient_data` = no samples yet
+ * (freshly wired, device idle, or ClickHouse unreachable) — the percentage is
+ * `null`, NEVER a fabricated number. Callers must render insufficient data as
+ * "—"/"insufficient", not as a measured percentage.
+ */
+export type UptimeMetricSource = 'clickhouse_health_samples' | 'insufficient_data';
+
 export interface DeviceUptimeResult {
   deviceId: string;
-  uptimePercent: number;
-  totalOnlineMinutes: number;
-  totalOfflineMinutes: number;
+  /** `true` only when computed from real ClickHouse samples. */
+  measured: boolean;
+  /** Measured uptime %, or `null` when there is insufficient data. */
+  uptimePercent: number | null;
+  /** Health samples observed over the window (0 ⇒ insufficient data). */
+  sampleCount: number;
+  totalOnlineMinutes: number | null;
+  totalOfflineMinutes: number | null;
   lastHeartbeat: Date | null;
-  isEstimated?: boolean;
-  metricSource?: 'heartbeat_status_heuristic';
+  windowDays: number;
+  metricSource: UptimeMetricSource;
+}
+
+export interface UptimeSummaryDevice {
+  id: string;
+  nickname: string;
+  measured: boolean;
+  uptimePercent: number | null;
+  sampleCount: number;
 }
 
 export interface UptimeSummaryResult {
-  avgUptimePercent: number;
+  /** `true` when at least one device has a real measurement. */
+  measured: boolean;
+  /** Average uptime % across measured devices, or `null` when none have data. */
+  avgUptimePercent: number | null;
   deviceCount: number;
+  /** Devices with real ClickHouse samples over the window. */
+  measuredDeviceCount: number;
+  /** Currently-online device count (live Display status — always real). */
   onlineCount: number;
   offlineCount: number;
-  devices: Array<{ id: string; nickname: string; uptimePercent: number }>;
-  isEstimated?: boolean;
-  metricSource?: 'heartbeat_status_heuristic';
+  devices: UptimeSummaryDevice[];
+  windowDays: number;
+  metricSource: UptimeMetricSource;
 }
 
 export interface ExportAnalyticsResult {

--- a/middleware/src/modules/clickhouse/clickhouse-watchdog.service.spec.ts
+++ b/middleware/src/modules/clickhouse/clickhouse-watchdog.service.spec.ts
@@ -1,0 +1,80 @@
+import { ClickHouseWatchdogService } from './clickhouse-watchdog.service';
+
+describe('ClickHouseWatchdogService (§12a freshness watchdog)', () => {
+  let mockDb: { display: { count: jest.Mock } };
+  let mockClickhouse: {
+    isEnabled: boolean;
+    getLatestSampleTime: jest.Mock;
+  };
+  let service: ClickHouseWatchdogService;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockDb = { display: { count: jest.fn().mockResolvedValue(0) } };
+    mockClickhouse = {
+      isEnabled: true,
+      getLatestSampleTime: jest.fn().mockResolvedValue({ available: true, lastSample: new Date() }),
+    };
+    service = new ClickHouseWatchdogService(mockDb as any, mockClickhouse as any);
+    // The alert path logs at error level before hitting Sentry (which is absent
+    // in unit tests) — assert on the log as the observable alert signal.
+    errorSpy = jest.spyOn((service as any).logger, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('does nothing when ClickHouse is disabled', async () => {
+    mockClickhouse.isEnabled = false;
+    await service.checkDeviceHealthFreshness();
+    expect(mockDb.display.count).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no displays are active', async () => {
+    mockDb.display.count.mockResolvedValue(0);
+    await service.checkDeviceHealthFreshness();
+    expect(mockClickhouse.getLatestSampleTime).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT alert when ClickHouse is unreachable (cannot confirm staleness)', async () => {
+    mockDb.display.count.mockResolvedValue(3);
+    mockClickhouse.getLatestSampleTime.mockResolvedValue({ available: false, lastSample: null });
+    await service.checkDeviceHealthFreshness();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT alert when samples are fresh', async () => {
+    mockDb.display.count.mockResolvedValue(3);
+    mockClickhouse.getLatestSampleTime.mockResolvedValue({
+      available: true,
+      lastSample: new Date(Date.now() - 60_000), // 1 minute old
+    });
+    await service.checkDeviceHealthFreshness();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('ALERTS when displays are active but no samples exist', async () => {
+    mockDb.display.count.mockResolvedValue(3);
+    mockClickhouse.getLatestSampleTime.mockResolvedValue({ available: true, lastSample: null });
+    await service.checkDeviceHealthFreshness();
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0][0]).toContain('device_health_samples is empty');
+  });
+
+  it('ALERTS when displays are active but the newest sample is stale', async () => {
+    mockDb.display.count.mockResolvedValue(3);
+    mockClickhouse.getLatestSampleTime.mockResolvedValue({
+      available: true,
+      lastSample: new Date(Date.now() - 30 * 60 * 1000), // 30 minutes old
+    });
+    await service.checkDeviceHealthFreshness();
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0][0]).toContain('stalled');
+  });
+
+  it('never throws even if the DB query fails', async () => {
+    mockDb.display.count.mockRejectedValueOnce(new Error('db down'));
+    await expect(service.checkDeviceHealthFreshness()).resolves.not.toThrow();
+  });
+});

--- a/middleware/src/modules/clickhouse/clickhouse-watchdog.service.ts
+++ b/middleware/src/modules/clickhouse/clickhouse-watchdog.service.ts
@@ -1,0 +1,97 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { DEVICE_OFFLINE_THRESHOLD_MS } from '@vizora/database';
+import { DatabaseService } from '../database/database.service';
+import { ClickHouseService } from './clickhouse.service';
+
+/**
+ * §12a freshness watchdog for the device-health time-series.
+ *
+ * If displays are actively heartbeating (so the realtime writer SHOULD be
+ * producing ClickHouse samples) but no `device_health_samples` row has landed
+ * inside the staleness window, the ingestion path has silently broken — a
+ * refactor disconnected the writer, the batch flush is wedged, etc. That is
+ * exactly the class of silent failure §12a exists to surface, so we fire an
+ * out-of-band operator alert (Sentry, mirroring McpAuditService.alertWrite-
+ * AuditFailure) rather than let uptime quietly rot.
+ *
+ * Fail-open: when ClickHouse itself is unreachable we CANNOT tell whether
+ * samples stopped, so we skip (debug-log) instead of alert-storming — the
+ * CH-down case is handled by graceful degradation elsewhere, not here.
+ */
+@Injectable()
+export class ClickHouseWatchdogService {
+  private readonly logger = new Logger(ClickHouseWatchdogService.name);
+
+  /** Alert if no sample has arrived in this long while displays are active. */
+  private readonly staleThresholdMs = 15 * 60 * 1000; // 15 minutes
+
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly clickhouse: ClickHouseService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_15_MINUTES)
+  async checkDeviceHealthFreshness(): Promise<void> {
+    try {
+      if (!this.clickhouse.isEnabled) return;
+
+      // Displays that heartbeated recently → the writer should be inserting.
+      const activeSince = new Date(Date.now() - DEVICE_OFFLINE_THRESHOLD_MS);
+      const activeDisplays = await this.db.display.count({
+        where: { lastHeartbeat: { gte: activeSince } },
+      });
+      if (activeDisplays === 0) return; // nothing should be producing samples
+
+      const freshness = await this.clickhouse.getLatestSampleTime();
+      if (!freshness.available) {
+        // ClickHouse unreachable — cannot confirm samples stopped. Fail-open.
+        this.logger.debug('ClickHouse unavailable; skipping device-health freshness check');
+        return;
+      }
+
+      if (freshness.lastSample === null) {
+        this.alertStale(
+          `${activeDisplays} display(s) are active but device_health_samples is empty — ` +
+            'device-health ingestion appears broken',
+          { activeDisplays, lastSampleAgeMinutes: null },
+        );
+        return;
+      }
+
+      const ageMs = Date.now() - freshness.lastSample.getTime();
+      if (ageMs > this.staleThresholdMs) {
+        this.alertStale(
+          `${activeDisplays} display(s) are active but the newest device_health_samples row is ` +
+            `${Math.round(ageMs / 60000)}m old — device-health ingestion appears stalled`,
+          { activeDisplays, lastSampleAgeMinutes: Math.round(ageMs / 60000) },
+        );
+      }
+    } catch (err) {
+      // The watchdog itself must never crash the process.
+      const detail = err instanceof Error ? err.message : String(err);
+      this.logger.error(`Device-health freshness check failed: ${detail}`);
+    }
+  }
+
+  /**
+   * Out-of-band operator alert. Routes through Sentry (already wired in
+   * middleware; fans out to whatever channels ops configured) plus a
+   * logger.error fallback. Lazy-require Sentry so unit tests don't need it
+   * mocked — mirrors McpAuditService.alertWriteAuditFailure.
+   */
+  private alertStale(message: string, extra: Record<string, unknown>): void {
+    this.logger.error(`[device-health-watchdog] ${message}`);
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const Sentry = require('@sentry/nestjs');
+      Sentry.captureMessage(`device-health ingestion stale — ${message}`, {
+        level: 'error',
+        tags: { event: 'device_health_samples_stale' },
+        extra,
+      });
+    } catch {
+      /* Sentry not loaded (e.g. unit tests) — logger.error above is the fallback. */
+    }
+  }
+}

--- a/middleware/src/modules/clickhouse/clickhouse.constants.ts
+++ b/middleware/src/modules/clickhouse/clickhouse.constants.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared ClickHouse constants + helpers for the middleware read/watchdog side.
+ * Mirrors realtime/src/services/clickhouse.service.ts (the writer). Kept in
+ * sync by hand — both are idempotent (CREATE TABLE IF NOT EXISTS) and
+ * `docker/clickhouse/init.sql` is the canonical schema for a fresh stack.
+ */
+
+export const DEVICE_HEALTH_SAMPLES_TABLE = 'device_health_samples';
+
+/** Uptime bucket size. A bucket counts as "up" if it holds ≥1 health sample. */
+export const UPTIME_BUCKET_MS = 5 * 60 * 1000; // 5 minutes
+
+/** ClickHouse INTERVAL clause matching UPTIME_BUCKET_MS (used in toStartOfInterval). */
+export const UPTIME_BUCKET_INTERVAL_SQL = 'INTERVAL 5 MINUTE';
+
+export const DEVICE_HEALTH_SAMPLES_DDL = `
+CREATE TABLE IF NOT EXISTS ${DEVICE_HEALTH_SAMPLES_TABLE} (
+  deviceId String,
+  organizationId String,
+  cpu Float32,
+  memory Float32,
+  temperature Nullable(Float32),
+  status String,
+  event_time DateTime
+) ENGINE = MergeTree()
+PARTITION BY toYYYYMM(event_time)
+ORDER BY (organizationId, deviceId, event_time)
+TTL event_time + INTERVAL 90 DAY DELETE
+`.trim();
+
+/** Resolve connection config from the environment (never throws). */
+export function resolveClickHouseConfig(): {
+  url: string;
+  username: string;
+  password: string;
+  database: string;
+} {
+  const url =
+    process.env.CLICKHOUSE_URL ||
+    `http://${process.env.CLICKHOUSE_HOST || 'localhost'}:${process.env.CLICKHOUSE_PORT || '8123'}`;
+  return {
+    url,
+    username: process.env.CLICKHOUSE_USER || 'default',
+    password: process.env.CLICKHOUSE_PASSWORD || '',
+    database: process.env.CLICKHOUSE_DATABASE || 'default',
+  };
+}
+
+/** Format a Date as a UTC ClickHouse DateTime literal ('YYYY-MM-DD HH:MM:SS'). */
+export function formatClickHouseDateTime(date: Date): string {
+  return date.toISOString().slice(0, 19).replace('T', ' ');
+}
+
+/** Parse a ClickHouse DateTime string ('YYYY-MM-DD HH:MM:SS', UTC) into a Date. */
+export function parseClickHouseDateTime(value: string): Date {
+  return new Date(`${value.replace(' ', 'T')}Z`);
+}

--- a/middleware/src/modules/clickhouse/clickhouse.module.ts
+++ b/middleware/src/modules/clickhouse/clickhouse.module.ts
@@ -1,0 +1,23 @@
+import { Global, Module } from '@nestjs/common';
+import { ClickHouseService } from './clickhouse.service';
+import { ClickHouseWatchdogService } from './clickhouse-watchdog.service';
+
+/**
+ * ClickHouse read + freshness-watchdog surface for the middleware.
+ *
+ * Global so any module (AnalyticsService today) can inject ClickHouseService
+ * without wiring an import. The realtime service has its own writer-side
+ * ClickHouseService — the two apps are independently deployed processes, so
+ * (matching the existing per-service DatabaseService / RedisService pattern)
+ * each owns a thin service over the shared @clickhouse/client, rather than a
+ * cross-package NestJS module.
+ *
+ * DatabaseService is provided by the @Global DatabaseModule, so the watchdog
+ * can inject it here without an explicit import.
+ */
+@Global()
+@Module({
+  providers: [ClickHouseService, ClickHouseWatchdogService],
+  exports: [ClickHouseService],
+})
+export class ClickHouseModule {}

--- a/middleware/src/modules/clickhouse/clickhouse.service.spec.ts
+++ b/middleware/src/modules/clickhouse/clickhouse.service.spec.ts
@@ -1,0 +1,159 @@
+jest.mock('@clickhouse/client', () => ({
+  createClient: jest.fn(),
+}));
+
+import { createClient } from '@clickhouse/client';
+import { ClickHouseService } from './clickhouse.service';
+import { DEVICE_HEALTH_SAMPLES_TABLE } from './clickhouse.constants';
+
+const resultSet = (rows: unknown[]) => ({ json: jest.fn().mockResolvedValue(rows) });
+
+describe('ClickHouseService (middleware reader)', () => {
+  let mockClient: {
+    query: jest.Mock;
+    command: jest.Mock;
+    ping: jest.Mock;
+    close: jest.Mock;
+  };
+  const originalEnabled = process.env.CLICKHOUSE_ENABLED;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.CLICKHOUSE_ENABLED; // default: enabled
+    mockClient = {
+      query: jest.fn(),
+      command: jest.fn().mockResolvedValue({}),
+      ping: jest.fn().mockResolvedValue({ success: true }),
+      close: jest.fn().mockResolvedValue(undefined),
+    };
+    (createClient as jest.Mock).mockReturnValue(mockClient);
+  });
+
+  afterAll(() => {
+    if (originalEnabled === undefined) delete process.env.CLICKHOUSE_ENABLED;
+    else process.env.CLICKHOUSE_ENABLED = originalEnabled;
+  });
+
+  describe('getDeviceUptimeAggregate', () => {
+    it('parses a real uptime aggregate from ClickHouse rows', async () => {
+      mockClient.query.mockResolvedValue(
+        resultSet([
+          {
+            up_buckets: '288',
+            sample_count: '1152',
+            first_sample: '2026-07-01 00:00:00',
+            last_sample: '2026-07-01 23:59:00',
+          },
+        ]),
+      );
+      const service = new ClickHouseService();
+
+      const agg = await service.getDeviceUptimeAggregate('o1', 'd1', new Date('2026-07-01T00:00:00Z'));
+
+      expect(agg).not.toBeNull();
+      expect(agg!.deviceId).toBe('d1');
+      expect(agg!.upBuckets).toBe(288);
+      expect(agg!.sampleCount).toBe(1152);
+      expect(agg!.firstSample.toISOString()).toBe('2026-07-01T00:00:00.000Z');
+      expect(agg!.lastSample.toISOString()).toBe('2026-07-01T23:59:00.000Z');
+      // Parameterized query — org + device + since are bound, not interpolated.
+      const call = mockClient.query.mock.calls[0][0];
+      expect(call.query_params).toMatchObject({ organizationId: 'o1', deviceId: 'd1' });
+      expect(call.query).toContain(DEVICE_HEALTH_SAMPLES_TABLE);
+    });
+
+    it('returns null (→ insufficient data) when the query throws (fail-open)', async () => {
+      mockClient.query.mockRejectedValueOnce(new Error('ClickHouse unreachable'));
+      const service = new ClickHouseService();
+
+      await expect(
+        service.getDeviceUptimeAggregate('o1', 'd1', new Date()),
+      ).resolves.toBeNull();
+    });
+
+    it('returns null when ClickHouse is disabled', async () => {
+      process.env.CLICKHOUSE_ENABLED = 'false';
+      const service = new ClickHouseService();
+
+      await expect(service.getDeviceUptimeAggregate('o1', 'd1', new Date())).resolves.toBeNull();
+      expect(createClient).not.toHaveBeenCalled();
+      delete process.env.CLICKHOUSE_ENABLED;
+    });
+  });
+
+  describe('getOrgUptimeAggregates', () => {
+    it('maps each grouped row to an aggregate', async () => {
+      mockClient.query.mockResolvedValue(
+        resultSet([
+          { deviceId: 'd1', up_buckets: '10', sample_count: '40', first_sample: '2026-07-01 00:00:00', last_sample: '2026-07-01 01:00:00' },
+          { deviceId: 'd2', up_buckets: '5', sample_count: '20', first_sample: '2026-07-01 00:00:00', last_sample: '2026-07-01 00:30:00' },
+        ]),
+      );
+      const service = new ClickHouseService();
+
+      const aggs = await service.getOrgUptimeAggregates('o1', new Date());
+      expect(aggs).toHaveLength(2);
+      expect(aggs![0]).toMatchObject({ deviceId: 'd1', upBuckets: 10, sampleCount: 40 });
+    });
+
+    it('returns null when the query throws (fail-open)', async () => {
+      mockClient.query.mockRejectedValueOnce(new Error('down'));
+      const service = new ClickHouseService();
+      await expect(service.getOrgUptimeAggregates('o1', new Date())).resolves.toBeNull();
+    });
+  });
+
+  describe('getLatestSampleTime', () => {
+    it('reports available + lastSample when samples exist', async () => {
+      mockClient.query.mockResolvedValue(
+        resultSet([{ last_sample: '2026-07-11 10:00:00', sample_count: '5' }]),
+      );
+      const service = new ClickHouseService();
+
+      const res = await service.getLatestSampleTime();
+      expect(res.available).toBe(true);
+      expect(res.lastSample?.toISOString()).toBe('2026-07-11T10:00:00.000Z');
+    });
+
+    it('reports available + null lastSample when the table is empty', async () => {
+      mockClient.query.mockResolvedValue(
+        resultSet([{ last_sample: '1970-01-01 00:00:00', sample_count: '0' }]),
+      );
+      const service = new ClickHouseService();
+
+      const res = await service.getLatestSampleTime();
+      expect(res.available).toBe(true);
+      expect(res.lastSample).toBeNull();
+    });
+
+    it('reports unavailable when the query throws (fail-open — do not alert)', async () => {
+      mockClient.query.mockRejectedValueOnce(new Error('unreachable'));
+      const service = new ClickHouseService();
+
+      const res = await service.getLatestSampleTime();
+      expect(res.available).toBe(false);
+      expect(res.lastSample).toBeNull();
+    });
+  });
+
+  describe('ensureSchema / isHealthy', () => {
+    it('ensureSchema issues the idempotent CREATE TABLE and swallows errors', async () => {
+      const service = new ClickHouseService();
+      await service.ensureSchema();
+      expect(mockClient.command).toHaveBeenCalledTimes(1);
+      expect(mockClient.command.mock.calls[0][0].query).toContain(
+        `CREATE TABLE IF NOT EXISTS ${DEVICE_HEALTH_SAMPLES_TABLE}`,
+      );
+
+      mockClient.command.mockRejectedValueOnce(new Error('DDL failed'));
+      await expect(service.ensureSchema()).resolves.not.toThrow();
+    });
+
+    it('isHealthy reflects ping and swallows errors', async () => {
+      const service = new ClickHouseService();
+      await expect(service.isHealthy()).resolves.toBe(true);
+      mockClient.ping.mockRejectedValueOnce(new Error('down'));
+      await expect(service.isHealthy()).resolves.toBe(false);
+    });
+  });
+});

--- a/middleware/src/modules/clickhouse/clickhouse.service.ts
+++ b/middleware/src/modules/clickhouse/clickhouse.service.ts
@@ -1,0 +1,260 @@
+import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { createClient, type ClickHouseClient } from '@clickhouse/client';
+import {
+  DEVICE_HEALTH_SAMPLES_TABLE,
+  DEVICE_HEALTH_SAMPLES_DDL,
+  UPTIME_BUCKET_INTERVAL_SQL,
+  resolveClickHouseConfig,
+  formatClickHouseDateTime,
+  parseClickHouseDateTime,
+} from './clickhouse.constants';
+
+/**
+ * Uptime aggregate for one device over a window, as measured from the durable
+ * `device_health_samples` time-series. `upBuckets` is the count of distinct
+ * time-buckets that held ≥1 sample (a heartbeat means the device was online in
+ * that bucket); `sampleCount === 0` means "no history" → insufficient data.
+ */
+export interface DeviceHealthUptimeAggregate {
+  deviceId: string;
+  upBuckets: number;
+  sampleCount: number;
+  firstSample: Date;
+  lastSample: Date;
+}
+
+/** Result of a freshness probe. `available:false` = ClickHouse unreachable. */
+export interface ClickHouseFreshness {
+  available: boolean;
+  lastSample: Date | null;
+}
+
+/**
+ * Read + schema + freshness side of ClickHouse for the middleware.
+ *
+ * ═══ FAIL-OPEN CONTRACT ═══ (same non-negotiable as the realtime writer)
+ * ClickHouse is optional infrastructure. Every query is wrapped: on any error
+ * (unreachable, bad response, missing table) the method returns `null` and the
+ * caller treats it as "insufficient data" — NEVER a fabricated number, NEVER a
+ * thrown error, NEVER a crashed request. The client connects lazily.
+ */
+@Injectable()
+export class ClickHouseService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(ClickHouseService.name);
+  private client: ClickHouseClient | null = null;
+  private readonly enabled: boolean;
+  private lastErrorLogAt = 0;
+  private readonly errorLogThrottleMs = 60_000;
+
+  constructor() {
+    // Default ON; opt out with CLICKHOUSE_ENABLED=false. Never hard-fails boot.
+    this.enabled = process.env.CLICKHOUSE_ENABLED !== 'false';
+  }
+
+  onModuleInit(): void {
+    if (!this.enabled) {
+      this.logger.log('ClickHouse disabled (CLICKHOUSE_ENABLED=false) — uptime reads return insufficient data');
+      return;
+    }
+    // Best-effort schema bootstrap; fail-open (docker init.sql is canonical).
+    void this.ensureSchema();
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.client) {
+      try {
+        await this.client.close();
+      } catch {
+        /* ignore — shutting down */
+      }
+      this.client = null;
+    }
+  }
+
+  get isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  /** Best-effort idempotent schema creation. Never throws. */
+  async ensureSchema(): Promise<void> {
+    try {
+      const client = this.getClient();
+      if (!client) return;
+      await client.command({
+        query: DEVICE_HEALTH_SAMPLES_DDL,
+        clickhouse_settings: { wait_end_of_query: 1 },
+      });
+    } catch (err) {
+      this.logThrottled('Failed to ensure ClickHouse device_health_samples schema', err);
+    }
+  }
+
+  /**
+   * Uptime aggregate for one device since `since`. Returns null when ClickHouse
+   * is unavailable or errors (caller → insufficient data). A device with no
+   * samples returns an aggregate with `sampleCount: 0`.
+   */
+  async getDeviceUptimeAggregate(
+    organizationId: string,
+    deviceId: string,
+    since: Date,
+  ): Promise<DeviceHealthUptimeAggregate | null> {
+    try {
+      const client = this.getClient();
+      if (!client) return null;
+      const resultSet = await client.query({
+        query: `
+          SELECT
+            uniqExact(toStartOfInterval(event_time, ${UPTIME_BUCKET_INTERVAL_SQL})) AS up_buckets,
+            count() AS sample_count,
+            min(event_time) AS first_sample,
+            max(event_time) AS last_sample
+          FROM ${DEVICE_HEALTH_SAMPLES_TABLE}
+          WHERE organizationId = {organizationId:String}
+            AND deviceId = {deviceId:String}
+            AND event_time >= {since:DateTime}
+        `,
+        query_params: {
+          organizationId,
+          deviceId,
+          since: formatClickHouseDateTime(since),
+        },
+        format: 'JSONEachRow',
+      });
+      const rows = await resultSet.json<{
+        up_buckets: string | number;
+        sample_count: string | number;
+        first_sample: string;
+        last_sample: string;
+      }>();
+      const row = rows[0];
+      if (!row) return { deviceId, upBuckets: 0, sampleCount: 0, firstSample: since, lastSample: since };
+      return {
+        deviceId,
+        upBuckets: Number(row.up_buckets),
+        sampleCount: Number(row.sample_count),
+        firstSample: parseClickHouseDateTime(row.first_sample),
+        lastSample: parseClickHouseDateTime(row.last_sample),
+      };
+    } catch (err) {
+      this.logThrottled(`Failed to query device uptime for ${deviceId}`, err);
+      return null;
+    }
+  }
+
+  /**
+   * Uptime aggregates for every device in an org that has samples since `since`.
+   * Returns null when ClickHouse is unavailable/errors. Devices with no samples
+   * are simply absent from the array (caller marks them insufficient).
+   */
+  async getOrgUptimeAggregates(
+    organizationId: string,
+    since: Date,
+  ): Promise<DeviceHealthUptimeAggregate[] | null> {
+    try {
+      const client = this.getClient();
+      if (!client) return null;
+      const resultSet = await client.query({
+        query: `
+          SELECT
+            deviceId,
+            uniqExact(toStartOfInterval(event_time, ${UPTIME_BUCKET_INTERVAL_SQL})) AS up_buckets,
+            count() AS sample_count,
+            min(event_time) AS first_sample,
+            max(event_time) AS last_sample
+          FROM ${DEVICE_HEALTH_SAMPLES_TABLE}
+          WHERE organizationId = {organizationId:String}
+            AND event_time >= {since:DateTime}
+          GROUP BY deviceId
+        `,
+        query_params: {
+          organizationId,
+          since: formatClickHouseDateTime(since),
+        },
+        format: 'JSONEachRow',
+      });
+      const rows = await resultSet.json<{
+        deviceId: string;
+        up_buckets: string | number;
+        sample_count: string | number;
+        first_sample: string;
+        last_sample: string;
+      }>();
+      return rows.map((row) => ({
+        deviceId: row.deviceId,
+        upBuckets: Number(row.up_buckets),
+        sampleCount: Number(row.sample_count),
+        firstSample: parseClickHouseDateTime(row.first_sample),
+        lastSample: parseClickHouseDateTime(row.last_sample),
+      }));
+    } catch (err) {
+      this.logThrottled(`Failed to query org uptime for ${organizationId}`, err);
+      return null;
+    }
+  }
+
+  /**
+   * Platform-wide latest sample time, for the freshness watchdog. `available`
+   * distinguishes "ClickHouse unreachable" (don't alert — can't tell) from
+   * "reachable but no recent samples" (`lastSample: null` → alert-worthy).
+   */
+  async getLatestSampleTime(): Promise<ClickHouseFreshness> {
+    try {
+      const client = this.getClient();
+      if (!client) return { available: false, lastSample: null };
+      // Bounded to the last day so ClickHouse prunes to recent partitions — the
+      // watchdog only cares about a <=15-min staleness threshold, so a 1-day
+      // window always captures a "fresh" sample while keeping the scan cheap.
+      const resultSet = await client.query({
+        query: `
+          SELECT max(event_time) AS last_sample, count() AS sample_count
+          FROM ${DEVICE_HEALTH_SAMPLES_TABLE}
+          WHERE event_time >= now() - INTERVAL 1 DAY
+        `,
+        format: 'JSONEachRow',
+      });
+      const rows = await resultSet.json<{ last_sample: string; sample_count: string | number }>();
+      const row = rows[0];
+      if (!row || Number(row.sample_count) === 0) {
+        return { available: true, lastSample: null };
+      }
+      return { available: true, lastSample: parseClickHouseDateTime(row.last_sample) };
+    } catch (err) {
+      this.logThrottled('Failed to query ClickHouse sample freshness', err);
+      return { available: false, lastSample: null };
+    }
+  }
+
+  /** Readiness probe. Returns false on any error (never throws). */
+  async isHealthy(): Promise<boolean> {
+    try {
+      const client = this.getClient();
+      if (!client) return false;
+      const result = await client.ping();
+      return result.success === true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Lazily create the client. Returns null (never throws) on failure. */
+  private getClient(): ClickHouseClient | null {
+    if (!this.enabled) return null;
+    if (this.client) return this.client;
+    try {
+      this.client = createClient(resolveClickHouseConfig());
+      return this.client;
+    } catch (err) {
+      this.logThrottled('Failed to create ClickHouse client', err);
+      return null;
+    }
+  }
+
+  private logThrottled(message: string, err: unknown): void {
+    const now = Date.now();
+    if (now - this.lastErrorLogAt < this.errorLogThrottleMs) return;
+    this.lastErrorLogAt = now;
+    const detail = err instanceof Error ? err.message : String(err);
+    this.logger.warn(`${message}: ${detail} (further ClickHouse errors throttled for 60s)`);
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,6 +246,9 @@ importers:
 
   middleware:
     dependencies:
+      '@clickhouse/client':
+        specifier: ^1.23.0
+        version: 1.23.1
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@3.25.76)
@@ -485,6 +488,9 @@ importers:
 
   realtime:
     dependencies:
+      '@clickhouse/client':
+        specifier: ^1.23.0
+        version: 1.23.1
       '@nestjs/common':
         specifier: ^11.0.0
         version: 11.1.12(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2)
@@ -1441,6 +1447,10 @@ packages:
 
   '@bufbuild/protobuf@2.11.0':
     resolution: {integrity: sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==}
+
+  '@clickhouse/client@1.23.1':
+    resolution: {integrity: sha512-vs3/Zc1dHvT171btW5nMoPsPCJ6QVJ5pp7obxzO5sjqwFx/jjz9wwCAqcFOdc2DhprugDBaVn+4dVY8hG3A9nw==}
+    engines: {node: '>=20'}
 
   '@codemirror/autocomplete@6.20.0':
     resolution: {integrity: sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==}
@@ -12138,6 +12148,8 @@ snapshots:
       css-tree: 3.2.1
 
   '@bufbuild/protobuf@2.11.0': {}
+
+  '@clickhouse/client@1.23.1': {}
 
   '@codemirror/autocomplete@6.20.0':
     dependencies:

--- a/realtime/.env.example
+++ b/realtime/.env.example
@@ -27,9 +27,15 @@ RELEASE_VERSION=1.0.0
 # Metrics endpoint: http://localhost:3002/metrics
 # No additional configuration needed
 
-# Optional: ClickHouse (for analytics)
-# CLICKHOUSE_HOST=localhost
-# CLICKHOUSE_PORT=8123
-# CLICKHOUSE_DATABASE=vizora
-# CLICKHOUSE_USERNAME=default
-# CLICKHOUSE_PASSWORD=
+# ClickHouse — durable device-health time-series (REAL uptime).
+# The gateway batches a device_health_samples row on every heartbeat
+# (fire-and-forget, fail-open — a ClickHouse outage never touches the heartbeat
+# path). Defaults match the docker-compose `analytics` profile. Set
+# CLICKHOUSE_ENABLED=false to disable entirely in dev without the profile.
+# CLICKHOUSE_URL=http://localhost:8123   # or CLICKHOUSE_HOST + CLICKHOUSE_PORT
+CLICKHOUSE_HOST=localhost
+CLICKHOUSE_PORT=8123
+CLICKHOUSE_DATABASE=default
+CLICKHOUSE_USER=default
+CLICKHOUSE_PASSWORD=
+# CLICKHOUSE_ENABLED=true

--- a/realtime/package.json
+++ b/realtime/package.json
@@ -78,6 +78,7 @@
     }
   },
   "dependencies": {
+    "@clickhouse/client": "^1.23.0",
     "@nestjs/common": "^11.0.0",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.0",

--- a/realtime/src/app/app.module.ts
+++ b/realtime/src/app/app.module.ts
@@ -9,6 +9,7 @@ import { DatabaseModule } from '../database/database.module';
 import { StorageModule } from '../storage/storage.module';
 import { DeviceGateway } from '../gateways/device.gateway';
 import { RedisService } from '../services/redis.service';
+import { ClickHouseService } from '../services/clickhouse.service';
 import { HeartbeatService } from '../services/heartbeat.service';
 import { PlaylistService } from '../services/playlist.service';
 import { NotificationService } from '../services/notification.service';
@@ -38,6 +39,7 @@ import { WsAuthGuard, WsDeviceGuard } from '../gateways/guards/ws-auth.guard';
     AppService,
     DeviceGateway,
     RedisService,
+    ClickHouseService,
     HeartbeatService,
     PlaylistService,
     NotificationService,

--- a/realtime/src/gateways/device.gateway.ts
+++ b/realtime/src/gateways/device.gateway.ts
@@ -1742,8 +1742,13 @@ export class DeviceGateway
         this.deviceStatusCache.set(deviceId, 'online');
       }
 
-      // Process heartbeat (store in ClickHouse, etc.)
-      await this.heartbeatService.processHeartbeat(deviceId, data);
+      // Process heartbeat: Redis live view + durable ClickHouse time-series.
+      // organizationId keys the ClickHouse sample (fail-open, non-blocking).
+      await this.heartbeatService.processHeartbeat(
+        deviceId,
+        data,
+        client.data.organizationId,
+      );
 
       // Update device metrics if available
       if (data.metrics) {

--- a/realtime/src/services/clickhouse.service.spec.ts
+++ b/realtime/src/services/clickhouse.service.spec.ts
@@ -1,0 +1,157 @@
+jest.mock('@clickhouse/client', () => ({
+  createClient: jest.fn(),
+}));
+
+import { createClient } from '@clickhouse/client';
+import {
+  ClickHouseService,
+  DEVICE_HEALTH_SAMPLES_TABLE,
+  formatClickHouseDateTime,
+} from './clickhouse.service';
+
+const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('ClickHouseService (realtime writer)', () => {
+  let mockClient: {
+    insert: jest.Mock;
+    command: jest.Mock;
+    ping: jest.Mock;
+    query: jest.Mock;
+    close: jest.Mock;
+  };
+  const originalEnabled = process.env.CLICKHOUSE_ENABLED;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.CLICKHOUSE_ENABLED; // default: enabled
+    mockClient = {
+      insert: jest.fn().mockResolvedValue({}),
+      command: jest.fn().mockResolvedValue({}),
+      ping: jest.fn().mockResolvedValue({ success: true }),
+      query: jest.fn(),
+      close: jest.fn().mockResolvedValue(undefined),
+    };
+    (createClient as jest.Mock).mockReturnValue(mockClient);
+  });
+
+  afterAll(() => {
+    if (originalEnabled === undefined) delete process.env.CLICKHOUSE_ENABLED;
+    else process.env.CLICKHOUSE_ENABLED = originalEnabled;
+  });
+
+  it('buffers samples and flushes them in a single batched JSONEachRow insert', async () => {
+    const service = new ClickHouseService();
+
+    service.enqueueDeviceHealthSample({
+      deviceId: 'd1',
+      organizationId: 'o1',
+      cpu: 12,
+      memory: 34,
+      temperature: 50,
+    });
+    service.enqueueDeviceHealthSample({ deviceId: 'd2', organizationId: 'o1' });
+
+    // Nothing inserted until a flush runs (non-blocking enqueue).
+    expect(mockClient.insert).not.toHaveBeenCalled();
+
+    await service.flush();
+
+    expect(mockClient.insert).toHaveBeenCalledTimes(1);
+    const arg = mockClient.insert.mock.calls[0][0];
+    expect(arg.table).toBe(DEVICE_HEALTH_SAMPLES_TABLE);
+    expect(arg.format).toBe('JSONEachRow');
+    expect(arg.values).toHaveLength(2);
+    expect(arg.values[0]).toMatchObject({
+      deviceId: 'd1',
+      organizationId: 'o1',
+      cpu: 12,
+      memory: 34,
+      temperature: 50,
+      status: 'online',
+    });
+    expect(arg.values[0].event_time).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+    // Missing metrics default to 0 / null, not undefined.
+    expect(arg.values[1]).toMatchObject({ cpu: 0, memory: 0, temperature: null });
+  });
+
+  it('is a no-op flush when the buffer is empty', async () => {
+    const service = new ClickHouseService();
+    await service.flush();
+    expect(mockClient.insert).not.toHaveBeenCalled();
+  });
+
+  it('auto-flushes once the batch threshold is exceeded', async () => {
+    const service = new ClickHouseService();
+    for (let i = 0; i < 250; i++) {
+      service.enqueueDeviceHealthSample({ deviceId: `d${i}`, organizationId: 'o1' });
+    }
+    await flushMicrotasks();
+    expect(mockClient.insert).toHaveBeenCalled();
+  });
+
+  it('NEVER throws and does not crash when the ClickHouse insert fails (fail-open)', async () => {
+    mockClient.insert.mockRejectedValueOnce(new Error('ClickHouse unreachable'));
+    const service = new ClickHouseService();
+
+    service.enqueueDeviceHealthSample({ deviceId: 'd1', organizationId: 'o1' });
+
+    await expect(service.flush()).resolves.not.toThrow();
+    // Batch was dropped (not retried into an unbounded buffer); a later flush is a no-op.
+    await service.flush();
+    expect(mockClient.insert).toHaveBeenCalledTimes(1);
+  });
+
+  it('NEVER throws when the client factory throws (fail-open)', async () => {
+    (createClient as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('bad config');
+    });
+    const service = new ClickHouseService();
+    service.enqueueDeviceHealthSample({ deviceId: 'd1', organizationId: 'o1' });
+    await expect(service.flush()).resolves.not.toThrow();
+    expect(mockClient.insert).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when disabled via CLICKHOUSE_ENABLED=false', async () => {
+    process.env.CLICKHOUSE_ENABLED = 'false';
+    const service = new ClickHouseService();
+
+    service.enqueueDeviceHealthSample({ deviceId: 'd1', organizationId: 'o1' });
+    await service.flush();
+
+    expect(createClient).not.toHaveBeenCalled();
+    expect(mockClient.insert).not.toHaveBeenCalled();
+    delete process.env.CLICKHOUSE_ENABLED;
+  });
+
+  it('ensureSchema issues the idempotent CREATE TABLE command', async () => {
+    const service = new ClickHouseService();
+    await service.ensureSchema();
+    expect(mockClient.command).toHaveBeenCalledTimes(1);
+    expect(mockClient.command.mock.calls[0][0].query).toContain(
+      `CREATE TABLE IF NOT EXISTS ${DEVICE_HEALTH_SAMPLES_TABLE}`,
+    );
+  });
+
+  it('ensureSchema swallows errors (fail-open)', async () => {
+    mockClient.command.mockRejectedValueOnce(new Error('DDL failed'));
+    const service = new ClickHouseService();
+    await expect(service.ensureSchema()).resolves.not.toThrow();
+  });
+
+  it('isHealthy reflects the ping result and swallows errors', async () => {
+    const service = new ClickHouseService();
+    await expect(service.isHealthy()).resolves.toBe(true);
+
+    mockClient.ping.mockResolvedValueOnce({ success: false });
+    await expect(service.isHealthy()).resolves.toBe(false);
+
+    mockClient.ping.mockRejectedValueOnce(new Error('down'));
+    await expect(service.isHealthy()).resolves.toBe(false);
+  });
+
+  it('formatClickHouseDateTime produces a UTC ClickHouse DateTime literal', () => {
+    expect(formatClickHouseDateTime(new Date('2026-07-11T08:09:10.123Z'))).toBe(
+      '2026-07-11 08:09:10',
+    );
+  });
+});

--- a/realtime/src/services/clickhouse.service.ts
+++ b/realtime/src/services/clickhouse.service.ts
@@ -1,0 +1,251 @@
+import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { createClient, type ClickHouseClient } from '@clickhouse/client';
+
+/**
+ * One row of the ClickHouse `device_health_samples` time-series. Column names
+ * mirror the DDL exactly so JSONEachRow inserts map 1:1.
+ */
+export interface DeviceHealthSample {
+  deviceId: string;
+  organizationId: string;
+  cpu: number;
+  memory: number;
+  temperature: number | null;
+  /** Connectivity state at sample time. A heartbeat always means 'online'. */
+  status: string;
+  /** UTC 'YYYY-MM-DD HH:MM:SS' — ClickHouse DateTime literal. */
+  event_time: string;
+}
+
+export const DEVICE_HEALTH_SAMPLES_TABLE = 'device_health_samples';
+
+/**
+ * Idempotent DDL. `docker/clickhouse/init.sql` is the canonical schema for a
+ * fresh stack; this app-side copy is a best-effort fallback so an already-
+ * provisioned ClickHouse (whose volume predates this table) still gets it.
+ */
+export const DEVICE_HEALTH_SAMPLES_DDL = `
+CREATE TABLE IF NOT EXISTS ${DEVICE_HEALTH_SAMPLES_TABLE} (
+  deviceId String,
+  organizationId String,
+  cpu Float32,
+  memory Float32,
+  temperature Nullable(Float32),
+  status String,
+  event_time DateTime
+) ENGINE = MergeTree()
+PARTITION BY toYYYYMM(event_time)
+ORDER BY (organizationId, deviceId, event_time)
+TTL event_time + INTERVAL 90 DAY DELETE
+`.trim();
+
+/** Resolve connection config from the environment (never throws). */
+export function resolveClickHouseConfig(): {
+  url: string;
+  username: string;
+  password: string;
+  database: string;
+} {
+  const url =
+    process.env.CLICKHOUSE_URL ||
+    `http://${process.env.CLICKHOUSE_HOST || 'localhost'}:${process.env.CLICKHOUSE_PORT || '8123'}`;
+  return {
+    url,
+    username: process.env.CLICKHOUSE_USER || 'default',
+    password: process.env.CLICKHOUSE_PASSWORD || '',
+    database: process.env.CLICKHOUSE_DATABASE || 'default',
+  };
+}
+
+/** Format a Date as a UTC ClickHouse DateTime literal ('YYYY-MM-DD HH:MM:SS'). */
+export function formatClickHouseDateTime(date: Date): string {
+  return date.toISOString().slice(0, 19).replace('T', ' ');
+}
+
+/**
+ * Batched, fire-and-forget writer for the durable device-health time-series.
+ *
+ * ═══ FAIL-OPEN CONTRACT (non-negotiable) ═══
+ * ClickHouse is optional infrastructure. A ClickHouse outage must NEVER throw
+ * into the heartbeat hot path, block live functionality, or crash the process:
+ *   - lazy connect        — the client is created on first use, not at boot;
+ *   - non-blocking enqueue — `enqueueDeviceHealthSample` only pushes to an
+ *                            in-memory ring buffer and returns synchronously.
+ *                            The hot path NEVER awaits a ClickHouse write;
+ *   - bounded buffer       — capped at `maxBufferSize`; oldest rows drop first
+ *                            so memory can't grow without limit while CH is down;
+ *   - swallowed errors     — every insert/DDL/ping error is caught + logged
+ *                            (throttled), never propagated;
+ *   - drop-on-failure      — a failed flush discards its batch rather than
+ *                            retry-storming. History is lost; the app is not.
+ * If ClickHouse is unreachable the app runs exactly as before, minus history.
+ */
+@Injectable()
+export class ClickHouseService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(ClickHouseService.name);
+  private client: ClickHouseClient | null = null;
+  private readonly enabled: boolean;
+
+  private buffer: DeviceHealthSample[] = [];
+  private flushTimer: NodeJS.Timeout | null = null;
+  private flushing = false;
+  private lastErrorLogAt = 0;
+
+  // Tunables — kept small; this is not a high-throughput analytics ingester.
+  private readonly maxBufferSize = 10_000;
+  private readonly flushBatchThreshold = 200;
+  private readonly flushIntervalMs = 5_000;
+  private readonly errorLogThrottleMs = 60_000;
+
+  constructor() {
+    // Default ON; opt out with CLICKHOUSE_ENABLED=false (e.g. dev without the
+    // docker `analytics` profile). Never hard-fails on missing config.
+    this.enabled = process.env.CLICKHOUSE_ENABLED !== 'false';
+  }
+
+  onModuleInit(): void {
+    if (!this.enabled) {
+      this.logger.log(
+        'ClickHouse disabled (CLICKHOUSE_ENABLED=false) — device-health samples will not be persisted',
+      );
+      return;
+    }
+    // Best-effort schema bootstrap; fail-open (docker init.sql is canonical).
+    void this.ensureSchema();
+    this.flushTimer = setInterval(() => {
+      void this.flush();
+    }, this.flushIntervalMs);
+    // Don't keep the event loop alive purely for the flush timer.
+    this.flushTimer.unref?.();
+    this.logger.log('ClickHouse device-health writer initialized');
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.flushTimer) {
+      clearInterval(this.flushTimer);
+      this.flushTimer = null;
+    }
+    // Best-effort final flush so a graceful shutdown doesn't lose the buffer.
+    await this.flush();
+    if (this.client) {
+      try {
+        await this.client.close();
+      } catch {
+        /* ignore — shutting down */
+      }
+      this.client = null;
+    }
+  }
+
+  /**
+   * Enqueue a device-health sample. Synchronous, non-blocking, never throws.
+   * This is the ONLY method the heartbeat hot path calls.
+   */
+  enqueueDeviceHealthSample(sample: {
+    deviceId: string;
+    organizationId: string;
+    cpu?: number | null;
+    memory?: number | null;
+    temperature?: number | null;
+    status?: string;
+    eventTime?: Date;
+  }): void {
+    if (!this.enabled) return;
+    try {
+      if (this.buffer.length >= this.maxBufferSize) {
+        // Bounded buffer: drop the oldest sample to keep the memory ceiling.
+        this.buffer.shift();
+      }
+      this.buffer.push({
+        deviceId: sample.deviceId,
+        organizationId: sample.organizationId,
+        cpu: Number.isFinite(sample.cpu as number) ? (sample.cpu as number) : 0,
+        memory: Number.isFinite(sample.memory as number) ? (sample.memory as number) : 0,
+        temperature: Number.isFinite(sample.temperature as number)
+          ? (sample.temperature as number)
+          : null,
+        status: sample.status || 'online',
+        event_time: formatClickHouseDateTime(sample.eventTime ?? new Date()),
+      });
+      if (this.buffer.length >= this.flushBatchThreshold) {
+        void this.flush();
+      }
+    } catch {
+      /* Never throw into the heartbeat path. */
+    }
+  }
+
+  /**
+   * Drain the buffer into ClickHouse in a single batched insert. Guarded so
+   * overlapping timer/threshold flushes don't double-insert. Fail-open.
+   */
+  async flush(): Promise<void> {
+    if (!this.enabled || this.flushing || this.buffer.length === 0) return;
+    this.flushing = true;
+    const batch = this.buffer.splice(0, this.buffer.length);
+    try {
+      const client = this.getClient();
+      if (!client) return; // client creation failed — batch dropped (fail-open)
+      await client.insert({
+        table: DEVICE_HEALTH_SAMPLES_TABLE,
+        format: 'JSONEachRow',
+        values: batch,
+      });
+    } catch (err) {
+      // Fail-open: drop the batch rather than grow unbounded / retry-storm.
+      this.logThrottled(
+        `Failed to flush ${batch.length} device-health samples to ClickHouse`,
+        err,
+      );
+    } finally {
+      this.flushing = false;
+    }
+  }
+
+  /** Best-effort idempotent schema creation. Never throws. */
+  async ensureSchema(): Promise<void> {
+    try {
+      const client = this.getClient();
+      if (!client) return;
+      await client.command({
+        query: DEVICE_HEALTH_SAMPLES_DDL,
+        clickhouse_settings: { wait_end_of_query: 1 },
+      });
+    } catch (err) {
+      this.logThrottled('Failed to ensure ClickHouse device_health_samples schema', err);
+    }
+  }
+
+  /** Readiness probe. Returns false on any error (never throws). */
+  async isHealthy(): Promise<boolean> {
+    try {
+      const client = this.getClient();
+      if (!client) return false;
+      const result = await client.ping();
+      return result.success === true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Lazily create the client. Returns null (never throws) on failure. */
+  private getClient(): ClickHouseClient | null {
+    if (!this.enabled) return null;
+    if (this.client) return this.client;
+    try {
+      this.client = createClient(resolveClickHouseConfig());
+      return this.client;
+    } catch (err) {
+      this.logThrottled('Failed to create ClickHouse client', err);
+      return null;
+    }
+  }
+
+  private logThrottled(message: string, err: unknown): void {
+    const now = Date.now();
+    if (now - this.lastErrorLogAt < this.errorLogThrottleMs) return;
+    this.lastErrorLogAt = now;
+    const detail = err instanceof Error ? err.message : String(err);
+    this.logger.warn(`${message}: ${detail} (further ClickHouse errors throttled for 60s)`);
+  }
+}

--- a/realtime/src/services/heartbeat.service.spec.ts
+++ b/realtime/src/services/heartbeat.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { DEVICE_OFFLINE_THRESHOLD_MS } from '@vizora/database';
 import { HeartbeatService } from './heartbeat.service';
 import { RedisService } from './redis.service';
+import { ClickHouseService } from './clickhouse.service';
 import { DatabaseService } from '../database/database.service';
 
 describe('HeartbeatService', () => {
@@ -11,6 +12,10 @@ describe('HeartbeatService', () => {
     set: jest.fn().mockResolvedValue(undefined),
     get: jest.fn().mockResolvedValue(null),
     increment: jest.fn().mockResolvedValue(1),
+  };
+
+  const mockClickHouseService = {
+    enqueueDeviceHealthSample: jest.fn(),
   };
 
   const mockDatabaseService = {
@@ -29,6 +34,7 @@ describe('HeartbeatService', () => {
       providers: [
         HeartbeatService,
         { provide: RedisService, useValue: mockRedisService },
+        { provide: ClickHouseService, useValue: mockClickHouseService },
         { provide: DatabaseService, useValue: mockDatabaseService },
       ],
     }).compile();
@@ -84,6 +90,49 @@ describe('HeartbeatService', () => {
       await expect(
         service.processHeartbeat('device-1', {} as any),
       ).resolves.not.toThrow();
+    });
+
+    it('enqueues a ClickHouse device-health sample when organizationId is provided', async () => {
+      const data = {
+        metrics: { cpuUsage: 42, memoryUsage: 71, temperature: 55 },
+        currentContent: { contentId: 'c-1' },
+      };
+
+      await service.processHeartbeat('device-1', data as any, 'org-1');
+
+      expect(mockClickHouseService.enqueueDeviceHealthSample).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deviceId: 'device-1',
+          organizationId: 'org-1',
+          cpu: 42,
+          memory: 71,
+          temperature: 55,
+          status: 'online',
+        }),
+      );
+    });
+
+    it('does NOT enqueue a ClickHouse sample when organizationId is absent', async () => {
+      await service.processHeartbeat('device-1', {} as any);
+
+      expect(mockClickHouseService.enqueueDeviceHealthSample).not.toHaveBeenCalled();
+    });
+
+    it('still writes Redis + does not throw when the ClickHouse writer throws (fail-open)', async () => {
+      mockClickHouseService.enqueueDeviceHealthSample.mockImplementationOnce(() => {
+        throw new Error('clickhouse buffer error');
+      });
+
+      await expect(
+        service.processHeartbeat('device-1', {} as any, 'org-1'),
+      ).resolves.not.toThrow();
+
+      // Redis heartbeat still stored despite the ClickHouse writer throwing.
+      expect(mockRedisService.set).toHaveBeenCalledWith(
+        'heartbeat:device-1:latest',
+        expect.any(String),
+        300,
+      );
     });
   });
 

--- a/realtime/src/services/heartbeat.service.ts
+++ b/realtime/src/services/heartbeat.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { DEVICE_OFFLINE_THRESHOLD_MS } from '@vizora/database';
 import { RedisService } from './redis.service';
+import { ClickHouseService } from './clickhouse.service';
 import { DatabaseService } from '../database/database.service';
 import {
   HeartbeatData as HeartbeatPayload,
@@ -50,12 +51,22 @@ export class HeartbeatService {
   constructor(
     private redisService: RedisService,
     private readonly db: DatabaseService,
+    private readonly clickhouse: ClickHouseService,
   ) {}
 
   /**
    * Process device heartbeat
+   *
+   * @param organizationId Owning org, taken from the authenticated socket. Used
+   *   to key the durable ClickHouse time-series. Optional so legacy callers and
+   *   tests keep compiling; when absent the ClickHouse sample is skipped (Redis
+   *   write is unaffected).
    */
-  async processHeartbeat(deviceId: string, data: HeartbeatPayload): Promise<void> {
+  async processHeartbeat(
+    deviceId: string,
+    data: HeartbeatPayload,
+    organizationId?: string,
+  ): Promise<void> {
     try {
       const heartbeat: StoredHeartbeat = {
         deviceId,
@@ -64,16 +75,26 @@ export class HeartbeatService {
         currentContent: data.currentContent,
       };
 
-      // Store in Redis for quick access
+      // Store in Redis for quick access (fast, 5-min-TTL live view)
       await this.redisService.set(
         `heartbeat:${deviceId}:latest`,
         JSON.stringify(heartbeat),
         300, // 5 minutes
       );
 
-      // TODO: Queue for ClickHouse insertion
-      // This would be done via a job queue (BullMQ) in production
-      // await this.queueClickHouseInsert(heartbeat);
+      // Durable time-series: enqueue a sample for the batched, fire-and-forget
+      // ClickHouse writer. Non-blocking and fail-open — a ClickHouse outage
+      // never reaches this path (see ClickHouseService fail-open contract).
+      if (organizationId) {
+        this.clickhouse.enqueueDeviceHealthSample({
+          deviceId,
+          organizationId,
+          cpu: data.metrics?.cpuUsage,
+          memory: data.metrics?.memoryUsage,
+          temperature: data.metrics?.temperature ?? null,
+          status: 'online',
+        });
+      }
 
       this.logger.debug(`Processed heartbeat for device: ${deviceId}`);
     } catch (error) {

--- a/web/src/lib/api/analytics.ts
+++ b/web/src/lib/api/analytics.ts
@@ -6,6 +6,44 @@ import type {
 } from '../types';
 import { ApiClient } from './client';
 
+/**
+ * Uptime source. `clickhouse_health_samples` = a real measurement over the
+ * durable device-health time-series. `insufficient_data` = no history yet
+ * (freshly wired, device idle, or ClickHouse unreachable) — `uptimePercent` is
+ * `null`, NEVER a fabricated number. Render insufficient data as "—", not 0%.
+ */
+export type UptimeMetricSource = 'clickhouse_health_samples' | 'insufficient_data';
+
+export interface DeviceUptime {
+  deviceId: string;
+  measured: boolean;
+  uptimePercent: number | null;
+  sampleCount: number;
+  totalOnlineMinutes: number | null;
+  totalOfflineMinutes: number | null;
+  lastHeartbeat: string | null;
+  windowDays: number;
+  metricSource: UptimeMetricSource;
+}
+
+export interface UptimeSummary {
+  measured: boolean;
+  avgUptimePercent: number | null;
+  deviceCount: number;
+  measuredDeviceCount: number;
+  onlineCount: number;
+  offlineCount: number;
+  devices: Array<{
+    id: string;
+    nickname: string;
+    measured: boolean;
+    uptimePercent: number | null;
+    sampleCount: number;
+  }>;
+  windowDays: number;
+  metricSource: UptimeMetricSource;
+}
+
 declare module './client' {
   interface ApiClient {
     getAnalyticsSummary(): Promise<AnalyticsSummary>;
@@ -16,8 +54,8 @@ declare module './client' {
     getBandwidthUsage(range?: string): Promise<BandwidthUsage[]>;
     getPlaylistPerformance(range?: string): Promise<PlaylistPerformance[]>;
     exportAnalytics(range?: string): Promise<AnalyticsExport>;
-    getDeviceUptime(deviceId: string, days?: number): Promise<{ deviceId: string; uptimePercent: number; totalOnlineMinutes: number; totalOfflineMinutes: number; lastHeartbeat: string | null }>;
-    getUptimeSummary(days?: number): Promise<{ avgUptimePercent: number; deviceCount: number; onlineCount: number; offlineCount: number; devices: Array<{ id: string; nickname: string; uptimePercent: number }> }>;
+    getDeviceUptime(deviceId: string, days?: number): Promise<DeviceUptime>;
+    getUptimeSummary(days?: number): Promise<UptimeSummary>;
   }
 }
 
@@ -56,36 +94,12 @@ ApiClient.prototype.exportAnalytics = async function (range: string = 'month'): 
 ApiClient.prototype.getDeviceUptime = async function (
   deviceId: string,
   days?: number,
-): Promise<{
-  deviceId: string;
-  uptimePercent: number;
-  totalOnlineMinutes: number;
-  totalOfflineMinutes: number;
-  lastHeartbeat: string | null;
-}> {
+): Promise<DeviceUptime> {
   const params = days ? `?days=${days}` : '';
-  return this.request<{
-    deviceId: string;
-    uptimePercent: number;
-    totalOnlineMinutes: number;
-    totalOfflineMinutes: number;
-    lastHeartbeat: string | null;
-  }>(`/analytics/device-uptime/${deviceId}${params}`);
+  return this.request<DeviceUptime>(`/analytics/device-uptime/${deviceId}${params}`);
 };
 
-ApiClient.prototype.getUptimeSummary = async function (days?: number): Promise<{
-  avgUptimePercent: number;
-  deviceCount: number;
-  onlineCount: number;
-  offlineCount: number;
-  devices: Array<{ id: string; nickname: string; uptimePercent: number }>;
-}> {
+ApiClient.prototype.getUptimeSummary = async function (days?: number): Promise<UptimeSummary> {
   const params = days ? `?days=${days}` : '';
-  return this.request<{
-    avgUptimePercent: number;
-    deviceCount: number;
-    onlineCount: number;
-    offlineCount: number;
-    devices: Array<{ id: string; nickname: string; uptimePercent: number }>;
-  }>(`/analytics/uptime-summary${params}`);
+  return this.request<UptimeSummary>(`/analytics/uptime-summary${params}`);
 };


### PR DESCRIPTION
**Batch PR-10** (P1 tier). Wires the provisioned-but-**dark** ClickHouse container (running on prod, zero app reads/writes until now) as the durable device-health time-series — so device uptime is **measured**, not the hardcoded `95/80/20`. Closes **displays #4, realtime #8, analytics #2/#3/#9** and resolves the standing "wire-or-remove ClickHouse" question.

## What
- **Writer (realtime):** every heartbeat enqueues a `device_health_samples` row via a batched, fire-and-forget `ClickHouseService` — bounded ring buffer, 5s/200-row flush, drop-on-failure.
- **Reader (middleware):** `AnalyticsService.getDeviceUptime`/`getUptimeSummary` now compute uptime as the fraction of 5-min buckets that held ≥1 heartbeat. The `95/80/20` magic numbers are gone.
- **Honest empty data:** no history / device idle / ClickHouse unreachable → `measured:false`, `uptimePercent:null`, `metricSource:'insufficient_data'` — **never a fabricated %**.
- **Freshness watchdog (§12a):** `@Cron` Sentry-alerts when displays are active but samples stop arriving; **skips** when ClickHouse itself is down (no alert-storm).
- **Schema:** `docker/clickhouse/init.sql` (canonical) + app-side idempotent `CREATE TABLE IF NOT EXISTS` bootstrap; DDL byte-consistent across both. **No Prisma migration** (ClickHouse DDL is separate).

## ⚠️ Fail-open (the design constraint)
This adds a new external dependency to the **heartbeat hot path** — the exact class as the Redis crash-loop just fixed. Enforced + test-exercised: the enqueue is synchronous and never throws; every insert/query/DDL/ping error is caught → the writer drops the batch, the reader returns `null`. **A ClickHouse outage runs the app exactly as before, minus history.** RT tests exercise the unreachable/bad-config/DDL-fail paths and still pass.

## Verification (independently re-run)
- middleware `tsc` 0 · realtime `tsc` 0
- middleware jest analytics+clickhouse+watchdog **58/58** · realtime jest heartbeat+clickhouse **43/43** (fail-open paths exercised in-test)

## Deploy note (not in this PR)
To *realize* real uptime on prod, the ClickHouse container must be running + reachable at `localhost:8123` and `CLICKHOUSE_ENABLED` not `false`. If it's behind the docker `analytics` profile and not up, the app stays fail-open (no data, no harm) until it's started. Verify at deploy time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)