### PR TITLE
fix(clickhouse): watchdog @Cron crashed middleware boot (EVERY_15_MINUTES is undefined)

### DIFF
--- a/middleware/src/main.ts
+++ b/middleware/src/main.ts
@@ -240,7 +240,13 @@ async function bootstrap() {
     } else if (code === 'EACCES') {
       Logger.error(`Permission denied binding to port ${port}. Ports below 1024 require elevated privileges.`);
     } else {
+      // Log the full stack — a bare `.message` (e.g. a TypeError thrown from a
+      // bootstrap hook or the http stack) hides WHERE the failure is and makes
+      // a prod boot failure undiagnosable from logs alone.
       Logger.error(`Underlying error: ${(error as Error)?.message || error}`);
+      if ((error as Error)?.stack) {
+        Logger.error((error as Error).stack);
+      }
     }
     process.exit(1);
   }

--- a/middleware/src/modules/clickhouse/clickhouse-watchdog.bootstrap.spec.ts
+++ b/middleware/src/modules/clickhouse/clickhouse-watchdog.bootstrap.spec.ts
@@ -1,0 +1,54 @@
+import { INestApplication } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
+import { Test } from '@nestjs/testing';
+import { ClickHouseWatchdogService } from './clickhouse-watchdog.service';
+import { DatabaseService } from '../database/database.service';
+import { ClickHouseService } from './clickhouse.service';
+
+/**
+ * Regression guard for the 2026-07-11 prod boot failure.
+ *
+ * The watchdog originally used `@Cron(CronExpression.EVERY_15_MINUTES)`, but
+ * @nestjs/schedule's `CronExpression` enum has NO `EVERY_15_MINUTES` member
+ * (only 10/30), so it resolved to `undefined`. `@Cron(undefined)` type-checks
+ * clean and passes the ordinary unit tests (which call the handler directly),
+ * but at real app bootstrap `ScheduleModule` hands the undefined expression to
+ * the cron parser, which throws `TypeError: Cannot read properties of undefined
+ * (reading 'toLowerCase')` from `SchedulerOrchestrator.onApplicationBootstrap`
+ * — i.e. `app.listen()` rejects and the whole middleware crash-loops.
+ *
+ * This test reproduces that path: it stands up a real Nest app with
+ * `ScheduleModule.forRoot()` and calls `app.init()` (which runs the scheduler
+ * bootstrap). It FAILS on an invalid/undefined cron expression and PASSES only
+ * when every @Cron on the watchdog is a valid expression.
+ */
+describe('ClickHouseWatchdogService — @Cron bootstrap (regression guard)', () => {
+  let app: INestApplication | undefined;
+
+  afterEach(async () => {
+    if (app) {
+      await app.close();
+      app = undefined;
+    }
+  });
+
+  it('registers its @Cron under ScheduleModule without crashing app bootstrap', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [ScheduleModule.forRoot()],
+      providers: [
+        ClickHouseWatchdogService,
+        { provide: DatabaseService, useValue: { display: { count: jest.fn().mockResolvedValue(0) } } },
+        {
+          provide: ClickHouseService,
+          useValue: { isEnabled: false, getLatestSampleTime: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+
+    // app.init() runs SchedulerOrchestrator.onApplicationBootstrap, which parses
+    // and schedules every @Cron. An undefined/invalid expression throws here.
+    await expect(app.init()).resolves.toBeDefined();
+  });
+});

--- a/middleware/src/modules/clickhouse/clickhouse-watchdog.service.ts
+++ b/middleware/src/modules/clickhouse/clickhouse-watchdog.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
+import { Cron } from '@nestjs/schedule';
 import { DEVICE_OFFLINE_THRESHOLD_MS } from '@vizora/database';
 import { DatabaseService } from '../database/database.service';
 import { ClickHouseService } from './clickhouse.service';
@@ -31,7 +31,13 @@ export class ClickHouseWatchdogService {
     private readonly clickhouse: ClickHouseService,
   ) {}
 
-  @Cron(CronExpression.EVERY_15_MINUTES)
+  // Every 15 minutes (second 0). NB: do NOT use `CronExpression.EVERY_15_MINUTES`
+  // — @nestjs/schedule's CronExpression enum has no such member (only 10/30),
+  // so it resolves to `undefined`, which makes ScheduleModule bootstrap hand an
+  // undefined expression to the cron parser and crash the whole app at
+  // `app.listen()` (a TypeError that unit tests, which call this method
+  // directly, never exercise). An explicit expression is unambiguous and safe.
+  @Cron('0 */15 * * * *')
   async checkDeviceHealthFreshness(): Promise<void> {
     try {
       if (!this.clickhouse.isEnabled) return;


### PR DESCRIPTION
**Root cause of the 2026-07-11 prod outage** (middleware crash-looped to 502 during the PR-10/14/16/11/12 deploy; rolled back).

## The bug
`ClickHouseWatchdogService` (from PR-10) used `@Cron(CronExpression.EVERY_15_MINUTES)`. But `@nestjs/schedule`'s `CronExpression` enum has **no `EVERY_15_MINUTES` member** (only `EVERY_10_MINUTES` / `EVERY_30_MINUTES`) — so it resolved to **`undefined`**. `@Cron(undefined)`:
- type-checks clean (tsc 0 — a real gap; see below),
- passes the direct-call unit tests,
- but at real bootstrap, `ScheduleModule` hands the undefined expression to the cron parser → **`TypeError: Cannot read properties of undefined (reading 'toLowerCase')`** thrown from `SchedulerOrchestrator.onApplicationBootstrap` → `app.listen()` (main.ts:212) rejects → **crash-loop / 502**.

This is why `CLICKHOUSE_ENABLED=false` didn't help during the incident — `@Cron` registration is decorator-driven and flag-independent.

## The fix
- `@Cron('0 */15 * * * *')` — an explicit expression (the raw-string pattern already used elsewhere, e.g. the analytics cleanup cron). Removed the now-unused `CronExpression` import.
- **Regression guard** — `clickhouse-watchdog.bootstrap.spec.ts` stands up a real Nest app with `ScheduleModule.forRoot()` + the watchdog and calls `app.init()` (the exact path that crashed). **Proven to FAIL with the identical toLowerCase TypeError on the old code and PASS on the fix.** This catches the class of bug that both tsc and the direct-call unit tests missed.
- **Diagnostics** — `main.ts` now logs the full error **stack** on a bind failure (the old handler logged only `.message`, which is precisely why this was undiagnosable from prod logs during the incident).

## Verification (independently run)
- middleware `tsc` 0 · clickhouse suites **20/20** (incl. the new bootstrap guard) · eslint 0 errors
- Audited every `CronExpression.*` usage in the tree: `EVERY_15_MINUTES` was the only non-existent one.

## Note (type-safety gap)
tsc did **not** flag `CronExpression.EVERY_15_MINUTES` despite it being absent from the `.d.ts` — worth follow-up, but the raw-string fix + the bootstrap test are robust regardless of the enum's contents.

Unblocks the re-deploy of PR-10/14/16/11/12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)