### PR TITLE
fix(clickhouse): listen on 0.0.0.0 in-container so host app reaches 8123

### DIFF
--- a/docker/clickhouse/config.d/low-memory.xml
+++ b/docker/clickhouse/config.d/low-memory.xml
@@ -9,6 +9,15 @@
   OOM-killed by docker, and so it can never push the shared box into OOM/swap.
 -->
 <clickhouse>
+    <!-- Listen on all interfaces INSIDE the container. The stock image config
+         binds loopback-only (127.0.0.1 + ::1), which the container's own
+         healthcheck (native protocol via localhost) passes, but which makes the
+         HTTP interface (8123) unreachable through docker's port-forward — so the
+         host-side app (PM2) can't connect. The published port is still
+         host-loopback-only (127.0.0.1:8123 in docker-compose.yml), so this does
+         not expose ClickHouse beyond the box. -->
+    <listen_host>0.0.0.0</listen_host>
+
     <!-- Total server memory cap: 512 MiB. Baseline CH usage is ~200-300 MiB;
          this leaves room for the light workload while staying under the 768M
          container limit (margin for untracked allocations). -->


### PR DESCRIPTION
ClickHouse activation follow-up. The stock image binds **loopback-only** inside the container (`127.0.0.1` + `::1`) — its healthcheck passes (native protocol, in-container localhost) but the **HTTP interface (8123) is unreachable through docker's port-forward**, so the host-side PM2 app got `@clickhouse/client HTTP request error` and real uptime stayed dark.

Added `<listen_host>0.0.0.0</listen_host>` to `config.d`. Published port is still **host-loopback-only** (`127.0.0.1:8123`), so ClickHouse is not exposed beyond the box.

**Verified on prod:** `ping=Ok`, `device_health_samples` queryable (0 rows — no active devices yet), middleware connects with no CH error, CH bounded at ~306M/768M, box RAM safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)