### PR TITLE
feat(auth): short access TTL + public /auth/refresh + frontend auto-refresh (PR-17b)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,7 +77,10 @@ MINIO_USE_SSL=false
 
 # User authentication secret
 JWT_SECRET=GENERATE_A_SECURE_64_CHAR_HEX_SECRET_HERE
-JWT_EXPIRES_IN=7d
+# Access-token lifetime. Short-lived by design (PR-17b): the frontend silently
+# re-ups the session via the rotating refresh token on any 401. Default 30m,
+# clamped to [60s, 7d]. Set "7d" to restore the old long-lived behavior.
+JWT_EXPIRES_IN=30m
 
 # Refresh-token session lifetime in days (default 30, clamped to [1, 365]).
 # Refresh tokens are opaque random strings (NOT JWTs) — no separate signing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ CORS_ORIGIN             # Comma-separated allowed origins
 
 ```
 JWT_SECRET              # User auth JWT secret (min 32 chars)
-JWT_EXPIRES_IN          # Access-token lifetime, default 7d
+JWT_EXPIRES_IN          # Access-token lifetime, default 30m (short-lived; frontend auto-refreshes on 401). Clamped [60s, 7d]. Set 7d to restore long-lived tokens.
 REFRESH_TOKEN_TTL_DAYS  # Refresh-token session lifetime in days (default 30, clamped [1,365]). Opaque random token, sha256-hashed at rest; no separate secret.
 DEVICE_JWT_SECRET       # Device auth JWT secret (min 32 chars; separate from JWT_SECRET)
 INTERNAL_API_SECRET     # Required in prod — service-to-service auth (middleware ↔ realtime)

--- a/middleware/src/modules/auth/auth.controller.spec.ts
+++ b/middleware/src/modules/auth/auth.controller.spec.ts
@@ -4,7 +4,6 @@ import { AuthService } from './auth.service';
 import { RefreshTokenService } from './refresh-token.service';
 import { Request, Response } from 'express';
 import { AUTH_CONSTANTS } from './constants/auth.constants';
-import { getAccessTokenTtlMs } from './jwt-expiry';
 import { ConflictException, UnauthorizedException } from '@nestjs/common';
 
 describe('AuthController', () => {
@@ -51,8 +50,8 @@ describe('AuthController', () => {
     };
 
     const mockRefreshTokenService = {
-      issueForUser: jest.fn().mockResolvedValue({ rawToken: 'refresh-raw', expiresAt: new Date(Date.now() + 60_000) }),
-      rotate: jest.fn().mockResolvedValue({ rawToken: 'refresh-rotated', expiresAt: new Date(Date.now() + 60_000) }),
+      issueForUser: jest.fn().mockResolvedValue({ rawToken: 'refresh-raw', expiresAt: new Date(Date.now() + 60_000), userId: 'user-123' }),
+      rotate: jest.fn().mockResolvedValue({ rawToken: 'refresh-rotated', expiresAt: new Date(Date.now() + 60_000), userId: 'user-123' }),
       revokeByRawToken: jest.fn().mockResolvedValue(undefined),
       listSessions: jest.fn().mockResolvedValue([]),
       revokeOtherSessions: jest.fn().mockResolvedValue(0),
@@ -268,8 +267,13 @@ describe('AuthController', () => {
   });
 
   describe('refresh', () => {
+    // /auth/refresh is PUBLIC (PR-17b): no authenticated caller, the refresh
+    // cookie is the sole credential and rotate() returns the token's own userId.
     const mockRequest = {
-      cookies: { [AUTH_CONSTANTS.COOKIE_NAME]: 'old-jwt-token' },
+      cookies: {
+        [AUTH_CONSTANTS.COOKIE_NAME]: 'old-jwt-token',
+        [AUTH_CONSTANTS.REFRESH_COOKIE_NAME]: 'presented-refresh',
+      },
       headers: { authorization: 'Bearer old-jwt-token' },
     } as any;
 
@@ -279,7 +283,7 @@ describe('AuthController', () => {
         expiresIn: AUTH_CONSTANTS.TOKEN_EXPIRY_SECONDS,
       });
 
-      const result = await controller.refresh('user-123', mockRequest, mockResponse as Response);
+      const result = await controller.refresh(mockRequest, mockResponse as Response);
 
       expect(result.success).toBe(true);
       expect(result.data.expiresIn).toBe(AUTH_CONSTANTS.TOKEN_EXPIRY_SECONDS);
@@ -299,33 +303,49 @@ describe('AuthController', () => {
         expiresIn: AUTH_CONSTANTS.TOKEN_EXPIRY_SECONDS,
       });
 
-      await controller.refresh('user-123', mockRequest, mockResponse as Response);
+      await controller.refresh(mockRequest, mockResponse as Response);
 
       expect(authService.refresh).toHaveBeenCalledWith('user-123', 'old-jwt-token');
     });
 
-    it('should propagate UnauthorizedException for invalid user', async () => {
-      authService.refresh.mockRejectedValue(new UnauthorizedException('User not found'));
-
-      await expect(controller.refresh('invalid-id', mockRequest, mockResponse as Response))
-        .rejects.toThrow(UnauthorizedException);
-    });
-
-    it('should issue a fresh refresh token when no refresh cookie is present (legacy session upgrade)', async () => {
+    it('derives the userId from the rotated token, not from any caller', async () => {
+      // The token OWNs the identity: whatever userId rotate() returns is the one
+      // whose access token gets minted — there is no caller id to fall back on.
+      refreshTokenService.rotate.mockResolvedValueOnce({
+        rawToken: 'refresh-rotated',
+        expiresAt: new Date(Date.now() + 60_000),
+        userId: 'token-owner-42',
+      } as any);
       authService.refresh.mockResolvedValue({
         token: 'new-jwt-token',
         expiresIn: AUTH_CONSTANTS.TOKEN_EXPIRY_SECONDS,
       });
 
-      await controller.refresh('user-123', mockRequest, mockResponse as Response);
+      await controller.refresh(mockRequest, mockResponse as Response);
 
-      expect(refreshTokenService.issueForUser).toHaveBeenCalledWith('user-123', expect.any(Object));
+      expect(authService.refresh).toHaveBeenCalledWith('token-owner-42', 'old-jwt-token');
+    });
+
+    it('should propagate UnauthorizedException for invalid user', async () => {
+      authService.refresh.mockRejectedValue(new UnauthorizedException('User not found'));
+
+      await expect(controller.refresh(mockRequest, mockResponse as Response))
+        .rejects.toThrow(UnauthorizedException);
+    });
+
+    it('rejects with 401 when no refresh cookie is present (public route, unauthenticated)', async () => {
+      const reqNoRefresh = {
+        cookies: { [AUTH_CONSTANTS.COOKIE_NAME]: 'old-jwt-token' },
+        headers: {},
+      } as any;
+
+      await expect(controller.refresh(reqNoRefresh, mockResponse as Response))
+        .rejects.toThrow(UnauthorizedException);
+      // No rotation, no issuance (the legacy access-guarded upgrade path is gone),
+      // and no access token minted.
       expect(refreshTokenService.rotate).not.toHaveBeenCalled();
-      expect(mockResponse.cookie).toHaveBeenCalledWith(
-        AUTH_CONSTANTS.REFRESH_COOKIE_NAME,
-        'refresh-raw',
-        expect.objectContaining({ httpOnly: true, path: '/' }),
-      );
+      expect(refreshTokenService.issueForUser).not.toHaveBeenCalled();
+      expect(authService.refresh).not.toHaveBeenCalled();
     });
 
     it('should rotate the presented refresh token and set the rotated cookie', async () => {
@@ -333,17 +353,11 @@ describe('AuthController', () => {
         token: 'new-jwt-token',
         expiresIn: AUTH_CONSTANTS.TOKEN_EXPIRY_SECONDS,
       });
-      const reqWithRefresh = {
-        cookies: {
-          [AUTH_CONSTANTS.COOKIE_NAME]: 'old-jwt-token',
-          [AUTH_CONSTANTS.REFRESH_COOKIE_NAME]: 'presented-refresh',
-        },
-        headers: {},
-      } as any;
 
-      await controller.refresh('user-123', reqWithRefresh, mockResponse as Response);
+      await controller.refresh(mockRequest, mockResponse as Response);
 
-      expect(refreshTokenService.rotate).toHaveBeenCalledWith('presented-refresh', 'user-123', expect.any(Object));
+      // rotate() is called with the presented token + context ONLY — no userId arg.
+      expect(refreshTokenService.rotate).toHaveBeenCalledWith('presented-refresh', expect.any(Object));
       expect(refreshTokenService.issueForUser).not.toHaveBeenCalled();
       expect(mockResponse.cookie).toHaveBeenCalledWith(
         AUTH_CONSTANTS.REFRESH_COOKIE_NAME,
@@ -364,7 +378,7 @@ describe('AuthController', () => {
         headers: {},
       } as any;
 
-      await expect(controller.refresh('user-123', reqWithRefresh, mockResponse as Response))
+      await expect(controller.refresh(reqWithRefresh, mockResponse as Response))
         .rejects.toThrow(UnauthorizedException);
       expect(authService.refresh).not.toHaveBeenCalled();
     });
@@ -574,14 +588,20 @@ describe('AuthController', () => {
       process.env.NODE_ENV = originalEnv;
     });
 
-    it('should include maxAge based on token expiry constant', async () => {
+    it('sets a LONG-lived access-cookie maxAge (presence marker) decoupled from the short JWT exp', async () => {
       await controller.register(registerDto, mockRegisterRequest, mockResponse as Response);
 
+      // PR-17b: the access cookie maxAge is the refresh-token TTL (~30d), NOT the
+      // 30m JWT exp — so the edge middleware's cookie-presence page guard doesn't
+      // log an idle user out. Security still rests on the JWT's own exp, which is
+      // validated server-side on every request.
+      const refreshTtlMs = refreshTokenService.getTtlSeconds() * 1000;
+      expect(refreshTtlMs).toBe(30 * 24 * 60 * 60 * 1000);
       expect(mockResponse.cookie).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.any(String),
+        AUTH_CONSTANTS.COOKIE_NAME,
+        'jwt-token',
         expect.objectContaining({
-          maxAge: getAccessTokenTtlMs(),
+          maxAge: refreshTtlMs,
         }),
       );
     });

--- a/middleware/src/modules/auth/auth.controller.ts
+++ b/middleware/src/modules/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Patch, Body, UseGuards, Get, Delete, Param, Res, Req, HttpCode, HttpStatus, BadRequestException, NotFoundException, UseInterceptors, UploadedFile } from '@nestjs/common';
+import { Controller, Post, Patch, Body, UseGuards, Get, Delete, Param, Res, Req, HttpCode, HttpStatus, BadRequestException, NotFoundException, UnauthorizedException, UseInterceptors, UploadedFile } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { Request, Response } from 'express';
 import { pipeline } from 'node:stream/promises';
@@ -21,7 +21,6 @@ import { Public } from './decorators/public.decorator';
 import { CurrentUser } from './decorators/current-user.decorator';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { AUTH_CONSTANTS } from './constants/auth.constants';
-import { getAccessTokenTtlMs } from './jwt-expiry';
 import { AuthenticatedUser } from './strategies/jwt.strategy';
 
 /**
@@ -78,9 +77,16 @@ export class AuthController {
       httpOnly: true,
       secure: isProduction,
       sameSite: isProduction ? 'strict' : 'lax',
-      // Match the token's real lifetime so the cookie doesn't outlive the JWT
-      // (a stale cookie = a "logged-in" UI that 401s on every call).
-      maxAge: getAccessTokenTtlMs(),
+      // DECOUPLED from the JWT lifetime (PR-17b). The cookie maxAge is a long
+      // "you have a session" PRESENCE marker (matched to the refresh-token TTL,
+      // ~30d) — NOT a security boundary. The real boundary is the JWT's own
+      // `exp` (short, 30m by default), which JwtStrategy validates server-side
+      // on EVERY request: a leaked/stolen cookie's JWT is still only good for
+      // 30m. Keeping the cookie long-lived stops `web/src/middleware.ts` (which
+      // gates page navigations on cookie PRESENCE, not JWT expiry) from bouncing
+      // an idle user to /login after 30m; when the JWT inside expires, the next
+      // API call 401s and the frontend auto-refresh mints a fresh JWT + cookie.
+      maxAge: this.refreshTokenService.getTtlSeconds() * 1000,
       path: '/',
     };
 
@@ -297,20 +303,19 @@ export class AuthController {
   }
 
   @ApiOperation({ summary: 'Refresh authentication token' })
-  @ApiBearerAuth('JWT-auth')
   @ApiCookieAuth()
   @ApiResponse({
     status: 200,
     description: 'Token refreshed successfully. Refresh-token session rotated.',
   })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  // NOTE: This endpoint keeps JwtAuthGuard for now (PR-17a is strictly
-  // additive). While the access token is still 7d, the frontend always holds a
-  // valid access token when it refreshes, so the guard is transparent and no
-  // existing session breaks. When the access TTL is shortened (PR-17b, with the
-  // coordinated frontend auto-refresh), flip this route to @Public() so a
-  // refresh token can be redeemed AFTER the access token has expired.
-  @UseGuards(JwtAuthGuard)
+  // PUBLIC by design (PR-17b): the access token is now short-lived, so a
+  // refresh must succeed AFTER the access token has expired — there is no
+  // authenticated caller to guard on. The refresh cookie IS the credential:
+  // rotate() derives the user from the token itself and re-verifies the user's
+  // live state (isActive + user_revoked + pwd_changed) before minting anything.
+  // No refresh cookie → the caller is simply unauthenticated → 401.
+  @Public()
   @Post('refresh')
   @Throttle({
     default: {
@@ -319,26 +324,31 @@ export class AuthController {
     },
   })
   async refresh(
-    @CurrentUser('id') userId: string,
     @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
   ) {
-    // Rotate the refresh-token session FIRST: a rotation failure (reuse
-    // detection / expiry) must short-circuit to 401 without minting a new
-    // access token. A legacy session predating refresh tokens has no refresh
-    // cookie — issue a fresh one so it upgrades in place.
     const presentedRefreshToken = this.extractRefreshToken(req);
-    const rotated = presentedRefreshToken
-      ? await this.refreshTokenService.rotate(presentedRefreshToken, userId, this.refreshContext(req))
-      : await this.refreshTokenService.issueForUser(userId, this.refreshContext(req));
+    if (!presentedRefreshToken) {
+      // Public route with no refresh cookie is just an unauthenticated request.
+      throw new UnauthorizedException('No refresh token');
+    }
+
+    // Rotate the refresh-token session FIRST: a rotation failure (reuse
+    // detection / expiry / revoked-or-inactive user) must short-circuit to 401
+    // without minting a new access token. The user is taken from the token
+    // itself — the token is the sole credential on this public route.
+    const rotated = await this.refreshTokenService.rotate(
+      presentedRefreshToken,
+      this.refreshContext(req),
+    );
     this.setRefreshCookie(res, rotated.rawToken);
 
-    // Extract the current access token so it can be revoked
+    // Extract the (possibly-expired) current access token so it can be revoked.
     const currentToken =
       req.cookies?.[AUTH_CONSTANTS.COOKIE_NAME] ||
       req.headers.authorization?.replace('Bearer ', '');
 
-    const result = await this.authService.refresh(userId, currentToken);
+    const result = await this.authService.refresh(rotated.userId, currentToken);
 
     // Set new httpOnly cookie with refreshed JWT token
     this.setAuthCookie(res, result.token);

--- a/middleware/src/modules/auth/jwt-expiry.spec.ts
+++ b/middleware/src/modules/auth/jwt-expiry.spec.ts
@@ -52,6 +52,16 @@ describe('resolveAccessTokenTtlSeconds (bounded, fail-safe)', () => {
     expect(resolveAccessTokenTtlSeconds('7d')).toBe(604800);
   });
 
+  it('PR-17b: defaults to a short 30-minute TTL when JWT_EXPIRES_IN is unset', () => {
+    // Access tokens are short-lived now; the frontend auto-refreshes on 401.
+    // Pin the default so a regression back to a long-lived 7d token is caught.
+    // (Passing an explicit '' exercises the unset/empty branch without the
+    // env-backed default parameter re-reading process.env.JWT_EXPIRES_IN.)
+    expect(ACCESS_TOKEN_TTL_DEFAULT_S).toBe(30 * 60);
+    expect(parseExpiryToSeconds(undefined)).toBe(30 * 60);
+    expect(resolveAccessTokenTtlSeconds('')).toBe(30 * 60);
+  });
+
   it('review #4: a huge fat-finger value clamps DOWN to MAX (no ~19-year token)', () => {
     // 604800000 ("ms" by habit) as seconds ≈ 19 years — must clamp to the 7d cap.
     expect(resolveAccessTokenTtlSeconds('604800000')).toBe(ACCESS_TOKEN_TTL_MAX_S);

--- a/middleware/src/modules/auth/jwt-expiry.ts
+++ b/middleware/src/modules/auth/jwt-expiry.ts
@@ -20,10 +20,16 @@
  * = 7d): `user_revoked`/`pwd_changed` Redis markers are written with that TTL, so
  * a token outliving it would resurrect a revoked session. Capping here makes that
  * impossible regardless of how JWT_EXPIRES_IN is set. MIN guards near-instant expiry.
+ *
+ * DEFAULT is 30 minutes (PR-17b): access tokens are now short-lived and the
+ * frontend silently re-ups the session via the rotating refresh token
+ * (POST /auth/refresh) on any 401. Override with JWT_EXPIRES_IN (e.g. "7d" to
+ * restore the old long-lived behavior, "1h" for a middle ground); the value is
+ * still clamped into [MIN, MAX].
  */
 export const ACCESS_TOKEN_TTL_MIN_S = 60;
 export const ACCESS_TOKEN_TTL_MAX_S = 7 * 24 * 60 * 60; // 604800
-export const ACCESS_TOKEN_TTL_DEFAULT_S = 7 * 24 * 60 * 60;
+export const ACCESS_TOKEN_TTL_DEFAULT_S = 30 * 60; // 1800 (30 minutes)
 
 const UNIT_SECONDS: Record<string, number> = { s: 1, m: 60, h: 3600, d: 86400, w: 604800 };
 
@@ -42,15 +48,17 @@ export function parseExpiryToSeconds(raw: string | undefined): number | null {
 
 /**
  * Resolve JWT_EXPIRES_IN to a bounded whole-seconds NUMBER. Fail-SAFE: unparseable
- * → 7d default; out-of-range → clamp into [MIN, MAX]. Never MORE permissive than
- * the default, never longer than the revocation-marker TTL. Non-clean inputs warn
- * so a misconfig is visible rather than silent.
+ * → 30m default; out-of-range → clamp into [MIN, MAX]. Never longer than the
+ * revocation-marker TTL, never near-instant. Non-clean inputs warn so a misconfig
+ * is visible rather than silent.
  */
 export function resolveAccessTokenTtlSeconds(raw = process.env.JWT_EXPIRES_IN): number {
   const parsed = parseExpiryToSeconds(raw);
   if (parsed === null || !Number.isFinite(parsed)) {
     // eslint-disable-next-line no-console
-    console.warn(`[auth] JWT_EXPIRES_IN="${raw}" is not a valid duration; using 7d default.`);
+    console.warn(
+      `[auth] JWT_EXPIRES_IN="${raw}" is not a valid duration; using ${ACCESS_TOKEN_TTL_DEFAULT_S}s default.`,
+    );
     return ACCESS_TOKEN_TTL_DEFAULT_S;
   }
   if (parsed < ACCESS_TOKEN_TTL_MIN_S) {

--- a/middleware/src/modules/auth/refresh-token.service.spec.ts
+++ b/middleware/src/modules/auth/refresh-token.service.spec.ts
@@ -105,7 +105,7 @@ describe('RefreshTokenService', () => {
     it('rotates an active token: atomically revokes+links the old, issues a successor in the same family', async () => {
       db.refreshToken.findUnique.mockResolvedValue({ ...base });
 
-      const issued = await service.rotate(raw, 'user-1', { ip: '9.9.9.9', userAgent: 'UA2' });
+      const issued = await service.rotate(raw, { ip: '9.9.9.9', userAgent: 'UA2' });
 
       // S2: the atomic claim revokes the old token AND links the successor hash
       // in the SAME update — replacedByTokenHash is never transiently null.
@@ -124,23 +124,36 @@ describe('RefreshTokenService', () => {
       // No separate post-hoc update() — the successor link is part of the claim.
       expect(db.refreshToken.update).not.toHaveBeenCalled();
       expect(issued.rawToken).not.toBe(raw);
+      // The issued session carries the token's own userId back to the caller.
+      expect(issued.userId).toBe('user-1');
     });
 
     it('rejects an unknown token', async () => {
       db.refreshToken.findUnique.mockResolvedValue(null);
-      await expect(service.rotate(raw, 'user-1')).rejects.toThrow(UnauthorizedException);
+      await expect(service.rotate(raw)).rejects.toThrow(UnauthorizedException);
       expect(db.refreshToken.create).not.toHaveBeenCalled();
     });
 
-    it('rejects a token belonging to another user (cross-user)', async () => {
-      db.refreshToken.findUnique.mockResolvedValue({ ...base, userId: 'someone-else' });
-      await expect(service.rotate(raw, 'user-1')).rejects.toThrow(UnauthorizedException);
-      expect(db.refreshToken.updateMany).not.toHaveBeenCalled();
+    it('derives the user from the token itself (no caller id): mints the successor + runs S1 for the token OWN userId', async () => {
+      // There is no expectedUserId anymore — the token IS the credential. A row
+      // owned by 'user-2' rotates for 'user-2': the successor and every S1
+      // check key off existing.userId, not any caller-supplied id.
+      db.refreshToken.findUnique.mockResolvedValue({ ...base, userId: 'user-2' });
+
+      const issued = await service.rotate(raw);
+
+      expect(issued.userId).toBe('user-2');
+      expect(db.user.findUnique).toHaveBeenCalledWith({
+        where: { id: 'user-2' },
+        select: { isActive: true },
+      });
+      expect(redis.exists).toHaveBeenCalledWith('user_revoked:user-2');
+      expect(db.refreshToken.create.mock.calls[0][0].data.userId).toBe('user-2');
     });
 
     it('rejects an expired token', async () => {
       db.refreshToken.findUnique.mockResolvedValue({ ...base, expiresAt: new Date(Date.now() - 1000) });
-      await expect(service.rotate(raw, 'user-1')).rejects.toThrow(UnauthorizedException);
+      await expect(service.rotate(raw)).rejects.toThrow(UnauthorizedException);
       expect(db.refreshToken.create).not.toHaveBeenCalled();
     });
 
@@ -151,7 +164,7 @@ describe('RefreshTokenService', () => {
         replacedByTokenHash: sha256('successor'),
       });
 
-      await expect(service.rotate(raw, 'user-1')).rejects.toThrow(/reuse/i);
+      await expect(service.rotate(raw)).rejects.toThrow(/reuse/i);
       expect(db.refreshToken.updateMany).toHaveBeenCalledWith({
         where: { familyId: 'fam-1', revokedAt: null },
         data: { revokedAt: expect.any(Date) },
@@ -166,7 +179,7 @@ describe('RefreshTokenService', () => {
         replacedByTokenHash: sha256('successor'),
       });
 
-      await expect(service.rotate(raw, 'user-1')).rejects.toThrow(/already rotated/i);
+      await expect(service.rotate(raw)).rejects.toThrow(/already rotated/i);
       // Family untouched — the user stays logged in.
       expect(db.refreshToken.updateMany).not.toHaveBeenCalled();
       expect(db.refreshToken.create).not.toHaveBeenCalled();
@@ -176,7 +189,7 @@ describe('RefreshTokenService', () => {
       db.refreshToken.findUnique.mockResolvedValue({ ...base });
       db.refreshToken.updateMany.mockResolvedValueOnce({ count: 0 }); // another racer already claimed it
 
-      await expect(service.rotate(raw, 'user-1')).rejects.toThrow(/already rotated/i);
+      await expect(service.rotate(raw)).rejects.toThrow(/already rotated/i);
       expect(db.refreshToken.create).not.toHaveBeenCalled();
     });
 
@@ -193,7 +206,7 @@ describe('RefreshTokenService', () => {
         replacedByTokenHash: sha256('successor'),
       });
 
-      await expect(service.rotate(raw, 'user-1')).rejects.toThrow(/already rotated/i);
+      await expect(service.rotate(raw)).rejects.toThrow(/already rotated/i);
       // Benign: no family-kill updateMany, no successor minted.
       expect(db.refreshToken.updateMany).not.toHaveBeenCalled();
       expect(db.refreshToken.create).not.toHaveBeenCalled();
@@ -204,7 +217,7 @@ describe('RefreshTokenService', () => {
       db.refreshToken.findUnique.mockResolvedValue({ ...base });
       db.user.findUnique.mockResolvedValue({ isActive: false });
 
-      await expect(service.rotate(raw, 'user-1')).rejects.toThrow(UnauthorizedException);
+      await expect(service.rotate(raw)).rejects.toThrow(UnauthorizedException);
       // No successor minted, family untouched.
       expect(db.refreshToken.updateMany).not.toHaveBeenCalled();
       expect(db.refreshToken.create).not.toHaveBeenCalled();
@@ -216,7 +229,7 @@ describe('RefreshTokenService', () => {
         Promise.resolve(key === 'user_revoked:user-1'),
       );
 
-      await expect(service.rotate(raw, 'user-1')).rejects.toThrow(UnauthorizedException);
+      await expect(service.rotate(raw)).rejects.toThrow(UnauthorizedException);
       expect(redis.exists).toHaveBeenCalledWith('user_revoked:user-1');
       expect(db.refreshToken.create).not.toHaveBeenCalled();
     });
@@ -229,7 +242,7 @@ describe('RefreshTokenService', () => {
         Promise.resolve(key === 'pwd_changed:user-1' ? String(newerEpoch) : null),
       );
 
-      await expect(service.rotate(raw, 'user-1')).rejects.toThrow(UnauthorizedException);
+      await expect(service.rotate(raw)).rejects.toThrow(UnauthorizedException);
       expect(redis.get).toHaveBeenCalledWith('pwd_changed:user-1');
       expect(db.refreshToken.create).not.toHaveBeenCalled();
     });
@@ -242,7 +255,7 @@ describe('RefreshTokenService', () => {
         Promise.resolve(key === 'pwd_changed:user-1' ? String(olderEpoch) : null),
       );
 
-      const issued = await service.rotate(raw, 'user-1');
+      const issued = await service.rotate(raw);
       expect(issued.rawToken).toEqual(expect.any(String));
       expect(db.refreshToken.create).toHaveBeenCalledTimes(1);
     });

--- a/middleware/src/modules/auth/refresh-token.service.ts
+++ b/middleware/src/modules/auth/refresh-token.service.ts
@@ -15,6 +15,13 @@ export interface IssuedRefreshToken {
   /** Plaintext token, to be placed in the httpOnly cookie. Never persisted. */
   rawToken: string;
   expiresAt: Date;
+  /**
+   * The user this session belongs to. On rotate() this is derived from the
+   * presented token itself (the token IS the credential) — the public
+   * /auth/refresh route has no authenticated caller, so the controller uses
+   * this to know whose access token to mint.
+   */
+  userId: string;
 }
 
 /** Session inventory row — deliberately free of any token material. */
@@ -101,23 +108,26 @@ export class RefreshTokenService {
   /**
    * Validate + rotate a presented refresh token.
    *
-   *  - unknown / wrong-user / expired token  → 401 (no family action)
+   *  - unknown / expired token                → 401 (no family action)
    *  - already-revoked within grace          → 401 (benign concurrent refresh; family preserved)
    *  - already-revoked outside grace          → REUSE: revoke the whole family, then 401
    *  - active token                           → atomically claim + issue a successor in the same family
    *
-   * `expectedUserId` is the authenticated caller's id (defense in depth: a
-   * refresh token can only be rotated by the user it belongs to).
+   * The user is derived from the presented token itself (`existing.userId`) —
+   * the token IS the credential. /auth/refresh is public (an expired access
+   * token must still be refreshable), so there is no authenticated caller to
+   * cross-check against. The S1 live-state re-verification below (isActive +
+   * `user_revoked` + `pwd_changed`) is therefore the PRIMARY security gate:
+   * it runs against the token's own userId before any successor is minted.
    */
   async rotate(
     rawToken: string,
-    expectedUserId: string,
     ctx: RefreshTokenContext = {},
   ): Promise<IssuedRefreshToken> {
     const tokenHash = this.hash(rawToken);
     const existing = await this.databaseService.refreshToken.findUnique({ where: { tokenHash } });
 
-    if (!existing || existing.userId !== expectedUserId) {
+    if (!existing) {
       throw new UnauthorizedException('Invalid refresh token');
     }
 
@@ -316,6 +326,6 @@ export class RefreshTokenService {
         lastUsedAt: new Date(),
       },
     });
-    return { rawToken, expiresAt };
+    return { rawToken, expiresAt, userId };
   }
 }

--- a/web/src/lib/api/__tests__/client.test.ts
+++ b/web/src/lib/api/__tests__/client.test.ts
@@ -66,3 +66,133 @@ describe('ApiClient auth error handling', () => {
     expect(client.isAuthenticated).toBe(true);
   });
 });
+
+describe('ApiClient auto-refresh on 401 (PR-17b)', () => {
+  const okEnvelope = (data: unknown) => ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => ({ success: true, data }),
+  });
+  const unauthorized = (message = 'Session expired') => ({
+    ok: false,
+    status: 401,
+    statusText: 'Unauthorized',
+    json: async () => ({ message }),
+  });
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      value: 'vizora_csrf_token=test-csrf',
+    });
+    global.fetch = jest.fn();
+  });
+
+  it('on a 401, redeems the refresh cookie ONCE and replays the original request', async () => {
+    const calls: string[] = [];
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      calls.push(url);
+      if (url.endsWith('/auth/refresh')) {
+        return Promise.resolve(okEnvelope({ expiresIn: 1800 }));
+      }
+      if (url.endsWith('/widgets')) {
+        const hits = calls.filter((u) => u.endsWith('/widgets')).length;
+        return Promise.resolve(hits === 1 ? unauthorized() : okEnvelope({ ok: 1 }));
+      }
+      return Promise.resolve(okEnvelope({}));
+    });
+
+    const client = new ApiClient('/api/v1');
+    const result = await client.request('/widgets');
+
+    expect(result).toEqual({ ok: 1 });
+    expect(calls.filter((u) => u.endsWith('/auth/refresh'))).toHaveLength(1);
+    expect(calls.filter((u) => u.endsWith('/widgets'))).toHaveLength(2); // original + replay
+    expect(client.isAuthenticated).toBe(true);
+  });
+
+  it('coalesces concurrent 401s into a SINGLE /auth/refresh (single-flight mutex)', async () => {
+    const calls: string[] = [];
+    let refreshCount = 0;
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      calls.push(url);
+      if (url.endsWith('/auth/refresh')) {
+        refreshCount += 1;
+        // Delay so all three initial 401s are in-flight before this resolves —
+        // if the mutex is missing, each would spawn its own refresh.
+        return new Promise((resolve) => setTimeout(() => resolve(okEnvelope({ expiresIn: 1800 })), 10));
+      }
+      const isReplay = calls.filter((u) => u === url).length > 1;
+      return Promise.resolve(isReplay ? okEnvelope({ url }) : unauthorized());
+    });
+
+    const client = new ApiClient('/api/v1');
+    const [a, b, c] = await Promise.all([
+      client.request('/a'),
+      client.request('/b'),
+      client.request('/c'),
+    ]);
+
+    expect(refreshCount).toBe(1);
+    expect(calls.filter((u) => u.endsWith('/auth/refresh'))).toHaveLength(1);
+    expect(a).toEqual({ url: '/api/v1/a' });
+    expect(b).toEqual({ url: '/api/v1/b' });
+    expect(c).toEqual({ url: '/api/v1/c' });
+  });
+
+  it('when the refresh also fails, clears auth and redirects a protected route to login', async () => {
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { pathname: '/dashboard', href: '' },
+    });
+
+    // Everything (including /auth/refresh) returns 401 → refresh cannot recover.
+    (global.fetch as jest.Mock).mockResolvedValue(unauthorized());
+
+    const client = new ApiClient('/api/v1');
+    client.setAuthenticated(true);
+
+    await expect(client.request('/widgets')).rejects.toBeInstanceOf(ApiError);
+    expect(client.isAuthenticated).toBe(false);
+    expect(window.location.href).toBe('/login?redirect=%2Fdashboard');
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    });
+  });
+
+  it('does NOT auto-refresh a failed login (bad credentials surface unchanged, no loop)', async () => {
+    const calls: string[] = [];
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      calls.push(url);
+      return Promise.resolve(unauthorized('Invalid credentials'));
+    });
+
+    const client = new ApiClient('/api/v1');
+    await expect(
+      client.request('/auth/login', { method: 'POST', body: '{}' }),
+    ).rejects.toMatchObject({ statusCode: 401, message: 'Invalid credentials' });
+
+    expect(calls.filter((u) => u.endsWith('/auth/refresh'))).toHaveLength(0);
+    expect(calls.filter((u) => u.endsWith('/auth/login'))).toHaveLength(1);
+  });
+
+  it('does NOT recurse when /auth/refresh itself returns 401', async () => {
+    const calls: string[] = [];
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      calls.push(url);
+      return Promise.resolve(unauthorized('Refresh token reuse detected'));
+    });
+
+    const client = new ApiClient('/api/v1');
+    await expect(client.request('/auth/refresh', { method: 'POST' })).rejects.toBeInstanceOf(ApiError);
+
+    expect(calls.filter((u) => u.endsWith('/auth/refresh'))).toHaveLength(1);
+  });
+});

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -146,8 +146,76 @@ export class ApiClient {
   private csrfInitialized = false;
   private csrfInitPromise: Promise<void> | null = null;
 
+  /**
+   * Shared in-flight `/auth/refresh` promise. A burst of concurrent 401s (N
+   * parallel dashboard requests all hitting an expired access token) must
+   * trigger exactly ONE refresh — the refresh token rotates on use, so N
+   * parallel refreshes would revoke each other and log the user out. All
+   * waiters await this single promise, then replay their own request.
+   */
+  private refreshInFlight: Promise<boolean> | null = null;
+
+  /**
+   * Endpoints where a 401 is a genuine credential/session outcome rather than a
+   * "token expired — go refresh" signal. Auto-refresh is skipped for these to
+   * (a) avoid an infinite loop on the refresh call itself and (b) let real
+   * bad-login / registration errors surface to the caller unchanged.
+   */
+  private static readonly REFRESH_EXEMPT_PREFIXES = [
+    '/auth/refresh',
+    '/auth/login',
+    '/auth/register',
+    '/auth/google',
+    '/auth/logout',
+  ];
+
   constructor(baseUrl: string) {
     this.baseUrl = baseUrl;
+  }
+
+  private isRefreshExempt(endpoint: string): boolean {
+    return ApiClient.REFRESH_EXEMPT_PREFIXES.some((prefix) => endpoint.startsWith(prefix));
+  }
+
+  /**
+   * Clear auth state and, from a protected route, bounce to login. Called when
+   * a 401 could not be recovered by a refresh (session genuinely expired).
+   */
+  private handleAuthExpired(): void {
+    this.isAuthenticated = false;
+    if (typeof window !== 'undefined') {
+      // Only redirect from protected routes (dashboard, admin), not public pages.
+      const currentPath = window.location.pathname;
+      if (currentPath.startsWith('/dashboard') || currentPath.startsWith('/admin')) {
+        window.location.href = `/login?redirect=${encodeURIComponent(currentPath)}`;
+      }
+    }
+  }
+
+  /**
+   * Redeem the httpOnly refresh cookie for a fresh access token, at most once
+   * concurrently (see `refreshInFlight`). Resolves true on success, false if the
+   * refresh token is missing/expired/revoked/reused.
+   */
+  private async refreshAuth(): Promise<boolean> {
+    if (!this.refreshInFlight) {
+      this.refreshInFlight = this.performRefresh().finally(() => {
+        this.refreshInFlight = null;
+      });
+    }
+    return this.refreshInFlight;
+  }
+
+  private async performRefresh(): Promise<boolean> {
+    try {
+      // allowRefresh=false: a 401 from /auth/refresh must NOT trigger another
+      // refresh (it's also on the exempt list, so this is belt-and-suspenders).
+      await this.request<{ expiresIn: number }>('/auth/refresh', { method: 'POST' }, 0, false);
+      this.isAuthenticated = true;
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   /**
@@ -208,7 +276,8 @@ export class ApiClient {
   async request<T>(
     endpoint: string,
     options: RequestInit = {},
-    retries = 3
+    retries = 3,
+    allowRefresh = true
   ): Promise<T> {
     // Ensure CSRF token is available before mutating requests
     const method = (options.method || 'GET').toUpperCase();
@@ -254,14 +323,19 @@ export class ApiClient {
         // Handle expired/invalid sessions. A 403 is a permission boundary,
         // not proof that the user's auth cookie is invalid.
         if (response.status === 401) {
-          this.isAuthenticated = false;
-          if (typeof window !== 'undefined') {
-            // Only redirect from protected routes (dashboard, admin), not public pages
-            const currentPath = window.location.pathname;
-            if (currentPath.startsWith('/dashboard') || currentPath.startsWith('/admin')) {
-              window.location.href = `/login?redirect=${encodeURIComponent(currentPath)}`;
+          // Access tokens are short-lived (PR-17b). On the FIRST 401 for a
+          // normal API call, silently redeem the rotating refresh cookie and
+          // replay the original request exactly ONCE. `allowRefresh` is false on
+          // the replay and on the refresh/login calls themselves, so a session
+          // that's genuinely gone can't loop.
+          if (allowRefresh && typeof window !== 'undefined' && !this.isRefreshExempt(endpoint)) {
+            const refreshed = await this.refreshAuth();
+            if (refreshed) {
+              return this.request<T>(endpoint, options, retries, false);
             }
           }
+          // Refresh not possible or it failed — the session is really expired.
+          this.handleAuthExpired();
         }
 
         throw await buildApiError(response, 'Request failed');
@@ -292,7 +366,7 @@ export class ApiClient {
           if (process.env.NODE_ENV === 'development') {
             devWarn(`[API] Request timeout, retrying... (${retries} attempts left)`);
           }
-          return this.request<T>(endpoint, options, retries - 1);
+          return this.request<T>(endpoint, options, retries - 1, allowRefresh);
         }
         throw new Error('Request timeout');
       }
@@ -309,6 +383,7 @@ export class ApiClient {
     endpoint: string,
     formData: FormData,
     method = 'POST',
+    allowRefresh = true,
   ): Promise<T> {
     await this.ensureCsrfToken();
 
@@ -334,7 +409,15 @@ export class ApiClient {
 
       if (!response.ok) {
         if (response.status === 401) {
-          this.isAuthenticated = false;
+          // Same short-TTL auto-refresh + single replay as request(); the shared
+          // single-flight means an upload's 401 reuses any in-flight refresh.
+          if (allowRefresh && typeof window !== 'undefined' && !this.isRefreshExempt(endpoint)) {
+            const refreshed = await this.refreshAuth();
+            if (refreshed) {
+              return this.requestFormData<T>(endpoint, formData, method, false);
+            }
+          }
+          this.handleAuthExpired();
         }
         throw await buildApiError(response, 'Upload failed');
       }


### PR DESCRIPTION
Completes the refresh-token flow (PR-17a shipped the infra). Access tokens are now **short-lived and silently auto-refreshed**; session revocation becomes prompt.

## Backend
- **`/auth/refresh` is now `@Public()`** — a short access token means refresh must succeed *after* access expiry, so there's no authenticated caller to guard on. The **refresh cookie is the sole credential**. `rotate()` drops `expectedUserId` and derives the user from the token; the **PR-17a S1 checks** (isActive fail-closed + `user_revoked` + `pwd_changed` strict-`<`) are now the **primary gate**, run before minting. Reuse-detection / 5s grace / atomic claim unchanged. `@Throttle`-limited. No cookie → 401.
- **Access TTL 7d → 30m** (`JWT_EXPIRES_IN` default 30m, clamped `[60s, 7d]`).
- **Cookie/JWT decoupling** — the access-**cookie** `maxAge` is long (= refresh TTL, ~30d) so it survives idle periods for the Next edge-middleware *presence* gate; the **JWT `exp` stays 30m** and is validated server-side every request — the real security boundary. A leaked cookie's JWT is still only good 30m. Closes the "idle >30m → hard-reload → bounced to login despite a valid refresh cookie" regression.

## Frontend (web ApiClient)
- On 401: one **single-flight** shared `/auth/refresh` → replay the original request once. **N concurrent 401s → exactly ONE refresh** (never trips rotation/grace). `/auth/{refresh,login,register,google,logout}` exempt (no loop); refresh-failure → clear auth + redirect protected routes to `/login`.

## Transition
Pre-17a sessions (no refresh cookie) get logged out **once** when their old 7d token expires, then re-login mints a refresh cookie. Acceptable, as scoped.

## Verification (independently re-run)
- middleware `tsc` 0 · web `tsc` 0 · auth jest **240/240** · web api jest **30/30** (incl. single-flight + loop-prevention).
- The `@Public`-refresh security is exactly the design PR-17a's adversarial review validated (**S1 = the gate**); the `rotate()` change preserves S1 verbatim.

## Deploy note
Backend + web both change → this deploy rebuilds **middleware AND web**. No migration. Existing 7d tokens stay valid until they expire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)