### PR TITLE
chore(clickhouse): memory-cap config + tighten limit for small VPS

### DIFF
--- a/docker/clickhouse/config.d/low-memory.xml
+++ b/docker/clickhouse/config.d/low-memory.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!--
+  Memory caps for running ClickHouse on the small shared Vizora VPS
+  (~3.7 GiB total RAM, already tight). The device-health-samples workload is
+  trivially light (a few rows per heartbeat + occasional uptime aggregates),
+  so ClickHouse does NOT need analytics-scale memory. We hard-cap the server's
+  total memory well below the container's docker limit (768M — see
+  docker-compose.yml) so ClickHouse self-limits gracefully rather than being
+  OOM-killed by docker, and so it can never push the shared box into OOM/swap.
+-->
+<clickhouse>
+    <!-- Total server memory cap: 512 MiB. Baseline CH usage is ~200-300 MiB;
+         this leaves room for the light workload while staying under the 768M
+         container limit (margin for untracked allocations). -->
+    <max_server_memory_usage>536870912</max_server_memory_usage>
+
+    <!-- Shrink caches from their multi-GiB defaults — pointless for this size. -->
+    <mark_cache_size>134217728</mark_cache_size> <!-- 128 MiB -->
+    <uncompressed_cache_size>0</uncompressed_cache_size> <!-- disabled (opt-in per query anyway) -->
+
+    <!-- This is a single low-traffic writer + dashboard reader; keep concurrency modest. -->
+    <max_concurrent_queries>16</max_concurrent_queries>
+</clickhouse>

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -112,6 +112,7 @@ services:
     volumes:
       - clickhouse_data:/var/lib/clickhouse
       - ./clickhouse/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+      - ./clickhouse/config.d:/etc/clickhouse-server/config.d:ro
     healthcheck:
       test: ["CMD", "clickhouse-client", "--query", "SELECT 1"]
       interval: 10s
@@ -120,7 +121,11 @@ services:
     deploy:
       resources:
         limits:
-          memory: 2G
+          # Tightened from 2G: the VPS is RAM-constrained (~3.7G) and this is a
+          # light device-health workload. Paired with a 512M in-server cap
+          # (clickhouse/config.d/low-memory.xml) so CH self-limits under this
+          # hard ceiling and can't OOM the shared box.
+          memory: 768M
     networks:
       - vizora-network
 


### PR DESCRIPTION
Prep for activating ClickHouse on the RAM-constrained prod VPS (~3.7G, already swapping). The device-health-samples workload is trivially light, so CH doesn't need analytics-scale memory.

- **New `clickhouse/config.d/low-memory.xml`**: `max_server_memory_usage=512M` + shrunk mark/uncompressed caches + modest `max_concurrent_queries`.
- **`docker-compose.yml`**: clickhouse memory limit **2G→768M** + mount `config.d`. The in-server 512M cap sits **below** the 768M docker hard cap, so CH degrades gracefully rather than being OOM-killed, and can **never push the shared box into OOM/swap** (worst case CH self-limits; the app is fail-open to CH being down per PR-10).

Loopback-only (`127.0.0.1:8123`) + `analytics` profile unchanged. Config-only; no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)