### PR TITLE
feat(content): wire stranded content-lifecycle backend to UI (PR-11)

### DIFF
--- a/middleware/src/modules/content/content.service.spec.ts
+++ b/middleware/src/modules/content/content.service.spec.ts
@@ -1940,6 +1940,37 @@ describe('ContentService', () => {
       });
     });
 
+    it('emits content.expired for each item flipped to expired (content-level signal)', async () => {
+      const expired1 = { ...mockContent, id: 'exp-1', organizationId: 'org-123', expiresAt: new Date('2020-01-01'), status: 'active' };
+      const expired2 = { ...mockContent, id: 'exp-2', organizationId: 'org-123', expiresAt: new Date('2020-01-01'), status: 'active' };
+      mockDatabaseService.content.findMany.mockResolvedValue([expired1, expired2]);
+      mockDatabaseService.playlistItem.deleteMany.mockResolvedValue({ count: 1 });
+      mockDatabaseService.content.update.mockResolvedValue({ status: 'expired' });
+
+      await service.checkExpiredContent();
+
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith('content.expired', {
+        action: 'expired',
+        entityType: 'content',
+        entityId: 'exp-1',
+        organizationId: 'org-123',
+      });
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith('content.expired', {
+        action: 'expired',
+        entityType: 'content',
+        entityId: 'exp-2',
+        organizationId: 'org-123',
+      });
+    });
+
+    it('does not emit content.expired when nothing expired', async () => {
+      mockDatabaseService.content.findMany.mockResolvedValue([]);
+
+      await service.checkExpiredContent();
+
+      expect(mockEventEmitter.emit).not.toHaveBeenCalledWith('content.expired', expect.anything());
+    });
+
     it('should only find active expired content', async () => {
       mockDatabaseService.content.findMany.mockResolvedValue([]);
 

--- a/middleware/src/modules/content/content.service.ts
+++ b/middleware/src/modules/content/content.service.ts
@@ -641,6 +641,14 @@ export class ContentService {
     // slot) until they reconnect, sometimes hours later.
     const affectedPlaylists: Array<{ playlistId: string; organizationId: string }> = [];
 
+    // Content-level signal for each item flipped to 'expired'. Emitted AFTER
+    // the transaction commits (below) so listeners never observe an item as
+    // expired before the DB row is durable. Without this, the dashboard would
+    // not reflect an auto-expiry until a manual reload and no content-level
+    // audit trail existed — the cron only emitted playlist.updated (content-mgmt
+    // #12 / notifications #2).
+    const expiredForSignal: Array<{ id: string; organizationId: string }> = [];
+
     for (const content of expiredContent) {
       await this.db.$transaction(async (tx) => {
         // Snapshot playlistIds BEFORE the updateMany / deleteMany — we
@@ -700,6 +708,22 @@ export class ContentService {
             organizationId: content.organizationId,
           });
         }
+      });
+
+      // Transaction committed — the row is now durably 'expired'.
+      expiredForSignal.push({ id: content.id, organizationId: content.organizationId });
+    }
+
+    // Per-item content-level signal. Caught by ValidationMonitorService's
+    // `content.**` @OnEvent wildcard (re-validation) and available for any
+    // future audit/notification consumer. Mirrors the EntityEvent shape used
+    // by content.created / content.updated / content.deleted.
+    for (const item of expiredForSignal) {
+      this.eventEmitter.emit('content.expired', {
+        action: 'expired',
+        entityType: 'content',
+        entityId: item.id,
+        organizationId: item.organizationId,
       });
     }
 

--- a/web/src/app/dashboard/content/__tests__/content-page.test.tsx
+++ b/web/src/app/dashboard/content/__tests__/content-page.test.tsx
@@ -9,6 +9,14 @@ const mockGetFolders = jest.fn();
 const mockGetDisplays = jest.fn();
 const mockGetPlaylists = jest.fn();
 const mockDeleteContent = jest.fn();
+const mockBulkDeleteContent = jest.fn();
+const mockBulkArchiveContent = jest.fn();
+const mockBulkSetContentDuration = jest.fn();
+const mockGetContentVersions = jest.fn().mockResolvedValue([]);
+const mockSetContentExpiration = jest.fn();
+const mockClearContentExpiration = jest.fn();
+const mockReplaceContentFile = jest.fn();
+const mockRestoreContentVersion = jest.fn();
 const mockUpdateContent = jest.fn();
 const mockUploadContent = jest.fn();
 const mockCreateContent = jest.fn();
@@ -29,6 +37,14 @@ jest.mock('@/lib/api', () => ({
     getDisplays: (...args: any[]) => mockGetDisplays(...args),
     getPlaylists: (...args: any[]) => mockGetPlaylists(...args),
     deleteContent: (...args: any[]) => mockDeleteContent(...args),
+    bulkDeleteContent: (...args: any[]) => mockBulkDeleteContent(...args),
+    bulkArchiveContent: (...args: any[]) => mockBulkArchiveContent(...args),
+    bulkSetContentDuration: (...args: any[]) => mockBulkSetContentDuration(...args),
+    getContentVersions: (...args: any[]) => mockGetContentVersions(...args),
+    setContentExpiration: (...args: any[]) => mockSetContentExpiration(...args),
+    clearContentExpiration: (...args: any[]) => mockClearContentExpiration(...args),
+    replaceContentFile: (...args: any[]) => mockReplaceContentFile(...args),
+    restoreContentVersion: (...args: any[]) => mockRestoreContentVersion(...args),
     updateContent: (...args: any[]) => mockUpdateContent(...args),
     uploadContent: (...args: any[]) => mockUploadContent(...args),
     createContent: (...args: any[]) => mockCreateContent(...args),
@@ -287,6 +303,14 @@ describe('ContentClient', () => {
     mockGetDisplays.mockResolvedValue({ data: [] });
     mockGetPlaylists.mockResolvedValue({ data: [] });
     mockDeleteContent.mockResolvedValue({});
+    mockBulkDeleteContent.mockResolvedValue({ deleted: 0, failed: 0, failedIds: [] });
+    mockBulkArchiveContent.mockResolvedValue({ archived: 0 });
+    mockBulkSetContentDuration.mockResolvedValue({ updated: 0 });
+    mockGetContentVersions.mockResolvedValue([]);
+    mockSetContentExpiration.mockResolvedValue(sampleContent[0]);
+    mockClearContentExpiration.mockResolvedValue(sampleContent[0]);
+    mockReplaceContentFile.mockResolvedValue({ content: sampleContent[0], fileHash: 'h' });
+    mockRestoreContentVersion.mockResolvedValue(sampleContent[0]);
     mockUpdateContent.mockResolvedValue(sampleContent[0]);
     mockUploadContent.mockResolvedValue({ id: 'new-1', title: 'New Content' });
     mockCreateContent.mockResolvedValue({ id: 'new-1', title: 'New Content' });
@@ -402,6 +426,7 @@ describe('ContentClient', () => {
 
   it('requires confirmation before bulk deleting selected content', async () => {
     mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
+    mockBulkDeleteContent.mockResolvedValueOnce({ deleted: 2, failed: 0, failedIds: [] });
     render(<ContentClient />);
 
     await waitFor(() => {
@@ -419,6 +444,8 @@ describe('ContentClient', () => {
       fireEvent.click(screen.getByRole('button', { name: /delete selected/i }));
     });
 
+    // Routes through the safe server-side bulk endpoint, never per-item hard deletes.
+    expect(mockBulkDeleteContent).not.toHaveBeenCalled();
     expect(mockDeleteContent).not.toHaveBeenCalled();
     expect(screen.getByTestId('confirm-dialog')).toHaveTextContent('Delete Selected Content');
 
@@ -427,15 +454,15 @@ describe('ContentClient', () => {
     });
 
     await waitFor(() => {
-      expect(mockDeleteContent).toHaveBeenCalledWith('c1');
-      expect(mockDeleteContent).toHaveBeenCalledWith('c2');
+      expect(mockBulkDeleteContent).toHaveBeenCalledWith(['c1', 'c2']);
     });
+    expect(mockDeleteContent).not.toHaveBeenCalled();
     expect(mockToast.success).toHaveBeenCalledWith('2 items deleted');
   });
 
   it('keeps bulk delete confirmation open when deletion fails', async () => {
     mockGetContent.mockResolvedValue({ data: sampleContent, meta: { total: 3 } });
-    mockDeleteContent.mockRejectedValueOnce(new Error('Delete failed'));
+    mockBulkDeleteContent.mockRejectedValueOnce(new Error('Delete failed'));
     render(<ContentClient />);
 
     await waitFor(() => {

--- a/web/src/app/dashboard/content/page-client.tsx
+++ b/web/src/app/dashboard/content/page-client.tsx
@@ -16,6 +16,7 @@ import LoadingSpinner from '@/components/LoadingSpinner';
 import EmptyState from '@/components/EmptyState';
 import SearchFilter from '@/components/SearchFilter';
 import ContentTagger, { ContentTag } from '@/components/ContentTagger';
+import ContentLifecyclePanel from '@/components/content/ContentLifecyclePanel';
 import DashboardSectionError from '@/components/DashboardSectionError';
 import { ViewToggle, getInitialView } from '@/components/ViewToggle';
 import { useToast } from '@/lib/hooks/useToast';
@@ -135,6 +136,8 @@ export default function ContentClient() {
  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
  const [isBulkDeleteModalOpen, setIsBulkDeleteModalOpen] = useState(false);
+ const [isBulkDurationModalOpen, setIsBulkDurationModalOpen] = useState(false);
+ const [bulkDurationValue, setBulkDurationValue] = useState(10);
  const [isPushModalOpen, setIsPushModalOpen] = useState(false);
  const [isAddToPlaylistModalOpen, setIsAddToPlaylistModalOpen] = useState(false);
  const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false);
@@ -153,6 +156,7 @@ export default function ContentClient() {
  url: '',
  file: null as File | null,
  });
+ const [editDuration, setEditDuration] = useState<number>(10);
  const [actionLoading, setActionLoading] = useState(false);
  const [filterType, setFilterType] = useState<string>('all');
  const [filterStatus, setFilterStatus] = useState<string>('all');
@@ -761,6 +765,7 @@ export default function ContentClient() {
  url: detail.url || '',
  file: null,
  });
+ setEditDuration(typeof detail.duration === 'number' && detail.duration > 0 ? detail.duration : 10);
  setFormErrors({});
  setIsEditModalOpen(true);
  })();
@@ -797,6 +802,7 @@ export default function ContentClient() {
  async () => {
  await apiClient.updateContent(selectedContent.id, {
  title: uploadForm.title,
+ duration: editDuration,
  });
  return true;
  },
@@ -804,7 +810,7 @@ export default function ContentClient() {
  // Commit optimistic update and sync rendered state
  commitOptimistic(updateId);
  setContent(prev => prev.map(item =>
-  item.id === selectedContent.id ? { ...item, title: uploadForm.title } : item
+  item.id === selectedContent.id ? { ...item, title: uploadForm.title, duration: editDuration } : item
  ));
  toast.success('Content updated successfully');
  setIsEditModalOpen(false);
@@ -1023,16 +1029,59 @@ export default function ContentClient() {
 
  try {
  setActionLoading(true);
- await Promise.all(
- selectedIds.map(id => apiClient.deleteContent(id))
- );
- toast.success(`${selectedIds.length} items deleted`);
+ // Route through the safe server-side bulk endpoint: it performs
+ // storage-aware, quota-adjusting deletes and reports partial failures
+ // instead of firing N independent hard-delete requests that can leave
+ // orphaned MinIO objects behind.
+ const result = await apiClient.bulkDeleteContent(selectedIds);
+ if (result.failed > 0) {
+ toast.warning(`${result.deleted} deleted, ${result.failed} could not be deleted`);
+ } else {
+ toast.success(`${result.deleted} item${result.deleted === 1 ? '' : 's'} deleted`);
+ }
  setSelectedItems(new Set());
  setIsBulkDeleteModalOpen(false);
  void loadContent();
  } catch (error: any) {
  toast.error(error.message || 'Failed to delete some items');
  throw error;
+ } finally {
+ setActionLoading(false);
+ }
+ };
+
+ const handleBulkArchive = async () => {
+ if (selectedItems.size === 0) return;
+ const selectedIds = Array.from(selectedItems);
+ try {
+ setActionLoading(true);
+ const result = await apiClient.bulkArchiveContent(selectedIds);
+ toast.success(`${result.archived} item${result.archived === 1 ? '' : 's'} archived`);
+ setSelectedItems(new Set());
+ void loadContent();
+ } catch (error: any) {
+ toast.error(error.message || 'Failed to archive items');
+ } finally {
+ setActionLoading(false);
+ }
+ };
+
+ const confirmBulkSetDuration = async () => {
+ if (selectedItems.size === 0) {
+ setIsBulkDurationModalOpen(false);
+ return;
+ }
+ const selectedIds = Array.from(selectedItems);
+ const duration = Math.max(1, Math.round(bulkDurationValue) || 1);
+ try {
+ setActionLoading(true);
+ const result = await apiClient.bulkSetContentDuration(selectedIds, duration);
+ toast.success(`Duration set to ${duration}s for ${result.updated} item${result.updated === 1 ? '' : 's'}`);
+ setIsBulkDurationModalOpen(false);
+ setSelectedItems(new Set());
+ void loadContent();
+ } catch (error: any) {
+ toast.error(error.message || 'Failed to update duration');
  } finally {
  setActionLoading(false);
  }
@@ -1069,6 +1118,12 @@ export default function ContentClient() {
  return 'bg-amber-500/20 text-amber-400 border border-amber-500/30';
  case 'rejected':
  return 'bg-red-500/20 text-red-400 border border-red-500/30';
+ case 'expired':
+ return 'bg-orange-500/20 text-orange-400 border border-orange-500/30';
+ case 'pending_approval':
+ return 'bg-blue-500/20 text-blue-400 border border-blue-500/30';
+ case 'draft':
+ return 'bg-slate-500/20 text-slate-400 border border-slate-500/30';
  case 'archived':
  return 'eh-badge-muted';
  default:
@@ -1453,6 +1508,27 @@ export default function ContentClient() {
  >
  <Icon name="folder" size="md" />
  Move to Folder
+ </button>
+ )}
+ {permissions.canManageContent && (
+ <button
+ onClick={() => setIsBulkDurationModalOpen(true)}
+ disabled={actionLoading}
+ className="eh-btn-secondary px-4 py-2 text-sm font-medium disabled:opacity-50 flex items-center gap-2"
+ >
+ <Icon name="clock" size="md" />
+ Set Duration
+ </button>
+ )}
+ {permissions.canManageContent && (
+ <button
+ onClick={handleBulkArchive}
+ disabled={actionLoading}
+ className="eh-btn-secondary px-4 py-2 text-sm font-medium disabled:opacity-50 flex items-center gap-2"
+ >
+ {actionLoading && <LoadingSpinner size="sm" />}
+ <Icon name="storage" size="md" />
+ Archive
  </button>
  )}
  {permissions.canDeleteContent && (
@@ -2129,6 +2205,46 @@ export default function ContentClient() {
  </p>
  </div>
 
+ {/* Playback duration (seconds) */}
+ <div>
+ <label className="block text-sm font-medium text-[var(--foreground-secondary)] mb-2">
+ Playback Duration (seconds)
+ </label>
+ <input
+ type="number"
+ min={1}
+ value={editDuration}
+ onChange={(e) => setEditDuration(Math.max(1, parseInt(e.target.value, 10) || 1))}
+ className="w-32 px-4 py-2 border border-[var(--border)] rounded-lg bg-[var(--surface)] text-[var(--foreground)] focus:ring-2 focus:ring-[#00E5A0] focus:border-transparent"
+ />
+ <p className="mt-1 text-xs text-[var(--foreground-tertiary)]">
+ How long this item shows in a playlist before advancing.
+ </p>
+ </div>
+
+ {selectedContent && (
+ <ContentLifecyclePanel
+ content={selectedContent}
+ replacementCandidates={content}
+ disabled={actionLoading}
+ onChanged={() => {
+ void loadContent();
+ const editedId = selectedContent.id;
+ void apiClient
+ .getContentItem(editedId)
+ .then((fresh) => {
+ setSelectedContent(fresh);
+ setEditDuration(
+ typeof fresh.duration === 'number' && fresh.duration > 0 ? fresh.duration : 10,
+ );
+ })
+ .catch(() => {
+ /* list already refreshed; detail refetch is best-effort */
+ });
+ }}
+ />
+ )}
+
  <div className="flex justify-end gap-3 pt-4">
  <button
  onClick={() => {
@@ -2367,6 +2483,50 @@ export default function ContentClient() {
  confirmText={`Delete ${selectedItems.size} Item${selectedItems.size === 1 ? '' : 's'}`}
  type="danger"
  />
+
+ {/* Bulk Set Duration Modal */}
+ <Modal
+ isOpen={isBulkDurationModalOpen && permissions.canManageContent}
+ onClose={() => {
+ if (!actionLoading) setIsBulkDurationModalOpen(false);
+ }}
+ title="Set Playback Duration"
+ >
+ <div className="space-y-4">
+ <p className="text-sm text-[var(--foreground-secondary)]">
+ Apply a playback duration to {selectedItems.size} selected item{selectedItems.size === 1 ? '' : 's'}.
+ </p>
+ <div>
+ <label className="block text-sm font-medium text-[var(--foreground-secondary)] mb-2">
+ Duration (seconds)
+ </label>
+ <input
+ type="number"
+ min={1}
+ value={bulkDurationValue}
+ onChange={(e) => setBulkDurationValue(Math.max(1, parseInt(e.target.value, 10) || 1))}
+ className="w-32 px-4 py-2 border border-[var(--border)] rounded-lg bg-[var(--surface)] text-[var(--foreground)] focus:ring-2 focus:ring-[#00E5A0] focus:border-transparent"
+ />
+ </div>
+ <div className="flex justify-end gap-3 pt-2">
+ <button
+ onClick={() => setIsBulkDurationModalOpen(false)}
+ disabled={actionLoading}
+ className="px-4 py-2 text-sm font-medium text-[var(--foreground-secondary)] bg-[var(--surface)] border border-[var(--border)] rounded-lg hover:bg-[var(--surface-hover)] transition disabled:opacity-50"
+ >
+ Cancel
+ </button>
+ <button
+ onClick={confirmBulkSetDuration}
+ disabled={actionLoading}
+ className="px-4 py-2 text-sm font-medium bg-[#00E5A0] text-[#061A21] rounded-lg hover:bg-[#00CC8E] transition disabled:opacity-50 flex items-center gap-2"
+ >
+ {actionLoading && <LoadingSpinner size="sm" />}
+ Apply
+ </button>
+ </div>
+ </div>
+ </Modal>
 
  {/* Create Folder Modal */}
  <Modal

--- a/web/src/components/content/ContentLifecyclePanel.tsx
+++ b/web/src/components/content/ContentLifecyclePanel.tsx
@@ -1,0 +1,374 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { apiClient } from '@/lib/api';
+import type { Content } from '@/lib/types';
+import { useToast } from '@/lib/hooks/useToast';
+import LoadingSpinner from '@/components/LoadingSpinner';
+import { Icon } from '@/theme/icons';
+
+interface ContentLifecyclePanelProps {
+  /** The full content-detail record (getContentItem) currently being edited. */
+  content: Content;
+  /**
+   * Candidate content for the auto-replacement selector — typically the
+   * currently-loaded list. Self is filtered out internally.
+   */
+  replacementCandidates: Content[];
+  /** Called after any lifecycle mutation so the parent can refresh list + detail. */
+  onChanged: () => void;
+  disabled?: boolean;
+}
+
+// Only file-backed content can have its underlying file swapped. URL / HTML /
+// template content is edited elsewhere, not "replaced".
+const FILE_REPLACEABLE_TYPES = new Set(['image', 'video', 'pdf']);
+
+const FILE_ACCEPT: Record<string, string> = {
+  image: 'image/*',
+  video: 'video/*',
+  pdf: 'application/pdf',
+};
+
+/**
+ * Convert an ISO timestamp to the value a `<input type="datetime-local">`
+ * expects — local time, minute precision, no zone: `YYYY-MM-DDTHH:mm`.
+ */
+function toDatetimeLocalValue(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(
+    d.getHours(),
+  )}:${pad(d.getMinutes())}`;
+}
+
+function formatTimestamp(value: string | Date | null | undefined): string {
+  if (!value) return '';
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? '' : d.toLocaleString();
+}
+
+export default function ContentLifecyclePanel({
+  content,
+  replacementCandidates,
+  onChanged,
+  disabled = false,
+}: ContentLifecyclePanelProps) {
+  const toast = useToast();
+
+  const [expiresAt, setExpiresAt] = useState(toDatetimeLocalValue(content.expiresAt));
+  const [replacementId, setReplacementId] = useState(content.replacementContentId ?? '');
+  const [savingExpiration, setSavingExpiration] = useState(false);
+
+  const [versions, setVersions] = useState<Content[] | null>(null);
+  const [versionsLoading, setVersionsLoading] = useState(false);
+  const [versionsError, setVersionsError] = useState<string | null>(null);
+  const [restoringId, setRestoringId] = useState<string | null>(null);
+
+  const [replaceFile, setReplaceFile] = useState<File | null>(null);
+  const [keepBackup, setKeepBackup] = useState(true);
+  const [replacing, setReplacing] = useState(false);
+
+  // Re-seed local form state whenever a different content item is opened.
+  useEffect(() => {
+    setExpiresAt(toDatetimeLocalValue(content.expiresAt));
+    setReplacementId(content.replacementContentId ?? '');
+    setReplaceFile(null);
+  }, [content.id, content.expiresAt, content.replacementContentId]);
+
+  const candidates = replacementCandidates.filter((c) => c.id !== content.id);
+  const canReplaceFile = FILE_REPLACEABLE_TYPES.has(content.type);
+  const busy = disabled || savingExpiration || replacing || restoringId !== null;
+
+  const loadVersions = useCallback(async () => {
+    setVersionsLoading(true);
+    setVersionsError(null);
+    try {
+      const list = await apiClient.getContentVersions(content.id);
+      setVersions(list);
+    } catch (error) {
+      setVersionsError(error instanceof Error ? error.message : 'Failed to load version history');
+    } finally {
+      setVersionsLoading(false);
+    }
+  }, [content.id]);
+
+  useEffect(() => {
+    void loadVersions();
+  }, [loadVersions]);
+
+  const handleSetExpiration = async () => {
+    if (!expiresAt) {
+      toast.error('Choose an expiration date first');
+      return;
+    }
+    const parsed = new Date(expiresAt);
+    if (Number.isNaN(parsed.getTime())) {
+      toast.error('Invalid expiration date');
+      return;
+    }
+    if (parsed.getTime() <= Date.now()) {
+      toast.error('Expiration must be in the future');
+      return;
+    }
+    setSavingExpiration(true);
+    try {
+      await apiClient.setContentExpiration(
+        content.id,
+        parsed.toISOString(),
+        replacementId || undefined,
+      );
+      toast.success('Expiration scheduled');
+      onChanged();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to set expiration');
+    } finally {
+      setSavingExpiration(false);
+    }
+  };
+
+  const handleClearExpiration = async () => {
+    setSavingExpiration(true);
+    try {
+      await apiClient.clearContentExpiration(content.id);
+      setExpiresAt('');
+      setReplacementId('');
+      toast.success('Expiration cleared');
+      onChanged();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to clear expiration');
+    } finally {
+      setSavingExpiration(false);
+    }
+  };
+
+  const handleReplaceFile = async () => {
+    if (!replaceFile) {
+      toast.error('Choose a replacement file first');
+      return;
+    }
+    setReplacing(true);
+    try {
+      await apiClient.replaceContentFile(content.id, replaceFile, { keepBackup });
+      toast.success(keepBackup ? 'File replaced (previous version kept)' : 'File replaced');
+      setReplaceFile(null);
+      onChanged();
+      void loadVersions();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to replace file');
+    } finally {
+      setReplacing(false);
+    }
+  };
+
+  const handleRestore = async (versionId: string) => {
+    setRestoringId(versionId);
+    try {
+      await apiClient.restoreContentVersion(versionId);
+      toast.success('Version restored');
+      onChanged();
+      void loadVersions();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to restore version');
+    } finally {
+      setRestoringId(null);
+    }
+  };
+
+  const nowLocal = toDatetimeLocalValue(new Date().toISOString());
+
+  return (
+    <div className="space-y-5 border-t border-[var(--border)] pt-4">
+      {/* Expiration + auto-replacement */}
+      <section className="space-y-2">
+        <h3 className="flex items-center gap-2 text-sm font-semibold text-[var(--foreground)]">
+          <Icon name="clock" size="md" />
+          Expiration &amp; auto-replacement
+        </h3>
+        {content.expiresAt ? (
+          <p className="text-xs text-[var(--foreground-tertiary)]">
+            Currently expires {formatTimestamp(content.expiresAt)}
+          </p>
+        ) : (
+          <p className="text-xs text-[var(--foreground-tertiary)]">No expiration set</p>
+        )}
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div>
+            <label
+              htmlFor="content-expires-at"
+              className="block text-xs font-medium text-[var(--foreground-secondary)] mb-1"
+            >
+              Expires at
+            </label>
+            <input
+              id="content-expires-at"
+              type="datetime-local"
+              value={expiresAt}
+              min={nowLocal}
+              disabled={busy}
+              onChange={(e) => setExpiresAt(e.target.value)}
+              className="w-full px-3 py-2 text-sm border border-[var(--border)] rounded-lg bg-[var(--surface)] text-[var(--foreground)] focus:ring-2 focus:ring-[#00E5A0] focus:border-transparent disabled:opacity-50"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="content-replacement"
+              className="block text-xs font-medium text-[var(--foreground-secondary)] mb-1"
+            >
+              Replace with (optional)
+            </label>
+            <select
+              id="content-replacement"
+              value={replacementId}
+              disabled={busy}
+              onChange={(e) => setReplacementId(e.target.value)}
+              className="w-full px-3 py-2 text-sm border border-[var(--border)] rounded-lg bg-[var(--surface)] text-[var(--foreground)] focus:ring-2 focus:ring-[#00E5A0] focus:border-transparent disabled:opacity-50"
+            >
+              <option value="">Remove from playlists on expiry</option>
+              {candidates.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.title}
+                  {c.status !== 'active' ? ` (${c.status})` : ''}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2 pt-1">
+          <button
+            type="button"
+            onClick={handleSetExpiration}
+            disabled={busy || !expiresAt}
+            className="bg-[#00E5A0] text-[#061A21] hover:bg-[#00CC8E] transition rounded-lg px-3 py-1.5 text-sm font-medium disabled:opacity-50 flex items-center gap-2"
+          >
+            {savingExpiration && <LoadingSpinner size="sm" />}
+            Schedule expiration
+          </button>
+          {content.expiresAt && (
+            <button
+              type="button"
+              onClick={handleClearExpiration}
+              disabled={busy}
+              className="bg-[var(--surface)] border border-[var(--border)] text-[var(--foreground-secondary)] hover:bg-[var(--surface-hover)] transition rounded-lg px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+            >
+              Clear expiration
+            </button>
+          )}
+        </div>
+      </section>
+
+      {/* File replacement */}
+      {canReplaceFile && (
+        <section className="space-y-2">
+          <h3 className="flex items-center gap-2 text-sm font-semibold text-[var(--foreground)]">
+            <Icon name="upload" size="md" />
+            Replace file
+          </h3>
+          <p className="text-xs text-[var(--foreground-tertiary)]">
+            Upload a new file for this item. Playlists keep pointing at it.
+          </p>
+          <input
+            type="file"
+            accept={FILE_ACCEPT[content.type]}
+            disabled={busy}
+            onChange={(e) => setReplaceFile(e.target.files?.[0] ?? null)}
+            className="block w-full text-sm text-[var(--foreground-secondary)] file:mr-3 file:rounded-lg file:border-0 file:bg-[var(--surface)] file:px-3 file:py-1.5 file:text-sm file:font-medium file:text-[var(--foreground)] disabled:opacity-50"
+          />
+          <label className="flex items-center gap-2 text-xs text-[var(--foreground-secondary)]">
+            <input
+              type="checkbox"
+              checked={keepBackup}
+              disabled={busy}
+              onChange={(e) => setKeepBackup(e.target.checked)}
+              className="h-4 w-4 rounded border-[var(--border)] text-[#00E5A0] focus:ring-[#00E5A0]"
+            />
+            Keep previous version (saved to version history)
+          </label>
+          <button
+            type="button"
+            onClick={handleReplaceFile}
+            disabled={busy || !replaceFile}
+            className="bg-[#00E5A0] text-[#061A21] hover:bg-[#00CC8E] transition rounded-lg px-3 py-1.5 text-sm font-medium disabled:opacity-50 flex items-center gap-2"
+          >
+            {replacing && <LoadingSpinner size="sm" />}
+            Replace file
+          </button>
+        </section>
+      )}
+
+      {/* Version history */}
+      <section className="space-y-2">
+        <div className="flex items-center justify-between">
+          <h3 className="flex items-center gap-2 text-sm font-semibold text-[var(--foreground)]">
+            <Icon name="refresh" size="md" />
+            Version history
+          </h3>
+          <button
+            type="button"
+            onClick={() => void loadVersions()}
+            disabled={versionsLoading}
+            className="text-xs text-[var(--primary)] hover:underline disabled:opacity-50"
+          >
+            Refresh
+          </button>
+        </div>
+        {versionsLoading && versions === null ? (
+          <div className="py-3 flex justify-center">
+            <LoadingSpinner size="sm" />
+          </div>
+        ) : versionsError ? (
+          <div className="text-xs text-red-500 dark:text-red-400">
+            {versionsError}{' '}
+            <button
+              type="button"
+              onClick={() => void loadVersions()}
+              className="underline hover:no-underline"
+            >
+              Retry
+            </button>
+          </div>
+        ) : versions && versions.length > 1 ? (
+          <ul className="space-y-1">
+            {versions.map((version) => {
+              const isCurrent = version.id === content.id;
+              return (
+                <li
+                  key={version.id}
+                  className="flex items-center justify-between gap-3 rounded-lg border border-[var(--border)] px-3 py-2 text-sm"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate text-[var(--foreground)]">
+                      v{version.versionNumber ?? 1} · {version.title}
+                    </p>
+                    <p className="text-xs text-[var(--foreground-tertiary)]">
+                      {isCurrent ? 'Current' : version.status}
+                      {version.createdAt ? ` · ${formatTimestamp(version.createdAt)}` : ''}
+                    </p>
+                  </div>
+                  {!isCurrent && (
+                    <button
+                      type="button"
+                      onClick={() => handleRestore(version.id)}
+                      disabled={busy}
+                      className="bg-[var(--surface)] border border-[var(--border)] text-[var(--foreground-secondary)] hover:bg-[var(--surface-hover)] transition rounded-lg px-3 py-1 text-xs font-medium disabled:opacity-50 flex items-center gap-1 shrink-0"
+                    >
+                      {restoringId === version.id && <LoadingSpinner size="sm" />}
+                      Restore
+                    </button>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        ) : (
+          <p className="text-xs text-[var(--foreground-tertiary)]">
+            No previous versions. Replacing the file with &ldquo;keep previous version&rdquo;
+            enabled adds one here.
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/web/src/components/content/__tests__/ContentLifecyclePanel.test.tsx
+++ b/web/src/components/content/__tests__/ContentLifecyclePanel.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import ContentLifecyclePanel from '../ContentLifecyclePanel';
+import type { Content } from '@/lib/types';
+
+const mockGetContentVersions = jest.fn();
+const mockSetContentExpiration = jest.fn();
+const mockClearContentExpiration = jest.fn();
+const mockReplaceContentFile = jest.fn();
+const mockRestoreContentVersion = jest.fn();
+
+jest.mock('@/lib/api', () => ({
+  apiClient: {
+    getContentVersions: (...args: any[]) => mockGetContentVersions(...args),
+    setContentExpiration: (...args: any[]) => mockSetContentExpiration(...args),
+    clearContentExpiration: (...args: any[]) => mockClearContentExpiration(...args),
+    replaceContentFile: (...args: any[]) => mockReplaceContentFile(...args),
+    restoreContentVersion: (...args: any[]) => mockRestoreContentVersion(...args),
+  },
+}));
+
+const mockToast = { success: jest.fn(), error: jest.fn(), info: jest.fn(), warning: jest.fn() };
+jest.mock('@/lib/hooks/useToast', () => ({ useToast: () => mockToast }));
+
+function makeContent(overrides: Partial<Content> = {}): Content {
+  return {
+    id: 'c1',
+    title: 'Lobby Banner',
+    type: 'image',
+    status: 'active',
+    duration: 10,
+    versionNumber: 1,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('ContentLifecyclePanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetContentVersions.mockResolvedValue([makeContent()]);
+  });
+
+  it('loads version history on mount', async () => {
+    render(
+      <ContentLifecyclePanel content={makeContent()} replacementCandidates={[]} onChanged={jest.fn()} />,
+    );
+    await waitFor(() => expect(mockGetContentVersions).toHaveBeenCalledWith('c1'));
+  });
+
+  it('schedules an expiration with a chosen replacement and fires onChanged', async () => {
+    const onChanged = jest.fn();
+    mockSetContentExpiration.mockResolvedValue(makeContent());
+    const candidate = makeContent({ id: 'c2', title: 'Backup Banner' });
+
+    render(
+      <ContentLifecyclePanel
+        content={makeContent()}
+        replacementCandidates={[candidate]}
+        onChanged={onChanged}
+      />,
+    );
+    await waitFor(() => expect(mockGetContentVersions).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText('Expires at'), { target: { value: '2099-06-15T10:30' } });
+    fireEvent.change(screen.getByLabelText('Replace with (optional)'), { target: { value: 'c2' } });
+    fireEvent.click(screen.getByRole('button', { name: /schedule expiration/i }));
+
+    await waitFor(() => expect(mockSetContentExpiration).toHaveBeenCalled());
+    const [id, iso, replacementId] = mockSetContentExpiration.mock.calls[0];
+    expect(id).toBe('c1');
+    expect(typeof iso).toBe('string');
+    expect(replacementId).toBe('c2');
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+  });
+
+  it('clears an existing expiration', async () => {
+    const onChanged = jest.fn();
+    mockClearContentExpiration.mockResolvedValue(makeContent());
+
+    render(
+      <ContentLifecyclePanel
+        content={makeContent({ expiresAt: '2099-01-01T00:00:00.000Z' })}
+        replacementCandidates={[]}
+        onChanged={onChanged}
+      />,
+    );
+    await waitFor(() => expect(mockGetContentVersions).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole('button', { name: /clear expiration/i }));
+
+    await waitFor(() => expect(mockClearContentExpiration).toHaveBeenCalledWith('c1'));
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+  });
+
+  it('replaces the file and reloads versions', async () => {
+    const onChanged = jest.fn();
+    mockReplaceContentFile.mockResolvedValue({ content: makeContent(), fileHash: 'h' });
+
+    render(
+      <ContentLifecyclePanel content={makeContent()} replacementCandidates={[]} onChanged={onChanged} />,
+    );
+    await waitFor(() => expect(mockGetContentVersions).toHaveBeenCalledTimes(1));
+
+    const file = new File(['x'], 'new.png', { type: 'image/png' });
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+    fireEvent.click(screen.getByRole('button', { name: /replace file/i }));
+
+    await waitFor(() =>
+      expect(mockReplaceContentFile).toHaveBeenCalledWith('c1', file, { keepBackup: true }),
+    );
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+    // versions reloaded after replace
+    await waitFor(() => expect(mockGetContentVersions).toHaveBeenCalledTimes(2));
+  });
+
+  it('restores a previous version', async () => {
+    const onChanged = jest.fn();
+    mockGetContentVersions.mockResolvedValue([
+      makeContent({ id: 'c1', versionNumber: 2 }),
+      makeContent({ id: 'c1-v1', versionNumber: 1, status: 'archived', title: 'Lobby Banner (v1)' }),
+    ]);
+    mockRestoreContentVersion.mockResolvedValue(makeContent());
+
+    render(
+      <ContentLifecyclePanel content={makeContent({ versionNumber: 2 })} replacementCandidates={[]} onChanged={onChanged} />,
+    );
+    await waitFor(() => expect(screen.getByRole('button', { name: /restore/i })).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /restore/i }));
+
+    await waitFor(() => expect(mockRestoreContentVersion).toHaveBeenCalledWith('c1-v1'));
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+  });
+});

--- a/web/src/lib/api/__tests__/content.test.ts
+++ b/web/src/lib/api/__tests__/content.test.ts
@@ -39,4 +39,114 @@ describe('content api methods', () => {
       '/content?page=1&limit=50&tagNames=Lunch%2C+Dinner&tagNames=Marketing&tagIds=tag-menu&tagIds=tag-promo',
     );
   });
+
+  it('sends title + duration on updateContent', async () => {
+    const client = new ApiClient('/api/v1');
+    const requestSpy = jest.spyOn(client, 'request').mockResolvedValue({ id: 'c1' } as any);
+
+    await client.updateContent('c1', { title: 'Menu', duration: 20 });
+
+    expect(JSON.parse((requestSpy.mock.calls[0][1] as RequestInit).body as string)).toEqual({
+      name: 'Menu',
+      duration: 20,
+    });
+  });
+
+  it('PATCHes expiration with replacement when provided', async () => {
+    const client = new ApiClient('/api/v1');
+    const requestSpy = jest.spyOn(client, 'request').mockResolvedValue({ id: 'c1' } as any);
+
+    await client.setContentExpiration('c1', '2099-01-01T00:00:00.000Z', 'repl-1');
+
+    expect(requestSpy).toHaveBeenCalledWith(
+      '/content/c1/expiration',
+      expect.objectContaining({ method: 'PATCH' }),
+    );
+    expect(JSON.parse((requestSpy.mock.calls[0][1] as RequestInit).body as string)).toEqual({
+      expiresAt: '2099-01-01T00:00:00.000Z',
+      replacementContentId: 'repl-1',
+    });
+  });
+
+  it('omits replacementContentId when not provided', async () => {
+    const client = new ApiClient('/api/v1');
+    const requestSpy = jest.spyOn(client, 'request').mockResolvedValue({ id: 'c1' } as any);
+
+    await client.setContentExpiration('c1', '2099-01-01T00:00:00.000Z');
+
+    expect(JSON.parse((requestSpy.mock.calls[0][1] as RequestInit).body as string)).toEqual({
+      expiresAt: '2099-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('DELETEs expiration on clearContentExpiration', async () => {
+    const client = new ApiClient('/api/v1');
+    const requestSpy = jest.spyOn(client, 'request').mockResolvedValue({ id: 'c1' } as any);
+
+    await client.clearContentExpiration('c1');
+
+    expect(requestSpy).toHaveBeenCalledWith(
+      '/content/c1/expiration',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  it('GETs the version chain and POSTs a restore', async () => {
+    const client = new ApiClient('/api/v1');
+    const requestSpy = jest.spyOn(client, 'request').mockResolvedValue([] as any);
+
+    await client.getContentVersions('c1');
+    expect(requestSpy).toHaveBeenCalledWith('/content/c1/versions');
+
+    await client.restoreContentVersion('v2');
+    expect(requestSpy).toHaveBeenCalledWith(
+      '/content/v2/restore',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('uploads a replacement file as multipart with keepBackup flag', async () => {
+    const client = new ApiClient('/api/v1');
+    const formSpy = jest
+      .spyOn(client, 'requestFormData')
+      .mockResolvedValue({ content: { id: 'c1' }, fileHash: 'abc' } as any);
+    const file = new File(['x'], 'new.png', { type: 'image/png' });
+
+    await client.replaceContentFile('c1', file, { keepBackup: true });
+
+    expect(formSpy).toHaveBeenCalledWith('/content/c1/replace', expect.any(FormData), 'POST');
+    const sentForm = formSpy.mock.calls[0][1] as FormData;
+    expect(sentForm.get('file')).toBe(file);
+    expect(sentForm.get('keepBackup')).toBe('true');
+  });
+
+  it('routes bulk delete/archive/duration to the safe bulk endpoints', async () => {
+    const client = new ApiClient('/api/v1');
+    const requestSpy = jest.spyOn(client, 'request').mockResolvedValue({} as any);
+
+    await client.bulkDeleteContent(['a', 'b']);
+    expect(requestSpy).toHaveBeenCalledWith(
+      '/content/bulk/delete',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(JSON.parse((requestSpy.mock.calls[0][1] as RequestInit).body as string)).toEqual({
+      ids: ['a', 'b'],
+    });
+
+    await client.bulkArchiveContent(['a']);
+    expect(requestSpy).toHaveBeenLastCalledWith(
+      '/content/bulk/archive',
+      expect.objectContaining({ method: 'POST' }),
+    );
+
+    await client.bulkSetContentDuration(['a', 'b'], 15);
+    expect(requestSpy).toHaveBeenLastCalledWith(
+      '/content/bulk/duration',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(JSON.parse((requestSpy.mock.calls[2][1] as RequestInit).body as string)).toEqual({
+      ids: ['a', 'b'],
+      duration: 15,
+    });
+  });
 });

--- a/web/src/lib/api/content.ts
+++ b/web/src/lib/api/content.ts
@@ -23,15 +23,37 @@ export interface ContentTagSummary {
   contentCount: number;
 }
 
+export interface ContentBulkDeleteResult {
+  deleted: number;
+  failed: number;
+  failedIds: string[];
+}
+
+export interface ContentReplaceResult {
+  content: Content;
+  fileHash: string;
+}
+
 declare module './client' {
   interface ApiClient {
     getContent(params?: ContentListParams): Promise<PaginatedResponse<Content>>;
     getContentTags(): Promise<ContentTagSummary[]>;
     getContentItem(id: string): Promise<Content>;
     createContent(data: { title: string; type: string; url?: string; file?: File; metadata?: Record<string, unknown> }): Promise<Content>;
-    updateContent(id: string, data: Partial<{ title: string; metadata?: Record<string, unknown> }>): Promise<Content>;
+    updateContent(id: string, data: Partial<{ title: string; duration: number; metadata?: Record<string, unknown> }>): Promise<Content>;
     deleteContent(id: string): Promise<void>;
     archiveContent(id: string): Promise<Content>;
+    // Content expiration (auto-replacement) — PATCH/DELETE /content/:id/expiration
+    setContentExpiration(id: string, expiresAt: string, replacementContentId?: string): Promise<Content>;
+    clearContentExpiration(id: string): Promise<Content>;
+    // File replacement + version history — /content/:id/{replace,versions,restore}
+    replaceContentFile(id: string, file: File, options?: { name?: string; keepBackup?: boolean }): Promise<ContentReplaceResult>;
+    getContentVersions(id: string): Promise<Content[]>;
+    restoreContentVersion(id: string): Promise<Content>;
+    // Safe bulk operations — POST /content/bulk/{delete,archive,duration}
+    bulkDeleteContent(ids: string[]): Promise<ContentBulkDeleteResult>;
+    bulkArchiveContent(ids: string[]): Promise<{ archived: number }>;
+    bulkSetContentDuration(ids: string[], duration: number): Promise<{ updated: number }>;
     getContentDownloadUrl(id: string, expirySeconds?: number): Promise<{ url: string; expiresIn: number }>;
     generateThumbnail(contentId: string): Promise<{ thumbnail: string }>;
     uploadContentWithProgress(data: { title: string; type: string; file: File | Blob }, onProgress?: (percent: number) => void): Promise<Content>;
@@ -197,6 +219,76 @@ ApiClient.prototype.deleteContent = async function (id: string): Promise<void> {
 ApiClient.prototype.archiveContent = async function (id: string): Promise<Content> {
   return this.request<Content>(`/content/${id}/archive`, {
     method: 'POST',
+  });
+};
+
+ApiClient.prototype.setContentExpiration = async function (
+  id: string,
+  expiresAt: string,
+  replacementContentId?: string,
+): Promise<Content> {
+  return this.request<Content>(`/content/${id}/expiration`, {
+    method: 'PATCH',
+    body: JSON.stringify({
+      expiresAt,
+      ...(replacementContentId ? { replacementContentId } : {}),
+    }),
+  });
+};
+
+ApiClient.prototype.clearContentExpiration = async function (id: string): Promise<Content> {
+  return this.request<Content>(`/content/${id}/expiration`, {
+    method: 'DELETE',
+  });
+};
+
+ApiClient.prototype.replaceContentFile = async function (
+  id: string,
+  file: File,
+  options: { name?: string; keepBackup?: boolean } = {},
+): Promise<ContentReplaceResult> {
+  const formData = new FormData();
+  formData.append('file', file);
+  if (options.name) {
+    formData.append('name', options.name);
+  }
+  if (options.keepBackup !== undefined) {
+    formData.append('keepBackup', String(options.keepBackup));
+  }
+  return this.requestFormData<ContentReplaceResult>(`/content/${id}/replace`, formData, 'POST');
+};
+
+ApiClient.prototype.getContentVersions = async function (id: string): Promise<Content[]> {
+  return this.request<Content[]>(`/content/${id}/versions`);
+};
+
+ApiClient.prototype.restoreContentVersion = async function (id: string): Promise<Content> {
+  return this.request<Content>(`/content/${id}/restore`, {
+    method: 'POST',
+  });
+};
+
+ApiClient.prototype.bulkDeleteContent = async function (ids: string[]): Promise<ContentBulkDeleteResult> {
+  return this.request<ContentBulkDeleteResult>('/content/bulk/delete', {
+    method: 'POST',
+    body: JSON.stringify({ ids }),
+  });
+};
+
+ApiClient.prototype.bulkArchiveContent = async function (ids: string[]): Promise<{ archived: number }> {
+  return this.request<{ archived: number }>('/content/bulk/archive', {
+    method: 'POST',
+    body: JSON.stringify({ ids }),
+  });
+};
+
+ApiClient.prototype.bulkSetContentDuration = async function (
+  ids: string[],
+  duration: number,
+): Promise<{ updated: number }> {
+  return this.request<{ updated: number }>('/content/bulk/duration', {
+    method: 'POST',
+    body: JSON.stringify({ ids, duration }),
   });
 };
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -23,11 +23,28 @@ export interface Content {
   type: 'image' | 'video' | 'pdf' | 'url' | 'html' | 'template';
   url?: string;
   thumbnailUrl?: string;
-  status: 'ready' | 'processing' | 'error' | 'active' | 'archived' | 'flagged' | 'rejected';
+  status:
+    | 'ready'
+    | 'processing'
+    | 'error'
+    | 'active'
+    | 'archived'
+    | 'flagged'
+    | 'rejected'
+    | 'expired'
+    | 'draft'
+    | 'pending_approval';
   duration?: number;
   fileSize?: number | null;
+  mimeType?: string | null;
   metadata?: Record<string, unknown>;
   folderId?: string;
+  // Content-detail-only lifecycle fields (present on getContentItem responses,
+  // omitted from the paginated list select). All optional so list rows type-check.
+  expiresAt?: string | null;
+  replacementContentId?: string | null;
+  versionNumber?: number;
+  previousVersionId?: string | null;
   createdAt: Date | string;
   updatedAt: Date | string;
 }


### PR DESCRIPTION
**Batch PR-11** (P1 tier). Theme #1 — *"backend shipped, no UI."* Drift-checked all 6 items; wired the **4 with real backend support**, and **flagged 2 as NEEDS-BACKEND** rather than half-building against a phantom. Closes content-mgmt #2/#3/#4, content-mgmt #12/notifications #2.

## Wired ✅
- **#2 expiration + auto-replacement** — new `ContentLifecyclePanel` wires `PATCH/DELETE /content/:id/expiration`: set an expiry + pick replacement content, or clear it. + API-client methods.
- **#3 file-replace + version history/restore** — real version storage exists (`versionNumber`/`previousVersionId` chain). Wired `POST :id/replace` (multipart, keep-backup), `GET :id/versions`, `POST :id/restore` with a per-version restore control.
- **#4 SAFE bulk-delete** — rerouted the bulk bar off a **per-item hard-delete loop** (`Promise.all(deleteContent)`) to `POST /content/bulk/delete` with partial-failure reporting; added bulk **Archive** + **Set Duration** + per-item duration edit; status badges for `expired`/`pending_approval`/`draft`.
- **#12/notifications #2** — emit `content.expired` per item **after** the expiration tx commits (consumed by `ValidationMonitor`'s `content.**` `@OnEvent`). `content.updated` was already emitted (drift: DONE).

## Flagged NEEDS-BACKEND (not built) 🚧
- **#1 approval path** — the 3 transition endpoints exist, but **nothing can set `status='draft'`** (create DTO has no status; default is `active`), so `submit-for-approval` is unreachable. Needs a create-as-draft / status setter. (Draft/pending badges added as forward-compat display only.)
- **#5 tag create** — `bulkAddTags` is **assign-only** and there's **no tag-create endpoint**; `listContentTags` returns only already-assigned tags, so the assignable pool is always empty → an assign UI would be a dead control. Needs `POST /content/tags`.

## Verification (independently re-run)
- WEB `tsc` 0 · MW `tsc` 0 · web content **65/65** (API client + panel + page) · MW `content.service` **126/126** (incl. 2 new `content.expired` tests)
- ⚠️ On-screen rendering needs a **manual walkthrough** (browser not driven in CI) — code is typed, wired, unit-tested. Suggest a manual pass of the edit modal (expiration/replace/versions) + bulk bar (safe delete / archive / duration).

No `schema.prisma` / migration; no new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)