### PR TITLE
fix(orgs): atomic settings-JSON update (lost-update race) + flag-enforcement WIP (PR-13)

### DIFF
--- a/middleware/src/modules/organizations/feature-flags.service.spec.ts
+++ b/middleware/src/modules/organizations/feature-flags.service.spec.ts
@@ -14,6 +14,7 @@ describe('FeatureFlagService', () => {
 
   beforeEach(() => {
     mockDb = {
+      $executeRaw: jest.fn().mockResolvedValue(1),
       organization: {
         findUnique: jest.fn(),
         update: jest.fn(),
@@ -21,6 +22,13 @@ describe('FeatureFlagService', () => {
     };
     service = new FeatureFlagService(mockDb as DatabaseService);
   });
+
+  // Pull the interpolated values out of a Prisma tagged-template
+  // `$executeRaw` call: values[0] is the stringified flags payload, [1] is
+  // the orgId. (call[0] is the TemplateStringsArray; the rest are the
+  // `${...}` bindings in SQL order.)
+  const rawFlagsPayload = (callIndex = 0): Record<string, boolean> =>
+    JSON.parse(mockDb.$executeRaw.mock.calls[callIndex][1]);
 
   describe('isEnabled', () => {
     it('should return true for features not explicitly disabled', async () => {
@@ -85,83 +93,93 @@ describe('FeatureFlagService', () => {
   });
 
   describe('setFlags', () => {
-    it('should update flags and return merged result', async () => {
-      // First call for setFlags, second for getFlags
-      mockDb.organization.findUnique
-        .mockResolvedValueOnce({ ...mockOrg, settings: {} })
-        .mockResolvedValueOnce({
-          ...mockOrg,
-          settings: { featureFlags: { advancedAnalytics: false } },
-        });
-      mockDb.organization.update.mockResolvedValue({});
+    it('should update flags via a single atomic write and return merged result', async () => {
+      mockDb.$executeRaw.mockResolvedValueOnce(1);
+      // getFlags reflect-read after the atomic write
+      mockDb.organization.findUnique.mockResolvedValueOnce({
+        ...mockOrg,
+        settings: { featureFlags: { advancedAnalytics: false } },
+      });
 
       const result = await service.setFlags('org-123', { advancedAnalytics: false });
 
-      expect(mockDb.organization.update).toHaveBeenCalledWith({
-        where: { id: 'org-123' },
-        data: {
-          settings: { featureFlags: { advancedAnalytics: false } },
-        },
-      });
+      // Exactly one atomic UPDATE, and NO read-modify-write via
+      // organization.update (the lost-update window is gone).
+      expect(mockDb.$executeRaw).toHaveBeenCalledTimes(1);
+      expect(mockDb.organization.update).not.toHaveBeenCalled();
+      expect(rawFlagsPayload()).toEqual({ advancedAnalytics: false });
       expect(result.advancedAnalytics).toBe(false);
     });
 
-    it('should ignore unknown flag keys', async () => {
-      mockDb.organization.findUnique
-        .mockResolvedValueOnce({ ...mockOrg, settings: {} })
-        .mockResolvedValueOnce({ ...mockOrg, settings: { featureFlags: {} } });
-      mockDb.organization.update.mockResolvedValue({});
-
-      await service.setFlags('org-123', { unknownFlag: true } as any);
-
-      expect(mockDb.organization.update).toHaveBeenCalledWith({
-        where: { id: 'org-123' },
-        data: { settings: { featureFlags: {} } },
-      });
-    });
-
-    it('should ignore non-boolean values', async () => {
-      mockDb.organization.findUnique
-        .mockResolvedValueOnce({ ...mockOrg, settings: {} })
-        .mockResolvedValueOnce({ ...mockOrg, settings: { featureFlags: {} } });
-      mockDb.organization.update.mockResolvedValue({});
-
-      await service.setFlags('org-123', { weatherWidget: 'yes' } as any);
-
-      expect(mockDb.organization.update).toHaveBeenCalledWith({
-        where: { id: 'org-123' },
-        data: { settings: { featureFlags: {} } },
-      });
-    });
-
-    it('should preserve existing settings when updating flags', async () => {
-      mockDb.organization.findUnique
-        .mockResolvedValueOnce({
-          ...mockOrg,
-          settings: { branding: { color: 'blue' }, featureFlags: { rssWidget: false } },
-        })
-        .mockResolvedValueOnce({
-          ...mockOrg,
-          settings: { branding: { color: 'blue' }, featureFlags: { rssWidget: false, weatherWidget: false } },
-        });
-      mockDb.organization.update.mockResolvedValue({});
+    it('should merge atomically at the DB level (jsonb_set + jsonb-merge, not whole-object overwrite)', async () => {
+      mockDb.$executeRaw.mockResolvedValueOnce(1);
+      mockDb.organization.findUnique.mockResolvedValueOnce({ ...mockOrg, settings: {} });
 
       await service.setFlags('org-123', { weatherWidget: false });
 
-      expect(mockDb.organization.update).toHaveBeenCalledWith({
-        where: { id: 'org-123' },
-        data: {
-          settings: {
-            branding: { color: 'blue' },
-            featureFlags: { rssWidget: false, weatherWidget: false },
-          },
-        },
-      });
+      const sql = mockDb.$executeRaw.mock.calls[0][0].join('?');
+      expect(sql).toContain('jsonb_set');
+      expect(sql).toContain("'{featureFlags}'");
+      expect(sql).toContain('||'); // merge onto existing featureFlags, preserving siblings
+      // orgId is the second interpolated binding
+      expect(mockDb.$executeRaw.mock.calls[0][2]).toBe('org-123');
     });
 
-    it('should throw NotFoundException for unknown org', async () => {
-      mockDb.organization.findUnique.mockResolvedValue(null);
+    it('should ignore unknown flag keys', async () => {
+      mockDb.$executeRaw.mockResolvedValueOnce(1);
+      mockDb.organization.findUnique.mockResolvedValueOnce({ ...mockOrg, settings: { featureFlags: {} } });
+
+      await service.setFlags('org-123', { unknownFlag: true } as any);
+
+      expect(rawFlagsPayload()).toEqual({});
+    });
+
+    it('should ignore non-boolean values', async () => {
+      mockDb.$executeRaw.mockResolvedValueOnce(1);
+      mockDb.organization.findUnique.mockResolvedValueOnce({ ...mockOrg, settings: { featureFlags: {} } });
+
+      await service.setFlags('org-123', { weatherWidget: 'yes' } as any);
+
+      expect(rawFlagsPayload()).toEqual({});
+    });
+
+    it('should throw NotFoundException when the atomic UPDATE matches no org', async () => {
+      mockDb.$executeRaw.mockResolvedValueOnce(0);
       await expect(service.setFlags('bad-id', {})).rejects.toThrow(NotFoundException);
+      expect(mockDb.organization.findUnique).not.toHaveBeenCalled();
+    });
+
+    // Lost-update regression: two concurrent writers each toggling a
+    // DIFFERENT flag must both survive. The old load→mutate-in-JS→write
+    // path had both writers read the same stale `featureFlags` and the
+    // last write win, dropping one flag. Here `$executeRaw` models the
+    // Postgres `jsonb_set(... || ...)` semantics against a shared store:
+    // each call merges its own key onto the current value, so nothing is
+    // lost. The real atomicity is enforced by Postgres row-locking during
+    // the UPDATE; this test proves the SERVICE no longer does a JS-side
+    // read-modify-write that could interleave and clobber.
+    it('preserves both writes when two concurrent setFlags target different flags', async () => {
+      const store: { featureFlags: Record<string, boolean> } = { featureFlags: {} };
+
+      mockDb.$executeRaw.mockImplementation(async (_strings: any, flagsJson: string) => {
+        const incoming = JSON.parse(flagsJson) as Record<string, boolean>;
+        store.featureFlags = { ...store.featureFlags, ...incoming };
+        return 1;
+      });
+      mockDb.organization.findUnique.mockImplementation(async () => ({
+        ...mockOrg,
+        settings: { featureFlags: { ...store.featureFlags } },
+      }));
+
+      await Promise.all([
+        service.setFlags('org-123', { weatherWidget: false }),
+        service.setFlags('org-123', { rssWidget: false }),
+      ]);
+
+      const flags = await service.getFlags('org-123');
+      expect(flags.weatherWidget).toBe(false);
+      expect(flags.rssWidget).toBe(false);
+      expect(mockDb.organization.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/middleware/src/modules/organizations/feature-flags.service.ts
+++ b/middleware/src/modules/organizations/feature-flags.service.ts
@@ -62,13 +62,22 @@ export class FeatureFlagService {
   /**
    * Update feature flags for an organization.
    * Only accepts known flag keys. Merges with existing flags.
+   *
+   * Atomic — the merge happens entirely inside one Postgres statement via
+   * `jsonb_set` + the `||` jsonb-merge operator, so there is NO
+   * load-row → mutate-JSON-in-JS → write-whole-object-back window. The
+   * previous read-modify-write lost updates under concurrency: two
+   * writers both read `settings.featureFlags`, each merged its own change
+   * onto the stale copy, and whichever `update()` landed last silently
+   * clobbered the other (including a concurrent branding/settings write to
+   * a *different* top-level key). `jsonb_set` rewrites only the
+   * `featureFlags` key and `||` shallow-merges the incoming flags onto
+   * whatever that key holds at execution time (the row is locked for the
+   * duration of the UPDATE), so concurrent writes to different keys all
+   * survive. Mirrors the atomic-write precedent in
+   * `StorageQuotaService.reserveQuota/decrementUsage`.
    */
   async setFlags(orgId: string, flags: Record<string, boolean>): Promise<Record<string, boolean>> {
-    const org = await this.db.organization.findUnique({ where: { id: orgId } });
-    if (!org) {
-      throw new NotFoundException('Organization not found');
-    }
-
     // Filter to only known flag keys
     const validFlags: Record<string, boolean> = {};
     for (const [key, value] of Object.entries(flags)) {
@@ -77,16 +86,21 @@ export class FeatureFlagService {
       }
     }
 
-    const settings = (org.settings as Record<string, any>) || {};
-    const currentFlags = settings.featureFlags || {};
-    const updatedFlags = { ...currentFlags, ...validFlags };
+    const affected = await this.db.$executeRaw`
+      UPDATE "organizations"
+      SET "settings" = jsonb_set(
+            COALESCE("settings", '{}'::jsonb),
+            '{featureFlags}',
+            COALESCE("settings" -> 'featureFlags', '{}'::jsonb) || ${JSON.stringify(validFlags)}::jsonb,
+            true
+          ),
+          "updatedAt" = NOW()
+      WHERE "id" = ${orgId}
+    `;
 
-    await this.db.organization.update({
-      where: { id: orgId },
-      data: {
-        settings: { ...settings, featureFlags: updatedFlags },
-      },
-    });
+    if (affected === 0) {
+      throw new NotFoundException('Organization not found');
+    }
 
     this.logger.log(
       `Feature flags updated for org ${orgId}: ${JSON.stringify(validFlags)}`,
@@ -100,6 +114,24 @@ export class FeatureFlagService {
 /**
  * Decorator to mark a route as requiring a specific feature flag.
  * Usage: @RequiresFeature('advancedAnalytics')
+ *
+ * WIP — NOT YET ENFORCED ON ANY CONTROLLER. As of this writing neither
+ * `@RequiresFeature()` nor `FeatureFlagGuard` is applied to a single route
+ * (grep confirms: the only references are this definition and the module
+ * provider registration). The eight flags in FEATURE_FLAGS are therefore
+ * backend no-ops today — they only drive the org settings toggles at
+ * `web .../dashboard/settings/feature-flags`.
+ *
+ * Do NOT wire the guard onto a live controller (analytics / fleet /
+ * moderation, etc.) without first auditing prod. All flags default ON, but
+ * that live settings UI lets an org admin flip any flag to `false`. Because
+ * the flags gate nothing today, an org may already hold an explicit `false`
+ * with no visible effect — the moment the guard is enforced, that org's
+ * currently-working endpoint starts returning 403. Enforcing blind would
+ * 403 paying customers. Precondition for enforcement: query prod
+ * `settings->'featureFlags'` for every org, confirm no org would lose access
+ * (or migrate their stored flags), THEN attach the guard per-flag to the
+ * intended controller. Until then this stays advisory.
  */
 export const FEATURE_KEY = 'requiredFeature';
 export const RequiresFeature = (feature: string) => SetMetadata(FEATURE_KEY, feature);


### PR DESCRIPTION
**Batch PR-13.** Ships the settings-JSON lost-update race fix (admin #14); documents feature-flag enforcement (admin #4) as WIP — **deliberately not enforced** after the audit found it would risk 403-ing customers.

## admin #14 — settings-JSON lost-update race (the fix) ✅
`FeatureFlagService.setFlags` was a read-modify-write on the whole `Organization.settings` jsonb (`findUnique` → merge in JS → `update` the whole object). Two concurrent writers to **different** top-level `settings` keys (e.g. `setFlags` racing `updateBranding`) clobbered each other.

Rewritten to a single **atomic `$executeRaw` UPDATE** using `jsonb_set` + the `||` merge operator — row-locked, rewrites only `settings.featureFlags`, merges onto the value *at execution time*. **Injection-safe** (`$executeRaw` tagged template: `orgId` + flags are bound params; flags pre-filtered to boolean keys). Mirrors the existing `StorageQuotaService` precedent. New concurrency regression test; 14/14 pass.

## admin #4 — feature-flag enforcement: **WIP, not enforced** 🚧
**Audit finding:** the `FeatureFlagGuard` + `@RequiresFeature` decorator are wired to **zero routes** today (grep: only their definitions + module registration). All 8 flags default ON, **but a live admin UI lets any org flip one to `false`** with no current effect. Attaching the guard now would suddenly **403 any org that already toggled a flag off** — a real customer-facing regression — and prod's per-org `featureFlags` state can't be verified from CI (§9a). So enforcement stays off; added a WIP doc-comment stating the precondition (audit/migrate prod per-org flags first). **No route changes → no endpoint can begin returning 403.**

## Follow-up flagged
`OrganizationsService.update`/`updateBranding` and admin `suspend`/`unsuspend`/`addNote` share the same `settings` RMW race — out of scope here, worth a dedicated pass.

## Verification (independently re-run)
- middleware `tsc` 0 · feature-flags **14/14**. No schema/migration; no new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)