### PR TITLE
feat(support): two-way notify loop + unify priority vocabulary (PR-16)

### DIFF
--- a/middleware/src/modules/mail/mail.service.ts
+++ b/middleware/src/modules/mail/mail.service.ts
@@ -423,6 +423,68 @@ export class MailService {
     await this.sendMail(to, subject, html, 'Device offline alert', 'noreply');
   }
 
+  // ---------------------------------------------------------------------------
+  // Support two-way notification loop
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Notify the requester (customer) that support — an admin or an automated
+   * agent — replied to their support request. Templated (no model-generated
+   * body). Non-critical: the SupportService caller wraps this fail-open, so a
+   * mail failure never blocks the message-add. `firstName` is user-controlled
+   * and is escaped before interpolation.
+   */
+  async sendSupportReplyEmail(
+    to: string,
+    firstName: string,
+    requestNumber: string,
+  ): Promise<void> {
+    const safeFirstName = MailService.escapeHtml(firstName);
+    const safeNumber = MailService.escapeHtml(requestNumber);
+    const subject = `New reply on your support request #${safeNumber}`;
+    const html = this.wrapInTemplate(`
+          <h1 style="color:#F0ECE8;font-size:22px;font-weight:700;margin:0 0 8px 0;">You have a new reply</h1>
+          <p style="color:#8A9BA3;font-size:14px;line-height:1.6;margin:0 0 24px 0;">
+            Hi ${safeFirstName},<br><br>
+            The Vizora support team replied to your support request
+            <strong style="color:#F0ECE8;">#${safeNumber}</strong>. Open the dashboard
+            and use the support chat to read the reply and continue the conversation.
+          </p>
+          ${this.ctaButton('View Conversation', this.dashboardUrl)}
+          <p style="color:#5A6B73;font-size:12px;line-height:1.5;margin:16px 0 0 0;">
+            You're receiving this because you opened a support request with Vizora.
+          </p>
+    `);
+    await this.sendMail(to, subject, html, 'Support reply', 'support');
+  }
+
+  /**
+   * Notify the ops/support mailbox that a customer added a message to a
+   * support request (the inbound leg of the two-way loop). Templated,
+   * non-critical. `requestNumber` and `organizationId` are internal ids
+   * (safe), but are escaped defensively for consistency.
+   */
+  async sendSupportCustomerReplyOpsEmail(
+    to: string,
+    requestNumber: string,
+    organizationId: string,
+  ): Promise<void> {
+    const safeNumber = MailService.escapeHtml(requestNumber);
+    const safeOrg = MailService.escapeHtml(organizationId);
+    const subject = `New customer reply on support request #${safeNumber}`;
+    const html = this.wrapInTemplate(`
+          <h1 style="color:#F0ECE8;font-size:22px;font-weight:700;margin:0 0 8px 0;">New customer reply</h1>
+          <p style="color:#8A9BA3;font-size:14px;line-height:1.6;margin:0 0 24px 0;">
+            A customer added a message to support request
+            <strong style="color:#F0ECE8;">#${safeNumber}</strong>
+            (organization <span style="color:#F0ECE8;">${safeOrg}</span>).
+            Open the support dashboard to respond.
+          </p>
+          ${this.ctaButton('Open Support Dashboard', `${this.appUrl}/admin/support`)}
+    `);
+    await this.sendMail(to, subject, html, 'Support customer reply', 'support');
+  }
+
   /**
    * Escape HTML-special characters so user-controlled input (e.g. device
    * nickname) cannot break out of the surrounding markup or inject script.

--- a/middleware/src/modules/mcp/lib/priority-mapping.spec.ts
+++ b/middleware/src/modules/mcp/lib/priority-mapping.spec.ts
@@ -1,0 +1,60 @@
+import {
+  canonicalPriorityToMcp,
+  mcpPriorityToCanonical,
+  type McpPriority,
+} from './priority-mapping';
+
+describe('priority-mapping', () => {
+  describe('mcpPriorityToCanonical (inbound: agent → DB)', () => {
+    it.each<[McpPriority, string]>([
+      ['urgent', 'critical'],
+      ['high', 'high'],
+      ['normal', 'medium'],
+      ['low', 'low'],
+    ])('maps %s → %s', (mcp, canonical) => {
+      expect(mcpPriorityToCanonical(mcp)).toBe(canonical);
+    });
+
+    it('never emits a non-canonical value for any MCP input', () => {
+      const canonical = ['critical', 'high', 'medium', 'low'];
+      for (const p of ['urgent', 'high', 'normal', 'low'] as McpPriority[]) {
+        expect(canonical).toContain(mcpPriorityToCanonical(p));
+      }
+    });
+  });
+
+  describe('canonicalPriorityToMcp (outbound: DB → agent)', () => {
+    it.each<[string, string]>([
+      ['critical', 'urgent'],
+      ['high', 'high'],
+      ['medium', 'normal'],
+      ['low', 'low'],
+    ])('maps %s → %s', (canonical, mcp) => {
+      expect(canonicalPriorityToMcp(canonical)).toBe(mcp);
+    });
+
+    it('returns null for null/undefined', () => {
+      expect(canonicalPriorityToMcp(null)).toBeNull();
+      expect(canonicalPriorityToMcp(undefined)).toBeNull();
+    });
+
+    it('passes through values already in the MCP vocabulary (legacy rows)', () => {
+      expect(canonicalPriorityToMcp('urgent')).toBe('urgent');
+      expect(canonicalPriorityToMcp('normal')).toBe('normal');
+    });
+
+    it('passes through unrecognized values unchanged instead of throwing', () => {
+      expect(canonicalPriorityToMcp('weird')).toBe('weird');
+      expect(canonicalPriorityToMcp('')).toBe('');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('canonical → mcp → canonical is stable', () => {
+      for (const p of ['critical', 'high', 'medium', 'low']) {
+        const mcp = canonicalPriorityToMcp(p) as McpPriority;
+        expect(mcpPriorityToCanonical(mcp)).toBe(p);
+      }
+    });
+  });
+});

--- a/middleware/src/modules/mcp/lib/priority-mapping.ts
+++ b/middleware/src/modules/mcp/lib/priority-mapping.ts
@@ -1,0 +1,63 @@
+/**
+ * Support-request priority vocabulary mapping.
+ *
+ * Two vocabularies exist for ticket priority:
+ *   - **Canonical (internal / DB ladder)**: critical | high | medium | low.
+ *     This is the single source of truth — the `support_requests.priority`
+ *     column, `SupportService`, the admin dashboard, and `getStats` all
+ *     speak it (see schema.prisma: `priority String @default("medium")`).
+ *   - **MCP wire vocabulary**: urgent | high | normal | low. The historical
+ *     terms the MCP tool surface exposes to agents.
+ *
+ * These helpers are the ONE place the two vocabularies are translated.
+ * The MCP boundary maps inbound priority (agent → DB) with
+ * `mcpPriorityToCanonical` before it reaches the service, and maps
+ * outbound priority (DB → agent) with `canonicalPriorityToMcp` before it
+ * crosses the wire. Internally, only the canonical ladder is ever stored
+ * or compared.
+ */
+
+export type CanonicalPriority = 'critical' | 'high' | 'medium' | 'low';
+export type McpPriority = 'urgent' | 'high' | 'normal' | 'low';
+
+const MCP_TO_CANONICAL: Record<McpPriority, CanonicalPriority> = {
+  urgent: 'critical',
+  high: 'high',
+  normal: 'medium',
+  low: 'low',
+};
+
+const CANONICAL_TO_MCP: Record<CanonicalPriority, McpPriority> = {
+  critical: 'urgent',
+  high: 'high',
+  medium: 'normal',
+  low: 'low',
+};
+
+/**
+ * Map an MCP-wire priority term to the canonical DB ladder. Used on the
+ * inbound edge of `update_support_request_priority` so the service only
+ * ever writes canonical values.
+ */
+export function mcpPriorityToCanonical(priority: McpPriority): CanonicalPriority {
+  return MCP_TO_CANONICAL[priority];
+}
+
+/**
+ * Map a stored priority to the MCP-wire vocabulary. Used on the outbound
+ * edge of `list_open_support_requests`.
+ *
+ * Tolerant of values that are already in the MCP vocabulary (legacy rows
+ * written before this mapping existed) and of unknown/empty values —
+ * anything unrecognized is passed through unchanged rather than throwing,
+ * because this runs inside the read path and must never fail a list call.
+ */
+export function canonicalPriorityToMcp(
+  priority: string | null | undefined,
+): string | null {
+  if (priority == null) return null;
+  if (priority in CANONICAL_TO_MCP) {
+    return CANONICAL_TO_MCP[priority as CanonicalPriority];
+  }
+  return priority;
+}

--- a/middleware/src/modules/mcp/tools/support.tools.spec.ts
+++ b/middleware/src/modules/mcp/tools/support.tools.spec.ts
@@ -185,6 +185,26 @@ describe('listOpenSupportRequestsTool', () => {
     ).rejects.toThrow(/100/);
   });
 
+  it('maps canonical DB priority to the MCP wire vocabulary on output', async () => {
+    const out = await listOpenSupportRequestsTool(
+      {},
+      ctx(['support:read']),
+      makeSupport([
+        { id: 'r1', priority: 'critical' },
+        { id: 'r2', priority: 'medium' },
+        { id: 'r3', priority: 'high' },
+        { id: 'r4', priority: 'low' },
+      ]) as never,
+    );
+    // critical→urgent, medium→normal, high→high, low→low.
+    expect(out.support_requests.map((r) => r.priority)).toEqual([
+      'urgent',
+      'normal',
+      'high',
+      'low',
+    ]);
+  });
+
   it('serializes Date createdAt as ISO string on the wire', async () => {
     const ts = new Date('2026-05-04T12:34:56Z');
     const out = await listOpenSupportRequestsTool(
@@ -209,7 +229,7 @@ describe('updateSupportRequestPriorityTool', () => {
     expect(svc.setRequestPriority).not.toHaveBeenCalled();
   });
 
-  it('returns { updated: true } when service confirms the update', async () => {
+  it('maps the MCP wire vocabulary to the canonical ladder before calling the service', async () => {
     const svc = { setRequestPriority: jest.fn().mockResolvedValue(true) };
     const out = await updateSupportRequestPriorityTool(
       { request_id: 'r1', priority: 'urgent' },
@@ -217,7 +237,18 @@ describe('updateSupportRequestPriorityTool', () => {
       svc as never,
     );
     expect(out).toEqual({ request_id: 'r1', updated: true });
-    expect(svc.setRequestPriority).toHaveBeenCalledWith('org_1', 'r1', 'urgent');
+    // urgent → critical (canonical). The service never sees MCP terms.
+    expect(svc.setRequestPriority).toHaveBeenCalledWith('org_1', 'r1', 'critical');
+  });
+
+  it('maps normal → medium on the inbound edge', async () => {
+    const svc = { setRequestPriority: jest.fn().mockResolvedValue(true) };
+    await updateSupportRequestPriorityTool(
+      { request_id: 'r1', priority: 'normal' },
+      ctx(['support:write']),
+      svc as never,
+    );
+    expect(svc.setRequestPriority).toHaveBeenCalledWith('org_1', 'r1', 'medium');
   });
 
   it('returns { updated: false } when no row matched (cross-org guard or deleted)', async () => {
@@ -262,7 +293,8 @@ describe('updateSupportRequestPriorityTool', () => {
     );
 
     expect(out).toEqual({ request_id: 'r1', updated: true });
-    expect(svc.setRequestPriority).toHaveBeenCalledWith(null, 'r1', 'urgent');
+    // urgent → critical (canonical) for platform-scope tokens too.
+    expect(svc.setRequestPriority).toHaveBeenCalledWith(null, 'r1', 'critical');
   });
 });
 

--- a/middleware/src/modules/mcp/tools/support.tools.ts
+++ b/middleware/src/modules/mcp/tools/support.tools.ts
@@ -7,6 +7,10 @@ import {
   type McpRequestContext,
 } from '../auth/mcp-context';
 import {
+  canonicalPriorityToMcp,
+  mcpPriorityToCanonical,
+} from '../lib/priority-mapping';
+import {
   CreateSupportMessageInput,
   type CreateSupportMessageInputT,
   ListOpenSupportRequestsInput,
@@ -82,7 +86,8 @@ function toTriageShape(r: Record<string, unknown>) {
     id: r.id as string,
     organization_id: r.organizationId as string,
     status: r.status as string,
-    priority: (r.priority as string | null) ?? null,
+    // Canonical DB ladder → MCP wire vocabulary (critical→urgent, medium→normal).
+    priority: canonicalPriorityToMcp(r.priority as string | null),
     category: (r.category as string | null) ?? null,
     ai_category: (r.aiCategory as string | null) ?? null,
     created_at:
@@ -136,10 +141,12 @@ export async function updateSupportRequestPriorityTool(
   const input = UpdateSupportRequestPriorityInput.parse(
     rawInput,
   ) as UpdateSupportRequestPriorityInputT;
+  // MCP wire vocabulary → canonical DB ladder (urgent→critical, normal→medium).
+  // The service only ever sees canonical values.
   const updated = await supportService.setRequestPriority(
     orgId,
     input.request_id,
-    input.priority,
+    mcpPriorityToCanonical(input.priority),
   );
   return UpdateSupportRequestResult.parse({
     request_id: input.request_id,

--- a/middleware/src/modules/support/support.service.spec.ts
+++ b/middleware/src/modules/support/support.service.spec.ts
@@ -2,6 +2,7 @@ import { NotFoundException, ForbiddenException } from '@nestjs/common';
 import { SupportService } from './support.service';
 import { DatabaseService } from '../database/database.service';
 import { NotificationsService } from '../notifications/notifications.service';
+import { MailService } from '../mail/mail.service';
 import { SupportClassifierService } from './support-classifier.service';
 import { SupportKnowledgeService } from './support-knowledge.service';
 
@@ -9,6 +10,7 @@ describe('SupportService', () => {
   let service: SupportService;
   let db: any;
   let notificationsService: any;
+  let mailService: any;
   let classifier: any;
   let knowledgeBase: any;
 
@@ -60,11 +62,22 @@ describe('SupportService', () => {
         findFirst: jest.fn(),
         findMany: jest.fn(),
       },
+      user: {
+        findUnique: jest.fn().mockResolvedValue({
+          email: 'requester@example.com',
+          firstName: 'Req',
+        }),
+      },
       $queryRaw: jest.fn(),
     };
 
     notificationsService = {
-      create: jest.fn(),
+      create: jest.fn().mockResolvedValue({}),
+    };
+
+    mailService = {
+      sendSupportReplyEmail: jest.fn().mockResolvedValue(undefined),
+      sendSupportCustomerReplyOpsEmail: jest.fn().mockResolvedValue(undefined),
     };
 
     classifier = {
@@ -81,6 +94,7 @@ describe('SupportService', () => {
     service = new SupportService(
       db as unknown as DatabaseService,
       notificationsService as unknown as NotificationsService,
+      mailService as unknown as MailService,
       classifier as unknown as SupportClassifierService,
       knowledgeBase as unknown as SupportKnowledgeService,
     );
@@ -1041,11 +1055,13 @@ describe('SupportService', () => {
 
     it('omits the organization guard for platform-scope tokens', async () => {
       db.supportRequest.updateMany.mockResolvedValueOnce({ count: 1 });
-      const ok = await service.setRequestPriority(null, 'r1', 'urgent');
+      // The service takes canonical ladder values only — the MCP boundary
+      // maps urgent→critical before calling (see mcp/lib/priority-mapping.ts).
+      const ok = await service.setRequestPriority(null, 'r1', 'critical');
       expect(ok).toBe(true);
       expect(db.supportRequest.updateMany).toHaveBeenCalledWith({
         where: { id: 'r1' },
-        data: { priority: 'urgent' },
+        data: { priority: 'critical' },
       });
     });
   });
@@ -1136,6 +1152,170 @@ describe('SupportService', () => {
         },
         select: { id: true, createdAt: true },
       });
+    });
+
+    it('emails the requester (two-way loop) after an agent reply lands', async () => {
+      db.supportRequest.findFirst.mockResolvedValueOnce({
+        id: 'r1',
+        organizationId: orgId,
+        userId: 'u-original',
+      });
+      db.supportMessage.create.mockResolvedValueOnce({
+        id: 'msg-new',
+        createdAt: new Date('2026-05-04T12:00:00Z'),
+      });
+      db.user.findUnique.mockResolvedValueOnce({
+        email: 'owner@example.com',
+        firstName: 'Owner',
+      });
+
+      await service.createAgentMessage(orgId, 'r1', 'Triage: high urgency');
+
+      expect(db.user.findUnique).toHaveBeenCalledWith({
+        where: { id: 'u-original' },
+        select: { email: true, firstName: true },
+      });
+      expect(mailService.sendSupportReplyEmail).toHaveBeenCalledWith(
+        'owner@example.com',
+        'Owner',
+        'R1', // 'r1'.substring(0, 8).toUpperCase()
+      );
+    });
+
+    it('is fail-open — a mail failure does NOT fail the agent message-add', async () => {
+      db.supportRequest.findFirst.mockResolvedValueOnce({
+        id: 'r1',
+        organizationId: orgId,
+        userId: 'u-original',
+      });
+      db.supportMessage.create.mockResolvedValueOnce({
+        id: 'msg-new',
+        createdAt: new Date('2026-05-04T12:00:00Z'),
+      });
+      mailService.sendSupportReplyEmail.mockRejectedValueOnce(new Error('SMTP down'));
+
+      const out = await service.createAgentMessage(orgId, 'r1', 'hello');
+
+      expect(out).toEqual({ id: 'msg-new', createdAt: new Date('2026-05-04T12:00:00Z') });
+    });
+  });
+
+  describe('two-way notification loop (addMessage)', () => {
+    const requesterId = 'requester-1';
+    const requestOwnedByRequester = {
+      ...mockRequest,
+      userId: requesterId,
+    };
+
+    const otherAdmin = {
+      id: 'admin-999',
+      organizationId: orgId,
+      role: 'admin',
+      isSuperAdmin: false,
+    };
+
+    const requesterUser = {
+      id: requesterId,
+      organizationId: orgId,
+      role: 'viewer',
+      isSuperAdmin: false,
+    };
+
+    const requestNumber = mockRequest.id.substring(0, 8).toUpperCase();
+
+    it('admin reply emails the requester with a dashboard link', async () => {
+      db.supportRequest.findUnique.mockResolvedValue(requestOwnedByRequester);
+      db.supportMessage.create.mockResolvedValue({ ...mockMessage, role: 'admin' });
+      db.user.findUnique.mockResolvedValueOnce({
+        email: 'requester@example.com',
+        firstName: 'Req',
+      });
+
+      await service.addMessage(mockRequest.id, otherAdmin, 'We are on it.');
+
+      expect(mailService.sendSupportReplyEmail).toHaveBeenCalledWith(
+        'requester@example.com',
+        'Req',
+        requestNumber,
+      );
+      // Admin reply must NOT notify the support side.
+      expect(notificationsService.create).not.toHaveBeenCalled();
+    });
+
+    it('does NOT email when an admin replies to their OWN request (no self-notify)', async () => {
+      const adminOwner = {
+        id: requesterId,
+        organizationId: orgId,
+        role: 'admin',
+        isSuperAdmin: false,
+      };
+      db.supportRequest.findUnique.mockResolvedValue(requestOwnedByRequester);
+      db.supportMessage.create.mockResolvedValue({ ...mockMessage, role: 'admin' });
+
+      await service.addMessage(mockRequest.id, adminOwner, 'note to self');
+
+      expect(mailService.sendSupportReplyEmail).not.toHaveBeenCalled();
+      expect(db.user.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('customer reply creates an in-app notification for the support side', async () => {
+      db.supportRequest.findUnique.mockResolvedValue(requestOwnedByRequester);
+      db.supportMessage.create.mockResolvedValue({ ...mockMessage, role: 'user' });
+
+      await service.addMessage(mockRequest.id, requesterUser, 'still broken');
+
+      expect(notificationsService.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'system',
+          organizationId: orgId,
+        }),
+      );
+      // Customer reply must NOT email the requester back.
+      expect(mailService.sendSupportReplyEmail).not.toHaveBeenCalled();
+    });
+
+    it('customer reply emails the ops mailbox when OPS_ALERT_EMAIL is set', async () => {
+      const prev = process.env.OPS_ALERT_EMAIL;
+      process.env.OPS_ALERT_EMAIL = 'ops@vizora.cloud';
+      try {
+        db.supportRequest.findUnique.mockResolvedValue(requestOwnedByRequester);
+        db.supportMessage.create.mockResolvedValue({ ...mockMessage, role: 'user' });
+
+        await service.addMessage(mockRequest.id, requesterUser, 'still broken');
+
+        expect(mailService.sendSupportCustomerReplyOpsEmail).toHaveBeenCalledWith(
+          'ops@vizora.cloud',
+          requestNumber,
+          orgId,
+        );
+      } finally {
+        if (prev === undefined) delete process.env.OPS_ALERT_EMAIL;
+        else process.env.OPS_ALERT_EMAIL = prev;
+      }
+    });
+
+    it('is fail-open — a notification failure does NOT fail the message-add', async () => {
+      db.supportRequest.findUnique.mockResolvedValue(requestOwnedByRequester);
+      const created = { ...mockMessage, role: 'user', content: 'still broken' };
+      db.supportMessage.create.mockResolvedValue(created);
+      notificationsService.create.mockRejectedValueOnce(new Error('notify down'));
+
+      const result = await service.addMessage(mockRequest.id, requesterUser, 'still broken');
+
+      expect(result).toEqual(created);
+    });
+
+    it('does NOT notify on the clientMutationId dedup early-return path', async () => {
+      db.supportRequest.findUnique.mockResolvedValue(requestOwnedByRequester);
+      db.supportMessage.findFirst.mockResolvedValueOnce({
+        ...mockMessage,
+        clientMutationId: 'dup-1',
+      });
+
+      await service.addMessage(mockRequest.id, requesterUser, 'retry', 'dup-1');
+
+      expect(notificationsService.create).not.toHaveBeenCalled();
+      expect(mailService.sendSupportReplyEmail).not.toHaveBeenCalled();
     });
   });
 });

--- a/middleware/src/modules/support/support.service.ts
+++ b/middleware/src/modules/support/support.service.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { Prisma } from '@vizora/database';
 import { DatabaseService } from '../database/database.service';
 import { NotificationsService } from '../notifications/notifications.service';
+import { MailService } from '../mail/mail.service';
 import { SupportClassifierService } from './support-classifier.service';
 import { SupportKnowledgeService } from './support-knowledge.service';
 
@@ -48,6 +49,7 @@ export class SupportService {
   constructor(
     private readonly db: DatabaseService,
     private readonly notificationsService: NotificationsService,
+    private readonly mailService: MailService,
     private readonly classifier: SupportClassifierService,
     private readonly knowledgeBase: SupportKnowledgeService,
   ) {}
@@ -344,7 +346,10 @@ export class SupportService {
   async setRequestPriority(
     organizationId: SupportMcpScope,
     requestId: string,
-    priority: 'urgent' | 'high' | 'normal' | 'low',
+    // Canonical DB ladder only. The MCP boundary maps its wire vocabulary
+    // (urgent/normal) to this ladder before calling — see
+    // mcp/lib/priority-mapping.ts. The service never sees MCP terms.
+    priority: 'critical' | 'high' | 'medium' | 'low',
   ): Promise<boolean> {
     const where: Prisma.SupportRequestWhereInput = { id: requestId };
     if (organizationId != null) {
@@ -419,6 +424,20 @@ export class SupportService {
       },
       select: { id: true, createdAt: true },
     });
+
+    // Two-way loop: an agent-authored reply notifies the requester, exactly
+    // like an admin reply. Author is the agent (no user id) so it can never
+    // be the requester. Best-effort — see notifyOnNewMessage.
+    await this.notifyOnNewMessage(
+      {
+        id: req.id,
+        organizationId: req.organizationId ?? (organizationId as string),
+        userId: req.userId,
+      },
+      null,
+      'admin',
+    );
+
     return created;
   }
 
@@ -611,6 +630,19 @@ export class SupportService {
     // If the request was resolved/closed and user sends a new message, reopen it
     await reopenIfNeeded();
 
+    // Two-way loop: notify the OTHER party of the new message. Only reached
+    // for a genuinely new message — the clientMutationId dedup / P2002 race
+    // paths return early above and intentionally do NOT re-notify.
+    await this.notifyOnNewMessage(
+      {
+        id: request.id,
+        organizationId: request.organizationId,
+        userId: request.userId,
+      },
+      user.id,
+      role,
+    );
+
     this.logger.log(`Added ${role} message to support request ${requestId}`);
 
     return message;
@@ -675,6 +707,96 @@ export class SupportService {
       resolvedThisWeek,
       total: openCount + inProgressCount + resolvedCount + closedCount,
     };
+  }
+
+  /**
+   * Two-way support notification loop. Fired on every genuinely-new message
+   * (REST `addMessage` + MCP `createAgentMessage`), it tells the OTHER party:
+   *
+   *  - An **admin/agent** reply (`role === 'admin'`) emails the requester
+   *    (the user who opened the request) that there's a reply — UNLESS the
+   *    admin is replying to their own request (don't email a party for their
+   *    own message).
+   *  - A **customer** reply (`role === 'user'`) notifies the support side:
+   *    an in-app notification for the org plus an email to the ops/support
+   *    mailbox (`OPS_ALERT_EMAIL ?? SMTP_TO`).
+   *
+   * Fail-open: every side-effect is individually wrapped (`safeNotify`) so a
+   * mail/notification outage can NEVER fail the message-add. The message is
+   * the source of truth; the notification is best-effort (mirrors the
+   * impression-persist / broadcastNotification pattern elsewhere).
+   */
+  private async notifyOnNewMessage(
+    request: { id: string; organizationId: string; userId: string },
+    authorUserId: string | null,
+    role: 'admin' | 'user',
+  ): Promise<void> {
+    const requestNumber = request.id.substring(0, 8).toUpperCase();
+
+    if (role === 'admin') {
+      // Don't email an admin their own message when they reply to a request
+      // they opened themselves. Agent replies pass authorUserId=null, so the
+      // requester is always notified for those.
+      if (authorUserId !== null && authorUserId === request.userId) {
+        return;
+      }
+      await this.safeNotify(`support reply email for request ${request.id}`, async () => {
+        const requester = await this.db.user.findUnique({
+          where: { id: request.userId },
+          select: { email: true, firstName: true },
+        });
+        if (requester?.email) {
+          await this.mailService.sendSupportReplyEmail(
+            requester.email,
+            requester.firstName ?? 'there',
+            requestNumber,
+          );
+        }
+      });
+      return;
+    }
+
+    // Customer replied → notify the support side (in-app + ops mailbox).
+    await this.safeNotify(
+      `support in-app notification for request ${request.id}`,
+      () =>
+        this.notificationsService.create({
+          title: `New support reply #${requestNumber}`,
+          message: `A customer replied to support request #${requestNumber}.`,
+          type: 'system',
+          severity: 'info',
+          organizationId: request.organizationId,
+        }),
+    );
+
+    const opsRecipient = process.env.OPS_ALERT_EMAIL || process.env.SMTP_TO;
+    if (opsRecipient) {
+      await this.safeNotify(
+        `support ops email for request ${request.id}`,
+        () =>
+          this.mailService.sendSupportCustomerReplyOpsEmail(
+            opsRecipient,
+            requestNumber,
+            request.organizationId,
+          ),
+      );
+    }
+  }
+
+  /**
+   * Run a best-effort notification side-effect. Swallows + logs any failure
+   * so the caller (message-add) is never broken by a mail/notification
+   * outage. Each side-effect gets its own guard so one failure doesn't block
+   * the others.
+   */
+  private async safeNotify(label: string, fn: () => Promise<unknown>): Promise<void> {
+    try {
+      await fn();
+    } catch (error) {
+      this.logger.warn(
+        `Failed to send ${label}: ${error instanceof Error ? error.message : error}`,
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
**Batch PR-16** (P1 tier). Support was silently **poll-only** — a reply never reached the other party — and two priority vocabularies were leaking raw MCP terms into the canonical DB column. Closes **admin #3, admin #6**.

> **admin #11** (revoke sessions on disable/role-change + password-reset-token flow) was **deliberately deferred** to the auth batch (PR-17) — it's auth-model work (stateless-JWT revocation), not a casual support change.

## What
- **admin #3 — two-way notification loop.** Wired at the **service layer**, so BOTH entry points fire it: the REST `addMessage` path *and* the MCP `create_support_message` tool (a Hermes-authored reply now emails the customer too).
  - Admin/agent reply → templated **email to the requester** (dashboard CTA, env-driven URL — no localhost).
  - Customer reply → **in-app org notification** + **email to the ops mailbox** (`OPS_ALERT_EMAIL ?? SMTP_TO`).
  - **Fail-open:** each side-effect is individually wrapped in `safeNotify` — a mail/notification outage can never fail the message-add (the message is the source of truth). Retry/dedup early-returns skip notifying, so no double-emails.
- **admin #6 — one priority ladder.** Canonical = `critical | high | medium | low`. A new shared `mcp/lib/priority-mapping` helper translates the MCP wire vocab at the boundary (`urgent→critical`, `normal→medium` inbound; inverse outbound). `setRequestPriority`'s param is narrowed to the canonical union so the service **can never again store an MCP term**. The outbound mapper tolerates legacy/unknown values (never throws in the read path).

## Verification (independently re-run)
- middleware `tsc` 0 · jest **141/141** across support service/controller, MCP support tools, priority-mapping, mail.

## Notes
- No `schema.prisma` / migration; no new deps.
- Surfaced (not in scope): rows written by the old buggy `setRequestPriority` may still hold `urgent`/`normal` in the canonical column — the outbound mapper tolerates them; a one-off backfill can normalize if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)