### PR TITLE
fix(pm2): middleware memory headroom 512M→640M (cut restart churn)

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -20,7 +20,11 @@ module.exports = {
       exec_mode: process.env.NODE_ENV === 'production' ? 'cluster' : 'fork',
       autorestart: true,
       watch: false,
-      max_memory_restart: '512M',
+      // 640M (was 512M): the working set legitimately approached 512M under load,
+      // causing a graceful restart every ~10min (cluster-covered, but churny).
+      // Kept modest — the prod VPS is RAM-constrained (~3.7G total), so 2×640M
+      // for the cluster is the safe headroom without risking OOM/swap.
+      max_memory_restart: '640M',
       env: {
         NODE_ENV: 'development',
         PORT: 3000,


### PR DESCRIPTION
The middleware working set approached the `512M` `max_memory_restart` under load → a graceful pm2 restart ~every 10min per instance (cluster-covered, no outage, but churny). Bumped to **640M** for headroom.

**Kept modest on purpose:** the prod VPS is RAM-constrained (~3.7G total, already swapping ~1.4G), so 2×640M for the cluster is the safe ceiling — a naive 1G would risk OOM/swap thrash. Separately reclaimed ~300M on prod by stopping a leftover `nx` build daemon (build-time process, not needed at runtime).

Config-only; applied on the next `pm2 reload ecosystem.config.js`. The underlying constraint is VPS RAM — a larger box (or reducing the Hermes/python ~658M footprint) is the real long-term fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)