### PR TITLE
feat(auth): TOTP MFA + backup codes + login challenge + per-org enforcement (auth #2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,6 +90,14 @@ REFRESH_TOKEN_TTL_DAYS=30
 # Device authentication secret (separate from user auth)
 DEVICE_JWT_SECRET=GENERATE_ANOTHER_SECURE_64_CHAR_HEX_SECRET_HERE
 
+# MFA (auth #2) TOTP-secret encryption key. AES-256-GCM at rest. Min 32 chars.
+# FAIL-CLOSED: any MFA operation (enroll/enable/challenge/disable) refuses to run
+# if this is missing or too short, so a plaintext TOTP secret is never persisted.
+# Non-MFA login is unaffected when unset. Keep CONSTANT across deploys — rotating
+# it makes every stored TOTP secret undecryptable (enrolled users must re-enroll).
+# Generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+MFA_ENCRYPTION_KEY=GENERATE_A_SECURE_64_CHAR_HEX_SECRET_HERE
+
 # =============================================================================
 # Manual Verification Tokens (local scripts only)
 # =============================================================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ JWT_SECRET              # User auth JWT secret (min 32 chars)
 JWT_EXPIRES_IN          # Access-token lifetime, default 30m (short-lived; frontend auto-refreshes on 401). Clamped [60s, 7d]. Set 7d to restore long-lived tokens.
 REFRESH_TOKEN_TTL_DAYS  # Refresh-token session lifetime in days (default 30, clamped [1,365]). Opaque random token, sha256-hashed at rest; no separate secret.
 DEVICE_JWT_SECRET       # Device auth JWT secret (min 32 chars; separate from JWT_SECRET)
+MFA_ENCRYPTION_KEY      # AES-256-GCM key (min 32 chars) for TOTP-secret encryption at rest (auth #2). Fail-closed: MFA ops refuse to run if unset. Non-MFA login unaffected. Keep CONSTANT across deploys (rotating it orphans every stored TOTP secret).
 INTERNAL_API_SECRET     # Required in prod — service-to-service auth (middleware ↔ realtime)
 BCRYPT_ROUNDS           # Password hashing rounds (10-15, default 12)
 GOOGLE_CLIENT_ID        # Optional — Google OAuth client ID

--- a/middleware/jest.config.js
+++ b/middleware/jest.config.js
@@ -33,6 +33,12 @@ module.exports = {
   detectOpenHandles: true,
   moduleNameMapper: {
     '^@vizora/database$': '<rootDir>/../test/__mocks__/database.ts',
+    // otplib (MFA / auth #2) v13 + its transitive crypto/base32 deps (@scure,
+    // @noble) ship pure ESM under pnpm's `.pnpm/` layout, which Jest's CJS
+    // runtime can't load. Map to a faithful RFC-6238 TOTP test double
+    // (generate/verify/generateSecret/generateURI). Production uses real otplib;
+    // only Jest resolves this stub.
+    '^otplib$': '<rootDir>/../test/__mocks__/otplib.ts',
   },
   transformIgnorePatterns: [
     'node_modules/(?!(@vizora|isomorphic-dompurify|@exodus|html-encoding-sniffer|jsdom|uuid)/)',

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -132,6 +132,7 @@
     "mongoose": "^9.7.4",
     "multer": "^2.2.0",
     "nodemailer": "^9.0.1",
+    "otplib": "^13.4.1",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "passport-local": "^1.0.0",

--- a/middleware/src/modules/auth/auth.controller.spec.ts
+++ b/middleware/src/modules/auth/auth.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { RefreshTokenService } from './refresh-token.service';
+import { MfaService } from './mfa/mfa.service';
 import { Request, Response } from 'express';
 import { AUTH_CONSTANTS } from './constants/auth.constants';
 import { ConflictException, UnauthorizedException } from '@nestjs/common';
@@ -59,6 +60,15 @@ describe('AuthController', () => {
       getTtlSeconds: jest.fn().mockReturnValue(30 * 24 * 60 * 60),
     };
 
+    const mockMfaService = {
+      enroll: jest.fn(),
+      enable: jest.fn(),
+      disable: jest.fn(),
+      status: jest.fn(),
+      regenerateBackupCodes: jest.fn(),
+      verifyChallenge: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
       providers: [
@@ -69,6 +79,10 @@ describe('AuthController', () => {
         {
           provide: RefreshTokenService,
           useValue: mockRefreshTokenService,
+        },
+        {
+          provide: MfaService,
+          useValue: mockMfaService,
         },
       ],
     }).compile();
@@ -263,6 +277,36 @@ describe('AuthController', () => {
         ipAddress: '203.0.113.20',
         userAgent: 'Mozilla/5.0 Chrome/126.0',
       });
+    });
+
+    it('MFA-enrolled Google user: returns mfaRequired + challengeToken and sets NO cookie/session (S1)', async () => {
+      authService.googleLogin.mockResolvedValue({
+        mfaRequired: true,
+        challengeToken: 'chal.jwt',
+      } as any);
+
+      const result = await controller.googleLogin(googleDto, mockGoogleRequest, mockResponse as Response);
+
+      expect(result).toEqual({ success: true, data: { mfaRequired: true, challengeToken: 'chal.jwt' } });
+      // No auth cookie and no refresh session on an MFA gate — mirrors /auth/login.
+      expect(mockResponse.cookie).not.toHaveBeenCalled();
+      expect(refreshTokenService.issueForUser).not.toHaveBeenCalled();
+    });
+
+    it('unenrolled Google user in mfaRequired org: returns mfaEnrollmentRequired and NO cookie/session (S1)', async () => {
+      authService.googleLogin.mockResolvedValue({
+        mfaEnrollmentRequired: true,
+        enrollmentToken: 'enr.jwt',
+      } as any);
+
+      const result = await controller.googleLogin(googleDto, mockGoogleRequest, mockResponse as Response);
+
+      expect(result).toEqual({
+        success: true,
+        data: { mfaEnrollmentRequired: true, enrollmentToken: 'enr.jwt' },
+      });
+      expect(mockResponse.cookie).not.toHaveBeenCalled();
+      expect(refreshTokenService.issueForUser).not.toHaveBeenCalled();
     });
   });
 

--- a/middleware/src/modules/auth/auth.controller.ts
+++ b/middleware/src/modules/auth/auth.controller.ts
@@ -16,10 +16,13 @@ import {
 } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { RefreshTokenService, RefreshTokenContext } from './refresh-token.service';
+import { MfaService } from './mfa/mfa.service';
 import { RegisterDto, LoginDto, ForgotPasswordDto, ResetPasswordDto, ChangePasswordDto, DeleteAccountDto, UpdateProfileDto, GoogleLoginDto } from './dto';
+import { EnableMfaDto, DisableMfaDto, MfaChallengeDto, RegenerateBackupCodesDto } from './mfa/dto/mfa.dto';
 import { Public } from './decorators/public.decorator';
 import { CurrentUser } from './decorators/current-user.decorator';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { EnrollmentOrJwtGuard } from './guards/enrollment-or-jwt.guard';
 import { AUTH_CONSTANTS } from './constants/auth.constants';
 import { AuthenticatedUser } from './strategies/jwt.strategy';
 
@@ -36,6 +39,11 @@ import { AuthenticatedUser } from './strategies/jwt.strategy';
  */
 const RATE_LIMIT_STRICT = process.env.NODE_ENV === 'production' ? 3 : 1000;
 const RATE_LIMIT_STANDARD = process.env.NODE_ENV === 'production' ? 5 : 1000;
+// MFA verification endpoints (challenge / enroll / enable / disable / regenerate).
+// Slightly higher than STANDARD because users legitimately mistype 6-digit
+// codes; the real brute-force cap is the per-challenge / per-user lockout in
+// MfaService, not this outer throttle.
+const RATE_LIMIT_MFA = process.env.NODE_ENV === 'production' ? 10 : 1000;
 // Refresh runs more often than login (the frontend re-ups the session), so it
 // gets a slightly higher cap than STANDARD while still throttling refresh-token
 // abuse / enumeration attempts.
@@ -48,6 +56,7 @@ export class AuthController {
   constructor(
     private authService: AuthService,
     private refreshTokenService: RefreshTokenService,
+    private mfaService: MfaService,
   ) {}
 
   /**
@@ -243,6 +252,20 @@ export class AuthController {
       userAgent: req.headers?.['user-agent'],
     });
 
+    // MFA branch (auth #2). When the account is MFA-enrolled OR the org requires
+    // MFA and the user isn't enrolled, `login` returns NO tokens — only a
+    // short-lived challenge/enrollment token. Do NOT set any auth cookie in
+    // these cases. The non-MFA path below is byte-for-byte unchanged.
+    if ('mfaRequired' in result) {
+      return { success: true, data: { mfaRequired: true, challengeToken: result.challengeToken } };
+    }
+    if ('mfaEnrollmentRequired' in result) {
+      return {
+        success: true,
+        data: { mfaEnrollmentRequired: true, enrollmentToken: result.enrollmentToken },
+      };
+    }
+
     // Set httpOnly cookie with JWT token
     this.setAuthCookie(res, result.token);
 
@@ -284,6 +307,20 @@ export class AuthController {
       ipAddress: req.ip || req.socket?.remoteAddress || '',
       userAgent: req.headers?.['user-agent'],
     });
+
+    // MFA branch (auth #2). A Google user who is MFA-enrolled OR is in an
+    // mfaRequired org without enrollment gets NO session here — only a
+    // short-lived challenge/enrollment token. Do NOT set any auth cookie or
+    // start a refresh session in these cases. Mirrors the /auth/login handler.
+    if ('mfaRequired' in result) {
+      return { success: true, data: { mfaRequired: true, challengeToken: result.challengeToken } };
+    }
+    if ('mfaEnrollmentRequired' in result) {
+      return {
+        success: true,
+        data: { mfaEnrollmentRequired: true, enrollmentToken: result.enrollmentToken },
+      };
+    }
 
     // Set httpOnly cookie with JWT token
     this.setAuthCookie(res, result.token);
@@ -356,6 +393,147 @@ export class AuthController {
     return {
       success: true,
       data: {
+        expiresIn: result.expiresIn,
+      },
+    };
+  }
+
+  // ===========================================================================
+  // MFA (auth #2) — TOTP enrollment, backup codes, login challenge
+  // ===========================================================================
+
+  @ApiOperation({ summary: 'Begin MFA enrollment — returns an otpauth URL + QR (does NOT enable MFA yet)' })
+  @ApiResponse({ status: 201, description: 'Pending secret created; scan the QR then call /auth/mfa/enable.' })
+  @ApiResponse({ status: 400, description: 'MFA already enabled.' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  // @Public bypasses the global JwtAuthGuard; EnrollmentOrJwtGuard then accepts
+  // EITHER a normal session JWT (voluntary enrollment) OR a forced-enrollment
+  // token (x-mfa-enrollment-token header).
+  @Public()
+  @UseGuards(EnrollmentOrJwtGuard)
+  @Post('mfa/enroll')
+  @Throttle({ default: { limit: RATE_LIMIT_MFA, ttl: RATE_LIMIT_TTL_MS } })
+  async mfaEnroll(@CurrentUser('id') userId: string) {
+    const data = await this.mfaService.enroll(userId);
+    return { success: true, data };
+  }
+
+  @ApiOperation({ summary: 'Enable MFA — verifies the pending secret and returns one-time backup codes' })
+  @ApiBody({ type: EnableMfaDto })
+  @ApiResponse({ status: 200, description: 'MFA enabled; backup codes returned once.' })
+  @ApiResponse({ status: 401, description: 'Invalid verification code.' })
+  @Public()
+  @UseGuards(EnrollmentOrJwtGuard)
+  @Post('mfa/enable')
+  @HttpCode(HttpStatus.OK)
+  @Throttle({ default: { limit: RATE_LIMIT_MFA, ttl: RATE_LIMIT_TTL_MS } })
+  async mfaEnable(
+    @CurrentUser() user: { id: string; mfaEnrollmentOnly?: boolean },
+    @Body() dto: EnableMfaDto,
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const { backupCodes } = await this.mfaService.enable(user.id, dto.code);
+
+    // Forced-enrollment flow: the caller authenticated with an enrollment token
+    // and has no session yet. Both factors are now satisfied (password at login
+    // + TOTP just now), so complete the login exactly as a normal login would.
+    if (user.mfaEnrollmentOnly) {
+      const result = await this.authService.issueSessionForUser(user.id, {
+        ipAddress: req.ip || req.socket?.remoteAddress || '',
+        userAgent: req.headers?.['user-agent'],
+      });
+      this.setAuthCookie(res, result.token);
+      await this.startRefreshSession(res, req, result.user.id);
+      return {
+        success: true,
+        data: {
+          backupCodes,
+          access_token: result.token,
+          user: result.user,
+          expiresIn: result.expiresIn,
+        },
+      };
+    }
+
+    return { success: true, data: { backupCodes } };
+  }
+
+  @ApiOperation({ summary: 'Disable MFA — requires a valid current TOTP or backup code' })
+  @ApiBearerAuth('JWT-auth')
+  @ApiCookieAuth()
+  @ApiBody({ type: DisableMfaDto })
+  @ApiResponse({ status: 200, description: 'MFA disabled.' })
+  @ApiResponse({ status: 401, description: 'Invalid verification code.' })
+  @UseGuards(JwtAuthGuard)
+  @Post('mfa/disable')
+  @HttpCode(HttpStatus.OK)
+  @Throttle({ default: { limit: RATE_LIMIT_MFA, ttl: RATE_LIMIT_TTL_MS } })
+  async mfaDisable(@CurrentUser('id') userId: string, @Body() dto: DisableMfaDto) {
+    await this.mfaService.disable(userId, dto.code);
+    return { success: true, data: { message: 'MFA disabled.' } };
+  }
+
+  @ApiOperation({ summary: 'MFA status for the current user' })
+  @ApiBearerAuth('JWT-auth')
+  @ApiCookieAuth()
+  @ApiResponse({ status: 200, description: '{ enabled, backupCodesRemaining }' })
+  @UseGuards(JwtAuthGuard)
+  @Get('mfa/status')
+  async mfaStatus(@CurrentUser('id') userId: string) {
+    const data = await this.mfaService.status(userId);
+    return { success: true, data };
+  }
+
+  @ApiOperation({ summary: 'Regenerate MFA backup codes — requires a valid current TOTP' })
+  @ApiBearerAuth('JWT-auth')
+  @ApiCookieAuth()
+  @ApiBody({ type: RegenerateBackupCodesDto })
+  @ApiResponse({ status: 200, description: 'New backup codes returned once; old codes invalidated.' })
+  @ApiResponse({ status: 401, description: 'Invalid verification code.' })
+  @UseGuards(JwtAuthGuard)
+  @Post('mfa/backup-codes/regenerate')
+  @HttpCode(HttpStatus.OK)
+  @Throttle({ default: { limit: RATE_LIMIT_MFA, ttl: RATE_LIMIT_TTL_MS } })
+  async mfaRegenerateBackupCodes(
+    @CurrentUser('id') userId: string,
+    @Body() dto: RegenerateBackupCodesDto,
+  ) {
+    const data = await this.mfaService.regenerateBackupCodes(userId, dto.code);
+    return { success: true, data };
+  }
+
+  @ApiOperation({ summary: 'Complete an MFA-gated login (TOTP or backup code)' })
+  @ApiBody({ type: MfaChallengeDto })
+  @ApiResponse({ status: 200, description: 'Login complete; tokens issued exactly as a normal login.' })
+  @ApiResponse({ status: 401, description: 'Invalid challenge token or code.' })
+  // PUBLIC by design: the login challenge happens AFTER password verification but
+  // BEFORE the session exists — there is no session to guard on. The challenge
+  // token IS the credential (short-lived, single-use, bound to the userId).
+  @Public()
+  @Post('mfa/challenge')
+  @HttpCode(HttpStatus.OK)
+  @Throttle({ default: { limit: RATE_LIMIT_MFA, ttl: RATE_LIMIT_TTL_MS } })
+  async mfaChallenge(
+    @Body() dto: MfaChallengeDto,
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const { userId } = await this.mfaService.verifyChallenge(dto.challengeToken, dto.code);
+
+    // Both factors satisfied — issue the session EXACTLY as a normal login.
+    const result = await this.authService.issueSessionForUser(userId, {
+      ipAddress: req.ip || req.socket?.remoteAddress || '',
+      userAgent: req.headers?.['user-agent'],
+    });
+    this.setAuthCookie(res, result.token);
+    await this.startRefreshSession(res, req, result.user.id);
+
+    return {
+      success: true,
+      data: {
+        access_token: result.token,
+        user: result.user,
         expiresIn: result.expiresIn,
       },
     };

--- a/middleware/src/modules/auth/auth.module.ts
+++ b/middleware/src/modules/auth/auth.module.ts
@@ -4,6 +4,8 @@ import { PassportModule } from '@nestjs/passport';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { RefreshTokenService } from './refresh-token.service';
+import { MfaService } from './mfa/mfa.service';
+import { EnrollmentOrJwtGuard } from './guards/enrollment-or-jwt.guard';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { DatabaseModule } from '../database/database.module';
 import { BillingModule } from '../billing/billing.module';
@@ -50,6 +52,8 @@ import { getAccessTokenTtlSeconds } from './jwt-expiry';
   providers: [
     AuthService,
     RefreshTokenService,
+    MfaService,
+    EnrollmentOrJwtGuard,
     JwtStrategy,
     {
       provide: APP_GUARD,
@@ -57,6 +61,6 @@ import { getAccessTokenTtlSeconds } from './jwt-expiry';
     },
     RolesGuard,
   ],
-  exports: [AuthService, RefreshTokenService, JwtModule],
+  exports: [AuthService, RefreshTokenService, MfaService, JwtModule],
 })
 export class AuthModule {}

--- a/middleware/src/modules/auth/auth.service.spec.ts
+++ b/middleware/src/modules/auth/auth.service.spec.ts
@@ -77,6 +77,7 @@ describe('AuthService', () => {
   let mockGeoService: any;
   let mockStorageService: any;
   let mockAlertRulesService: any;
+  let mockMfaService: any;
 
   const mockUser = {
     id: 'user-123',
@@ -189,6 +190,16 @@ describe('AuthService', () => {
       seedDefaultRuleForOrg: jest.fn().mockResolvedValue(undefined),
     };
 
+    // MFA service mock. Default: resolveLoginBranch returns { kind: 'none' } so
+    // every existing (non-MFA) login test exercises the UNCHANGED password->token
+    // path. Individual MFA tests override resolveLoginBranch per-case.
+    mockMfaService = {
+      resolveLoginBranch: jest.fn().mockReturnValue({ kind: 'none' }),
+      issueChallengeToken: jest.fn().mockReturnValue('challenge.jwt'),
+      issueEnrollmentToken: jest.fn().mockReturnValue('enrollment.jwt'),
+      verifyChallenge: jest.fn(),
+    };
+
     // Directly instantiate the service with mocked dependencies
     service = new AuthService(
       mockDatabaseService as DatabaseService,
@@ -200,6 +211,7 @@ describe('AuthService', () => {
       mockStorageService as any,
       mockEventEmitter as any,
       mockAlertRulesService as any,
+      mockMfaService as any,
     );
     
     // Reset bcrypt mocks
@@ -436,6 +448,114 @@ describe('AuthService', () => {
       expect(result).toHaveProperty('user');
       expect(result).toHaveProperty('token', 'mock-jwt-token');
       expect(result).toHaveProperty('expiresIn', getAccessTokenTtlSeconds());
+    });
+
+    describe('MFA branch (auth #2)', () => {
+      it('non-MFA login is UNCHANGED: resolveLoginBranch=none -> password->token, no challenge', async () => {
+        mockDatabaseService.user.findUnique.mockResolvedValue({
+          ...mockUser,
+          organization: mockOrganization,
+        });
+        mockDatabaseService.user.update.mockResolvedValue(mockUser);
+        mockDatabaseService.auditLog.create.mockResolvedValue({});
+        (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+        mockMfaService.resolveLoginBranch.mockReturnValue({ kind: 'none' });
+
+        const result: any = await service.login(loginDto);
+
+        // Byte-for-byte the same response shape as before MFA existed.
+        expect(result).toEqual(
+          expect.objectContaining({ token: 'mock-jwt-token', expiresIn: getAccessTokenTtlSeconds() }),
+        );
+        expect(result.user).toBeDefined();
+        expect(result).not.toHaveProperty('mfaRequired');
+        expect(result).not.toHaveProperty('mfaEnrollmentRequired');
+        // Normal path still updates lastLoginAt + mints a token.
+        expect(mockDatabaseService.user.update).toHaveBeenCalled();
+        expect(mockJwtService.sign).toHaveBeenCalled();
+      });
+
+      it('enrolled user gets a challenge token and NO session token', async () => {
+        mockDatabaseService.user.findUnique.mockResolvedValue({
+          ...mockUser,
+          mfaEnabled: true,
+          organization: mockOrganization,
+        });
+        (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+        mockMfaService.resolveLoginBranch.mockReturnValue({
+          kind: 'challenge',
+          challengeToken: 'chal.jwt',
+        });
+
+        const result: any = await service.login(loginDto);
+
+        expect(result).toEqual({ mfaRequired: true, challengeToken: 'chal.jwt' });
+        expect(result).not.toHaveProperty('token');
+        expect(result).not.toHaveProperty('user');
+        // No session was minted and lastLoginAt was NOT bumped (login not complete).
+        expect(mockJwtService.sign).not.toHaveBeenCalled();
+        expect(mockDatabaseService.user.update).not.toHaveBeenCalled();
+        // Password was correct, so the password lockout counter was cleared.
+        expect(mockRedisService.del).toHaveBeenCalledWith(`login_attempts:${loginDto.email}`);
+      });
+
+      it('org-required + not-enrolled user gets an enrollment token and NO session token', async () => {
+        mockDatabaseService.user.findUnique.mockResolvedValue({
+          ...mockUser,
+          mfaEnabled: false,
+          organization: { ...mockOrganization, mfaRequired: true },
+        });
+        (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+        mockMfaService.resolveLoginBranch.mockReturnValue({
+          kind: 'enroll',
+          enrollmentToken: 'enr.jwt',
+        });
+
+        const result: any = await service.login(loginDto);
+
+        expect(result).toEqual({ mfaEnrollmentRequired: true, enrollmentToken: 'enr.jwt' });
+        expect(mockJwtService.sign).not.toHaveBeenCalled();
+        expect(mockDatabaseService.user.update).not.toHaveBeenCalled();
+      });
+
+      it('MFA branch is only reached AFTER a correct password (wrong password never issues a challenge)', async () => {
+        mockDatabaseService.user.findUnique.mockResolvedValue({
+          ...mockUser,
+          mfaEnabled: true,
+          organization: mockOrganization,
+        });
+        (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+
+        await expect(service.login(loginDto)).rejects.toThrow(UnauthorizedException);
+        expect(mockMfaService.resolveLoginBranch).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('issueSessionForUser (MFA completion)', () => {
+      it('issues the normal session (token + user + expiresIn) and bumps lastLoginAt', async () => {
+        mockDatabaseService.user.findUnique.mockResolvedValue({
+          ...mockUser,
+          organization: mockOrganization,
+        });
+        mockDatabaseService.user.update.mockResolvedValue(mockUser);
+        mockDatabaseService.auditLog.create.mockResolvedValue({});
+
+        const result: any = await service.issueSessionForUser('user-123', {});
+
+        expect(result).toHaveProperty('token', 'mock-jwt-token');
+        expect(result).toHaveProperty('expiresIn', getAccessTokenTtlSeconds());
+        expect(result.user).toBeDefined();
+        expect(mockDatabaseService.user.update).toHaveBeenCalledWith(
+          expect.objectContaining({ where: { id: 'user-123' } }),
+        );
+      });
+
+      it('rejects an inactive/missing user', async () => {
+        mockDatabaseService.user.findUnique.mockResolvedValue(null);
+        await expect(service.issueSessionForUser('gone', {})).rejects.toThrow(
+          UnauthorizedException,
+        );
+      });
     });
 
     it('normalizes email (lowercase + trim) for both user lookup and lockout key', async () => {
@@ -1357,6 +1477,79 @@ describe('AuthService', () => {
 
       await expect(service.googleLogin('malformed')).rejects.toThrow(UnauthorizedException);
       await expect(service.googleLogin('malformed')).rejects.toThrow('Invalid Google token');
+    });
+
+    describe('MFA branch (S1 — Google login is gated like password login)', () => {
+      it('MFA-enrolled Google user gets a challenge token and NO session (no token, no cookie)', async () => {
+        mockGoogleSuccess(buildGooglePayload());
+        const oauthUser = {
+          ...mockUser,
+          passwordHash: '', // OAuth user has no password
+          mfaEnabled: true,
+          organization: mockOrganization,
+        };
+        mockDatabaseService.user.findUnique.mockResolvedValue(oauthUser);
+        mockMfaService.resolveLoginBranch.mockReturnValue({
+          kind: 'challenge',
+          challengeToken: 'chal.jwt',
+        });
+
+        const result: any = await service.googleLogin(FAKE_TOKEN, googleLoginContext);
+
+        expect(result).toEqual({ mfaRequired: true, challengeToken: 'chal.jwt' });
+        expect(result).not.toHaveProperty('token');
+        expect(result).not.toHaveProperty('user');
+        // resolveLoginBranch was given the user with organization loaded.
+        expect(mockMfaService.resolveLoginBranch).toHaveBeenCalledWith(oauthUser);
+        // No session minted: no lastLoginAt bump, no JWT signed, no login audit.
+        expect(mockDatabaseService.user.update).not.toHaveBeenCalled();
+        expect(mockJwtService.sign).not.toHaveBeenCalled();
+        expect(mockDatabaseService.auditLog.create).not.toHaveBeenCalled();
+      });
+
+      it('unenrolled Google user in an mfaRequired org gets an enrollment token and NO session', async () => {
+        mockGoogleSuccess(buildGooglePayload());
+        const oauthUser = {
+          ...mockUser,
+          passwordHash: '',
+          mfaEnabled: false,
+          organization: { ...mockOrganization, mfaRequired: true },
+        };
+        mockDatabaseService.user.findUnique.mockResolvedValue(oauthUser);
+        mockMfaService.resolveLoginBranch.mockReturnValue({
+          kind: 'enroll',
+          enrollmentToken: 'enr.jwt',
+        });
+
+        const result: any = await service.googleLogin(FAKE_TOKEN, googleLoginContext);
+
+        expect(result).toEqual({ mfaEnrollmentRequired: true, enrollmentToken: 'enr.jwt' });
+        expect(mockDatabaseService.user.update).not.toHaveBeenCalled();
+        expect(mockJwtService.sign).not.toHaveBeenCalled();
+      });
+
+      it('non-MFA Google user is UNCHANGED: still returns a full session token', async () => {
+        mockGoogleSuccess(buildGooglePayload());
+        const oauthUser = {
+          ...mockUser,
+          passwordHash: '',
+          organization: mockOrganization,
+        };
+        mockDatabaseService.user.findUnique.mockResolvedValue(oauthUser);
+        mockDatabaseService.user.update.mockResolvedValue(oauthUser);
+        mockDatabaseService.auditLog.create.mockResolvedValue(googleLoginAuditLog);
+        // Default resolveLoginBranch => { kind: 'none' }.
+
+        const result: any = await service.googleLogin(FAKE_TOKEN, googleLoginContext);
+        await flushLoginAlertTasks();
+
+        expect(result).toHaveProperty('token', 'mock-jwt-token');
+        expect(result).toHaveProperty('user');
+        expect(result).not.toHaveProperty('mfaRequired');
+        expect(result).not.toHaveProperty('mfaEnrollmentRequired');
+        expect(mockDatabaseService.user.update).toHaveBeenCalled();
+        expect(mockJwtService.sign).toHaveBeenCalled();
+      });
     });
   });
 

--- a/middleware/src/modules/auth/auth.service.ts
+++ b/middleware/src/modules/auth/auth.service.ts
@@ -28,6 +28,7 @@ import { StorageService } from '../storage/storage.service';
 import { getCleanupSafeMinioObjectKey, isMinioUrl } from '../storage/minio-object-key';
 import { AlertRulesService } from '../notifications/alert-rules/alert-rules.service';
 import { resolvePublicAppUrl } from '../common/utils/public-app-url';
+import { MfaService } from './mfa/mfa.service';
 
 // Account lockout constants
 const MAX_LOGIN_ATTEMPTS = 10;
@@ -56,6 +57,7 @@ export class AuthService {
     private events: EventEmitter2,
     @Inject(forwardRef(() => AlertRulesService))
     private alertRulesService: AlertRulesService,
+    private mfaService: MfaService,
   ) {}
 
   async register(dto: RegisterDto, clientIp?: string, userAgent?: string | string[]) {
@@ -330,6 +332,22 @@ export class AuthService {
       this.events.emit('user.welcomed', { organizationId: user.organizationId, userId: user.id });
     }
 
+    // MFA branch (auth #2) — route Google login through the SAME gate as
+    // password login. Evaluated AFTER the user is resolved/created + validated
+    // and BEFORE any session/token is minted. `organization` is loaded on both
+    // the existing-user (findUnique include) and auto-register (create include)
+    // branches, so resolveLoginBranch can see org.mfaRequired. For a user who is
+    // NOT MFA-enrolled and whose org does NOT require MFA, resolveLoginBranch
+    // returns { kind: 'none' } and Google login is unchanged: no lastLoginAt
+    // bump and no token are performed here.
+    const mfaBranch = this.mfaService.resolveLoginBranch(user);
+    if (mfaBranch.kind === 'challenge') {
+      return { mfaRequired: true as const, challengeToken: mfaBranch.challengeToken };
+    }
+    if (mfaBranch.kind === 'enroll') {
+      return { mfaEnrollmentRequired: true as const, enrollmentToken: mfaBranch.enrollmentToken };
+    }
+
     // Update last login
     await this.databaseService.user.update({
       where: { id: user.id },
@@ -545,11 +563,77 @@ export class AuthService {
       throw new ForbiddenException('Account is inactive. Contact support.');
     }
 
+    // MFA branch (auth #2). Evaluated AFTER password + isActive verification and
+    // BEFORE any token issuance. For a user who is NOT MFA-enrolled and whose
+    // org does NOT require MFA, resolveLoginBranch returns { kind: 'none' } and
+    // this block is skipped entirely — every statement below runs UNCHANGED, so
+    // non-MFA login is byte-for-byte identical to before this feature.
+    const mfaBranch = this.mfaService.resolveLoginBranch(user);
+    if (mfaBranch.kind !== 'none') {
+      // The password was correct, so clear the password lockout counter exactly
+      // as the normal success path does — a subsequent MFA failure must not be
+      // compounded by the password lock. The login COMPLETES later, at
+      // /auth/mfa/challenge (enrolled) or /auth/mfa/enable (forced enrollment);
+      // no session token is issued here.
+      try {
+        await this.redisService.del(lockoutKey);
+      } catch (error) {
+        this.logger.error(`Failed to clear lockout counter (best-effort): ${error instanceof Error ? error.message : 'Unknown'}`);
+      }
+      if (mfaBranch.kind === 'challenge') {
+        return { mfaRequired: true as const, challengeToken: mfaBranch.challengeToken };
+      }
+      return { mfaEnrollmentRequired: true as const, enrollmentToken: mfaBranch.enrollmentToken };
+    }
+
     // Clear lockout counter on successful login (best-effort cleanup)
     try {
       await this.redisService.del(lockoutKey);
     } catch (error) {
       this.logger.error(`Failed to clear lockout counter (best-effort): ${error instanceof Error ? error.message : 'Unknown'}`);
+    }
+
+    // Update last login timestamp
+    await this.databaseService.user.update({
+      where: { id: user.id },
+      data: { lastLoginAt: new Date() },
+    });
+
+    // Generate JWT token
+    const token = this.generateToken(user, user.organization);
+
+    // Log audit event and run the M12 unrecognized-login alert check.
+    await this.createLoginAuditAndCheckUnrecognizedLogin(user, context);
+
+    return {
+      user: {
+        ...this.sanitizeUser(user),
+        organization: {
+          name: user.organization.name,
+          subscriptionTier: user.organization.subscriptionTier,
+        },
+      },
+      token,
+      expiresIn: getAccessTokenTtlSeconds(),
+    };
+  }
+
+  /**
+   * Complete a login for a user whose second factor has just been satisfied
+   * (MFA challenge success, or forced-enrollment `enable`). Issues the session
+   * EXACTLY as the tail of `login` does — same lastLoginAt update, same
+   * generateToken, same audit + unrecognized-login check, same response shape —
+   * so an MFA login is indistinguishable from a normal login downstream.
+   * The password + second factor were both verified before this is called.
+   */
+  async issueSessionForUser(userId: string, context: LoginContext = {}) {
+    const user = await this.databaseService.user.findUnique({
+      where: { id: userId },
+      include: { organization: true },
+    });
+
+    if (!user || !user.isActive) {
+      throw new UnauthorizedException('User not found or inactive');
     }
 
     // Update last login timestamp
@@ -1294,8 +1378,11 @@ export class AuthService {
     }
   }
 
-  private sanitizeUser(user: { passwordHash?: string | null; [key: string]: unknown }) {
-    const { passwordHash: _, ...sanitized } = user;
+  private sanitizeUser(user: { passwordHash?: string | null; mfaSecret?: string | null; [key: string]: unknown }) {
+    // Strip the password hash AND the encrypted MFA secret (auth #2) — the
+    // ciphertext must never cross the wire in any response body. mfaEnabled /
+    // mfaEnrolledAt are non-sensitive and kept for the UI.
+    const { passwordHash: _pw, mfaSecret: _mfa, ...sanitized } = user;
     return sanitized;
   }
 

--- a/middleware/src/modules/auth/guards/enrollment-or-jwt.guard.ts
+++ b/middleware/src/modules/auth/guards/enrollment-or-jwt.guard.ts
@@ -1,0 +1,47 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { Request } from 'express';
+import { MfaService } from '../mfa/mfa.service';
+
+/** Header carrying the forced-enrollment token (NOT the Authorization header,
+ * so an enrollment token can never be confused with an access token). */
+export const MFA_ENROLLMENT_HEADER = 'x-mfa-enrollment-token';
+
+/**
+ * Guard for the MFA enroll/enable endpoints. Accepts EITHER:
+ *   - a valid enrollment token (x-mfa-enrollment-token header) — the
+ *     forced-enrollment flow, where the user has no session yet; OR
+ *   - a normal session JWT (cookie/Bearer) — voluntary enrollment from settings,
+ *     validated by the full JwtStrategy (revocation + pwd-change checks).
+ *
+ * On the enrollment-token path it sets `request.user = { id, mfaEnrollmentOnly:
+ * true }` so the handler knows the caller is mid-forced-enrollment and must be
+ * handed session tokens once `enable` succeeds.
+ */
+@Injectable()
+export class EnrollmentOrJwtGuard extends AuthGuard('jwt') implements CanActivate {
+  constructor(private readonly mfaService: MfaService) {
+    super();
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest<Request>();
+    const enrollmentToken = req.headers[MFA_ENROLLMENT_HEADER];
+    const raw = Array.isArray(enrollmentToken) ? enrollmentToken[0] : enrollmentToken;
+
+    if (raw && typeof raw === 'string' && raw.length > 0) {
+      // Verify the enrollment token (typed + signed with the derived MFA key).
+      const { userId } = this.mfaService.verifyEnrollmentToken(raw);
+      (req as Request & { user?: unknown }).user = { id: userId, mfaEnrollmentOnly: true };
+      return true;
+    }
+
+    // No enrollment token — fall back to normal session authentication.
+    const result = super.canActivate(context);
+    if (typeof result === 'boolean') return result;
+    if (result instanceof Promise) return result;
+    // Observable → promise
+    const { lastValueFrom } = await import('rxjs');
+    return lastValueFrom(result);
+  }
+}

--- a/middleware/src/modules/auth/mfa/dto/mfa.dto.ts
+++ b/middleware/src/modules/auth/mfa/dto/mfa.dto.ts
@@ -1,0 +1,48 @@
+import { IsBoolean, IsNotEmpty, IsString, MaxLength, MinLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * A single MFA verification code. Accepts EITHER a 6-digit TOTP or a formatted
+ * single-use backup code (e.g. `abcde-12345`), so the bound is loose on purpose.
+ * The service decides which kind it is.
+ */
+export class MfaCodeDto {
+  @ApiProperty({ description: 'A 6-digit TOTP code or a single-use backup code', example: '123456' })
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(4)
+  @MaxLength(64)
+  code: string;
+}
+
+/** Body for POST /auth/mfa/enable — verifies the pending secret. */
+export class EnableMfaDto extends MfaCodeDto {}
+
+/** Body for POST /auth/mfa/disable — requires a valid TOTP or backup code. */
+export class DisableMfaDto extends MfaCodeDto {}
+
+/** Body for POST /auth/mfa/backup-codes/regenerate — requires a valid TOTP. */
+export class RegenerateBackupCodesDto extends MfaCodeDto {}
+
+/** Body for POST /auth/mfa/challenge — completes an MFA-gated login. */
+export class MfaChallengeDto {
+  @ApiProperty({ description: 'The short-lived challenge token returned by /auth/login' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(4096)
+  challengeToken: string;
+
+  @ApiProperty({ description: 'A 6-digit TOTP code or a single-use backup code', example: '123456' })
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(4)
+  @MaxLength(64)
+  code: string;
+}
+
+/** Body for the org admin endpoint that toggles per-org MFA enforcement. */
+export class SetMfaRequiredDto {
+  @ApiProperty({ description: 'Whether all members of the org must use MFA', example: true })
+  @IsBoolean()
+  mfaRequired: boolean;
+}

--- a/middleware/src/modules/auth/mfa/mfa-crypto.spec.ts
+++ b/middleware/src/modules/auth/mfa/mfa-crypto.spec.ts
@@ -1,0 +1,86 @@
+import {
+  decryptSecret,
+  encryptSecret,
+  getMfaTokenSecret,
+  hashBackupCode,
+  isMfaEncryptionConfigured,
+  normalizeBackupCode,
+} from './mfa-crypto';
+
+describe('mfa-crypto', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    process.env.MFA_ENCRYPTION_KEY = 'a'.repeat(64);
+    process.env.JWT_SECRET = 'b'.repeat(64);
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  describe('AES-256-GCM secret encryption', () => {
+    it('round-trips a secret through encrypt -> decrypt', () => {
+      const plaintext = 'JBSWY3DPEHPK3PXP';
+      const ciphertext = encryptSecret(plaintext);
+      expect(ciphertext).not.toContain(plaintext);
+      expect(decryptSecret(ciphertext)).toBe(plaintext);
+    });
+
+    it('produces the iv:tag:ciphertext hex format with a random IV each time', () => {
+      const a = encryptSecret('same-secret');
+      const b = encryptSecret('same-secret');
+      expect(a.split(':')).toHaveLength(3);
+      expect(a.split(':').every((p) => /^[0-9a-f]+$/.test(p))).toBe(true);
+      // Random IV => two encryptions of the same plaintext differ.
+      expect(a).not.toBe(b);
+    });
+
+    it('rejects a tampered ciphertext (GCM auth tag)', () => {
+      const ciphertext = encryptSecret('tamper-me');
+      const [iv, tag, data] = ciphertext.split(':');
+      // Flip a byte in the data.
+      const flipped = (parseInt(data.slice(0, 2), 16) ^ 0xff).toString(16).padStart(2, '0');
+      const tampered = `${iv}:${tag}:${flipped}${data.slice(2)}`;
+      expect(() => decryptSecret(tampered)).toThrow();
+    });
+
+    it('FAIL-CLOSED: encrypt throws when MFA_ENCRYPTION_KEY is missing/short', () => {
+      delete process.env.MFA_ENCRYPTION_KEY;
+      expect(isMfaEncryptionConfigured()).toBe(false);
+      expect(() => encryptSecret('x')).toThrow(/MFA_ENCRYPTION_KEY/);
+
+      process.env.MFA_ENCRYPTION_KEY = 'too-short';
+      expect(isMfaEncryptionConfigured()).toBe(false);
+      expect(() => encryptSecret('x')).toThrow(/MFA_ENCRYPTION_KEY/);
+    });
+  });
+
+  describe('MFA token signing secret', () => {
+    it('derives deterministically from JWT_SECRET but is NOT equal to it', () => {
+      const s1 = getMfaTokenSecret();
+      const s2 = getMfaTokenSecret();
+      expect(s1).toBe(s2);
+      expect(s1).not.toBe(process.env.JWT_SECRET);
+    });
+
+    it('changes when JWT_SECRET changes (bound to the access-token key)', () => {
+      const s1 = getMfaTokenSecret();
+      process.env.JWT_SECRET = 'c'.repeat(64);
+      expect(getMfaTokenSecret()).not.toBe(s1);
+    });
+  });
+
+  describe('backup code hashing', () => {
+    it('normalizes formatting + case before hashing', () => {
+      expect(normalizeBackupCode('ABcde-12345')).toBe('abcde12345');
+      expect(hashBackupCode('ABcde-12345')).toBe(hashBackupCode('abcde 12345'));
+    });
+
+    it('produces a 64-char sha256 hex that is not the plaintext', () => {
+      const h = hashBackupCode('abcde-12345');
+      expect(h).toMatch(/^[0-9a-f]{64}$/);
+      expect(h).not.toContain('abcde');
+    });
+  });
+});

--- a/middleware/src/modules/auth/mfa/mfa-crypto.ts
+++ b/middleware/src/modules/auth/mfa/mfa-crypto.ts
@@ -1,0 +1,93 @@
+/**
+ * Cryptographic helpers for MFA (auth #2). Standalone (no NestJS imports) so
+ * the service and its tests can import without a DI graph.
+ *
+ * Two independent secrets:
+ *  1. TOTP secret encryption — AES-256-GCM keyed off MFA_ENCRYPTION_KEY. The
+ *     base32 TOTP secret is encrypted at rest; plaintext exists only transiently
+ *     in memory during enroll/verify. FAIL-CLOSED: a missing/short key throws,
+ *     so any MFA operation refuses to run rather than persist a plaintext secret.
+ *  2. MFA challenge/enrollment token signing — a key DERIVED from JWT_SECRET via
+ *     HMAC with a fixed label. Tokens signed with this key can NEVER be verified
+ *     under JWT_SECRET, so an MFA token presented as an access token fails
+ *     signature verification in JwtStrategy before `validate()` is even reached.
+ *     This is the PRIMARY guarantee that a challenge/enrollment token cannot be
+ *     used as a session token (the explicit type check in JwtStrategy is
+ *     belt-and-suspenders on top).
+ */
+import * as crypto from 'crypto';
+
+const MIN_ENCRYPTION_KEY_LENGTH = 32;
+const GCM_IV_BYTES = 12;
+const MFA_TOKEN_SECRET_LABEL = 'vizora-mfa-token-v1';
+
+/**
+ * Resolve the 32-byte AES key from MFA_ENCRYPTION_KEY. Fail-closed: throws if
+ * the env var is missing or shorter than 32 chars. sha256 normalizes any
+ * sufficiently-long input to exactly 32 bytes.
+ */
+function getEncryptionKey(): Buffer {
+  const raw = process.env.MFA_ENCRYPTION_KEY;
+  if (!raw || raw.length < MIN_ENCRYPTION_KEY_LENGTH) {
+    throw new Error(
+      `MFA_ENCRYPTION_KEY must be set and at least ${MIN_ENCRYPTION_KEY_LENGTH} characters to use MFA`,
+    );
+  }
+  return crypto.createHash('sha256').update(raw, 'utf8').digest();
+}
+
+/** True when a usable MFA_ENCRYPTION_KEY is configured (for fail-closed guards). */
+export function isMfaEncryptionConfigured(): boolean {
+  const raw = process.env.MFA_ENCRYPTION_KEY;
+  return typeof raw === 'string' && raw.length >= MIN_ENCRYPTION_KEY_LENGTH;
+}
+
+/** Encrypt a TOTP secret. Returns `iv:tag:ciphertext` (all hex). */
+export function encryptSecret(plaintext: string): string {
+  const key = getEncryptionKey();
+  const iv = crypto.randomBytes(GCM_IV_BYTES);
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+  const enc = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `${iv.toString('hex')}:${tag.toString('hex')}:${enc.toString('hex')}`;
+}
+
+/** Decrypt an `iv:tag:ciphertext` payload produced by encryptSecret. */
+export function decryptSecret(payload: string): string {
+  const key = getEncryptionKey();
+  const parts = payload.split(':');
+  if (parts.length !== 3) {
+    throw new Error('Malformed encrypted MFA secret');
+  }
+  const [ivHex, tagHex, dataHex] = parts;
+  const iv = Buffer.from(ivHex, 'hex');
+  const tag = Buffer.from(tagHex, 'hex');
+  const data = Buffer.from(dataHex, 'hex');
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(data), decipher.final()]).toString('utf8');
+}
+
+/**
+ * Signing secret for MFA challenge/enrollment JWTs, derived from JWT_SECRET.
+ * Cryptographically independent of the access-token key: an attacker cannot
+ * derive it without JWT_SECRET, and JwtStrategy (which verifies with JWT_SECRET)
+ * cannot verify a token signed with it.
+ */
+export function getMfaTokenSecret(): string {
+  const jwtSecret = process.env.JWT_SECRET;
+  if (!jwtSecret || jwtSecret.length < MIN_ENCRYPTION_KEY_LENGTH) {
+    throw new Error('JWT_SECRET must be set to issue MFA tokens');
+  }
+  return crypto.createHmac('sha256', jwtSecret).update(MFA_TOKEN_SECRET_LABEL).digest('hex');
+}
+
+/** Normalize a backup code (strip separators, lowercase) before hashing/compare. */
+export function normalizeBackupCode(code: string): string {
+  return code.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
+}
+
+/** SHA-256 hex of a normalized backup code (what we store — never the plaintext). */
+export function hashBackupCode(code: string): string {
+  return crypto.createHash('sha256').update(normalizeBackupCode(code)).digest('hex');
+}

--- a/middleware/src/modules/auth/mfa/mfa.constants.ts
+++ b/middleware/src/modules/auth/mfa/mfa.constants.ts
@@ -1,0 +1,55 @@
+/**
+ * MFA (auth #2) constants. Centralized so token lifetimes, lockout thresholds,
+ * and the TOTP config are a single source of truth across the service, guard,
+ * and tests.
+ */
+export const MFA_CONSTANTS = {
+  /** Login-challenge token lifetime. Short-lived (spec: <= 5 min). */
+  CHALLENGE_TOKEN_TTL_SECONDS: 5 * 60,
+
+  /**
+   * Forced-enrollment token lifetime. Slightly longer than the challenge —
+   * enrollment is a two-step flow (enroll -> scan QR in an authenticator app ->
+   * enable), which takes longer than typing one code.
+   */
+  ENROLLMENT_TOKEN_TTL_SECONDS: 15 * 60,
+
+  /** JWT `type` claim values for the two MFA token kinds. */
+  CHALLENGE_TOKEN_TYPE: 'mfa_challenge',
+  ENROLLMENT_TOKEN_TYPE: 'mfa_enrollment',
+
+  /** Number of single-use backup codes issued when MFA is enabled. */
+  BACKUP_CODE_COUNT: 10,
+
+  /**
+   * Max failed code attempts against a single challenge token before it locks.
+   * Combined with the endpoint @Throttle, this caps brute force of the 10^6 TOTP
+   * space per challenge. Defence-in-depth ONLY — a fresh /auth/login mints a new
+   * jti, so this per-token counter alone does not bound a determined attacker.
+   */
+  MAX_CHALLENGE_ATTEMPTS: 5,
+
+  /**
+   * Max failed login-challenge attempts per USER per window — the REAL
+   * brute-force bound. Keyed on userId (NOT the token jti), so re-logging-in to
+   * mint a fresh challenge token cannot reset the budget. Cleared on a
+   * successful challenge.
+   */
+  MAX_CHALLENGE_ATTEMPTS_PER_USER: 10,
+  CHALLENGE_LOCKOUT_SECONDS: 15 * 60,
+
+  /** Max failed verify attempts (enable/disable/regenerate) per user per window. */
+  MAX_VERIFY_ATTEMPTS: 10,
+  VERIFY_LOCKOUT_SECONDS: 15 * 60,
+
+  /**
+   * TOTP config — standard RFC 6238: SHA1, 6 digits, 30s step, window +/-1 (one
+   * step of clock skew tolerance each side; NOT a wide window).
+   */
+  TOTP_DIGITS: 6,
+  TOTP_STEP_SECONDS: 30,
+  TOTP_WINDOW: 1,
+
+  /** Issuer label shown in the authenticator app (otpauth `issuer`). */
+  TOTP_ISSUER: 'Vizora',
+} as const;

--- a/middleware/src/modules/auth/mfa/mfa.service.spec.ts
+++ b/middleware/src/modules/auth/mfa/mfa.service.spec.ts
@@ -1,0 +1,322 @@
+import { JwtService } from '@nestjs/jwt';
+import {
+  BadRequestException,
+  HttpException,
+  ServiceUnavailableException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { generate, generateSecret } from 'otplib';
+import { MfaService } from './mfa.service';
+import { MFA_CONSTANTS } from './mfa.constants';
+import { encryptSecret } from './mfa-crypto';
+
+describe('MfaService', () => {
+  let service: MfaService;
+  let mockDb: any;
+  let mockRedis: any;
+  let jwt: JwtService;
+  let secret: string;
+  let validCode: string;
+
+  const WRONG_CODE = 'wrongcode'; // not 6 digits + no backup match => always invalid
+
+  beforeAll(() => {
+    process.env.MFA_ENCRYPTION_KEY = 'a'.repeat(64);
+    process.env.JWT_SECRET = 'b'.repeat(64);
+  });
+
+  beforeEach(async () => {
+    mockDb = {
+      user: { findUnique: jest.fn(), update: jest.fn().mockResolvedValue({}) },
+      mfaBackupCode: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+        deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+        createMany: jest.fn().mockResolvedValue({ count: 10 }),
+        count: jest.fn().mockResolvedValue(10),
+      },
+      $transaction: jest.fn((arg: any) =>
+        Array.isArray(arg) ? Promise.all(arg) : arg(mockDb),
+      ),
+    };
+    mockRedis = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue('OK'),
+      exists: jest.fn().mockResolvedValue(0),
+      incr: jest.fn().mockResolvedValue(1),
+      incrementWithTtl: jest.fn().mockResolvedValue(1),
+      setIfNotExists: jest.fn().mockResolvedValue(true),
+      expire: jest.fn().mockResolvedValue(1),
+      del: jest.fn().mockResolvedValue(1),
+    };
+    jwt = new JwtService({});
+    service = new MfaService(mockDb, jwt, mockRedis);
+
+    secret = generateSecret();
+    validCode = await generate({ secret });
+  });
+
+  describe('enroll', () => {
+    it('stores a PENDING encrypted secret and returns an otpauth URL + QR (does not enable)', async () => {
+      mockDb.user.findUnique.mockResolvedValue({ mfaEnabled: false, email: 'u@e.com' });
+
+      const result = await service.enroll('u1');
+
+      expect(result.otpauthUrl).toContain('otpauth://totp/');
+      expect(result.qrDataUrl).toMatch(/^data:image\/png;base64,/);
+      const update = mockDb.user.update.mock.calls[0][0];
+      expect(update.data.mfaEnabled).toBe(false);
+      expect(update.data.mfaSecret).toEqual(expect.stringMatching(/^[0-9a-f]+:[0-9a-f]+:[0-9a-f]+$/));
+      // The stored value is ciphertext, never the raw base32 secret.
+      expect(update.data.mfaSecret).not.toContain(':undefined');
+    });
+
+    it('rejects enrollment when MFA is already enabled', async () => {
+      mockDb.user.findUnique.mockResolvedValue({ mfaEnabled: true, email: 'u@e.com' });
+      await expect(service.enroll('u1')).rejects.toThrow(BadRequestException);
+    });
+
+    it('FAIL-CLOSED: refuses when MFA_ENCRYPTION_KEY is unset', async () => {
+      const saved = process.env.MFA_ENCRYPTION_KEY;
+      delete process.env.MFA_ENCRYPTION_KEY;
+      await expect(service.enroll('u1')).rejects.toThrow(ServiceUnavailableException);
+      process.env.MFA_ENCRYPTION_KEY = saved;
+    });
+  });
+
+  describe('enable', () => {
+    beforeEach(() => {
+      mockDb.user.findUnique.mockResolvedValue({
+        mfaEnabled: false,
+        mfaSecret: encryptSecret(secret),
+      });
+    });
+
+    it('enables MFA on a valid code and returns 10 one-time backup codes', async () => {
+      const result = await service.enable('u1', validCode);
+      expect(result.backupCodes).toHaveLength(MFA_CONSTANTS.BACKUP_CODE_COUNT);
+      expect(mockDb.user.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ mfaEnabled: true }) }),
+      );
+      expect(mockDb.mfaBackupCode.createMany).toHaveBeenCalled();
+      // Backup codes are returned in plaintext but stored as sha256 hashes.
+      const rows = mockDb.mfaBackupCode.createMany.mock.calls[0][0].data;
+      expect(rows[0].codeHash).toMatch(/^[0-9a-f]{64}$/);
+      expect(rows[0]).not.toHaveProperty('code');
+    });
+
+    it('rejects an invalid code and records a verify failure', async () => {
+      await expect(service.enable('u1', WRONG_CODE)).rejects.toThrow(UnauthorizedException);
+      expect(mockRedis.incr).toHaveBeenCalledWith('mfa_verify_fail:u1');
+      expect(mockDb.user.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects when there is no pending secret', async () => {
+      mockDb.user.findUnique.mockResolvedValue({ mfaEnabled: false, mfaSecret: null });
+      await expect(service.enable('u1', validCode)).rejects.toThrow(BadRequestException);
+    });
+
+    it('locks out after too many failed verify attempts', async () => {
+      mockRedis.get.mockResolvedValue(String(MFA_CONSTANTS.MAX_VERIFY_ATTEMPTS));
+      await expect(service.enable('u1', validCode)).rejects.toThrow(HttpException);
+    });
+  });
+
+  describe('disable', () => {
+    beforeEach(() => {
+      mockDb.user.findUnique.mockResolvedValue({
+        mfaEnabled: true,
+        mfaSecret: encryptSecret(secret),
+      });
+    });
+
+    it('disables on a valid TOTP and clears secret + backup codes', async () => {
+      await service.disable('u1', validCode);
+      expect(mockDb.$transaction).toHaveBeenCalled();
+    });
+
+    it('disables on a valid unused backup code', async () => {
+      mockDb.mfaBackupCode.findFirst.mockResolvedValue({ id: 'bc1' });
+      mockDb.mfaBackupCode.updateMany.mockResolvedValue({ count: 1 });
+      await service.disable('u1', 'abcde-12345');
+      expect(mockDb.mfaBackupCode.updateMany).toHaveBeenCalled();
+      expect(mockDb.$transaction).toHaveBeenCalled();
+    });
+
+    it('rejects an invalid code', async () => {
+      await expect(service.disable('u1', WRONG_CODE)).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('rejects when MFA is not enabled', async () => {
+      mockDb.user.findUnique.mockResolvedValue({ mfaEnabled: false, mfaSecret: null });
+      await expect(service.disable('u1', validCode)).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('status', () => {
+    it('returns enabled + remaining backup codes', async () => {
+      mockDb.user.findUnique.mockResolvedValue({ mfaEnabled: true });
+      mockDb.mfaBackupCode.count.mockResolvedValue(7);
+      expect(await service.status('u1')).toEqual({ enabled: true, backupCodesRemaining: 7 });
+    });
+
+    it('reports 0 remaining when disabled', async () => {
+      mockDb.user.findUnique.mockResolvedValue({ mfaEnabled: false });
+      expect(await service.status('u1')).toEqual({ enabled: false, backupCodesRemaining: 0 });
+    });
+  });
+
+  describe('regenerateBackupCodes', () => {
+    it('requires a valid TOTP and issues a fresh set', async () => {
+      mockDb.user.findUnique.mockResolvedValue({ mfaEnabled: true, mfaSecret: encryptSecret(secret) });
+      const result = await service.regenerateBackupCodes('u1', validCode);
+      expect(result.backupCodes).toHaveLength(MFA_CONSTANTS.BACKUP_CODE_COUNT);
+      expect(mockDb.mfaBackupCode.deleteMany).toHaveBeenCalledWith({ where: { userId: 'u1' } });
+    });
+
+    it('rejects an invalid TOTP', async () => {
+      mockDb.user.findUnique.mockResolvedValue({ mfaEnabled: true, mfaSecret: encryptSecret(secret) });
+      await expect(service.regenerateBackupCodes('u1', WRONG_CODE)).rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  describe('challenge tokens', () => {
+    beforeEach(() => {
+      mockDb.user.findUnique.mockResolvedValue({
+        mfaEnabled: true,
+        mfaSecret: encryptSecret(secret),
+        isActive: true,
+      });
+    });
+
+    it('verifies a valid TOTP and atomically claims the single-use marker', async () => {
+      const token = service.issueChallengeToken('u1');
+      const result = await service.verifyChallenge(token, validCode);
+      expect(result).toEqual({ userId: 'u1' });
+      // Single-use is an atomic SET NX claim (not a plain set), so there is no
+      // exists-then-set TOCTOU window.
+      expect(mockRedis.setIfNotExists).toHaveBeenCalledWith(
+        expect.stringMatching(/^mfa_chal_used:/),
+        '1',
+        MFA_CONSTANTS.CHALLENGE_TOKEN_TTL_SECONDS,
+      );
+      // Success clears the per-USER failure counter (not the per-jti one).
+      expect(mockRedis.del).toHaveBeenCalledWith('mfa_chal_user_fail:u1');
+    });
+
+    it('consumes an unused backup code as the second factor', async () => {
+      mockDb.mfaBackupCode.findFirst.mockResolvedValue({ id: 'bc1' });
+      mockDb.mfaBackupCode.updateMany.mockResolvedValue({ count: 1 });
+      const token = service.issueChallengeToken('u1');
+      const result = await service.verifyChallenge(token, 'abcde-12345');
+      expect(result).toEqual({ userId: 'u1' });
+      expect(mockDb.mfaBackupCode.updateMany).toHaveBeenCalled();
+    });
+
+    it('rejects a wrong code and atomically increments BOTH the per-user and per-jti counters', async () => {
+      const token = service.issueChallengeToken('u1');
+      await expect(service.verifyChallenge(token, WRONG_CODE)).rejects.toThrow(UnauthorizedException);
+      // Per-USER counter (the real bound) — keyed on userId, atomic INCR+TTL.
+      expect(mockRedis.incrementWithTtl).toHaveBeenCalledWith(
+        'mfa_chal_user_fail:u1',
+        MFA_CONSTANTS.CHALLENGE_LOCKOUT_SECONDS,
+      );
+      // Per-jti counter (defence in depth).
+      expect(mockRedis.incrementWithTtl).toHaveBeenCalledWith(
+        expect.stringMatching(/^mfa_chal_fail:/),
+        MFA_CONSTANTS.CHALLENGE_TOKEN_TTL_SECONDS,
+      );
+    });
+
+    it('rejects a replayed challenge via the atomic NX claim (setIfNotExists=false)', async () => {
+      // The code is correct, but the used-marker is already claimed → the
+      // atomic SET NX loses → this is a replay, reject with 401. No reliance on
+      // a separate exists() pre-check.
+      mockRedis.setIfNotExists.mockResolvedValue(false);
+      const token = service.issueChallengeToken('u1');
+      await expect(service.verifyChallenge(token, validCode)).rejects.toThrow(/already been used/);
+      expect(mockRedis.setIfNotExists).toHaveBeenCalledWith(
+        expect.stringMatching(/^mfa_chal_used:/),
+        '1',
+        MFA_CONSTANTS.CHALLENGE_TOKEN_TTL_SECONDS,
+      );
+    });
+
+    it('is per-USER keyed: a fresh challenge token does NOT reset the lockout', async () => {
+      // The per-user counter is already at the cap. A brand-new challenge token
+      // (different jti, per-jti counter empty) must STILL be locked — proving
+      // the bound survives minting a fresh token.
+      mockRedis.get.mockImplementation((key: string) =>
+        Promise.resolve(
+          key === 'mfa_chal_user_fail:u1'
+            ? String(MFA_CONSTANTS.MAX_CHALLENGE_ATTEMPTS_PER_USER)
+            : null,
+        ),
+      );
+      const freshToken = service.issueChallengeToken('u1');
+      await expect(service.verifyChallenge(freshToken, validCode)).rejects.toThrow(HttpException);
+      // Rejected at the per-user gate — the code was never even verified.
+      expect(mockRedis.setIfNotExists).not.toHaveBeenCalled();
+    });
+
+    it('locks the challenge after too many failed attempts', async () => {
+      mockRedis.get.mockResolvedValue(String(MFA_CONSTANTS.MAX_CHALLENGE_ATTEMPTS));
+      const token = service.issueChallengeToken('u1');
+      await expect(service.verifyChallenge(token, validCode)).rejects.toThrow(HttpException);
+    });
+
+    it('rejects a forged / wrong-secret challenge token', async () => {
+      const forged = jwt.sign(
+        { sub: 'u1', type: MFA_CONSTANTS.CHALLENGE_TOKEN_TYPE, jti: 'x' },
+        { secret: 'not-the-derived-mfa-secret-000000000000', expiresIn: 60 },
+      );
+      await expect(service.verifyChallenge(forged, validCode)).rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  describe('token typing (challenge vs enrollment cannot be swapped)', () => {
+    it('verifyEnrollmentToken accepts an enrollment token and rejects a challenge token', () => {
+      const enroll = service.issueEnrollmentToken('u1');
+      expect(service.verifyEnrollmentToken(enroll)).toEqual({ userId: 'u1' });
+
+      const challenge = service.issueChallengeToken('u1');
+      expect(() => service.verifyEnrollmentToken(challenge)).toThrow(UnauthorizedException);
+    });
+
+    it('verifyChallenge rejects an enrollment token used as a challenge token', async () => {
+      mockDb.user.findUnique.mockResolvedValue({
+        mfaEnabled: true,
+        mfaSecret: encryptSecret(secret),
+        isActive: true,
+      });
+      const enroll = service.issueEnrollmentToken('u1');
+      await expect(service.verifyChallenge(enroll, validCode)).rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  describe('resolveLoginBranch', () => {
+    it('returns none for a non-MFA user in a non-requiring org', () => {
+      expect(
+        service.resolveLoginBranch({ id: 'u1', mfaEnabled: false, organization: { mfaRequired: false } }),
+      ).toEqual({ kind: 'none' });
+    });
+
+    it('returns a challenge for an enrolled user', () => {
+      const branch = service.resolveLoginBranch({
+        id: 'u1',
+        mfaEnabled: true,
+        organization: { mfaRequired: false },
+      });
+      expect(branch.kind).toBe('challenge');
+    });
+
+    it('returns enroll when the org requires MFA and the user is not enrolled', () => {
+      const branch = service.resolveLoginBranch({
+        id: 'u1',
+        mfaEnabled: false,
+        organization: { mfaRequired: true },
+      });
+      expect(branch.kind).toBe('enroll');
+    });
+  });
+});

--- a/middleware/src/modules/auth/mfa/mfa.service.ts
+++ b/middleware/src/modules/auth/mfa/mfa.service.ts
@@ -1,0 +1,534 @@
+import {
+  BadRequestException,
+  HttpException,
+  HttpStatus,
+  Injectable,
+  Logger,
+  ServiceUnavailableException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import * as crypto from 'crypto';
+import { generateSecret, generateURI, verify as verifyTotpCode } from 'otplib';
+import * as QRCode from 'qrcode';
+import { DatabaseService } from '../../database/database.service';
+import { RedisService } from '../../redis/redis.service';
+import { MFA_CONSTANTS } from './mfa.constants';
+import {
+  decryptSecret,
+  encryptSecret,
+  getMfaTokenSecret,
+  hashBackupCode,
+  isMfaEncryptionConfigured,
+} from './mfa-crypto';
+
+/** Payload of the MFA challenge / enrollment JWTs (signed with a derived key). */
+interface MfaTokenPayload {
+  sub: string;
+  type: string;
+  jti: string;
+  iat?: number;
+  exp?: number;
+}
+
+/**
+ * MFA (auth #2) domain service — TOTP enroll/enable/disable/status, single-use
+ * backup codes, login-challenge verification, and the short-lived challenge /
+ * enrollment tokens.
+ *
+ * SECURITY POSTURE:
+ *  - The TOTP secret is AES-256-GCM encrypted at rest (mfa-crypto). Plaintext
+ *    exists only transiently in memory during enroll/verify. Fail-closed: if
+ *    MFA_ENCRYPTION_KEY is missing, every MFA operation refuses to run.
+ *  - Backup codes are sha256-hashed, single-use (usedAt), never stored plaintext.
+ *  - Challenge/enrollment tokens are typed JWTs signed with a key DERIVED from
+ *    JWT_SECRET (getMfaTokenSecret), so they cannot authenticate as access
+ *    tokens. Challenge tokens are strictly single-use (Redis jti marker) and
+ *    lock after K failed attempts.
+ *  - No secret or code material is ever logged or returned except the one-time
+ *    backup-code display and the enroll QR/secret.
+ */
+@Injectable()
+export class MfaService {
+  private readonly logger = new Logger(MfaService.name);
+
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly jwtService: JwtService,
+    private readonly redisService: RedisService,
+  ) {}
+
+  // ---------------------------------------------------------------------------
+  // Fail-closed guard
+  // ---------------------------------------------------------------------------
+
+  private assertConfigured(): void {
+    if (!isMfaEncryptionConfigured()) {
+      // 503, not 500: this is a server-config gap, not a client error. Never
+      // proceed — refusing is the fail-closed behavior (no plaintext secrets).
+      throw new ServiceUnavailableException('MFA is not configured on this server');
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // TOTP helpers
+  // ---------------------------------------------------------------------------
+
+  /** Verify a 6-digit TOTP against a plaintext base32 secret (window +/-1 step). */
+  private async verifyTotp(secretPlaintext: string, token: string): Promise<boolean> {
+    // Constant-time comparison is handled inside otplib's verify.
+    const cleaned = token.replace(/\s+/g, '');
+    if (!/^\d{6}$/.test(cleaned)) return false;
+    try {
+      const result = await verifyTotpCode({
+        secret: secretPlaintext,
+        token: cleaned,
+        algorithm: 'sha1',
+        digits: MFA_CONSTANTS.TOTP_DIGITS,
+        period: MFA_CONSTANTS.TOTP_STEP_SECONDS,
+        // epochTolerance is in SECONDS; one step (30s) each side == window +/-1.
+        epochTolerance: MFA_CONSTANTS.TOTP_STEP_SECONDS,
+      });
+      return result.valid === true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Consume a single-use backup code for a user. Atomic: only the first caller
+   * to flip usedAt from null wins, so a code can never be redeemed twice.
+   * Returns true if a matching unused code was consumed.
+   */
+  private async consumeBackupCode(userId: string, code: string): Promise<boolean> {
+    const codeHash = hashBackupCode(code);
+    const match = await this.databaseService.mfaBackupCode.findFirst({
+      where: { userId, codeHash, usedAt: null },
+      select: { id: true },
+    });
+    if (!match) return false;
+    const claimed = await this.databaseService.mfaBackupCode.updateMany({
+      where: { id: match.id, usedAt: null },
+      data: { usedAt: new Date() },
+    });
+    return claimed.count === 1;
+  }
+
+  /** Generate + persist a fresh set of backup codes, returning the plaintext once. */
+  private async generateBackupCodes(userId: string): Promise<string[]> {
+    // Replace any existing codes (regeneration / re-enable).
+    await this.databaseService.mfaBackupCode.deleteMany({ where: { userId } });
+
+    const plaintextCodes: string[] = [];
+    const rows: { userId: string; codeHash: string }[] = [];
+    for (let i = 0; i < MFA_CONSTANTS.BACKUP_CODE_COUNT; i++) {
+      // 10 hex chars, displayed grouped as xxxxx-xxxxx for readability. Hashing
+      // normalizes (strips the dash) so the display format is not significant.
+      const raw = crypto.randomBytes(5).toString('hex');
+      const display = `${raw.slice(0, 5)}-${raw.slice(5)}`;
+      plaintextCodes.push(display);
+      rows.push({ userId, codeHash: hashBackupCode(display) });
+    }
+    await this.databaseService.mfaBackupCode.createMany({ data: rows });
+    return plaintextCodes;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Verify-attempt lockout (enable / disable / regenerate)
+  // ---------------------------------------------------------------------------
+
+  private async assertNotVerifyLocked(userId: string): Promise<void> {
+    const key = `mfa_verify_fail:${userId}`;
+    let fails = 0;
+    try {
+      const raw = await this.redisService.get(key);
+      fails = raw ? parseInt(raw, 10) : 0;
+    } catch {
+      // Redis down — fail OPEN on the lockout read so the user can still verify;
+      // the @Throttle on the endpoint remains the outer brute-force cap.
+      return;
+    }
+    if (fails >= MFA_CONSTANTS.MAX_VERIFY_ATTEMPTS) {
+      throw new HttpException(
+        'Too many incorrect codes. Try again later.',
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+  }
+
+  private async bumpVerifyFailure(userId: string): Promise<void> {
+    const key = `mfa_verify_fail:${userId}`;
+    try {
+      const count = await this.redisService.incr(key);
+      if (count === 1) {
+        await this.redisService.expire(key, MFA_CONSTANTS.VERIFY_LOCKOUT_SECONDS);
+      }
+    } catch {
+      // best-effort
+    }
+  }
+
+  private async clearVerifyFailures(userId: string): Promise<void> {
+    try {
+      await this.redisService.del(`mfa_verify_fail:${userId}`);
+    } catch {
+      // best-effort
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Login-challenge lockout (per USER, not per token)
+  // ---------------------------------------------------------------------------
+  //
+  // The per-jti counter in verifyChallenge is defence-in-depth only: every
+  // /auth/login mints a NEW challenge token (new jti), so a per-token budget
+  // resets at will. These helpers add the REAL bound, keyed on userId, so
+  // re-logging-in cannot reset the counter. Mirrors the mfa_verify_fail pattern.
+
+  private async assertNotChallengeLocked(userId: string): Promise<void> {
+    const key = `mfa_chal_user_fail:${userId}`;
+    let fails = 0;
+    try {
+      const raw = await this.redisService.get(key);
+      fails = raw ? parseInt(raw, 10) : 0;
+    } catch {
+      // Redis down — fail OPEN on the lockout read so a genuine user can still
+      // complete MFA; the @Throttle on /auth/mfa/challenge remains the outer cap.
+      return;
+    }
+    if (fails >= MFA_CONSTANTS.MAX_CHALLENGE_ATTEMPTS_PER_USER) {
+      throw new HttpException(
+        'Too many incorrect codes. Please try again later.',
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+  }
+
+  private async recordChallengeFailure(userId: string): Promise<void> {
+    // Atomic INCR (+ TTL on first hit): N concurrent wrong attempts are each
+    // counted, so a burst of parallel requests cannot all slip under the cap by
+    // racing a read-of-0.
+    try {
+      await this.redisService.incrementWithTtl(
+        `mfa_chal_user_fail:${userId}`,
+        MFA_CONSTANTS.CHALLENGE_LOCKOUT_SECONDS,
+      );
+    } catch {
+      // best-effort
+    }
+  }
+
+  private async clearChallengeFailures(userId: string): Promise<void> {
+    try {
+      await this.redisService.del(`mfa_chal_user_fail:${userId}`);
+    } catch {
+      // best-effort
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Enrollment / management
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Begin enrollment: generate a secret, store it as a PENDING (encrypted,
+   * not-yet-enabled) secret, and return the otpauth URL + QR data URL. Does NOT
+   * enable MFA. Blocked if MFA is already enabled (disable first to re-enroll).
+   */
+  async enroll(userId: string): Promise<{ otpauthUrl: string; qrDataUrl: string }> {
+    this.assertConfigured();
+    const user = await this.databaseService.user.findUnique({
+      where: { id: userId },
+      select: { mfaEnabled: true, email: true },
+    });
+    if (!user) throw new UnauthorizedException('User not found');
+    if (user.mfaEnabled) {
+      throw new BadRequestException('MFA is already enabled. Disable it first to re-enroll.');
+    }
+
+    const secret = generateSecret({ length: 20 });
+    const otpauthUrl = generateURI({
+      strategy: 'totp',
+      issuer: MFA_CONSTANTS.TOTP_ISSUER,
+      label: user.email,
+      secret,
+      algorithm: 'sha1',
+      digits: MFA_CONSTANTS.TOTP_DIGITS,
+      period: MFA_CONSTANTS.TOTP_STEP_SECONDS,
+    });
+
+    // Persist the PENDING secret (encrypted). mfaEnabled stays false, so this is
+    // not yet an active factor — `enable` promotes it after code verification.
+    await this.databaseService.user.update({
+      where: { id: userId },
+      data: { mfaSecret: encryptSecret(secret), mfaEnabled: false, mfaEnrolledAt: null },
+    });
+
+    const qrDataUrl = await QRCode.toDataURL(otpauthUrl);
+    return { otpauthUrl, qrDataUrl };
+  }
+
+  /**
+   * Complete enrollment: verify a TOTP against the pending secret, flip
+   * mfaEnabled, and issue a fresh set of backup codes (returned ONCE).
+   */
+  async enable(userId: string, code: string): Promise<{ backupCodes: string[] }> {
+    this.assertConfigured();
+    await this.assertNotVerifyLocked(userId);
+
+    const user = await this.databaseService.user.findUnique({
+      where: { id: userId },
+      select: { mfaEnabled: true, mfaSecret: true },
+    });
+    if (!user) throw new UnauthorizedException('User not found');
+    if (user.mfaEnabled) throw new BadRequestException('MFA is already enabled');
+    if (!user.mfaSecret) {
+      throw new BadRequestException('No pending enrollment. Call /auth/mfa/enroll first.');
+    }
+
+    const secret = decryptSecret(user.mfaSecret);
+    const valid = await this.verifyTotp(secret, code);
+    if (!valid) {
+      await this.bumpVerifyFailure(userId);
+      throw new UnauthorizedException('Invalid verification code');
+    }
+
+    await this.clearVerifyFailures(userId);
+    await this.databaseService.user.update({
+      where: { id: userId },
+      data: { mfaEnabled: true, mfaEnrolledAt: new Date() },
+    });
+
+    const backupCodes = await this.generateBackupCodes(userId);
+    return { backupCodes };
+  }
+
+  /**
+   * Disable MFA. Requires a valid current TOTP OR an unused backup code. Clears
+   * the secret, backup codes, and mfaEnabled.
+   */
+  async disable(userId: string, code: string): Promise<void> {
+    this.assertConfigured();
+    await this.assertNotVerifyLocked(userId);
+
+    const user = await this.databaseService.user.findUnique({
+      where: { id: userId },
+      select: { mfaEnabled: true, mfaSecret: true },
+    });
+    if (!user) throw new UnauthorizedException('User not found');
+    if (!user.mfaEnabled || !user.mfaSecret) {
+      throw new BadRequestException('MFA is not enabled');
+    }
+
+    const secret = decryptSecret(user.mfaSecret);
+    const totpValid = await this.verifyTotp(secret, code);
+    const ok = totpValid || (await this.consumeBackupCode(userId, code));
+    if (!ok) {
+      await this.bumpVerifyFailure(userId);
+      throw new UnauthorizedException('Invalid verification code');
+    }
+
+    await this.clearVerifyFailures(userId);
+    await this.databaseService.$transaction([
+      this.databaseService.user.update({
+        where: { id: userId },
+        data: { mfaEnabled: false, mfaSecret: null, mfaEnrolledAt: null },
+      }),
+      this.databaseService.mfaBackupCode.deleteMany({ where: { userId } }),
+    ]);
+  }
+
+  /** { enabled, backupCodesRemaining } for the current user. */
+  async status(userId: string): Promise<{ enabled: boolean; backupCodesRemaining: number }> {
+    const user = await this.databaseService.user.findUnique({
+      where: { id: userId },
+      select: { mfaEnabled: true },
+    });
+    if (!user) throw new UnauthorizedException('User not found');
+    const backupCodesRemaining = user.mfaEnabled
+      ? await this.databaseService.mfaBackupCode.count({ where: { userId, usedAt: null } })
+      : 0;
+    return { enabled: user.mfaEnabled, backupCodesRemaining };
+  }
+
+  /** Regenerate backup codes. Requires a valid current TOTP (not a backup code). */
+  async regenerateBackupCodes(userId: string, code: string): Promise<{ backupCodes: string[] }> {
+    this.assertConfigured();
+    await this.assertNotVerifyLocked(userId);
+
+    const user = await this.databaseService.user.findUnique({
+      where: { id: userId },
+      select: { mfaEnabled: true, mfaSecret: true },
+    });
+    if (!user) throw new UnauthorizedException('User not found');
+    if (!user.mfaEnabled || !user.mfaSecret) {
+      throw new BadRequestException('MFA is not enabled');
+    }
+
+    const secret = decryptSecret(user.mfaSecret);
+    const valid = await this.verifyTotp(secret, code);
+    if (!valid) {
+      await this.bumpVerifyFailure(userId);
+      throw new UnauthorizedException('Invalid verification code');
+    }
+
+    await this.clearVerifyFailures(userId);
+    const backupCodes = await this.generateBackupCodes(userId);
+    return { backupCodes };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Challenge / enrollment tokens
+  // ---------------------------------------------------------------------------
+
+  private signMfaToken(userId: string, type: string, ttlSeconds: number): string {
+    return this.jwtService.sign(
+      { sub: userId, type, jti: crypto.randomUUID() },
+      { secret: getMfaTokenSecret(), expiresIn: ttlSeconds, algorithm: 'HS256' },
+    );
+  }
+
+  private verifyMfaToken(token: string, expectedType: string): MfaTokenPayload {
+    let payload: MfaTokenPayload;
+    try {
+      payload = this.jwtService.verify<MfaTokenPayload>(token, {
+        secret: getMfaTokenSecret(),
+        algorithms: ['HS256'],
+      });
+    } catch {
+      throw new UnauthorizedException('Invalid or expired token');
+    }
+    if (!payload || payload.type !== expectedType || !payload.sub || !payload.jti) {
+      throw new UnauthorizedException('Invalid token');
+    }
+    return payload;
+  }
+
+  /** Issue a single-use, short-lived login-challenge token for an enrolled user. */
+  issueChallengeToken(userId: string): string {
+    return this.signMfaToken(
+      userId,
+      MFA_CONSTANTS.CHALLENGE_TOKEN_TYPE,
+      MFA_CONSTANTS.CHALLENGE_TOKEN_TTL_SECONDS,
+    );
+  }
+
+  /** Issue a short-lived enrollment token that authorizes ONLY enroll + enable. */
+  issueEnrollmentToken(userId: string): string {
+    return this.signMfaToken(
+      userId,
+      MFA_CONSTANTS.ENROLLMENT_TOKEN_TYPE,
+      MFA_CONSTANTS.ENROLLMENT_TOKEN_TTL_SECONDS,
+    );
+  }
+
+  /**
+   * Verify an enrollment token and return the bound userId. Used by the guard
+   * on the enroll/enable endpoints in the forced-enrollment flow.
+   */
+  verifyEnrollmentToken(token: string): { userId: string } {
+    const payload = this.verifyMfaToken(token, MFA_CONSTANTS.ENROLLMENT_TOKEN_TYPE);
+    return { userId: payload.sub };
+  }
+
+  /**
+   * Complete an MFA login challenge: verify the challenge token, enforce
+   * single-use + per-challenge lockout, and verify the code as EITHER a TOTP or
+   * an unused backup code (consuming the backup code on use). Returns the userId
+   * on success; the caller then issues the normal session exactly as login does.
+   */
+  async verifyChallenge(challengeToken: string, code: string): Promise<{ userId: string }> {
+    this.assertConfigured();
+    const payload = this.verifyMfaToken(challengeToken, MFA_CONSTANTS.CHALLENGE_TOKEN_TYPE);
+    const { sub: userId, jti } = payload;
+
+    const usedKey = `mfa_chal_used:${jti}`;
+    const failKey = `mfa_chal_fail:${jti}`;
+
+    // Per-USER brute-force lockout (the REAL bound — keyed on userId so a fresh
+    // challenge token cannot reset the budget). Checked first.
+    await this.assertNotChallengeLocked(userId);
+
+    // Per-challenge brute-force lockout (defence in depth — bounds one token).
+    const failRaw = await this.redisService.get(failKey);
+    const fails = failRaw ? parseInt(failRaw, 10) : 0;
+    if (fails >= MFA_CONSTANTS.MAX_CHALLENGE_ATTEMPTS) {
+      throw new HttpException(
+        'Too many incorrect codes for this login. Please log in again.',
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
+    const user = await this.databaseService.user.findUnique({
+      where: { id: userId },
+      select: { mfaEnabled: true, mfaSecret: true, isActive: true },
+    });
+    if (!user || !user.isActive || !user.mfaEnabled || !user.mfaSecret) {
+      // The user disabled MFA or was deactivated after the challenge was issued.
+      throw new UnauthorizedException('MFA is not available for this account');
+    }
+
+    const secret = decryptSecret(user.mfaSecret);
+    const totpValid = await this.verifyTotp(secret, code);
+    const ok = totpValid || (await this.consumeBackupCode(userId, code));
+
+    if (!ok) {
+      // Count the failure against BOTH the per-user bound (real cap) and the
+      // per-jti counter (defence in depth). Both increments are atomic.
+      await this.recordChallengeFailure(userId);
+      await this.redisService.incrementWithTtl(
+        failKey,
+        MFA_CONSTANTS.CHALLENGE_TOKEN_TTL_SECONDS,
+      );
+      throw new UnauthorizedException('Invalid verification code');
+    }
+
+    // Single-use: atomically CLAIM the used-marker (SET NX). The claim happens
+    // AFTER the code is verified (a mistyped code never burns the token) but
+    // BEFORE the session is issued. `setIfNotExists` returns false when the
+    // marker already exists — the token was already consumed → reject as a
+    // replay. Atomic (no exists-then-set TOCTOU) and fail-CLOSED (a Redis error
+    // returns false, so a replay is never allowed through). TTL matches the
+    // token lifetime; by expiry the token is dead anyway, so the marker
+    // self-cleans.
+    const claimed = await this.redisService.setIfNotExists(
+      usedKey,
+      '1',
+      MFA_CONSTANTS.CHALLENGE_TOKEN_TTL_SECONDS,
+    );
+    if (!claimed) {
+      throw new UnauthorizedException('This login challenge has already been used');
+    }
+
+    // Second factor satisfied — clear the per-user challenge failure counter.
+    await this.clearChallengeFailures(userId);
+    return { userId };
+  }
+
+  /**
+   * Decide the MFA branch at login time (called by AuthService.login after the
+   * password + isActive checks pass). Returns:
+   *   - { kind: 'challenge', challengeToken } for an enrolled user, or
+   *   - { kind: 'enroll', enrollmentToken } when the org requires MFA and the
+   *     user is not enrolled, or
+   *   - { kind: 'none' } for a normal (unchanged) login.
+   * Never throws for a normal login — a missing MFA config only matters once a
+   * user is actually enrolled/required.
+   */
+  resolveLoginBranch(user: {
+    id: string;
+    mfaEnabled: boolean;
+    organization: { mfaRequired: boolean };
+  }):
+    | { kind: 'none' }
+    | { kind: 'challenge'; challengeToken: string }
+    | { kind: 'enroll'; enrollmentToken: string } {
+    if (user.mfaEnabled) {
+      return { kind: 'challenge', challengeToken: this.issueChallengeToken(user.id) };
+    }
+    if (user.organization?.mfaRequired) {
+      return { kind: 'enroll', enrollmentToken: this.issueEnrollmentToken(user.id) };
+    }
+    return { kind: 'none' };
+  }
+}

--- a/middleware/src/modules/auth/strategies/jwt.strategy.spec.ts
+++ b/middleware/src/modules/auth/strategies/jwt.strategy.spec.ts
@@ -102,6 +102,35 @@ describe('JwtStrategy', () => {
       });
     });
 
+    describe('MFA tokens (auth #2)', () => {
+      it('rejects an mfa_challenge token as an access token', async () => {
+        const payload: JwtPayload = {
+          sub: 'user-123',
+          email: 'u@e.com',
+          organizationId: 'org-123',
+          role: 'admin',
+          type: 'mfa_challenge',
+        };
+        await expect(strategy.validate(payload)).rejects.toThrow(UnauthorizedException);
+        await expect(strategy.validate(payload)).rejects.toThrow(
+          'MFA tokens are not valid for user authentication',
+        );
+        expect(mockDatabaseService.user.findUnique).not.toHaveBeenCalled();
+      });
+
+      it('rejects an mfa_enrollment token as an access token', async () => {
+        const payload: JwtPayload = {
+          sub: 'user-123',
+          email: 'u@e.com',
+          organizationId: 'org-123',
+          role: 'admin',
+          type: 'mfa_enrollment',
+        };
+        await expect(strategy.validate(payload)).rejects.toThrow(UnauthorizedException);
+        expect(mockDatabaseService.user.findUnique).not.toHaveBeenCalled();
+      });
+    });
+
     describe('user tokens', () => {
       const userPayload: JwtPayload = {
         sub: 'user-123',

--- a/middleware/src/modules/auth/strategies/jwt.strategy.ts
+++ b/middleware/src/modules/auth/strategies/jwt.strategy.ts
@@ -80,6 +80,16 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       throw new UnauthorizedException('Device tokens are not valid for user authentication');
     }
 
+    // Reject MFA challenge/enrollment tokens as access tokens (auth #2). These
+    // are signed with a SEPARATE key derived from JWT_SECRET (getMfaTokenSecret),
+    // so they already fail signature verification here before validate() is
+    // reached — this is belt-and-suspenders so an MFA token can NEVER stand in
+    // for a session token. Existing behavior is unchanged: type-less and 'user'
+    // tokens still pass; only these two new types are rejected.
+    if (payload.type === 'mfa_challenge' || payload.type === 'mfa_enrollment') {
+      throw new UnauthorizedException('MFA tokens are not valid for user authentication');
+    }
+
     // Check if THIS specific token has been revoked (logout / refresh).
     if (payload.jti) {
       const isRevoked = await this.redisService.exists(`revoked_token:${payload.jti}`);

--- a/middleware/src/modules/common/middleware/csrf.middleware.ts
+++ b/middleware/src/modules/common/middleware/csrf.middleware.ts
@@ -78,6 +78,10 @@ export class CsrfMiddleware implements NestMiddleware {
       '/api/v1/auth/google',
       '/api/v1/auth/forgot-password',
       '/api/v1/auth/reset-password',
+      // Public MFA login challenge: carries its own short-lived, single-use
+      // challenge token as the credential (no cookie surface), rate-limited +
+      // per-challenge lockout. Same rationale as login/register above.
+      '/api/v1/auth/mfa/challenge',
       '/api/v1/devices/pairing/request',
       '/api/v1/devices/pairing/status',
       '/api/v1/webhooks/stripe', // Validates X-Stripe-Signature
@@ -87,6 +91,7 @@ export class CsrfMiddleware implements NestMiddleware {
       '/api/auth/google',
       '/api/auth/forgot-password',
       '/api/auth/reset-password',
+      '/api/auth/mfa/challenge',
       '/api/devices/pairing/request',
       '/api/devices/pairing/status',
       '/api/webhooks/stripe',

--- a/middleware/src/modules/organizations/organizations.controller.ts
+++ b/middleware/src/modules/organizations/organizations.controller.ts
@@ -22,6 +22,7 @@ import { CreateOrganizationDto } from './dto/create-organization.dto';
 import { UpdateOrganizationDto } from './dto/update-organization.dto';
 import { UpdateFeatureFlagsDto } from './dto/update-feature-flags.dto';
 import { BrandingConfigDto } from './dto/branding-config.dto';
+import { SetMfaRequiredDto } from '../auth/mfa/dto/mfa.dto';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { RolesGuard } from '../auth/guards/roles.guard';
@@ -70,6 +71,19 @@ export class OrganizationsController {
     @Body() dto: UpdateFeatureFlagsDto,
   ) {
     return this.featureFlagService.setFlags(organizationId, dto as Record<string, boolean>);
+  }
+
+  // Toggle per-org MFA enforcement (auth #2). Org-admin scoped to their OWN org
+  // (organizationId comes from the token, not the body) — a super-admin also
+  // has role 'admin'. RolesGuard enforces the 'admin' role.
+  @Patch('current/mfa-required')
+  @UseGuards(RolesGuard)
+  @Roles('admin')
+  async setMfaRequired(
+    @CurrentUser('organizationId') organizationId: string,
+    @Body() dto: SetMfaRequiredDto,
+  ) {
+    return this.organizationsService.setMfaRequired(organizationId, dto.mfaRequired);
   }
 
   // Get by ID - only allow access to own organization

--- a/middleware/src/modules/organizations/organizations.service.ts
+++ b/middleware/src/modules/organizations/organizations.service.ts
@@ -577,6 +577,21 @@ export class OrganizationsService {
     return this.sanitizeOrg(updated);
   }
 
+  /**
+   * Toggle per-org MFA enforcement (auth #2). When enabled, members who are not
+   * MFA-enrolled are forced through TOTP enrollment before receiving session
+   * tokens on their next login. Returns the resulting flag.
+   */
+  async setMfaRequired(id: string, mfaRequired: boolean): Promise<{ mfaRequired: boolean }> {
+    await this.findOne(id); // 404s for a non-existent org
+    const updated = await this.db.organization.update({
+      where: { id },
+      data: { mfaRequired },
+      select: { mfaRequired: true },
+    });
+    return { mfaRequired: updated.mfaRequired };
+  }
+
   async remove(id: string, requestingUserId?: string) {
     const org = await this.findOne(id);
 

--- a/middleware/src/modules/redis/redis.service.spec.ts
+++ b/middleware/src/modules/redis/redis.service.spec.ts
@@ -11,6 +11,8 @@ jest.mock('ioredis', () => {
     setex: jest.fn().mockResolvedValue('OK'),
     del: jest.fn().mockResolvedValue(1),
     exists: jest.fn(),
+    incr: jest.fn().mockResolvedValue(1),
+    expire: jest.fn().mockResolvedValue(1),
     on: jest.fn(),
   }));
 });
@@ -286,6 +288,77 @@ describe('RedisService', () => {
       it('should return false when client not available', async () => {
         await service.onModuleDestroy();
         const result = await service.exists('test-key');
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('incrementWithTtl', () => {
+      it('increments and sets TTL on the first hit (count === 1)', async () => {
+        const client = service.getClient();
+        (client?.incr as jest.Mock).mockResolvedValue(1);
+
+        const result = await service.incrementWithTtl('counter', 900);
+
+        expect(result).toBe(1);
+        expect(client?.incr).toHaveBeenCalledWith('counter');
+        expect(client?.expire).toHaveBeenCalledWith('counter', 900);
+      });
+
+      it('does NOT reset TTL on subsequent hits (count > 1) — fixed window, not sliding', async () => {
+        const client = service.getClient();
+        (client?.incr as jest.Mock).mockResolvedValue(4);
+
+        const result = await service.incrementWithTtl('counter', 900);
+
+        expect(result).toBe(4);
+        expect(client?.expire).not.toHaveBeenCalled();
+      });
+
+      it('returns 0 on error (best-effort)', async () => {
+        const client = service.getClient();
+        (client?.incr as jest.Mock).mockRejectedValue(new Error('Redis error'));
+
+        const result = await service.incrementWithTtl('counter', 900);
+        expect(result).toBe(0);
+      });
+
+      it('returns 0 when client not available', async () => {
+        await service.onModuleDestroy();
+        const result = await service.incrementWithTtl('counter', 900);
+        expect(result).toBe(0);
+      });
+    });
+
+    describe('setIfNotExists', () => {
+      it('returns true and issues SET NX EX when the key is newly claimed', async () => {
+        const client = service.getClient();
+        (client?.set as jest.Mock).mockResolvedValue('OK');
+
+        const result = await service.setIfNotExists('used-key', '1', 300);
+
+        expect(result).toBe(true);
+        expect(client?.set).toHaveBeenCalledWith('used-key', '1', 'EX', 300, 'NX');
+      });
+
+      it('returns false when the key already exists (SET NX returns null)', async () => {
+        const client = service.getClient();
+        (client?.set as jest.Mock).mockResolvedValue(null);
+
+        const result = await service.setIfNotExists('used-key', '1', 300);
+        expect(result).toBe(false);
+      });
+
+      it('returns false on error (fail CLOSED — never allow the claim through)', async () => {
+        const client = service.getClient();
+        (client?.set as jest.Mock).mockRejectedValue(new Error('Redis error'));
+
+        const result = await service.setIfNotExists('used-key', '1', 300);
+        expect(result).toBe(false);
+      });
+
+      it('returns false when client not available', async () => {
+        await service.onModuleDestroy();
+        const result = await service.setIfNotExists('used-key', '1', 300);
         expect(result).toBe(false);
       });
     });

--- a/middleware/src/modules/redis/redis.service.ts
+++ b/middleware/src/modules/redis/redis.service.ts
@@ -209,6 +209,46 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
     }
   }
 
+  /**
+   * Atomically increment a counter and set its TTL on the first hit. INCR is
+   * atomic server-side, so N concurrent callers each observe a distinct
+   * post-increment value — none can race a read-of-0 (unlike get-then-incr).
+   * The TTL is applied only when the counter is first created (return value 1)
+   * so the window is fixed, not sliding. Returns the new counter value, or 0 if
+   * Redis is unavailable (best-effort, matches `incr`).
+   */
+  async incrementWithTtl(key: string, ttlSeconds: number): Promise<number> {
+    if (!this.client) return 0;
+    try {
+      const count = await this.client.incr(key);
+      if (count === 1) {
+        await this.client.expire(key, ttlSeconds);
+      }
+      return count;
+    } catch (error) {
+      this.logger.error(`Redis INCR/EXPIRE error for key ${key}: ${error}`);
+      return 0;
+    }
+  }
+
+  /**
+   * Atomically claim a key iff it does not already exist (`SET key value NX EX
+   * ttl`). Returns true when this call created the key, false when it already
+   * existed (or on a Redis error). The single round-trip removes the TOCTOU of a
+   * separate exists-then-set, and — because a Redis error returns false — the
+   * caller fails CLOSED (treats the claim as lost) rather than open.
+   */
+  async setIfNotExists(key: string, value: string, ttlSeconds: number): Promise<boolean> {
+    if (!this.client) return false;
+    try {
+      const result = await this.client.set(key, value, 'EX', ttlSeconds, 'NX');
+      return result === 'OK';
+    } catch (error) {
+      this.logger.error(`Redis SET NX error for key ${key}: ${error}`);
+      return false;
+    }
+  }
+
   async expire(key: string, ttlSeconds: number): Promise<boolean> {
     if (!this.client) return false;
     try {

--- a/middleware/test/__mocks__/otplib.ts
+++ b/middleware/test/__mocks__/otplib.ts
@@ -1,0 +1,139 @@
+/**
+ * Faithful RFC-6238 TOTP test double for `otplib` (auth #2).
+ *
+ * Why this exists: otplib v13 and its transitive deps (@scure/base, @noble/*)
+ * are pure ESM and, under pnpm's `.pnpm/` layout, cannot be loaded by Jest's
+ * CommonJS runtime. Rather than reconfigure the shared transform pipeline for
+ * the whole suite, jest.config.js maps `otplib` to this module for tests only.
+ * Production code uses the real otplib.
+ *
+ * This implements the SAME standard algorithm the real library uses (HMAC-SHA1,
+ * 6 digits, 30s step, symmetric epochTolerance in seconds), so enroll -> enable
+ * -> challenge round-trips behave exactly as in production.
+ */
+import * as crypto from 'crypto';
+
+const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+function base32Encode(buf: Buffer): string {
+  let bits = 0;
+  let value = 0;
+  let out = '';
+  for (const byte of buf) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      out += BASE32_ALPHABET[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) {
+    out += BASE32_ALPHABET[(value << (5 - bits)) & 31];
+  }
+  return out;
+}
+
+function base32Decode(input: string): Buffer {
+  const clean = input.replace(/=+$/, '').toUpperCase().replace(/\s+/g, '');
+  let bits = 0;
+  let value = 0;
+  const bytes: number[] = [];
+  for (const ch of clean) {
+    const idx = BASE32_ALPHABET.indexOf(ch);
+    if (idx === -1) continue;
+    value = (value << 5) | idx;
+    bits += 5;
+    if (bits >= 8) {
+      bytes.push((value >>> (bits - 8)) & 0xff);
+      bits -= 8;
+    }
+  }
+  return Buffer.from(bytes);
+}
+
+function hotp(secret: string, counter: number, digits: number): string {
+  const key = base32Decode(secret);
+  const buf = Buffer.alloc(8);
+  // big-endian 64-bit counter (high 32 bits are 0 for our epochs)
+  buf.writeUInt32BE(Math.floor(counter / 0x100000000), 0);
+  buf.writeUInt32BE(counter >>> 0, 4);
+  const hmac = crypto.createHmac('sha1', key).update(buf).digest();
+  const offset = hmac[hmac.length - 1] & 0x0f;
+  const bin =
+    ((hmac[offset] & 0x7f) << 24) |
+    ((hmac[offset + 1] & 0xff) << 16) |
+    ((hmac[offset + 2] & 0xff) << 8) |
+    (hmac[offset + 3] & 0xff);
+  return (bin % 10 ** digits).toString().padStart(digits, '0');
+}
+
+interface GenOpts {
+  secret: string;
+  digits?: number;
+  period?: number;
+  epoch?: number; // seconds
+  algorithm?: string;
+}
+
+interface VerifyOpts extends GenOpts {
+  token: string;
+  epochTolerance?: number | [number, number]; // seconds
+}
+
+export function generateSecret(opts?: { length?: number }): string {
+  return base32Encode(crypto.randomBytes(opts?.length ?? 20));
+}
+
+export function generateURI(opts: {
+  strategy?: string;
+  issuer: string;
+  label: string;
+  secret: string;
+  algorithm?: string;
+  digits?: number;
+  period?: number;
+}): string {
+  const params = new URLSearchParams({
+    secret: opts.secret,
+    issuer: opts.issuer,
+  });
+  return `otpauth://totp/${encodeURIComponent(opts.issuer)}:${encodeURIComponent(
+    opts.label,
+  )}?${params.toString()}`;
+}
+
+export function generateSync(opts: GenOpts): string {
+  const period = opts.period ?? 30;
+  const digits = opts.digits ?? 6;
+  const epoch = opts.epoch ?? Math.floor(Date.now() / 1000);
+  return hotp(opts.secret, Math.floor(epoch / period), digits);
+}
+
+export async function generate(opts: GenOpts): Promise<string> {
+  return generateSync(opts);
+}
+
+export function verifySync(opts: VerifyOpts): { valid: boolean; delta?: number } {
+  const period = opts.period ?? 30;
+  const digits = opts.digits ?? 6;
+  const epoch = opts.epoch ?? Math.floor(Date.now() / 1000);
+  const tol = opts.epochTolerance ?? 0;
+  const [past, future] = Array.isArray(tol) ? tol : [tol, tol];
+  const counter = Math.floor(epoch / period);
+  const backSteps = Math.floor(past / period);
+  const fwdSteps = Math.floor(future / period);
+  const tokenBuf = Buffer.from(opts.token);
+  for (let d = -backSteps; d <= fwdSteps; d++) {
+    const candidate = Buffer.from(hotp(opts.secret, counter + d, digits));
+    // timingSafeEqual throws on length mismatch — guard it (a wrong-length token
+    // simply can't match).
+    if (candidate.length === tokenBuf.length && crypto.timingSafeEqual(candidate, tokenBuf)) {
+      return { valid: true, delta: d };
+    }
+  }
+  return { valid: false };
+}
+
+export async function verify(opts: VerifyOpts): Promise<{ valid: boolean; delta?: number }> {
+  return verifySync(opts);
+}

--- a/packages/database/prisma/migrations/20260712120000_add_mfa/migration.sql
+++ b/packages/database/prisma/migrations/20260712120000_add_mfa/migration.sql
@@ -1,0 +1,46 @@
+-- Multi-factor auth (TOTP) — auth #2 — 2026-07-12
+-- Additive only: three nullable/defaulted columns on `users`, one defaulted
+-- column on `organizations`, and one new `mfa_backup_codes` table. Touches no
+-- existing auth path — a user with mfaEnabled=false (the default for every
+-- existing row) logs in exactly as before. Idempotent (IF NOT EXISTS + guarded
+-- FK) so `migrate deploy` is re-runnable, matching the recent migration
+-- convention in this tree. No CONCURRENTLY (runs inside the migration txn).
+
+-- AlterTable: users — TOTP enrollment state (mfaSecret is AES-256-GCM ciphertext)
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "mfaEnabled" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "mfaSecret" TEXT;
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "mfaEnrolledAt" TIMESTAMP(3);
+
+-- AlterTable: organizations — per-org MFA enforcement flag
+ALTER TABLE "organizations" ADD COLUMN IF NOT EXISTS "mfaRequired" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable: single-use TOTP backup codes (sha256 hashes only)
+CREATE TABLE IF NOT EXISTS "mfa_backup_codes" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "codeHash" TEXT NOT NULL,
+    "usedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "mfa_backup_codes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "mfa_backup_codes_userId_idx" ON "mfa_backup_codes"("userId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "mfa_backup_codes_codeHash_idx" ON "mfa_backup_codes"("codeHash");
+
+-- AddForeignKey
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'mfa_backup_codes_userId_fkey'
+      AND table_name = 'mfa_backup_codes'
+  ) THEN
+    ALTER TABLE "mfa_backup_codes"
+      ADD CONSTRAINT "mfa_backup_codes_userId_fkey"
+      FOREIGN KEY ("userId") REFERENCES "users"("id")
+      ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -37,6 +37,10 @@ model Organization {
   // Timestamp of the last entitlement-rung transition. The ladder clock keys on THIS,
   // not updatedAt (which any unrelated org write resets — B8 grace-reset bug).
   entitlementStateSince  DateTime?
+  // Per-org MFA enforcement (auth #2). When true, members who are NOT enrolled
+  // are forced through TOTP enrollment before they receive session tokens;
+  // enrolled members hit the normal login challenge. Opt-in, default off.
+  mfaRequired            Boolean   @default(false)
   storageUsedBytes       BigInt    @default(0) // Current storage usage in bytes
   storageQuotaBytes      BigInt    @default(1073741824) // 1GB default quota in bytes (trial)
   settings               Json?     @db.JsonB
@@ -88,6 +92,14 @@ model User {
   isActive     Boolean   @default(true)
   isSuperAdmin Boolean   @default(false) // Vizora platform admin (separate from org admin)
   lastLoginAt  DateTime?
+  // TOTP multi-factor auth (auth #2). Opt-in per user. `mfaSecret` holds the
+  // AES-256-GCM ciphertext (iv:tag:data) of the base32 TOTP secret — NEVER
+  // plaintext. While `mfaEnabled` is false but `mfaSecret` is set, the secret
+  // is a PENDING enrollment awaiting a verified code; once enabled it is the
+  // active secret. `mfaEnrolledAt` marks when MFA was turned on.
+  mfaEnabled    Boolean   @default(false)
+  mfaSecret     String? // AES-256-GCM ciphertext of the TOTP secret; never plaintext
+  mfaEnrolledAt DateTime?
   createdAt    DateTime  @default(now())
   updatedAt    DateTime  @updatedAt
 
@@ -99,6 +111,7 @@ model User {
   apiKeys                 ApiKey[]
   passwordResetTokens     PasswordResetToken[]
   refreshTokens           RefreshToken[]
+  mfaBackupCodes          MfaBackupCode[]
   supportRequests         SupportRequest[]     @relation("SupportRequestUser")
   resolvedSupportRequests SupportRequest[]     @relation("SupportRequestResolver")
 
@@ -148,6 +161,24 @@ model RefreshToken {
   @@index([expiresAt])
   @@index([familyId])
   @@map("refresh_tokens")
+}
+
+// Single-use TOTP backup/recovery codes (auth #2). Ten are generated when a
+// user enables MFA; the plaintext is shown ONCE at generation and only the
+// SHA-256 hash of the normalized code is stored. A code is consumed by setting
+// `usedAt` on redemption and is never valid again (single-use). Regenerating
+// backup codes deletes the old rows and issues a fresh set.
+model MfaBackupCode {
+  id        String    @id @default(uuid())
+  userId    String
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  codeHash  String // SHA-256 hash of the normalized backup code — plaintext is never stored
+  usedAt    DateTime? // set once on redemption; a used code is never valid again
+  createdAt DateTime  @default(now())
+
+  @@index([userId])
+  @@index([codeHash])
+  @@map("mfa_backup_codes")
 }
 
 // ============================================================================

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,7 +106,7 @@ importers:
         version: 22.4.2(@babel/traverse@7.28.6)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(chokidar@4.0.3)(eslint@9.39.2(jiti@2.4.2))(nx@22.4.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))(typescript@5.9.3)
       '@nx/next':
         specifier: ^22.4.2
-        version: 22.4.2(7b2b49defd937f56a264b1ab99dfc0a0)
+        version: 22.4.2(5edec27dce29874a0b41a90c8fe4823d)
       '@nx/node':
         specifier: ^22.4.2
         version: 22.4.2(@babel/traverse@7.28.6)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(eslint@9.39.2(jiti@2.4.2))(nx@22.4.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))(typescript@5.9.3)
@@ -344,7 +344,7 @@ importers:
         version: 5.9.2
       isomorphic-dompurify:
         specifier: ^3.0.0
-        version: 3.0.0
+        version: 3.0.0(@noble/hashes@2.2.0)
       minio:
         specifier: ^8.0.7
         version: 8.0.7
@@ -357,6 +357,9 @@ importers:
       nodemailer:
         specifier: ^9.0.1
         version: 9.0.3
+      otplib:
+        specifier: ^13.4.1
+        version: 13.4.1
       passport:
         specifier: ^0.7.0
         version: 0.7.0
@@ -708,7 +711,7 @@ importers:
         version: 10.1.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
+        version: 29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -720,7 +723,7 @@ importers:
         version: 3.4.19(tsx@4.21.0)(yaml@2.8.2)
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(jest-util@30.2.0)(jest@29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(jest-util@30.2.0)(jest@29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@types/node@20.19.9)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -3038,6 +3041,10 @@ packages:
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
     engines: {node: '>= 16'}
 
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
+
   '@nodable/entities@2.2.0':
     resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
 
@@ -3385,6 +3392,24 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
+
+  '@otplib/core@13.4.1':
+    resolution: {integrity: sha512-KIXgK1hNtWJEBMTastbe1bpmuais+3f+ATeO8TkMs2rNkfGO1FbQy8+/UWVEu3TR/iTJerU0idkPudaPmLP2BA==}
+
+  '@otplib/hotp@13.4.1':
+    resolution: {integrity: sha512-g9q04SwpG5ZtMnVkUcgcoAlwCH4YLROZN1qhyBwgkBzqYYVSYhpP6gSGaxGHwePLt1c+e6NqDlgIZN+e1/XPuA==}
+
+  '@otplib/plugin-base32-scure@13.4.1':
+    resolution: {integrity: sha512-Fs/r5qisC05SRhT6xWXaypB6PVC0vgWf6zztmi0J5RnQ09OJiPDWCJFH6cDm6ANsrdvB9di7X+Jb7L13BoEbUA==}
+
+  '@otplib/plugin-crypto-noble@13.4.1':
+    resolution: {integrity: sha512-PJfVW8/1hdS6CfxLheKPZSLTwDq4TijZbN4yRjxlv0ODdzmxpM+wGwWr1JXMdy0xJPxLziydQD5gdVqrR4/gAg==}
+
+  '@otplib/totp@13.4.1':
+    resolution: {integrity: sha512-QOkBVPrf6AM4qZaReZPSk9/I8ATVdZpIISJz115MqeVtcrbcr5llPZ0J7804tpnjnp1vCRkI5Qjd47HhgVteBQ==}
+
+  '@otplib/uri@13.4.1':
+    resolution: {integrity: sha512-xaIm7bvICMhoB2rZIR5luiaMdssWR5nY5nXnR1fdezUgZuEO58D6zrGzLp7pQuBmlpmL0HagnscDQFoskp9yiA==}
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -3857,6 +3882,9 @@ packages:
 
   '@scarf/scarf@1.4.0':
     resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
+
+  '@scure/base@2.2.0':
+    resolution: {integrity: sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==}
 
   '@sentry-internal/node-cpu-profiler@2.2.0':
     resolution: {integrity: sha512-oLHVYurqZfADPh5hvmQYS5qx8t0UZzT2u6+/68VXsFruQEOnYJTODKgU3BVLmemRs3WE6kCJjPeFdHVYOQGSzQ==}
@@ -8770,6 +8798,9 @@ packages:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
     engines: {node: '>=10'}
 
+  otplib@13.4.1:
+    resolution: {integrity: sha512-o5CxfDw6bh7hoDv0NUUIcc0RqzJ9ipfUrzeKheKJ+vs4rXZnDlA9n4a/7R1cDjpmLjKLix4BgNVRmoDkm5rLSQ==}
+
   p-cancelable@2.1.1:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
     engines: {node: '>=8'}
@@ -12560,7 +12591,9 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@exodus/bytes@1.15.0': {}
+  '@exodus/bytes@1.15.0(@noble/hashes@2.2.0)':
+    optionalDependencies:
+      '@noble/hashes': 2.2.0
 
   '@hono/node-server@1.19.14(hono@4.12.25)':
     dependencies:
@@ -13990,6 +14023,8 @@ snapshots:
 
   '@noble/hashes@1.4.0': {}
 
+  '@noble/hashes@2.2.0': {}
+
   '@nodable/entities@2.2.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -14174,13 +14209,13 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/next@22.4.2(7b2b49defd937f56a264b1ab99dfc0a0)':
+  '@nx/next@22.4.2(5edec27dce29874a0b41a90c8fe4823d)':
     dependencies:
       '@babel/plugin-proposal-decorators': 7.28.6(@babel/core@7.28.6)
       '@nx/devkit': 22.4.2(nx@22.4.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18)))
       '@nx/eslint': 22.4.2(@babel/traverse@7.28.6)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.39.2(jiti@2.4.2))(nx@22.4.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18)))
       '@nx/js': 22.4.2(@babel/traverse@7.28.6)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18))(nx@22.4.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18)))
-      '@nx/react': 22.4.2(8efa5a34dc3e9fec32c04f0935bed43e)
+      '@nx/react': 22.4.2(2dbd51095c5e92cfcf73481351e257f7)
       '@nx/web': 22.4.2(@babel/traverse@7.28.6)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18))(nx@22.4.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18)))
       '@nx/webpack': 22.4.2(@babel/traverse@7.28.6)(@rspack/core@1.6.8(@swc/helpers@0.5.18))(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18))(html-webpack-plugin@5.6.6(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.104.1))(lightningcss@1.31.1)(nx@22.4.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18)))(typescript@5.9.3)(webpack-cli@5.1.4)
       '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.3)
@@ -14283,7 +14318,7 @@ snapshots:
   '@nx/nx-win32-x64-msvc@22.4.2':
     optional: true
 
-  '@nx/react@22.4.2(8efa5a34dc3e9fec32c04f0935bed43e)':
+  '@nx/react@22.4.2(2dbd51095c5e92cfcf73481351e257f7)':
     dependencies:
       '@nx/devkit': 22.4.2(nx@22.4.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18)))
       '@nx/eslint': 22.4.2(@babel/traverse@7.28.6)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.39.2(jiti@2.4.2))(nx@22.4.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18)))
@@ -14300,7 +14335,7 @@ snapshots:
       semver: 7.7.3
       tslib: 2.8.1
     optionalDependencies:
-      '@nx/vite': 22.4.2(@babel/traverse@7.28.6)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18))(nx@22.4.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18)))(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.9)(jiti@2.4.2)(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.9)(jiti@2.4.2)(jsdom@28.1.0)(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@nx/vite': 22.4.2(@babel/traverse@7.28.6)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18))(nx@22.4.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18)))(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.9)(jiti@2.4.2)(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.9)(jiti@2.4.2)(jsdom@28.1.0(@noble/hashes@2.2.0))(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/traverse'
@@ -14358,11 +14393,11 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vite@22.4.2(@babel/traverse@7.28.6)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18))(nx@22.4.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18)))(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.9)(jiti@2.4.2)(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.9)(jiti@2.4.2)(jsdom@28.1.0)(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@nx/vite@22.4.2(@babel/traverse@7.28.6)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18))(nx@22.4.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18)))(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.9)(jiti@2.4.2)(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.9)(jiti@2.4.2)(jsdom@28.1.0(@noble/hashes@2.2.0))(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@nx/devkit': 22.4.2(nx@22.4.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18)))
       '@nx/js': 22.4.2(@babel/traverse@7.28.6)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18))(nx@22.4.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18)))
-      '@nx/vitest': 22.4.2(@babel/traverse@7.28.6)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18))(nx@22.4.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18)))(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.9)(jiti@2.4.2)(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.9)(jiti@2.4.2)(jsdom@28.1.0)(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@nx/vitest': 22.4.2(@babel/traverse@7.28.6)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18))(nx@22.4.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18)))(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.9)(jiti@2.4.2)(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.9)(jiti@2.4.2)(jsdom@28.1.0(@noble/hashes@2.2.0))(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.3)
       ajv: 8.17.1
       enquirer: 2.3.6
@@ -14371,7 +14406,7 @@ snapshots:
       tsconfig-paths: 4.2.0
       tslib: 2.8.1
       vite: 7.3.1(@types/node@20.19.9)(jiti@2.4.2)(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.9)(jiti@2.4.2)(jsdom@28.1.0)(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.9)(jiti@2.4.2)(jsdom@28.1.0(@noble/hashes@2.2.0))(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -14383,7 +14418,7 @@ snapshots:
       - verdaccio
     optional: true
 
-  '@nx/vitest@22.4.2(@babel/traverse@7.28.6)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18))(nx@22.4.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18)))(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.9)(jiti@2.4.2)(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.9)(jiti@2.4.2)(jsdom@28.1.0)(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@nx/vitest@22.4.2(@babel/traverse@7.28.6)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18))(nx@22.4.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18)))(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.9)(jiti@2.4.2)(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.9)(jiti@2.4.2)(jsdom@28.1.0(@noble/hashes@2.2.0))(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@nx/devkit': 22.4.2(nx@22.4.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18)))
       '@nx/js': 22.4.2(@babel/traverse@7.28.6)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18))(nx@22.4.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.18)))
@@ -14392,7 +14427,7 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       vite: 7.3.1(@types/node@20.19.9)(jiti@2.4.2)(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.9)(jiti@2.4.2)(jsdom@28.1.0)(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.9)(jiti@2.4.2)(jsdom@28.1.0(@noble/hashes@2.2.0))(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -14757,6 +14792,33 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.5.0(@opentelemetry/api@1.9.0)
+
+  '@otplib/core@13.4.1': {}
+
+  '@otplib/hotp@13.4.1':
+    dependencies:
+      '@otplib/core': 13.4.1
+      '@otplib/uri': 13.4.1
+
+  '@otplib/plugin-base32-scure@13.4.1':
+    dependencies:
+      '@otplib/core': 13.4.1
+      '@scure/base': 2.2.0
+
+  '@otplib/plugin-crypto-noble@13.4.1':
+    dependencies:
+      '@noble/hashes': 2.2.0
+      '@otplib/core': 13.4.1
+
+  '@otplib/totp@13.4.1':
+    dependencies:
+      '@otplib/core': 13.4.1
+      '@otplib/hotp': 13.4.1
+      '@otplib/uri': 13.4.1
+
+  '@otplib/uri@13.4.1':
+    dependencies:
+      '@otplib/core': 13.4.1
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
@@ -15182,6 +15244,8 @@ snapshots:
   '@rspack/lite-tapable@1.1.0': {}
 
   '@scarf/scarf@1.4.0': {}
+
+  '@scure/base@2.2.0': {}
 
   '@sentry-internal/node-cpu-profiler@2.2.0':
     dependencies:
@@ -17758,10 +17822,10 @@ snapshots:
       whatwg-mimetype: 3.0.0
       whatwg-url: 11.0.0
 
-  data-urls@7.0.0:
+  data-urls@7.0.0(@noble/hashes@2.2.0):
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -19089,9 +19153,9 @@ snapshots:
     dependencies:
       whatwg-encoding: 2.0.0
 
-  html-encoding-sniffer@6.0.0:
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
     dependencies:
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -19453,10 +19517,10 @@ snapshots:
 
   isobject@3.0.1: {}
 
-  isomorphic-dompurify@3.0.0:
+  isomorphic-dompurify@3.0.0(@noble/hashes@2.2.0):
     dependencies:
       dompurify: 3.3.2
-      jsdom: 28.1.0
+      jsdom: 28.1.0(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
       - canvas
@@ -20411,16 +20475,16 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jsdom@28.1.0:
+  jsdom@28.1.0(@noble/hashes@2.2.0):
     dependencies:
       '@acemir/cssom': 0.9.31
       '@asamuzakjp/dom-selector': 6.8.1
       '@bramus/specificity': 2.4.2
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
       cssstyle: 6.2.0
-      data-urls: 7.0.0
+      data-urls: 7.0.0(@noble/hashes@2.2.0)
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.2.0)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
@@ -20432,7 +20496,7 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -21299,6 +21363,15 @@ snapshots:
       log-symbols: 4.1.0
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
+
+  otplib@13.4.1:
+    dependencies:
+      '@otplib/core': 13.4.1
+      '@otplib/hotp': 13.4.1
+      '@otplib/plugin-base32-scure': 13.4.1
+      '@otplib/plugin-crypto-noble': 13.4.1
+      '@otplib/totp': 13.4.1
+      '@otplib/uri': 13.4.1
 
   p-cancelable@2.1.1: {}
 
@@ -23655,7 +23728,7 @@ snapshots:
       yaml: 2.8.2
     optional: true
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.9)(jiti@2.4.2)(jsdom@28.1.0)(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.9)(jiti@2.4.2)(jsdom@28.1.0(@noble/hashes@2.2.0))(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@20.19.9)(jiti@2.4.2)(less@4.5.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -23680,7 +23753,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 20.19.9
-      jsdom: 28.1.0
+      jsdom: 28.1.0(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -23921,9 +23994,9 @@ snapshots:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
 
-  whatwg-url@16.0.1:
+  whatwg-url@16.0.1(@noble/hashes@2.2.0):
     dependencies:
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:

--- a/web/src/app/(auth)/__tests__/login-page.test.tsx
+++ b/web/src/app/(auth)/__tests__/login-page.test.tsx
@@ -4,6 +4,9 @@ import LoginContent from '../login-content';
 jest.mock('@/lib/api', () => ({
   apiClient: {
     login: jest.fn(),
+    mfaChallenge: jest.fn(),
+    mfaEnroll: jest.fn(),
+    mfaEnable: jest.fn(),
   },
 }));
 
@@ -80,5 +83,49 @@ describe('LoginPage', () => {
   it('renders forgot password link', () => {
     render(<LoginContent />);
     expect(screen.getByText('Forgot password?')).toBeInTheDocument();
+  });
+
+  it('shows the MFA challenge step when login returns mfaRequired', async () => {
+    const { apiClient } = require('@/lib/api');
+    const { loginSchema } = require('@/lib/validation');
+    loginSchema.parse.mockReturnValue(true);
+    apiClient.login.mockResolvedValue({ mfaRequired: true, challengeToken: 'ct-123' });
+
+    render(<LoginContent />);
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'mfa@test.com' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
+    fireEvent.submit(screen.getByText('Log in', { selector: 'button' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: /Two-factor authentication/i }),
+      ).toBeInTheDocument();
+    });
+    // The password form is gone; a code input is shown instead.
+    expect(screen.getByLabelText(/Authentication code/i)).toBeInTheDocument();
+  });
+
+  it('shows the forced-enrollment step when login returns mfaEnrollmentRequired', async () => {
+    const { apiClient } = require('@/lib/api');
+    const { loginSchema } = require('@/lib/validation');
+    loginSchema.parse.mockReturnValue(true);
+    apiClient.login.mockResolvedValue({ mfaEnrollmentRequired: true, enrollmentToken: 'et-123' });
+    apiClient.mfaEnroll.mockResolvedValue({
+      otpauthUrl: 'otpauth://totp/Vizora:u@e.com?secret=ABCDEF&issuer=Vizora',
+      qrDataUrl: 'data:image/png;base64,AAAA',
+    });
+
+    render(<LoginContent />);
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'force@test.com' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
+    fireEvent.submit(screen.getByText('Log in', { selector: 'button' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: /Two-factor authentication required/i }),
+      ).toBeInTheDocument();
+    });
+    // The enrollment token was used to fetch the QR.
+    await waitFor(() => expect(apiClient.mfaEnroll).toHaveBeenCalledWith('et-123'));
   });
 });

--- a/web/src/app/(auth)/login-content.tsx
+++ b/web/src/app/(auth)/login-content.tsx
@@ -10,6 +10,8 @@ import ValuePanel from '@/components/auth/ValuePanel';
 import FormField from '@/components/auth/FormField';
 import PasswordInput from '@/components/auth/PasswordInput';
 import GoogleSignInButton from '@/components/auth/GoogleSignInButton';
+import MfaChallengeForm from '@/components/auth/MfaChallengeForm';
+import MfaEnrollFlow from '@/components/auth/MfaEnrollFlow';
 
 function isValidRedirectUrl(url: string): boolean {
   return url.startsWith('/') && !url.startsWith('//') && !url.includes('://');
@@ -25,6 +27,10 @@ export default function LoginContent() {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const [rememberMe, setRememberMe] = useState(false);
+  // MFA (auth #2) continuation state — set when /auth/login returns a challenge
+  // or forced-enrollment token instead of a session.
+  const [mfaChallengeToken, setMfaChallengeToken] = useState<string | null>(null);
+  const [mfaEnrollmentToken, setMfaEnrollmentToken] = useState<string | null>(null);
 
   const update = (field: string, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }));
@@ -73,7 +79,16 @@ export default function LoginContent() {
     }
 
     try {
-      await apiClient.login(formData.email, formData.password);
+      const result = await apiClient.login(formData.email, formData.password);
+      // MFA continuations: don't redirect — render the challenge / enrollment step.
+      if ('mfaRequired' in result) {
+        setMfaChallengeToken(result.challengeToken);
+        return;
+      }
+      if ('mfaEnrollmentRequired' in result) {
+        setMfaEnrollmentToken(result.enrollmentToken);
+        return;
+      }
       window.location.href = redirectUrl;
     } catch (err: unknown) {
       if (process.env.NODE_ENV === 'development') {
@@ -93,6 +108,53 @@ export default function LoginContent() {
       setLoading(false);
     }
   };
+
+  // MFA challenge step (enrolled user) — replaces the login form after a correct
+  // password until the second factor is verified.
+  if (mfaChallengeToken) {
+    return (
+      <div className="min-h-screen flex bg-[var(--background)]">
+        <div className="hidden md:flex md:w-[35%] lg:w-[38%]">
+          <ValuePanel variant="login" />
+        </div>
+        <div className="flex-1 flex flex-col justify-center lg:justify-start px-6 py-8 sm:px-10 lg:pl-6 lg:pr-10 lg:pt-28 xl:pl-8 xl:pr-14">
+          <MfaChallengeForm
+            challengeToken={mfaChallengeToken}
+            onSuccess={() => {
+              window.location.href = redirectUrl;
+            }}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // Forced-enrollment step (org requires MFA, user not enrolled).
+  if (mfaEnrollmentToken) {
+    return (
+      <div className="min-h-screen flex bg-[var(--background)]">
+        <div className="hidden md:flex md:w-[35%] lg:w-[38%]">
+          <ValuePanel variant="login" />
+        </div>
+        <div className="flex-1 flex flex-col justify-center lg:justify-start px-6 py-8 sm:px-10 lg:pl-6 lg:pr-10 lg:pt-28 xl:pl-8 xl:pr-14">
+          <div className="w-full max-w-md lg:max-w-2xl mx-auto md:mx-0">
+            <h1 className="text-2xl sm:text-3xl font-bold text-[var(--foreground)] eh-heading mb-2">
+              Two-factor authentication required
+            </h1>
+            <p className="text-sm text-[var(--foreground-tertiary)] mb-6">
+              Your organization requires two-factor authentication. Set it up now to continue.
+            </p>
+            <MfaEnrollFlow
+              enrollmentToken={mfaEnrollmentToken}
+              onComplete={() => {
+                window.location.href = redirectUrl;
+              }}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen flex bg-[var(--background)]">

--- a/web/src/app/dashboard/settings/page.tsx
+++ b/web/src/app/dashboard/settings/page.tsx
@@ -827,6 +827,23 @@ export default function SettingsPage() {
  </div>
  </div>
 
+ {/* Security */}
+ <div className="eh-dash-card bg-[var(--surface)] rounded-lg shadow-md p-6">
+ <h3 className="eh-dash-subtitle text-lg font-semibold text-[var(--foreground)] mb-4">Security</h3>
+ <div className="space-y-3">
+ <Link
+ href="/dashboard/settings/security"
+ className="w-full px-4 py-3 text-sm bg-[var(--background)] text-[var(--foreground-secondary)] rounded-lg hover:bg-[var(--surface-hover)] transition font-medium text-left flex items-center gap-2"
+ >
+ <Icon name="key" size="md" className="text-[var(--foreground-secondary)]" />
+ Two-Factor Authentication
+ <span className="ml-auto text-[var(--foreground-tertiary)]">
+ <Icon name="chevronRight" size="md" />
+ </span>
+ </Link>
+ </div>
+ </div>
+
  {/* Account Actions */}
  <div className="eh-dash-card bg-[var(--surface)] rounded-lg shadow-md p-6">
  <h3 className="eh-dash-subtitle text-lg font-semibold text-[var(--foreground)] mb-4">Account</h3>

--- a/web/src/app/dashboard/settings/security/page.tsx
+++ b/web/src/app/dashboard/settings/security/page.tsx
@@ -1,0 +1,245 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { apiClient } from '@/lib/api';
+import type { MfaStatus } from '@/lib/api/mfa';
+import { Icon } from '@/theme/icons';
+import { useToast } from '@/lib/hooks/useToast';
+import MfaEnrollFlow from '@/components/auth/MfaEnrollFlow';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Security settings (auth #2): TOTP enrollment status, enable/disable, backup
+ * code regeneration, and (for org admins) the per-org "require MFA" toggle.
+ */
+export default function SecuritySettingsPage() {
+  const toast = useToast();
+  const [status, setStatus] = useState<MfaStatus | null>(null);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [orgMfaRequired, setOrgMfaRequired] = useState(false);
+  const [enrolling, setEnrolling] = useState(false);
+  const [disableCode, setDisableCode] = useState('');
+  const [regenCode, setRegenCode] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [newBackupCodes, setNewBackupCodes] = useState<string[] | null>(null);
+
+  const loadStatus = async () => {
+    try {
+      const s = await apiClient.mfaStatus();
+      setStatus(s);
+    } catch {
+      // leave null — the card renders a loading state
+    }
+  };
+
+  useEffect(() => {
+    loadStatus();
+    (async () => {
+      try {
+        const user = await apiClient.getCurrentUser();
+        setIsAdmin(user.role === 'admin' || user.isSuperAdmin === true);
+        const org = user.organization as { mfaRequired?: boolean } | undefined;
+        setOrgMfaRequired(org?.mfaRequired === true);
+      } catch {
+        // ignore
+      }
+    })();
+  }, []);
+
+  const handleDisable = async () => {
+    if (!disableCode.trim()) return;
+    setBusy(true);
+    try {
+      await apiClient.mfaDisable(disableCode.trim());
+      toast.success('Two-factor authentication disabled');
+      setDisableCode('');
+      await loadStatus();
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Failed to disable MFA');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleRegenerate = async () => {
+    if (!regenCode.trim()) return;
+    setBusy(true);
+    try {
+      const { backupCodes } = await apiClient.mfaRegenerateBackupCodes(regenCode.trim());
+      setNewBackupCodes(backupCodes);
+      setRegenCode('');
+      toast.success('New backup codes generated');
+      await loadStatus();
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Failed to regenerate backup codes');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleToggleOrgRequired = async (next: boolean) => {
+    setBusy(true);
+    try {
+      const res = await apiClient.setOrgMfaRequired(next);
+      setOrgMfaRequired(res.mfaRequired);
+      toast.success(next ? 'MFA is now required for all members' : 'MFA requirement removed');
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Failed to update MFA policy');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <Link href="/dashboard/settings" className="text-sm text-[var(--foreground-tertiary)] hover:text-[var(--primary)]">
+          ← Back to settings
+        </Link>
+        <h2 className="eh-dash-title font-[var(--font-sora)] text-2xl text-[var(--foreground)] mt-2">Security</h2>
+        <p className="mt-2 text-[var(--foreground-secondary)]">Two-factor authentication and account security</p>
+      </div>
+
+      {/* MFA status / management */}
+      <div className="eh-dash-card bg-[var(--surface)] rounded-lg shadow-md p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="eh-dash-subtitle text-lg font-semibold text-[var(--foreground)]">Two-factor authentication</h3>
+          {status && (
+            <span
+              className={`px-2.5 py-1 rounded-full text-xs font-medium ${
+                status.enabled
+                  ? 'bg-[#00E5A0]/10 text-[#00E5A0]'
+                  : 'bg-[var(--background)] text-[var(--foreground-tertiary)] border border-[var(--border)]'
+              }`}
+            >
+              {status.enabled ? 'Enabled' : 'Disabled'}
+            </span>
+          )}
+        </div>
+
+        {!status && <p className="text-sm text-[var(--foreground-tertiary)]">Loading…</p>}
+
+        {status && !status.enabled && !enrolling && (
+          <div className="space-y-3">
+            <p className="text-sm text-[var(--foreground-secondary)]">
+              Add a second step to your login with an authenticator app (TOTP).
+            </p>
+            <button onClick={() => setEnrolling(true)} className="eh-btn-neon rounded-xl px-4 py-2 text-sm font-medium transition">
+              Set up two-factor
+            </button>
+          </div>
+        )}
+
+        {status && !status.enabled && enrolling && (
+          <MfaEnrollFlow
+            onComplete={async () => {
+              setEnrolling(false);
+              await loadStatus();
+            }}
+            onCancel={() => setEnrolling(false)}
+          />
+        )}
+
+        {status && status.enabled && (
+          <div className="space-y-6">
+            <p className="text-sm text-[var(--foreground-secondary)]">
+              Two-factor authentication is on. Backup codes remaining:{' '}
+              <span className="font-semibold text-[var(--foreground)]">{status.backupCodesRemaining}</span>
+            </p>
+
+            {newBackupCodes && (
+              <div className="p-4 rounded-lg bg-[var(--background)] border border-[var(--border)]">
+                <p className="text-sm font-medium text-[var(--foreground)] mb-2">Your new backup codes (shown once):</p>
+                <div className="grid grid-cols-2 gap-2 font-mono text-sm">
+                  {newBackupCodes.map((c) => (
+                    <span key={c} className="text-[var(--foreground)]">{c}</span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Regenerate backup codes */}
+            <div className="space-y-2">
+              <label className="block text-sm font-semibold text-[var(--foreground-secondary)]">
+                Regenerate backup codes
+              </label>
+              <p className="text-xs text-[var(--foreground-tertiary)]">
+                Enter a current 6-digit code to invalidate old backup codes and get a new set.
+              </p>
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  value={regenCode}
+                  onChange={(e) => setRegenCode(e.target.value)}
+                  placeholder="123456"
+                  className="eh-input px-4 py-2 border border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] rounded-lg focus:ring-2 focus:ring-[#00E5A0] focus:border-transparent"
+                />
+                <button
+                  onClick={handleRegenerate}
+                  disabled={busy || regenCode.trim().length < 6}
+                  className="px-4 py-2 text-sm font-medium bg-[var(--background)] text-[var(--foreground-secondary)] border border-[var(--border)] rounded-lg hover:bg-[var(--surface-hover)] transition disabled:opacity-50"
+                >
+                  Regenerate
+                </button>
+              </div>
+            </div>
+
+            {/* Disable */}
+            <div className="space-y-2">
+              <label className="block text-sm font-semibold text-[var(--foreground-secondary)]">Disable two-factor</label>
+              <p className="text-xs text-[var(--foreground-tertiary)]">
+                Enter a current 6-digit code or a backup code to turn off two-factor authentication.
+              </p>
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={disableCode}
+                  onChange={(e) => setDisableCode(e.target.value)}
+                  placeholder="123456"
+                  className="eh-input px-4 py-2 border border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] rounded-lg focus:ring-2 focus:ring-red-500 focus:border-transparent"
+                />
+                <button
+                  onClick={handleDisable}
+                  disabled={busy || disableCode.trim().length < 4}
+                  className="px-4 py-2 text-sm font-medium bg-red-600 text-white rounded-lg hover:bg-red-700 transition disabled:opacity-50"
+                >
+                  Disable
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Org-level enforcement (admins only) */}
+      {isAdmin && (
+        <div className="eh-dash-card bg-[var(--surface)] rounded-lg shadow-md p-6">
+          <h3 className="eh-dash-subtitle text-lg font-semibold text-[var(--foreground)] mb-4">Organization policy</h3>
+          <label className="flex items-center justify-between p-4 bg-[var(--background)] rounded-lg cursor-pointer">
+            <div>
+              <div className="font-medium text-[var(--foreground)] flex items-center gap-2">
+                <Icon name="key" size="md" className="text-[var(--foreground-secondary)]" />
+                Require two-factor authentication
+              </div>
+              <div className="text-sm text-[var(--foreground-secondary)]">
+                Members who aren&apos;t enrolled are prompted to set up MFA on their next login.
+              </div>
+            </div>
+            <input
+              type="checkbox"
+              checked={orgMfaRequired}
+              disabled={busy}
+              onChange={(e) => handleToggleOrgRequired(e.target.checked)}
+              className="w-5 h-5 accent-[#00E5A0] cursor-pointer"
+            />
+          </label>
+        </div>
+      )}
+
+      <toast.ToastContainer />
+    </div>
+  );
+}

--- a/web/src/components/auth/MfaChallengeForm.tsx
+++ b/web/src/components/auth/MfaChallengeForm.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState } from 'react';
+import { apiClient } from '@/lib/api';
+
+/**
+ * Login-challenge step (auth #2). Shown after a correct password when the
+ * account is MFA-enrolled. Posts the challenge token + a TOTP or backup code to
+ * /auth/mfa/challenge; on success the server sets the session cookie and we
+ * continue exactly as a normal login.
+ */
+export default function MfaChallengeForm({
+  challengeToken,
+  onSuccess,
+}: {
+  challengeToken: string;
+  onSuccess: () => void;
+}) {
+  const [code, setCode] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (loading) return;
+    setLoading(true);
+    setError('');
+    try {
+      await apiClient.mfaChallenge(challengeToken, code.trim());
+      onSuccess();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Verification failed';
+      if (message.toLowerCase().includes('log in again')) {
+        setError('This login expired. Please start over.');
+      } else {
+        setError('Invalid code. Enter the current 6-digit code or a backup code.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="w-full max-w-md lg:max-w-2xl mx-auto md:mx-0">
+      <h1 className="text-2xl sm:text-3xl font-bold text-[var(--foreground)] eh-heading mb-2">
+        Two-factor authentication
+      </h1>
+      <p className="text-sm text-[var(--foreground-tertiary)] mb-6">
+        Enter the 6-digit code from your authenticator app, or one of your backup codes.
+      </p>
+
+      {error && (
+        <div className="flex items-start gap-3 px-4 py-3 rounded-lg mb-6 bg-[var(--error)]/10 border border-[var(--error)]/30 text-[var(--error)]">
+          <p className="text-sm">{error}</p>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+        <div>
+          <label htmlFor="mfa-code" className="block text-[13px] font-semibold text-[var(--foreground-secondary)] mb-1.5">
+            Authentication code
+          </label>
+          <input
+            id="mfa-code"
+            type="text"
+            inputMode="text"
+            autoComplete="one-time-code"
+            autoFocus
+            value={code}
+            onChange={(e) => {
+              setCode(e.target.value);
+              if (error) setError('');
+            }}
+            placeholder="123456"
+            className="eh-input w-full px-4 py-2 border border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] rounded-lg focus:ring-2 focus:ring-[#00E5A0] focus:border-transparent tracking-widest"
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={loading || code.trim().length < 4}
+          className="w-full sm:w-auto sm:min-w-[220px] sm:mx-auto sm:block eh-btn-neon py-3 sm:px-12 rounded-lg text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {loading ? 'Verifying...' : 'Verify'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/web/src/components/auth/MfaEnrollFlow.tsx
+++ b/web/src/components/auth/MfaEnrollFlow.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { apiClient } from '@/lib/api';
+import type { MfaEnrollData, MfaEnableResult } from '@/lib/api/mfa';
+
+/**
+ * TOTP enrollment flow (auth #2). Three steps:
+ *   1. fetch a pending secret + QR (POST /auth/mfa/enroll)
+ *   2. user scans the QR, enters a code, we enable (POST /auth/mfa/enable)
+ *   3. show the one-time backup codes with copy/download
+ *
+ * Reused in two contexts:
+ *   - voluntary (settings): no `enrollmentToken`; the user already has a session.
+ *   - forced (login, org requires MFA): pass `enrollmentToken`; on enable the
+ *     server completes the login and `onComplete` fires so the caller can route
+ *     to the dashboard.
+ */
+export default function MfaEnrollFlow({
+  enrollmentToken,
+  onComplete,
+  onCancel,
+}: {
+  enrollmentToken?: string;
+  onComplete?: (result: MfaEnableResult) => void;
+  onCancel?: () => void;
+}) {
+  const [enroll, setEnroll] = useState<MfaEnrollData | null>(null);
+  const [code, setCode] = useState('');
+  const [backupCodes, setBackupCodes] = useState<string[] | null>(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<MfaEnableResult | null>(null);
+
+  const beginEnroll = useCallback(async () => {
+    setError('');
+    try {
+      const data = await apiClient.mfaEnroll(enrollmentToken);
+      setEnroll(data);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Could not start enrollment');
+    }
+  }, [enrollmentToken]);
+
+  useEffect(() => {
+    beginEnroll();
+  }, [beginEnroll]);
+
+  const handleEnable = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (loading) return;
+    setLoading(true);
+    setError('');
+    try {
+      const res = await apiClient.mfaEnable(code.trim(), enrollmentToken);
+      setBackupCodes(res.backupCodes);
+      setResult(res);
+    } catch {
+      setError('Invalid code. Enter the current 6-digit code from your app.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const secretParam = enroll ? new URL(enroll.otpauthUrl).searchParams.get('secret') : null;
+
+  const copyCodes = () => {
+    if (backupCodes) void navigator.clipboard?.writeText(backupCodes.join('\n'));
+  };
+  const downloadCodes = () => {
+    if (!backupCodes) return;
+    const blob = new Blob([backupCodes.join('\n') + '\n'], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'vizora-backup-codes.txt';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  // Step 3 — backup codes
+  if (backupCodes) {
+    return (
+      <div className="space-y-4">
+        <div>
+          <h3 className="text-lg font-semibold text-[var(--foreground)]">Save your backup codes</h3>
+          <p className="text-sm text-[var(--foreground-secondary)] mt-1">
+            Each code works once. Store them somewhere safe — they let you sign in if you lose your
+            authenticator. They will not be shown again.
+          </p>
+        </div>
+        <div className="grid grid-cols-2 gap-2 p-4 rounded-lg bg-[var(--background)] border border-[var(--border)] font-mono text-sm">
+          {backupCodes.map((c) => (
+            <span key={c} className="text-[var(--foreground)]">{c}</span>
+          ))}
+        </div>
+        <div className="flex gap-2">
+          <button onClick={copyCodes} className="px-3 py-1.5 text-sm font-medium bg-[var(--background)] text-[var(--foreground-secondary)] border border-[var(--border)] rounded-lg hover:bg-[var(--surface-hover)] transition">
+            Copy
+          </button>
+          <button onClick={downloadCodes} className="px-3 py-1.5 text-sm font-medium bg-[var(--background)] text-[var(--foreground-secondary)] border border-[var(--border)] rounded-lg hover:bg-[var(--surface-hover)] transition">
+            Download
+          </button>
+        </div>
+        <button
+          onClick={() => result && onComplete?.(result)}
+          className="eh-btn-neon rounded-xl px-4 py-2 text-sm font-medium transition"
+        >
+          {enrollmentToken ? 'Continue to dashboard' : 'Done'}
+        </button>
+      </div>
+    );
+  }
+
+  // Steps 1 & 2 — QR + verify
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-lg font-semibold text-[var(--foreground)]">Set up two-factor authentication</h3>
+        <p className="text-sm text-[var(--foreground-secondary)] mt-1">
+          Scan this QR code with an authenticator app (Google Authenticator, 1Password, Authy), then
+          enter the 6-digit code it shows.
+        </p>
+      </div>
+
+      {error && (
+        <div className="px-4 py-3 rounded-lg bg-[var(--error)]/10 border border-[var(--error)]/30 text-[var(--error)] text-sm">
+          {error}
+        </div>
+      )}
+
+      {enroll ? (
+        <>
+          <div className="flex flex-col items-center gap-3">
+            <img
+              src={enroll.qrDataUrl}
+              alt="MFA QR code"
+              width={192}
+              height={192}
+              className="rounded-lg border border-[var(--border)] bg-white p-2"
+            />
+            {secretParam && (
+              <p className="text-xs text-[var(--foreground-tertiary)] break-all text-center">
+                Or enter this key manually: <span className="font-mono text-[var(--foreground-secondary)]">{secretParam}</span>
+              </p>
+            )}
+          </div>
+
+          <form onSubmit={handleEnable} className="space-y-3">
+            <label htmlFor="mfa-enable-code" className="block text-[13px] font-semibold text-[var(--foreground-secondary)]">
+              Verification code
+            </label>
+            <input
+              id="mfa-enable-code"
+              type="text"
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              value={code}
+              onChange={(e) => {
+                setCode(e.target.value);
+                if (error) setError('');
+              }}
+              placeholder="123456"
+              className="eh-input w-full px-4 py-2 border border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] rounded-lg focus:ring-2 focus:ring-[#00E5A0] focus:border-transparent tracking-widest"
+            />
+            <div className="flex gap-2">
+              <button
+                type="submit"
+                disabled={loading || code.trim().length < 6}
+                className="eh-btn-neon rounded-xl px-4 py-2 text-sm font-medium transition disabled:opacity-50"
+              >
+                {loading ? 'Verifying...' : 'Enable two-factor'}
+              </button>
+              {onCancel && (
+                <button
+                  type="button"
+                  onClick={onCancel}
+                  className="px-4 py-2 text-sm font-medium text-[var(--foreground-secondary)] bg-[var(--surface)] border border-[var(--border)] rounded-lg hover:bg-[var(--surface-hover)] transition"
+                >
+                  Cancel
+                </button>
+              )}
+            </div>
+          </form>
+        </>
+      ) : (
+        !error && <p className="text-sm text-[var(--foreground-tertiary)]">Preparing enrollment…</p>
+      )}
+    </div>
+  );
+}

--- a/web/src/lib/api/__tests__/mfa.test.ts
+++ b/web/src/lib/api/__tests__/mfa.test.ts
@@ -1,0 +1,74 @@
+import { ApiClient } from '../client';
+import '../mfa';
+
+describe('mfa api methods', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      value: 'vizora_csrf_token=test-csrf',
+    });
+    global.fetch = jest.fn();
+  });
+
+  const okJson = (data: unknown) => ({ ok: true, status: 200, json: async () => ({ success: true, data }) });
+
+  it('enroll sends the x-mfa-enrollment-token header when a token is provided', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      okJson({ otpauthUrl: 'otpauth://totp/x', qrDataUrl: 'data:image/png;base64,AA' }),
+    );
+    const client = new ApiClient('/api/v1');
+
+    await client.mfaEnroll('enrollment-token-abc');
+
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe('/api/v1/auth/mfa/enroll');
+    expect(init.method).toBe('POST');
+    expect(init.headers['x-mfa-enrollment-token']).toBe('enrollment-token-abc');
+  });
+
+  it('enroll omits the enrollment header when no token (voluntary flow)', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      okJson({ otpauthUrl: 'otpauth://totp/x', qrDataUrl: 'data:image/png;base64,AA' }),
+    );
+    const client = new ApiClient('/api/v1');
+
+    await client.mfaEnroll();
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(init.headers?.['x-mfa-enrollment-token']).toBeUndefined();
+  });
+
+  it('mfaChallenge posts challengeToken + code and marks authenticated', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      okJson({ access_token: 'jwt', user: { id: 'u1' }, expiresIn: 1800 }),
+    );
+    const client = new ApiClient('/api/v1');
+
+    const res = await client.mfaChallenge('ct-1', '123456');
+
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe('/api/v1/auth/mfa/challenge');
+    expect(JSON.parse(init.body)).toEqual({ challengeToken: 'ct-1', code: '123456' });
+    expect(client.isAuthenticated).toBe(true);
+    expect(res).toEqual({ access_token: 'jwt', user: { id: 'u1' }, expiresIn: 1800 });
+  });
+
+  it('mfaEnable marks authenticated only when a session is returned (forced flow)', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(okJson({ backupCodes: ['a', 'b'], access_token: 'jwt' }));
+    const client = new ApiClient('/api/v1');
+
+    await client.mfaEnable('123456', 'enr-token');
+    expect(client.isAuthenticated).toBe(true);
+  });
+
+  it('setOrgMfaRequired PATCHes the org policy endpoint', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(okJson({ mfaRequired: true }));
+    const client = new ApiClient('/api/v1');
+
+    await expect(client.setOrgMfaRequired(true)).resolves.toEqual({ mfaRequired: true });
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe('/api/v1/organizations/current/mfa-required');
+    expect(init.method).toBe('PATCH');
+  });
+});

--- a/web/src/lib/api/auth.ts
+++ b/web/src/lib/api/auth.ts
@@ -2,14 +2,18 @@
 
 import { devLog } from '../logger';
 import { ApiClient, LoginResponse, RegisterResponse, AuthUser } from './client';
+import { MfaChallengeRequired, MfaEnrollmentRequired } from './mfa';
 
 export interface GoogleLoginResponse extends LoginResponse {
   isNewUser: boolean;
 }
 
+/** login() may return a normal session OR an MFA continuation (challenge/enroll). */
+export type LoginResult = LoginResponse | MfaChallengeRequired | MfaEnrollmentRequired;
+
 declare module './client' {
   interface ApiClient {
-    login(email: string, password: string): Promise<LoginResponse>;
+    login(email: string, password: string): Promise<LoginResult>;
     register(email: string, password: string, organizationName: string, firstName: string, lastName: string): Promise<RegisterResponse>;
     googleLogin(credential: string): Promise<GoogleLoginResponse>;
     logout(): Promise<void>;
@@ -26,17 +30,21 @@ declare module './client' {
   }
 }
 
-ApiClient.prototype.login = async function (email: string, password: string): Promise<LoginResponse> {
+ApiClient.prototype.login = async function (email: string, password: string): Promise<LoginResult> {
   if (process.env.NODE_ENV === 'development') {
     devLog('[API] Login called');
   }
-  const response = await this.request<LoginResponse>('/auth/login', {
+  const response = await this.request<LoginResult>('/auth/login', {
     method: 'POST',
     body: JSON.stringify({ email, password }),
   });
 
-  // Mark as authenticated - token is in httpOnly cookie
-  this.isAuthenticated = true;
+  // Only a full login (no MFA continuation) establishes a session. When MFA is
+  // required the server issued NO auth cookie — the flow completes at
+  // /auth/mfa/challenge (or /auth/mfa/enable for forced enrollment).
+  if (!('mfaRequired' in response) && !('mfaEnrollmentRequired' in response)) {
+    this.isAuthenticated = true;
+  }
   return response;
 };
 

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -1,6 +1,7 @@
 // Barrel file — re-exports everything for backwards compatibility
 // Import domain modules to register prototype extensions on ApiClient
 import './auth';
+import './mfa';
 import './content';
 import './displays';
 import './playlists';

--- a/web/src/lib/api/mfa.ts
+++ b/web/src/lib/api/mfa.ts
@@ -1,0 +1,113 @@
+// MFA (auth #2) API methods
+
+import { ApiClient, AuthUser, LoginResponse } from './client';
+
+/** Login responded that an enrolled user must complete a TOTP challenge. */
+export interface MfaChallengeRequired {
+  mfaRequired: true;
+  challengeToken: string;
+}
+
+/** Login responded that the org requires MFA and the user must enroll first. */
+export interface MfaEnrollmentRequired {
+  mfaEnrollmentRequired: true;
+  enrollmentToken: string;
+}
+
+export interface MfaStatus {
+  enabled: boolean;
+  backupCodesRemaining: number;
+}
+
+export interface MfaEnrollData {
+  otpauthUrl: string;
+  qrDataUrl: string;
+}
+
+/** enable() returns backup codes; in the forced-enrollment flow it also
+ * returns a completed session (access_token/user) so the caller can proceed. */
+export interface MfaEnableResult {
+  backupCodes: string[];
+  access_token?: string;
+  user?: AuthUser;
+  expiresIn?: number;
+}
+
+const ENROLLMENT_HEADER = 'x-mfa-enrollment-token';
+
+declare module './client' {
+  interface ApiClient {
+    mfaEnroll(enrollmentToken?: string): Promise<MfaEnrollData>;
+    mfaEnable(code: string, enrollmentToken?: string): Promise<MfaEnableResult>;
+    mfaDisable(code: string): Promise<{ message: string }>;
+    mfaStatus(): Promise<MfaStatus>;
+    mfaRegenerateBackupCodes(code: string): Promise<{ backupCodes: string[] }>;
+    mfaChallenge(challengeToken: string, code: string): Promise<LoginResponse>;
+    setOrgMfaRequired(mfaRequired: boolean): Promise<{ mfaRequired: boolean }>;
+  }
+}
+
+ApiClient.prototype.mfaEnroll = async function (enrollmentToken?: string): Promise<MfaEnrollData> {
+  return this.request<MfaEnrollData>('/auth/mfa/enroll', {
+    method: 'POST',
+    ...(enrollmentToken ? { headers: { [ENROLLMENT_HEADER]: enrollmentToken } } : {}),
+  });
+};
+
+ApiClient.prototype.mfaEnable = async function (
+  code: string,
+  enrollmentToken?: string,
+): Promise<MfaEnableResult> {
+  const result = await this.request<MfaEnableResult>('/auth/mfa/enable', {
+    method: 'POST',
+    body: JSON.stringify({ code }),
+    ...(enrollmentToken ? { headers: { [ENROLLMENT_HEADER]: enrollmentToken } } : {}),
+  });
+  // Forced-enrollment path returns a completed session — mark authenticated.
+  if (result.access_token) {
+    this.isAuthenticated = true;
+  }
+  return result;
+};
+
+ApiClient.prototype.mfaDisable = async function (code: string): Promise<{ message: string }> {
+  return this.request<{ message: string }>('/auth/mfa/disable', {
+    method: 'POST',
+    body: JSON.stringify({ code }),
+  });
+};
+
+ApiClient.prototype.mfaStatus = async function (): Promise<MfaStatus> {
+  return this.request<MfaStatus>('/auth/mfa/status');
+};
+
+ApiClient.prototype.mfaRegenerateBackupCodes = async function (
+  code: string,
+): Promise<{ backupCodes: string[] }> {
+  return this.request<{ backupCodes: string[] }>('/auth/mfa/backup-codes/regenerate', {
+    method: 'POST',
+    body: JSON.stringify({ code }),
+  });
+};
+
+ApiClient.prototype.mfaChallenge = async function (
+  challengeToken: string,
+  code: string,
+): Promise<LoginResponse> {
+  const response = await this.request<LoginResponse>('/auth/mfa/challenge', {
+    method: 'POST',
+    body: JSON.stringify({ challengeToken, code }),
+  });
+  // Session cookie is set by the server; mark authenticated exactly as login does.
+  this.isAuthenticated = true;
+  return response;
+};
+
+ApiClient.prototype.setOrgMfaRequired = async function (
+  mfaRequired: boolean,
+): Promise<{ mfaRequired: boolean }> {
+  return this.request<{ mfaRequired: boolean }>('/organizations/current/mfa-required', {
+    method: 'PATCH',
+    body: JSON.stringify({ mfaRequired }),
+  });
+};


### PR DESCRIPTION
Opt-in per user; **non-MFA login is byte-for-byte unchanged**. Closes auth #2. The last of the three requested auth items.

## What
- **TOTP** (otplib, SHA1/6-digit/30s, window ±1). Secret **AES-256-GCM encrypted at rest** (`MFA_ENCRYPTION_KEY`, fail-closed). Enroll → pending secret + QR; enable verifies a code + issues 10 **sha256-hashed single-use** backup codes (shown once). Disable requires a valid factor. Status + regenerate.
- **Login challenge:** password valid AND (MFA-enrolled OR org requires MFA) → login returns `{mfaRequired, challengeToken}` (**no session**); `POST /auth/mfa/challenge` (TOTP or backup code) issues the normal session. Challenge/enrollment tokens are typed, short-lived, single-use, and signed with a key **HMAC-derived from JWT_SECRET** so they can never verify as access tokens.
- **Per-org enforcement:** `Organization.mfaRequired` (org-admin toggle). Unenrolled users get `{mfaEnrollmentRequired, enrollmentToken}` → must enroll before access (no hard-lock).
- Additive migration (users.mfa*, organizations.mfaRequired, `mfa_backup_codes`). Frontend: enroll flow, challenge step, forced-enrollment routing, security settings.

## Multi-vector adversarial review — 2 HIGH + 1 race fixed **in this PR**
- **S1 (HIGH):** `googleLogin` bypassed MFA entirely → now routed through the same `resolveLoginBranch` gate (org loaded), so SSO users hit the challenge/enrollment.
- **S2 (HIGH):** the TOTP-challenge lockout was keyed on the **challenge-token jti** — a fresh login reset the budget → **brute-forceable**. Added a **user-keyed** lockout (atomic Redis `INCR`, cleared on success) that fresh tokens can't reset.
- **S3:** challenge single-use was a check-then-set TOCTOU that **failed open** on Redis error → now an atomic `SET NX` claim, **fail-closed**.

Verified **CLEAN** by the review: AES-GCM crypto, secret-never-leaks (`sanitizeUser` strips `mfaSecret`), MFA-token type-confusion, enrollment cross-user/chosen-secret, backup-code double-spend (DB-atomic), CSRF, migration safety, password-alone→session (impossible).

## Verification (independently re-run)
- middleware `tsc` 0 · `prisma validate` OK · web `tsc` 0 · jest **323/323** (mfa + auth + redis, incl. the S1/S2/S3 regression tests).

## Deploy note
**Set `MFA_ENCRYPTION_KEY` (≥32 chars) on prod before enabling MFA** — it's fail-closed (MFA ops 503 without it; non-MFA login unaffected).

## Follow-ups (flagged, not blocking)
`mfaRequired` isn't retroactive to live sessions (revoke on toggle); optional per-code TOTP replay cache (`afterTimeStep`); Google-login now enforced (was S1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)