### PR TITLE
feat(auth): refresh-token infrastructure + session inventory (PR-17a)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,11 @@ MINIO_USE_SSL=false
 JWT_SECRET=GENERATE_A_SECURE_64_CHAR_HEX_SECRET_HERE
 JWT_EXPIRES_IN=7d
 
+# Refresh-token session lifetime in days (default 30, clamped to [1, 365]).
+# Refresh tokens are opaque random strings (NOT JWTs) — no separate signing
+# secret is needed; only their SHA-256 hash is stored server-side.
+REFRESH_TOKEN_TTL_DAYS=30
+
 # Device authentication secret (separate from user auth)
 DEVICE_JWT_SECRET=GENERATE_ANOTHER_SECURE_64_CHAR_HEX_SECRET_HERE
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,8 @@ CORS_ORIGIN             # Comma-separated allowed origins
 
 ```
 JWT_SECRET              # User auth JWT secret (min 32 chars)
-JWT_EXPIRES_IN          # Token lifetime, default 7d
+JWT_EXPIRES_IN          # Access-token lifetime, default 7d
+REFRESH_TOKEN_TTL_DAYS  # Refresh-token session lifetime in days (default 30, clamped [1,365]). Opaque random token, sha256-hashed at rest; no separate secret.
 DEVICE_JWT_SECRET       # Device auth JWT secret (min 32 chars; separate from JWT_SECRET)
 INTERNAL_API_SECRET     # Required in prod — service-to-service auth (middleware ↔ realtime)
 BCRYPT_ROUNDS           # Password hashing rounds (10-15, default 12)

--- a/middleware/src/modules/auth/auth.controller.spec.ts
+++ b/middleware/src/modules/auth/auth.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import { RefreshTokenService } from './refresh-token.service';
 import { Request, Response } from 'express';
 import { AUTH_CONSTANTS } from './constants/auth.constants';
 import { getAccessTokenTtlMs } from './jwt-expiry';
@@ -9,6 +10,7 @@ import { ConflictException, UnauthorizedException } from '@nestjs/common';
 describe('AuthController', () => {
   let controller: AuthController;
   let authService: jest.Mocked<AuthService>;
+  let refreshTokenService: jest.Mocked<RefreshTokenService>;
   let mockResponse: Partial<Response>;
 
   const mockUser = {
@@ -48,6 +50,16 @@ describe('AuthController', () => {
       deleteAvatar: jest.fn(),
     };
 
+    const mockRefreshTokenService = {
+      issueForUser: jest.fn().mockResolvedValue({ rawToken: 'refresh-raw', expiresAt: new Date(Date.now() + 60_000) }),
+      rotate: jest.fn().mockResolvedValue({ rawToken: 'refresh-rotated', expiresAt: new Date(Date.now() + 60_000) }),
+      revokeByRawToken: jest.fn().mockResolvedValue(undefined),
+      listSessions: jest.fn().mockResolvedValue([]),
+      revokeOtherSessions: jest.fn().mockResolvedValue(0),
+      revokeSession: jest.fn().mockResolvedValue(undefined),
+      getTtlSeconds: jest.fn().mockReturnValue(30 * 24 * 60 * 60),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
       providers: [
@@ -55,11 +67,16 @@ describe('AuthController', () => {
           provide: AuthService,
           useValue: mockAuthService,
         },
+        {
+          provide: RefreshTokenService,
+          useValue: mockRefreshTokenService,
+        },
       ],
     }).compile();
 
     controller = module.get<AuthController>(AuthController);
     authService = module.get(AuthService);
+    refreshTokenService = module.get(RefreshTokenService);
   });
 
   describe('register', () => {
@@ -293,6 +310,64 @@ describe('AuthController', () => {
       await expect(controller.refresh('invalid-id', mockRequest, mockResponse as Response))
         .rejects.toThrow(UnauthorizedException);
     });
+
+    it('should issue a fresh refresh token when no refresh cookie is present (legacy session upgrade)', async () => {
+      authService.refresh.mockResolvedValue({
+        token: 'new-jwt-token',
+        expiresIn: AUTH_CONSTANTS.TOKEN_EXPIRY_SECONDS,
+      });
+
+      await controller.refresh('user-123', mockRequest, mockResponse as Response);
+
+      expect(refreshTokenService.issueForUser).toHaveBeenCalledWith('user-123', expect.any(Object));
+      expect(refreshTokenService.rotate).not.toHaveBeenCalled();
+      expect(mockResponse.cookie).toHaveBeenCalledWith(
+        AUTH_CONSTANTS.REFRESH_COOKIE_NAME,
+        'refresh-raw',
+        expect.objectContaining({ httpOnly: true, path: '/' }),
+      );
+    });
+
+    it('should rotate the presented refresh token and set the rotated cookie', async () => {
+      authService.refresh.mockResolvedValue({
+        token: 'new-jwt-token',
+        expiresIn: AUTH_CONSTANTS.TOKEN_EXPIRY_SECONDS,
+      });
+      const reqWithRefresh = {
+        cookies: {
+          [AUTH_CONSTANTS.COOKIE_NAME]: 'old-jwt-token',
+          [AUTH_CONSTANTS.REFRESH_COOKIE_NAME]: 'presented-refresh',
+        },
+        headers: {},
+      } as any;
+
+      await controller.refresh('user-123', reqWithRefresh, mockResponse as Response);
+
+      expect(refreshTokenService.rotate).toHaveBeenCalledWith('presented-refresh', 'user-123', expect.any(Object));
+      expect(refreshTokenService.issueForUser).not.toHaveBeenCalled();
+      expect(mockResponse.cookie).toHaveBeenCalledWith(
+        AUTH_CONSTANTS.REFRESH_COOKIE_NAME,
+        'refresh-rotated',
+        expect.objectContaining({ httpOnly: true, path: '/' }),
+      );
+    });
+
+    it('should propagate reuse-detection 401 without minting a new access token', async () => {
+      refreshTokenService.rotate.mockRejectedValueOnce(
+        new UnauthorizedException('Refresh token reuse detected'),
+      );
+      const reqWithRefresh = {
+        cookies: {
+          [AUTH_CONSTANTS.COOKIE_NAME]: 'old-jwt-token',
+          [AUTH_CONSTANTS.REFRESH_COOKIE_NAME]: 'stolen-refresh',
+        },
+        headers: {},
+      } as any;
+
+      await expect(controller.refresh('user-123', reqWithRefresh, mockResponse as Response))
+        .rejects.toThrow(UnauthorizedException);
+      expect(authService.refresh).not.toHaveBeenCalled();
+    });
   });
 
   describe('logout', () => {
@@ -341,6 +416,83 @@ describe('AuthController', () => {
       await controller.logout('user-123', mockRequest, mockResponse as Response);
 
       expect(authService.logout).toHaveBeenCalledWith('user-123', 'jwt-token-from-header');
+    });
+
+    it('should revoke the refresh token and clear the refresh cookie', async () => {
+      authService.logout.mockResolvedValue({ message: 'Logged out successfully' });
+
+      const mockRequest = {
+        cookies: {
+          [AUTH_CONSTANTS.COOKIE_NAME]: 'jwt-token',
+          [AUTH_CONSTANTS.REFRESH_COOKIE_NAME]: 'refresh-to-revoke',
+        },
+        headers: {},
+      } as any;
+
+      await controller.logout('user-123', mockRequest, mockResponse as Response);
+
+      expect(refreshTokenService.revokeByRawToken).toHaveBeenCalledWith('refresh-to-revoke');
+      expect(mockResponse.clearCookie).toHaveBeenCalledWith(
+        AUTH_CONSTANTS.REFRESH_COOKIE_NAME,
+        expect.objectContaining({ httpOnly: true, path: '/' }),
+      );
+    });
+  });
+
+  describe('sessions', () => {
+    it('should list the caller own sessions and mark the current one', async () => {
+      const sessions = [
+        { id: 's1', userAgent: 'UA', ip: '1.2.3.4', createdAt: new Date(), lastUsedAt: new Date(), current: true },
+      ];
+      refreshTokenService.listSessions.mockResolvedValue(sessions);
+      const req = { cookies: { [AUTH_CONSTANTS.REFRESH_COOKIE_NAME]: 'current-refresh' }, headers: {} } as any;
+
+      const result = await controller.listSessions('user-123', req);
+
+      expect(refreshTokenService.listSessions).toHaveBeenCalledWith('user-123', 'current-refresh');
+      expect(result).toEqual({ success: true, data: { sessions } });
+    });
+
+    it('should not expose any token hash in the session list', async () => {
+      refreshTokenService.listSessions.mockResolvedValue([
+        { id: 's1', userAgent: 'UA', ip: '1.2.3.4', createdAt: new Date(), lastUsedAt: new Date(), current: true },
+      ]);
+      const req = { cookies: {}, headers: {} } as any;
+
+      const result = await controller.listSessions('user-123', req);
+
+      const serialized = JSON.stringify(result);
+      expect(serialized).not.toMatch(/tokenHash/i);
+      expect(serialized).not.toMatch(/replacedByTokenHash/i);
+    });
+
+    it('should revoke all other sessions and return the count', async () => {
+      refreshTokenService.revokeOtherSessions.mockResolvedValue(3);
+      const req = { cookies: { [AUTH_CONSTANTS.REFRESH_COOKIE_NAME]: 'current-refresh' }, headers: {} } as any;
+
+      const result = await controller.revokeOtherSessions('user-123', req);
+
+      expect(refreshTokenService.revokeOtherSessions).toHaveBeenCalledWith('user-123', 'current-refresh');
+      expect(result).toEqual({ success: true, data: { revokedCount: 3 } });
+    });
+
+    it('should revoke a specific session by id', async () => {
+      const result = await controller.revokeSession('user-123', 'session-9');
+
+      expect(refreshTokenService.revokeSession).toHaveBeenCalledWith('user-123', 'session-9');
+      expect(result.success).toBe(true);
+    });
+
+    it('returns the same idempotent success for a missing or cross-user id (no 404/403 oracle)', async () => {
+      // S3: the service treats missing and cross-user ids identically (scoped
+      // no-op), so the controller returns the same success either way — it no
+      // longer surfaces a 404-vs-403 distinction that would leak existence.
+      refreshTokenService.revokeSession.mockResolvedValue(undefined);
+
+      const result = await controller.revokeSession('user-123', 'missing-or-foreign');
+
+      expect(refreshTokenService.revokeSession).toHaveBeenCalledWith('user-123', 'missing-or-foreign');
+      expect(result.success).toBe(true);
     });
   });
 

--- a/middleware/src/modules/auth/auth.controller.ts
+++ b/middleware/src/modules/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Patch, Body, UseGuards, Get, Delete, Res, Req, HttpCode, HttpStatus, BadRequestException, NotFoundException, UseInterceptors, UploadedFile } from '@nestjs/common';
+import { Controller, Post, Patch, Body, UseGuards, Get, Delete, Param, Res, Req, HttpCode, HttpStatus, BadRequestException, NotFoundException, UseInterceptors, UploadedFile } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { Request, Response } from 'express';
 import { pipeline } from 'node:stream/promises';
@@ -15,6 +15,7 @@ import {
   ApiConsumes,
 } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
+import { RefreshTokenService, RefreshTokenContext } from './refresh-token.service';
 import { RegisterDto, LoginDto, ForgotPasswordDto, ResetPasswordDto, ChangePasswordDto, DeleteAccountDto, UpdateProfileDto, GoogleLoginDto } from './dto';
 import { Public } from './decorators/public.decorator';
 import { CurrentUser } from './decorators/current-user.decorator';
@@ -36,12 +37,19 @@ import { AuthenticatedUser } from './strategies/jwt.strategy';
  */
 const RATE_LIMIT_STRICT = process.env.NODE_ENV === 'production' ? 3 : 1000;
 const RATE_LIMIT_STANDARD = process.env.NODE_ENV === 'production' ? 5 : 1000;
+// Refresh runs more often than login (the frontend re-ups the session), so it
+// gets a slightly higher cap than STANDARD while still throttling refresh-token
+// abuse / enumeration attempts.
+const RATE_LIMIT_REFRESH = process.env.NODE_ENV === 'production' ? 10 : 1000;
 const RATE_LIMIT_TTL_MS = 60_000;
 
 @ApiTags('auth')
 @Controller('auth')
 export class AuthController {
-  constructor(private authService: AuthService) {}
+  constructor(
+    private authService: AuthService,
+    private refreshTokenService: RefreshTokenService,
+  ) {}
 
   /**
    * Stable, browser-reachable avatar URL. Relative so it flows through the
@@ -104,6 +112,61 @@ export class AuthController {
     res.clearCookie(AUTH_CONSTANTS.COOKIE_NAME, cookieOptions);
   }
 
+  /**
+   * Set the long-lived refresh token as an httpOnly cookie. Mirrors the
+   * access-cookie attributes (httpOnly + Secure + SameSite, scoped to the
+   * origin host) but with the 30d refresh TTL instead of the access TTL.
+   */
+  private setRefreshCookie(res: Response, token: string): void {
+    const isProduction = process.env.NODE_ENV === 'production';
+    res.cookie(AUTH_CONSTANTS.REFRESH_COOKIE_NAME, token, {
+      httpOnly: true,
+      secure: isProduction,
+      sameSite: isProduction ? 'strict' : 'lax',
+      maxAge: this.refreshTokenService.getTtlSeconds() * 1000,
+      path: '/',
+    });
+  }
+
+  /** Clear the refresh cookie on logout — same attributes as setRefreshCookie. */
+  private clearRefreshCookie(res: Response): void {
+    const isProduction = process.env.NODE_ENV === 'production';
+    res.clearCookie(AUTH_CONSTANTS.REFRESH_COOKIE_NAME, {
+      httpOnly: true,
+      secure: isProduction,
+      sameSite: isProduction ? 'strict' : 'lax',
+      path: '/',
+    });
+  }
+
+  /** Read the raw refresh token from the request cookie, if present. */
+  private extractRefreshToken(req: Request): string | undefined {
+    return req.cookies?.[AUTH_CONSTANTS.REFRESH_COOKIE_NAME];
+  }
+
+  /** Session metadata (ip + user-agent) recorded on refresh-token rows. */
+  private refreshContext(req: Request): RefreshTokenContext {
+    const ua = req.headers?.['user-agent'];
+    return {
+      ip: req.ip || req.socket?.remoteAddress || undefined,
+      userAgent: Array.isArray(ua) ? ua.find(Boolean) : ua || undefined,
+    };
+  }
+
+  /**
+   * Issue a fresh refresh-token session cookie for a user who just logged in
+   * (login / register / google). Best-effort: a refresh-token write failure
+   * must never block the access-token login the caller already completed.
+   */
+  private async startRefreshSession(res: Response, req: Request, userId: string): Promise<void> {
+    try {
+      const issued = await this.refreshTokenService.issueForUser(userId, this.refreshContext(req));
+      this.setRefreshCookie(res, issued.rawToken);
+    } catch {
+      // Non-fatal — the user is logged in via the access cookie regardless.
+    }
+  }
+
   // Environment-aware rate limits: STRICT in production, RELAXED in dev/test
   @ApiOperation({ summary: 'Register a new user and organization' })
   @ApiBody({ type: RegisterDto })
@@ -131,6 +194,9 @@ export class AuthController {
 
     // Set httpOnly cookie with JWT token
     this.setAuthCookie(res, result.token);
+
+    // Start a rotating refresh-token session alongside the access token.
+    await this.startRefreshSession(res, req, result.user.id);
 
     // Return response with token in body (for mobile clients) and cookie (for web)
     return {
@@ -174,6 +240,9 @@ export class AuthController {
     // Set httpOnly cookie with JWT token
     this.setAuthCookie(res, result.token);
 
+    // Start a rotating refresh-token session alongside the access token.
+    await this.startRefreshSession(res, req, result.user.id);
+
     // Return response with token in body (for mobile clients) and cookie (for web)
     return {
       success: true,
@@ -213,6 +282,9 @@ export class AuthController {
     // Set httpOnly cookie with JWT token
     this.setAuthCookie(res, result.token);
 
+    // Start a rotating refresh-token session alongside the access token.
+    await this.startRefreshSession(res, req, result.user.id);
+
     return {
       success: true,
       data: {
@@ -229,17 +301,39 @@ export class AuthController {
   @ApiCookieAuth()
   @ApiResponse({
     status: 200,
-    description: 'Token refreshed successfully.',
+    description: 'Token refreshed successfully. Refresh-token session rotated.',
   })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
+  // NOTE: This endpoint keeps JwtAuthGuard for now (PR-17a is strictly
+  // additive). While the access token is still 7d, the frontend always holds a
+  // valid access token when it refreshes, so the guard is transparent and no
+  // existing session breaks. When the access TTL is shortened (PR-17b, with the
+  // coordinated frontend auto-refresh), flip this route to @Public() so a
+  // refresh token can be redeemed AFTER the access token has expired.
   @UseGuards(JwtAuthGuard)
   @Post('refresh')
+  @Throttle({
+    default: {
+      limit: RATE_LIMIT_REFRESH,
+      ttl: RATE_LIMIT_TTL_MS,
+    },
+  })
   async refresh(
     @CurrentUser('id') userId: string,
     @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
   ) {
-    // Extract the current token so it can be revoked
+    // Rotate the refresh-token session FIRST: a rotation failure (reuse
+    // detection / expiry) must short-circuit to 401 without minting a new
+    // access token. A legacy session predating refresh tokens has no refresh
+    // cookie — issue a fresh one so it upgrades in place.
+    const presentedRefreshToken = this.extractRefreshToken(req);
+    const rotated = presentedRefreshToken
+      ? await this.refreshTokenService.rotate(presentedRefreshToken, userId, this.refreshContext(req))
+      : await this.refreshTokenService.issueForUser(userId, this.refreshContext(req));
+    this.setRefreshCookie(res, rotated.rawToken);
+
+    // Extract the current access token so it can be revoked
     const currentToken =
       req.cookies?.[AUTH_CONSTANTS.COOKIE_NAME] ||
       req.headers.authorization?.replace('Bearer ', '');
@@ -280,13 +374,78 @@ export class AuthController {
 
     const result = await this.authService.logout(userId, token);
 
-    // Clear the auth cookie
+    // Revoke the refresh-token session so logout is real (not just a cookie
+    // clear) — a stolen refresh cookie can no longer be redeemed after logout.
+    const presentedRefreshToken = this.extractRefreshToken(req);
+    if (presentedRefreshToken) {
+      await this.refreshTokenService.revokeByRawToken(presentedRefreshToken);
+    }
+
+    // Clear the auth + refresh cookies
     this.clearAuthCookie(res);
+    this.clearRefreshCookie(res);
 
     return {
       success: true,
       ...result,
     };
+  }
+
+  @ApiOperation({ summary: 'List active login sessions for the authenticated user' })
+  @ApiBearerAuth('JWT-auth')
+  @ApiCookieAuth()
+  @ApiResponse({ status: 200, description: 'Active refresh-token sessions (no token material exposed).' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @UseGuards(JwtAuthGuard)
+  @Get('sessions')
+  async listSessions(
+    @CurrentUser('id') userId: string,
+    @Req() req: Request,
+  ) {
+    const sessions = await this.refreshTokenService.listSessions(
+      userId,
+      this.extractRefreshToken(req),
+    );
+    return { success: true, data: { sessions } };
+  }
+
+  @ApiOperation({ summary: 'Revoke all OTHER sessions for the authenticated user' })
+  @ApiBearerAuth('JWT-auth')
+  @ApiCookieAuth()
+  @ApiResponse({ status: 200, description: 'Other sessions revoked; the current session is kept.' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @UseGuards(JwtAuthGuard)
+  @Delete('sessions')
+  @HttpCode(HttpStatus.OK)
+  async revokeOtherSessions(
+    @CurrentUser('id') userId: string,
+    @Req() req: Request,
+  ) {
+    const revokedCount = await this.refreshTokenService.revokeOtherSessions(
+      userId,
+      this.extractRefreshToken(req),
+    );
+    return { success: true, data: { revokedCount } };
+  }
+
+  @ApiOperation({ summary: 'Revoke a specific session by id (idempotent, scoped to the caller)' })
+  @ApiBearerAuth('JWT-auth')
+  @ApiCookieAuth()
+  @ApiResponse({
+    status: 200,
+    description:
+      'Session revoked (idempotent — same response whether the id was owned, already revoked, or does not exist for this user).',
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @UseGuards(JwtAuthGuard)
+  @Delete('sessions/:id')
+  @HttpCode(HttpStatus.OK)
+  async revokeSession(
+    @CurrentUser('id') userId: string,
+    @Param('id') sessionId: string,
+  ) {
+    await this.refreshTokenService.revokeSession(userId, sessionId);
+    return { success: true, data: { message: 'Session revoked.' } };
   }
 
   @ApiOperation({ summary: 'Get current authenticated user' })

--- a/middleware/src/modules/auth/auth.module.ts
+++ b/middleware/src/modules/auth/auth.module.ts
@@ -3,6 +3,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import { RefreshTokenService } from './refresh-token.service';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { DatabaseModule } from '../database/database.module';
 import { BillingModule } from '../billing/billing.module';
@@ -48,6 +49,7 @@ import { getAccessTokenTtlSeconds } from './jwt-expiry';
   controllers: [AuthController],
   providers: [
     AuthService,
+    RefreshTokenService,
     JwtStrategy,
     {
       provide: APP_GUARD,
@@ -55,6 +57,6 @@ import { getAccessTokenTtlSeconds } from './jwt-expiry';
     },
     RolesGuard,
   ],
-  exports: [AuthService, JwtModule],
+  exports: [AuthService, RefreshTokenService, JwtModule],
 })
 export class AuthModule {}

--- a/middleware/src/modules/auth/auth.service.spec.ts
+++ b/middleware/src/modules/auth/auth.service.spec.ts
@@ -136,6 +136,11 @@ describe('AuthService', () => {
         updateMany: jest.fn(),
         deleteMany: jest.fn(),
       },
+      refreshToken: {
+        // S1(b): password change / reset / account deletion revoke the user's
+        // active refresh-token sessions. Default to "none matched".
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
       // Mock $transaction to execute the callback with the same mock database
       $transaction: jest.fn().mockImplementation(async (callback) => {
         return callback(mockDatabaseService);
@@ -1381,6 +1386,20 @@ describe('AuthService', () => {
         mockUser.email,
         mockUser.firstName,
       );
+    });
+
+    it('S1(b): revokes the user active refresh-token sessions on password change', async () => {
+      mockDatabaseService.user.findUnique.mockResolvedValue(mockUser);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+      (bcrypt.hash as jest.Mock).mockResolvedValue('new-hashed-password');
+      mockDatabaseService.user.update.mockResolvedValue({ ...mockUser });
+
+      await service.changePassword('user-123', 'current-pw', 'new-pw');
+
+      expect(mockDatabaseService.refreshToken.updateMany).toHaveBeenCalledWith({
+        where: { userId: 'user-123', revokedAt: null },
+        data: { revokedAt: expect.any(Date) },
+      });
     });
 
     it('throws and does NOT email when the current password is wrong', async () => {

--- a/middleware/src/modules/auth/auth.service.ts
+++ b/middleware/src/modules/auth/auth.service.ts
@@ -768,6 +768,13 @@ export class AuthService {
     // account must not leave the legitimate user's live sessions valid.
     await this.redisService.del(`user_auth:${tokenRecord.userId}`);
     await this.markPasswordChanged(tokenRecord.userId);
+
+    // Revoke rotating refresh-token sessions issued before the reset — the
+    // account-takeover case must not leave live refresh lineages valid.
+    await this.databaseService.refreshToken.updateMany({
+      where: { userId: tokenRecord.userId, revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
   }
 
   /**
@@ -827,6 +834,14 @@ export class AuthService {
     // session). JwtStrategy.validate rejects tokens with iat < this timestamp;
     // the user's fresh re-login passes.
     await this.markPasswordChanged(userId);
+
+    // Revoke rotating refresh-token sessions too, so a stolen refresh lineage
+    // can't outlive the password change (defense in depth with the pwd_changed
+    // marker that RefreshTokenService.rotate now re-checks).
+    await this.databaseService.refreshToken.updateMany({
+      where: { userId, revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
 
     // Security notification (M12): tell the user their password changed, so an
     // unauthorized change is noticed. Non-blocking — sendMail already swallows
@@ -1163,6 +1178,19 @@ export class AuthService {
       await this.redisService.del(`user_auth:${userId}`);
     } catch (err) {
       this.logger.warn(`Failed to invalidate tokens for deleted user ${userId}: ${err instanceof Error ? err.message : 'Unknown'}`);
+    }
+
+    // 10. Revoke the user's refresh-token sessions so no rotating lineage can
+    // outlive the deletion. The anonymize path (non-sole-admin) keeps the user
+    // row, so cascade deletion doesn't cover it. Best-effort — additive to the
+    // JWT invalidation above.
+    try {
+      await this.databaseService.refreshToken.updateMany({
+        where: { userId, revokedAt: null },
+        data: { revokedAt: new Date() },
+      });
+    } catch (err) {
+      this.logger.warn(`Failed to revoke refresh tokens for deleted user ${userId}: ${err instanceof Error ? err.message : 'Unknown'}`);
     }
 
     this.logger.log(`Account deleted for user ${userId}`);

--- a/middleware/src/modules/auth/constants/auth.constants.ts
+++ b/middleware/src/modules/auth/constants/auth.constants.ts
@@ -17,6 +17,16 @@ export const AUTH_CONSTANTS = {
   // Cookie name for JWT token
   COOKIE_NAME: 'vizora_auth_token',
 
+  // Cookie name for the long-lived refresh token (PR-17a). Opaque random
+  // string; only its SHA-256 hash is persisted server-side.
+  REFRESH_COOKIE_NAME: 'vizora_refresh_token',
+
+  // Default refresh-token lifetime (30 days). Overridable via
+  // REFRESH_TOKEN_TTL_DAYS (clamped to [1, 365] in RefreshTokenService).
+  REFRESH_TOKEN_DEFAULT_TTL_DAYS: 30,
+  REFRESH_TOKEN_TTL_MIN_DAYS: 1,
+  REFRESH_TOKEN_TTL_MAX_DAYS: 365,
+
   // CSRF token header name
   CSRF_HEADER_NAME: 'x-csrf-token',
 

--- a/middleware/src/modules/auth/refresh-token.service.spec.ts
+++ b/middleware/src/modules/auth/refresh-token.service.spec.ts
@@ -1,0 +1,363 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UnauthorizedException } from '@nestjs/common';
+import * as crypto from 'crypto';
+import { RefreshTokenService } from './refresh-token.service';
+import { DatabaseService } from '../database/database.service';
+import { RedisService } from '../redis/redis.service';
+
+const sha256 = (v: string) => crypto.createHash('sha256').update(v).digest('hex');
+
+describe('RefreshTokenService', () => {
+  let service: RefreshTokenService;
+  let db: {
+    refreshToken: {
+      findUnique: jest.Mock;
+      findMany: jest.Mock;
+      create: jest.Mock;
+      update: jest.Mock;
+      updateMany: jest.Mock;
+    };
+    user: {
+      findUnique: jest.Mock;
+    };
+  };
+  let redis: {
+    exists: jest.Mock;
+    get: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    db = {
+      refreshToken: {
+        findUnique: jest.fn(),
+        findMany: jest.fn(),
+        create: jest.fn().mockResolvedValue({}),
+        update: jest.fn().mockResolvedValue({}),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      user: {
+        // S1: rotate() re-checks the user's live state before minting a
+        // successor. Default to an active user; individual tests override.
+        findUnique: jest.fn().mockResolvedValue({ isActive: true }),
+      },
+    };
+    redis = {
+      // S1 markers: default to "no marker set" (benign concurrent-safe path).
+      exists: jest.fn().mockResolvedValue(false),
+      get: jest.fn().mockResolvedValue(null),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RefreshTokenService,
+        { provide: DatabaseService, useValue: db },
+        { provide: RedisService, useValue: redis },
+      ],
+    }).compile();
+
+    service = module.get<RefreshTokenService>(RefreshTokenService);
+  });
+
+  afterEach(() => {
+    delete process.env.REFRESH_TOKEN_TTL_DAYS;
+    jest.clearAllMocks();
+  });
+
+  describe('issueForUser', () => {
+    it('stores only the SHA-256 hash and returns the raw token once', async () => {
+      const issued = await service.issueForUser('user-1', { ip: '1.2.3.4', userAgent: 'UA' });
+
+      expect(issued.rawToken).toEqual(expect.any(String));
+      expect(db.refreshToken.create).toHaveBeenCalledTimes(1);
+      const data = db.refreshToken.create.mock.calls[0][0].data;
+      // The persisted hash matches the returned raw token; plaintext is never stored.
+      expect(data.tokenHash).toBe(sha256(issued.rawToken));
+      expect(data.tokenHash).not.toBe(issued.rawToken);
+      expect(data.userId).toBe('user-1');
+      expect(data.familyId).toEqual(expect.any(String));
+      expect(data.ip).toBe('1.2.3.4');
+      expect(data.userAgent).toBe('UA');
+    });
+
+    it('starts a new family per login', async () => {
+      const a = await service.issueForUser('user-1');
+      const b = await service.issueForUser('user-1');
+      const famA = db.refreshToken.create.mock.calls[0][0].data.familyId;
+      const famB = db.refreshToken.create.mock.calls[1][0].data.familyId;
+      expect(famA).not.toBe(famB);
+      expect(a.rawToken).not.toBe(b.rawToken);
+    });
+  });
+
+  describe('rotate', () => {
+    const raw = 'presented-raw-token';
+    const base = {
+      id: 'rt-1',
+      userId: 'user-1',
+      tokenHash: sha256(raw),
+      familyId: 'fam-1',
+      createdAt: new Date(Date.now() - 60_000),
+      expiresAt: new Date(Date.now() + 60_000),
+      revokedAt: null as Date | null,
+      replacedByTokenHash: null as string | null,
+    };
+
+    it('rotates an active token: atomically revokes+links the old, issues a successor in the same family', async () => {
+      db.refreshToken.findUnique.mockResolvedValue({ ...base });
+
+      const issued = await service.rotate(raw, 'user-1', { ip: '9.9.9.9', userAgent: 'UA2' });
+
+      // S2: the atomic claim revokes the old token AND links the successor hash
+      // in the SAME update — replacedByTokenHash is never transiently null.
+      expect(db.refreshToken.updateMany).toHaveBeenCalledWith({
+        where: { id: 'rt-1', revokedAt: null },
+        data: expect.objectContaining({
+          revokedAt: expect.any(Date),
+          lastUsedAt: expect.any(Date),
+          replacedByTokenHash: sha256(issued.rawToken),
+        }),
+      });
+      // Successor created in the same family, matching the linked hash.
+      const created = db.refreshToken.create.mock.calls[0][0].data;
+      expect(created.familyId).toBe('fam-1');
+      expect(created.tokenHash).toBe(sha256(issued.rawToken));
+      // No separate post-hoc update() — the successor link is part of the claim.
+      expect(db.refreshToken.update).not.toHaveBeenCalled();
+      expect(issued.rawToken).not.toBe(raw);
+    });
+
+    it('rejects an unknown token', async () => {
+      db.refreshToken.findUnique.mockResolvedValue(null);
+      await expect(service.rotate(raw, 'user-1')).rejects.toThrow(UnauthorizedException);
+      expect(db.refreshToken.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects a token belonging to another user (cross-user)', async () => {
+      db.refreshToken.findUnique.mockResolvedValue({ ...base, userId: 'someone-else' });
+      await expect(service.rotate(raw, 'user-1')).rejects.toThrow(UnauthorizedException);
+      expect(db.refreshToken.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('rejects an expired token', async () => {
+      db.refreshToken.findUnique.mockResolvedValue({ ...base, expiresAt: new Date(Date.now() - 1000) });
+      await expect(service.rotate(raw, 'user-1')).rejects.toThrow(UnauthorizedException);
+      expect(db.refreshToken.create).not.toHaveBeenCalled();
+    });
+
+    it('REUSE: revokes the entire family when a long-revoked token is presented', async () => {
+      db.refreshToken.findUnique.mockResolvedValue({
+        ...base,
+        revokedAt: new Date(Date.now() - 5 * 60_000), // revoked 5 min ago (outside grace)
+        replacedByTokenHash: sha256('successor'),
+      });
+
+      await expect(service.rotate(raw, 'user-1')).rejects.toThrow(/reuse/i);
+      expect(db.refreshToken.updateMany).toHaveBeenCalledWith({
+        where: { familyId: 'fam-1', revokedAt: null },
+        data: { revokedAt: expect.any(Date) },
+      });
+      expect(db.refreshToken.create).not.toHaveBeenCalled();
+    });
+
+    it('does NOT kill the family for a benign concurrent refresh (revoked within grace)', async () => {
+      db.refreshToken.findUnique.mockResolvedValue({
+        ...base,
+        revokedAt: new Date(Date.now() - 1000), // just rotated, within grace
+        replacedByTokenHash: sha256('successor'),
+      });
+
+      await expect(service.rotate(raw, 'user-1')).rejects.toThrow(/already rotated/i);
+      // Family untouched — the user stays logged in.
+      expect(db.refreshToken.updateMany).not.toHaveBeenCalled();
+      expect(db.refreshToken.create).not.toHaveBeenCalled();
+    });
+
+    it('treats a lost claim race as a benign concurrent refresh (no family kill)', async () => {
+      db.refreshToken.findUnique.mockResolvedValue({ ...base });
+      db.refreshToken.updateMany.mockResolvedValueOnce({ count: 0 }); // another racer already claimed it
+
+      await expect(service.rotate(raw, 'user-1')).rejects.toThrow(/already rotated/i);
+      expect(db.refreshToken.create).not.toHaveBeenCalled();
+    });
+
+    // --- S2: atomic successor linkage defeats the self-lockout interleaving ---
+    it('S2: a lagging reader of a just-claimed token (replacedByTokenHash already set) gets a benign 401, family NOT revoked', async () => {
+      // Interleaving: a sibling rotate committed the atomic claim (revokedAt +
+      // replacedByTokenHash set together). This lagging reader observes the row
+      // AFTER the claim. Because replacedByTokenHash is already set and the
+      // revoke is within the grace window, it is a benign concurrent refresh —
+      // NOT reuse — so the family must be preserved.
+      db.refreshToken.findUnique.mockResolvedValue({
+        ...base,
+        revokedAt: new Date(Date.now() - 100), // just claimed, within grace
+        replacedByTokenHash: sha256('successor'),
+      });
+
+      await expect(service.rotate(raw, 'user-1')).rejects.toThrow(/already rotated/i);
+      // Benign: no family-kill updateMany, no successor minted.
+      expect(db.refreshToken.updateMany).not.toHaveBeenCalled();
+      expect(db.refreshToken.create).not.toHaveBeenCalled();
+    });
+
+    // --- S1: re-check user state before minting a successor ---
+    it('S1: rejects rotation when the user is no longer active (fail-closed)', async () => {
+      db.refreshToken.findUnique.mockResolvedValue({ ...base });
+      db.user.findUnique.mockResolvedValue({ isActive: false });
+
+      await expect(service.rotate(raw, 'user-1')).rejects.toThrow(UnauthorizedException);
+      // No successor minted, family untouched.
+      expect(db.refreshToken.updateMany).not.toHaveBeenCalled();
+      expect(db.refreshToken.create).not.toHaveBeenCalled();
+    });
+
+    it('S1: rejects rotation when a user_revoked marker is set', async () => {
+      db.refreshToken.findUnique.mockResolvedValue({ ...base });
+      redis.exists.mockImplementation((key: string) =>
+        Promise.resolve(key === 'user_revoked:user-1'),
+      );
+
+      await expect(service.rotate(raw, 'user-1')).rejects.toThrow(UnauthorizedException);
+      expect(redis.exists).toHaveBeenCalledWith('user_revoked:user-1');
+      expect(db.refreshToken.create).not.toHaveBeenCalled();
+    });
+
+    it('S1: rejects rotation when pwd_changed is NEWER than the token createdAt (strict <)', async () => {
+      const createdAt = new Date('2026-01-01T00:00:00Z');
+      db.refreshToken.findUnique.mockResolvedValue({ ...base, createdAt });
+      const newerEpoch = Math.floor(createdAt.getTime() / 1000) + 60;
+      redis.get.mockImplementation((key: string) =>
+        Promise.resolve(key === 'pwd_changed:user-1' ? String(newerEpoch) : null),
+      );
+
+      await expect(service.rotate(raw, 'user-1')).rejects.toThrow(UnauthorizedException);
+      expect(redis.get).toHaveBeenCalledWith('pwd_changed:user-1');
+      expect(db.refreshToken.create).not.toHaveBeenCalled();
+    });
+
+    it('S1: allows rotation when pwd_changed is OLDER than the token createdAt (fresh post-change session)', async () => {
+      const createdAt = new Date('2026-01-01T00:00:00Z');
+      db.refreshToken.findUnique.mockResolvedValue({ ...base, createdAt });
+      const olderEpoch = Math.floor(createdAt.getTime() / 1000) - 60;
+      redis.get.mockImplementation((key: string) =>
+        Promise.resolve(key === 'pwd_changed:user-1' ? String(olderEpoch) : null),
+      );
+
+      const issued = await service.rotate(raw, 'user-1');
+      expect(issued.rawToken).toEqual(expect.any(String));
+      expect(db.refreshToken.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('revokeByRawToken', () => {
+    it('revokes the matching non-revoked token and never throws', async () => {
+      await service.revokeByRawToken('some-raw');
+      expect(db.refreshToken.updateMany).toHaveBeenCalledWith({
+        where: { tokenHash: sha256('some-raw'), revokedAt: null },
+        data: { revokedAt: expect.any(Date) },
+      });
+    });
+
+    it('swallows DB errors', async () => {
+      db.refreshToken.updateMany.mockRejectedValueOnce(new Error('db down'));
+      await expect(service.revokeByRawToken('x')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('listSessions', () => {
+    it('only queries the caller own non-revoked, unexpired tokens and never returns hashes', async () => {
+      const now = new Date();
+      db.refreshToken.findMany.mockResolvedValue([
+        { id: 's1', tokenHash: sha256('cur'), userAgent: 'UA1', ip: '1.1.1.1', createdAt: now, lastUsedAt: now },
+        { id: 's2', tokenHash: sha256('other'), userAgent: 'UA2', ip: '2.2.2.2', createdAt: now, lastUsedAt: null },
+      ]);
+
+      const sessions = await service.listSessions('user-1', 'cur');
+
+      const where = db.refreshToken.findMany.mock.calls[0][0].where;
+      expect(where).toMatchObject({ userId: 'user-1', revokedAt: null });
+      expect(where.expiresAt).toEqual({ gt: expect.any(Date) });
+
+      expect(sessions).toEqual([
+        { id: 's1', userAgent: 'UA1', ip: '1.1.1.1', createdAt: now, lastUsedAt: now, current: true },
+        { id: 's2', userAgent: 'UA2', ip: '2.2.2.2', createdAt: now, lastUsedAt: null, current: false },
+      ]);
+      // Defense in depth: no token material leaks.
+      expect(JSON.stringify(sessions)).not.toMatch(/tokenHash/);
+      for (const s of sessions) {
+        expect(s).not.toHaveProperty('tokenHash');
+      }
+    });
+  });
+
+  describe('revokeSession', () => {
+    it('revokes an owned session via a single userId-scoped updateMany (no findUnique lookup)', async () => {
+      await service.revokeSession('user-1', 'sess-1');
+      // No pre-lookup — the scoped updateMany is the only DB touch, so there is
+      // no cross-user existence oracle.
+      expect(db.refreshToken.findUnique).not.toHaveBeenCalled();
+      expect(db.refreshToken.updateMany).toHaveBeenCalledWith({
+        where: { id: 'sess-1', userId: 'user-1', revokedAt: null },
+        data: { revokedAt: expect.any(Date) },
+      });
+    });
+
+    it('is a scoped no-op for a missing OR cross-user id (identical response, no 404-vs-403 oracle)', async () => {
+      // A missing id and another user's id are indistinguishable: both resolve
+      // to a userId-scoped updateMany that matches nothing and returns quietly.
+      db.refreshToken.updateMany.mockResolvedValue({ count: 0 });
+
+      await expect(service.revokeSession('user-1', 'missing-or-foreign')).resolves.toBeUndefined();
+      expect(db.refreshToken.updateMany).toHaveBeenCalledWith({
+        where: { id: 'missing-or-foreign', userId: 'user-1', revokedAt: null },
+        data: { revokedAt: expect.any(Date) },
+      });
+    });
+
+    it('is idempotent for an already-revoked own session', async () => {
+      db.refreshToken.updateMany.mockResolvedValue({ count: 0 });
+      await expect(service.revokeSession('user-1', 'already-revoked')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('revokeOtherSessions', () => {
+    it('revokes all the caller other sessions, keeping the current one', async () => {
+      db.refreshToken.updateMany.mockResolvedValue({ count: 4 });
+      const count = await service.revokeOtherSessions('user-1', 'current-raw');
+      expect(count).toBe(4);
+      expect(db.refreshToken.updateMany).toHaveBeenCalledWith({
+        where: { userId: 'user-1', revokedAt: null, tokenHash: { not: sha256('current-raw') } },
+        data: { revokedAt: expect.any(Date) },
+      });
+    });
+
+    it('revokes every session when no current token is supplied', async () => {
+      db.refreshToken.updateMany.mockResolvedValue({ count: 2 });
+      await service.revokeOtherSessions('user-1');
+      expect(db.refreshToken.updateMany).toHaveBeenCalledWith({
+        where: { userId: 'user-1', revokedAt: null },
+        data: { revokedAt: expect.any(Date) },
+      });
+    });
+  });
+
+  describe('getTtlSeconds', () => {
+    it('defaults to 30 days', () => {
+      expect(service.getTtlSeconds()).toBe(30 * 24 * 60 * 60);
+    });
+
+    it('honors REFRESH_TOKEN_TTL_DAYS within bounds', () => {
+      process.env.REFRESH_TOKEN_TTL_DAYS = '7';
+      expect(service.getTtlSeconds()).toBe(7 * 24 * 60 * 60);
+    });
+
+    it('clamps out-of-range values', () => {
+      process.env.REFRESH_TOKEN_TTL_DAYS = '9999';
+      expect(service.getTtlSeconds()).toBe(365 * 24 * 60 * 60);
+    });
+
+    it('falls back to the default on garbage', () => {
+      process.env.REFRESH_TOKEN_TTL_DAYS = 'abc';
+      expect(service.getTtlSeconds()).toBe(30 * 24 * 60 * 60);
+    });
+  });
+});

--- a/middleware/src/modules/auth/refresh-token.service.ts
+++ b/middleware/src/modules/auth/refresh-token.service.ts
@@ -1,0 +1,321 @@
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import * as crypto from 'crypto';
+import { DatabaseService } from '../database/database.service';
+import { RedisService } from '../redis/redis.service';
+import { AUTH_CONSTANTS } from './constants/auth.constants';
+
+/** Session metadata captured at issuance / rotation time. */
+export interface RefreshTokenContext {
+  ip?: string;
+  userAgent?: string;
+}
+
+/** Result of issuing or rotating a refresh token — the raw token is returned ONCE. */
+export interface IssuedRefreshToken {
+  /** Plaintext token, to be placed in the httpOnly cookie. Never persisted. */
+  rawToken: string;
+  expiresAt: Date;
+}
+
+/** Session inventory row — deliberately free of any token material. */
+export interface RefreshSession {
+  id: string;
+  userAgent: string | null;
+  ip: string | null;
+  createdAt: Date;
+  lastUsedAt: Date | null;
+  current: boolean;
+}
+
+/**
+ * Refresh-token infrastructure (PR-17a).
+ *
+ * Opaque 256-bit random tokens (NOT JWTs — no signing secret needed, same
+ * shape as password-reset tokens). Only the SHA-256 hash is stored; the
+ * plaintext lives solely in the httpOnly `vizora_refresh_token` cookie.
+ *
+ * Rotation-on-use with reuse detection: every redemption revokes the presented
+ * token and issues a successor in the same `familyId`. Presenting an
+ * already-rotated (revoked) token is treated as theft and revokes the entire
+ * family. A short grace window absorbs benign concurrent refreshes (a browser
+ * firing two refreshes at once) so they don't trip the theft response.
+ *
+ * This is ADDITIVE to the existing access-token flow — nothing here changes how
+ * the access JWT is issued or validated.
+ */
+@Injectable()
+export class RefreshTokenService {
+  private readonly logger = new Logger(RefreshTokenService.name);
+
+  /**
+   * Grace window (ms) during which re-presenting a just-rotated token is
+   * treated as a benign concurrent refresh rather than token theft. Without
+   * it, a browser that fires two refreshes simultaneously would revoke the
+   * whole family and log the user out. Kept deliberately short: the successor
+   * hash is now linked atomically with the revoke (see rotate), so genuine
+   * sibling refreshes resolve in milliseconds and don't need a wide window.
+   */
+  private static readonly REUSE_GRACE_MS = 5_000;
+
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly redisService: RedisService,
+  ) {}
+
+  private hash(rawToken: string): string {
+    return crypto.createHash('sha256').update(rawToken).digest('hex');
+  }
+
+  private ttlMs(): number {
+    const raw = process.env.REFRESH_TOKEN_TTL_DAYS;
+    let days = AUTH_CONSTANTS.REFRESH_TOKEN_DEFAULT_TTL_DAYS;
+    if (raw !== undefined && raw.trim() !== '') {
+      const parsed = Number(raw);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        days = Math.min(
+          Math.max(Math.floor(parsed), AUTH_CONSTANTS.REFRESH_TOKEN_TTL_MIN_DAYS),
+          AUTH_CONSTANTS.REFRESH_TOKEN_TTL_MAX_DAYS,
+        );
+      } else {
+        this.logger.warn(
+          `REFRESH_TOKEN_TTL_DAYS="${raw}" is not a positive number; using ${days}d default.`,
+        );
+      }
+    }
+    return days * 24 * 60 * 60 * 1000;
+  }
+
+  /** Resolved refresh-token lifetime in seconds — used for the cookie maxAge. */
+  getTtlSeconds(): number {
+    return Math.floor(this.ttlMs() / 1000);
+  }
+
+  /**
+   * Start a brand-new session lineage (called on login/register/google, and as
+   * a fallback when a legacy session with no refresh cookie refreshes).
+   */
+  async issueForUser(userId: string, ctx: RefreshTokenContext = {}): Promise<IssuedRefreshToken> {
+    return this.create(userId, crypto.randomUUID(), ctx);
+  }
+
+  /**
+   * Validate + rotate a presented refresh token.
+   *
+   *  - unknown / wrong-user / expired token  → 401 (no family action)
+   *  - already-revoked within grace          → 401 (benign concurrent refresh; family preserved)
+   *  - already-revoked outside grace          → REUSE: revoke the whole family, then 401
+   *  - active token                           → atomically claim + issue a successor in the same family
+   *
+   * `expectedUserId` is the authenticated caller's id (defense in depth: a
+   * refresh token can only be rotated by the user it belongs to).
+   */
+  async rotate(
+    rawToken: string,
+    expectedUserId: string,
+    ctx: RefreshTokenContext = {},
+  ): Promise<IssuedRefreshToken> {
+    const tokenHash = this.hash(rawToken);
+    const existing = await this.databaseService.refreshToken.findUnique({ where: { tokenHash } });
+
+    if (!existing || existing.userId !== expectedUserId) {
+      throw new UnauthorizedException('Invalid refresh token');
+    }
+
+    const now = Date.now();
+
+    if (existing.expiresAt.getTime() <= now) {
+      throw new UnauthorizedException('Refresh token expired');
+    }
+
+    if (existing.revokedAt) {
+      const rotatedRecently =
+        existing.replacedByTokenHash !== null &&
+        now - existing.revokedAt.getTime() <= RefreshTokenService.REUSE_GRACE_MS;
+      if (rotatedRecently) {
+        // Benign concurrent refresh — a sibling request already rotated this
+        // token and set a fresh cookie. Reject this one WITHOUT killing the
+        // family so the user stays logged in. Logged (S4) so an anomalous rate
+        // of grace hits is observable; no token material, only user + family.
+        this.logger.warn(
+          `refresh_token.grace_hit user=${existing.userId} family=${existing.familyId}`,
+        );
+        throw new UnauthorizedException('Refresh token already rotated');
+      }
+      // Genuine reuse of a long-revoked token → token theft. Kill the lineage.
+      await this.databaseService.refreshToken.updateMany({
+        where: { familyId: existing.familyId, revokedAt: null },
+        data: { revokedAt: new Date() },
+      });
+      // Distinct tag from grace_hit (S4) so genuine theft can be alerted on
+      // separately from benign concurrency. No token material.
+      this.logger.warn(
+        `refresh_token.reuse_detected user=${existing.userId} family=${existing.familyId}`,
+      );
+      throw new UnauthorizedException('Refresh token reuse detected');
+    }
+
+    // S1: re-verify the user's live state before minting a successor. A refresh
+    // token far outlives the 60s access-token cache, so a long-running refresh
+    // lineage must re-check that the account wasn't deactivated, revoked, or
+    // password-changed out from under it. Mirrors JwtStrategy.validate — same
+    // Redis keys, same strict-`<` pwd_changed semantics — and fails closed on
+    // the isActive check (a missing user is rejected).
+    const user = await this.databaseService.user.findUnique({
+      where: { id: existing.userId },
+      select: { isActive: true },
+    });
+    if (!user || !user.isActive) {
+      throw new UnauthorizedException('User not found or inactive');
+    }
+    if (await this.redisService.exists(`user_revoked:${existing.userId}`)) {
+      throw new UnauthorizedException('User account is no longer active');
+    }
+    const pwdChangedAt = await this.redisService.get(`pwd_changed:${existing.userId}`);
+    if (pwdChangedAt && Math.floor(existing.createdAt.getTime() / 1000) < Number(pwdChangedAt)) {
+      throw new UnauthorizedException('Session expired — please log in again');
+    }
+
+    // S2: generate the successor token up-front so its hash is written as part
+    // of the SAME atomic claim that revokes the presented token. This closes
+    // the self-lockout window — a lagging concurrent reader can no longer
+    // observe revokedAt!=null && replacedByTokenHash===null and wrongly hit the
+    // reuse branch; replacedByTokenHash is never transiently null for a
+    // revoked-by-rotation token.
+    const successorRawToken = crypto.randomBytes(32).toString('hex');
+    const successorHash = this.hash(successorRawToken);
+
+    // Atomically claim the rotation AND link the successor in one update: only
+    // ONE concurrent caller can flip revokedAt from null. A losing racer gets
+    // count 0 → benign concurrent refresh (family preserved).
+    const claimed = await this.databaseService.refreshToken.updateMany({
+      where: { id: existing.id, revokedAt: null },
+      data: {
+        revokedAt: new Date(),
+        lastUsedAt: new Date(),
+        replacedByTokenHash: successorHash,
+      },
+    });
+    if (claimed.count === 0) {
+      this.logger.warn(
+        `refresh_token.grace_hit user=${existing.userId} family=${existing.familyId}`,
+      );
+      throw new UnauthorizedException('Refresh token already rotated');
+    }
+
+    return this.persist(existing.userId, existing.familyId, successorRawToken, ctx);
+  }
+
+  /** Revoke a single token by its raw value (logout). Best-effort, never throws. */
+  async revokeByRawToken(rawToken: string): Promise<void> {
+    try {
+      const tokenHash = this.hash(rawToken);
+      await this.databaseService.refreshToken.updateMany({
+        where: { tokenHash, revokedAt: null },
+        data: { revokedAt: new Date() },
+      });
+    } catch (err) {
+      this.logger.warn(
+        `Failed to revoke refresh token on logout: ${err instanceof Error ? err.message : 'unknown'}`,
+      );
+    }
+  }
+
+  /**
+   * List the caller's own active sessions. Token hashes are NEVER returned.
+   * `currentRawToken` (if supplied) flags the session backing this request.
+   */
+  async listSessions(userId: string, currentRawToken?: string): Promise<RefreshSession[]> {
+    const currentHash = currentRawToken ? this.hash(currentRawToken) : null;
+    const rows = await this.databaseService.refreshToken.findMany({
+      where: { userId, revokedAt: null, expiresAt: { gt: new Date() } },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        tokenHash: true,
+        userAgent: true,
+        ip: true,
+        createdAt: true,
+        lastUsedAt: true,
+      },
+    });
+    return rows.map((r) => ({
+      id: r.id,
+      userAgent: r.userAgent,
+      ip: r.ip,
+      createdAt: r.createdAt,
+      lastUsedAt: r.lastUsedAt,
+      current: currentHash !== null && r.tokenHash === currentHash,
+    }));
+  }
+
+  /**
+   * Revoke one session by id, scoped to the caller. The lookup + mutation are a
+   * single `userId`-scoped `updateMany`, so a missing id and an id owned by
+   * another user are handled identically — no 404-vs-403 branch that would leak
+   * whether a session id exists in some OTHER user's account (cross-user
+   * existence oracle). Idempotent: an already-revoked or non-matching id is a
+   * silent no-op.
+   */
+  async revokeSession(userId: string, sessionId: string): Promise<void> {
+    await this.databaseService.refreshToken.updateMany({
+      where: { id: sessionId, userId, revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
+  }
+
+  /**
+   * Revoke all of the caller's OTHER active sessions, keeping the current one
+   * (identified by its raw token). Returns the number revoked.
+   */
+  async revokeOtherSessions(userId: string, currentRawToken?: string): Promise<number> {
+    const where: {
+      userId: string;
+      revokedAt: null;
+      tokenHash?: { not: string };
+    } = { userId, revokedAt: null };
+    if (currentRawToken) {
+      where.tokenHash = { not: this.hash(currentRawToken) };
+    }
+    const result = await this.databaseService.refreshToken.updateMany({
+      where,
+      data: { revokedAt: new Date() },
+    });
+    return result.count;
+  }
+
+  /** Persist a fresh token row (random raw token) and return its value once. */
+  private async create(
+    userId: string,
+    familyId: string,
+    ctx: RefreshTokenContext,
+  ): Promise<IssuedRefreshToken> {
+    return this.persist(userId, familyId, crypto.randomBytes(32).toString('hex'), ctx);
+  }
+
+  /**
+   * Persist a token row for an ALREADY-GENERATED raw token and return it once.
+   * Rotation generates the successor token before the atomic claim (so its hash
+   * can be linked in that same update, see rotate/S2), then hands the
+   * pre-generated token here to insert the successor row.
+   */
+  private async persist(
+    userId: string,
+    familyId: string,
+    rawToken: string,
+    ctx: RefreshTokenContext,
+  ): Promise<IssuedRefreshToken> {
+    const expiresAt = new Date(Date.now() + this.ttlMs());
+    await this.databaseService.refreshToken.create({
+      data: {
+        userId,
+        tokenHash: this.hash(rawToken),
+        familyId,
+        expiresAt,
+        userAgent: ctx.userAgent ?? null,
+        ip: ctx.ip ?? null,
+        lastUsedAt: new Date(),
+      },
+    });
+    return { rawToken, expiresAt };
+  }
+}

--- a/packages/database/prisma/migrations/20260712000000_add_refresh_tokens/migration.sql
+++ b/packages/database/prisma/migrations/20260712000000_add_refresh_tokens/migration.sql
@@ -1,0 +1,51 @@
+-- Refresh tokens + session inventory (PR-17a) — 2026-07-12
+-- Strictly additive: a single new table. Touches neither `users` nor any
+-- existing auth path, so no issued access token or session is affected.
+-- Idempotent (IF NOT EXISTS + guarded FK) so `migrate deploy` is re-runnable
+-- and matches the recent migration convention in this tree.
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "refresh_tokens" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "familyId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "revokedAt" TIMESTAMP(3),
+    "replacedByTokenHash" TEXT,
+    "userAgent" TEXT,
+    "ip" TEXT,
+    "lastUsedAt" TIMESTAMP(3),
+
+    CONSTRAINT "refresh_tokens_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "refresh_tokens_tokenHash_key" ON "refresh_tokens"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "refresh_tokens_userId_idx" ON "refresh_tokens"("userId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "refresh_tokens_tokenHash_idx" ON "refresh_tokens"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "refresh_tokens_expiresAt_idx" ON "refresh_tokens"("expiresAt");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "refresh_tokens_familyId_idx" ON "refresh_tokens"("familyId");
+
+-- AddForeignKey
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'refresh_tokens_userId_fkey'
+      AND table_name = 'refresh_tokens'
+  ) THEN
+    ALTER TABLE "refresh_tokens"
+      ADD CONSTRAINT "refresh_tokens_userId_fkey"
+      FOREIGN KEY ("userId") REFERENCES "users"("id")
+      ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -98,6 +98,7 @@ model User {
   notifications           Notification[]
   apiKeys                 ApiKey[]
   passwordResetTokens     PasswordResetToken[]
+  refreshTokens           RefreshToken[]
   supportRequests         SupportRequest[]     @relation("SupportRequestUser")
   resolvedSupportRequests SupportRequest[]     @relation("SupportRequestResolver")
 
@@ -120,6 +121,33 @@ model PasswordResetToken {
   @@index([token])
   @@index([userId])
   @@map("password_reset_tokens")
+}
+
+// Long-lived refresh tokens for silent re-authentication + session inventory
+// (PR-17a). Additive to the existing access-token flow — the access JWT is
+// unchanged. The raw token is a 256-bit random string held only in the
+// httpOnly `vizora_refresh_token` cookie; only its SHA-256 hash is ever
+// stored. Rotation on every refresh with reuse detection: presenting an
+// already-rotated token revokes the whole `familyId` lineage (theft response).
+model RefreshToken {
+  id                  String    @id @default(uuid())
+  userId              String
+  user                User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  tokenHash           String    @unique // SHA-256 hash of the raw token — plaintext is never stored
+  familyId            String // rotation lineage; reuse of a revoked token kills the whole family
+  createdAt           DateTime  @default(now())
+  expiresAt           DateTime
+  revokedAt           DateTime? // set on logout, rotation, session revocation, or reuse-triggered family kill
+  replacedByTokenHash String? // hash of the successor token issued when this one was rotated
+  userAgent           String? // session metadata for the inventory UI
+  ip                  String? // session metadata for the inventory UI
+  lastUsedAt          DateTime? // updated on each rotation
+
+  @@index([userId])
+  @@index([tokenHash])
+  @@index([expiresAt])
+  @@index([familyId])
+  @@map("refresh_tokens")
 }
 
 // ============================================================================


### PR DESCRIPTION
**Batch PR-17a** — the strictly-additive, backward-compatible first increment of auth-session-security. **No access-token TTL change** (still 7d), no login-body change; existing tokens/cookies validate exactly as before. Closes auth #3 (infra) + auth #4 (session inventory). MFA (auth #2), the short-TTL flip + frontend auto-refresh, and ApiKeyGuard (auth #1) are later increments.

## What
- Opaque **256-bit random** refresh tokens; only the **sha256 hash** is stored; plaintext lives solely in an httpOnly+Secure+SameSite cookie. New `RefreshToken` → `refresh_tokens` (additive migration, FK to `users` ON DELETE CASCADE, idempotent, no `CONCURRENTLY`).
- **Rotation-on-use with reuse detection** (revoked-token reuse → whole `familyId` revoked). `POST /auth/refresh` rotates; login/register/google start a session **best-effort** (never blocks login); logout truly revokes.
- **Session inventory:** `GET /auth/sessions`, `DELETE /auth/sessions/:id`, `DELETE /auth/sessions` — all own-scoped; hashes never returned.

## Multi-vector adversarial security review — findings fixed **in this PR**
- **S2 (self-lockout, live bug):** `replacedByTokenHash` is now set in the **same atomic claim** as `revokedAt`, so a lagging concurrent reader can't misread a benign double-refresh as theft and revoke the family.
- **S1 (latent auth bypass, arms when `/auth/refresh` goes `@Public`):** `rotate()` now re-checks live user state (`isActive` + `user_revoked` + `pwd_changed` — same Redis keys/semantics as `JwtStrategy`) before minting; and `changePassword`/`resetPassword`/`deleteAccount` now revoke the user's active refresh families. Makes the future TTL flip safe by construction.
- **S3:** `revokeSession` collapsed to one userId-scoped `updateMany` (removed the 404-vs-403 cross-user existence oracle; idempotent).
- **S4:** reuse grace 30s→5s + distinct structured logs (`grace_hit` vs `reuse_detected`; userId+familyId only).

Verified **NOT exploitable** by the review: double-redemption (atomic CAS), cross-user rotate/revoke, standalone lockout, CSRF (not exempt + `SameSite:strict`), cookie leakage, migration/backward-compat.

## Verification (independently re-run)
- middleware `tsc` 0 · `prisma validate` OK · auth jest **272/272** (incl. new rotation / reuse / user-state / oracle / atomicity tests).

## Follow-ups (flagged, next increments)
- **PR-17b** release-gate: flip `/auth/refresh` to `@Public()` + shorten access TTL + frontend auto-refresh (S1/S2 make this safe). Revoking a session doesn't kill that session's still-valid access JWT until the access TTL is short (known limitation).
- Add an `expiresAt < now()` prune of `refresh_tokens` to db-maintainer (S5).
- MFA (auth #2), ApiKeyGuard wiring (auth #1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)